### PR TITLE
Set shortwave code to run at step 3n rather than 3n+1

### DIFF
--- a/jcm/model.py
+++ b/jcm/model.py
@@ -28,7 +28,7 @@ def set_physics_flags(state: PhysicsState,
         This could also apply to forcing and coupling.
     '''
     model_step = physics_data.date.model_step
-    compute_shortwave = (jnp.mod(model_step, nstrad) == 1)
+    compute_shortwave = (jnp.mod(model_step, nstrad) == 0)
     shortwave_data = physics_data.shortwave_rad.copy(compute_shortwave=compute_shortwave)
     physics_data = physics_data.copy(shortwave_rad=shortwave_data)
 


### PR DESCRIPTION
As it stands, to get the shortwave fields to show up in output you have to pass the model an initial state with nonzero sim_time = 3n + 1 timesteps, or set save_interval to something that isn't a multiple of 3 timesteps. Fixing this should be an inconsequential change and then all the shortwave outputs and gradients will be nonzero again without having to think about it.