### PR TITLE
fixing bug in post process function

### DIFF
--- a/jcm/model.py
+++ b/jcm/model.py
@@ -285,8 +285,6 @@ class SpeedyModel:
         from jcm.physics import dynamics_state_to_physics_state
 
         physics_state = dynamics_state_to_physics_state(state, self.primitive)
-        # convert back to SI to match convention for user-defined initial PhysicsStates
-        physics_state.surface_pressure = physics_state.surface_pressure * p0
         
         physics_data = None
         if self.post_process_physics:
@@ -299,6 +297,9 @@ class SpeedyModel:
             for term in self.physics_terms:
                 _, physics_data = term(physics_state, physics_data, self.parameters, self.boundaries, self.geometry)
 
+        # convert back to SI to match convention for user-defined initial PhysicsStates
+        physics_state.surface_pressure = physics_state.surface_pressure * p0
+        
         return {
             'dynamics': physics_state,
             'physics': physics_data


### PR DESCRIPTION
We were converting from normalized to regular surface pressure before running the physics data, but we should be doing that after. Speedy parameterizations expect normalized surface pressure. 

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
