### PR TITLE
Change `self` to `cls` in classmethods

### DIFF
--- a/jcm/boundaries.py
+++ b/jcm/boundaries.py
@@ -30,11 +30,11 @@ class BoundaryData:
 
 
     @classmethod
-    def zeros(self,nodal_shape,fmask=None,forog=None,orog=None,phi0=None,phis0=None,
+    def zeros(cls,nodal_shape,fmask=None,forog=None,orog=None,phi0=None,phis0=None,
               alb0=None,sice_am=None,fmask_l=None,rhcapl=None,cdland=None,
               stlcl_ob=None,snowd_am=None,soilw_am=None,tsea=None,
               fmask_s=None,lfluxland=None, land_coupling_flag=None):
-        return BoundaryData(
+        return cls(
             fmask=fmask if fmask is not None else jnp.zeros((nodal_shape)),
             forog=forog if forog is not None else jnp.zeros((nodal_shape)),
             orog=orog if orog is not None else jnp.zeros((nodal_shape)),
@@ -55,11 +55,11 @@ class BoundaryData:
         )
 
     @classmethod
-    def ones(self,nodal_shape,fmask=None,forog=None,orog=None,phi0=None,phis0=None,
+    def ones(cls,nodal_shape,fmask=None,forog=None,orog=None,phi0=None,phis0=None,
              alb0=None,sice_am=None,fmask_l=None,rhcapl=None,cdland=None,
              stlcl_ob=None,snowd_am=None,soilw_am=None,tsea=None,
              fmask_s=None,lfluxland=None, land_coupling_flag=None):
-        return BoundaryData(
+        return cls(
             fmask=fmask if fmask is not None else jnp.ones((nodal_shape)),
             forog=forog if forog is not None else jnp.ones((nodal_shape)),
             orog=orog if orog is not None else jnp.ones((nodal_shape)),

--- a/jcm/date.py
+++ b/jcm/date.py
@@ -57,7 +57,7 @@ class Timedelta:
     seconds = values // np.timedelta64(1, 's')
     # no need to worry about overflow, because timedelta64 represents values
     # internally with int64 and normalization uses native array operations
-    return Timedelta(0, seconds)
+    return cls(0, seconds)
 
   def to_timedelta64(self) -> np.timedelta64 | np.ndarray:
     seconds = np.int64(self.days) * 24 * 60 * 60 + np.int64(self.seconds)
@@ -164,22 +164,22 @@ class DateData:
     model_step: jnp.int32
 
     @classmethod
-    def zeros(self, model_time=None, model_year=None, model_step=None):
-        return DateData(
+    def zeros(cls, model_time=None, model_year=None, model_step=None):
+        return cls(
           tyear=fraction_of_year_elapsed(model_time) if model_time is not None else 0.0,
           model_year=model_year if model_year is not None else 1950,
           model_step=model_step if model_step is not None else jnp.int32(0))
 
     @classmethod
-    def set_date(self, model_time, model_year=None, model_step=None):
-        return DateData(
+    def set_date(cls, model_time, model_year=None, model_step=None):
+        return cls(
           tyear=fraction_of_year_elapsed(model_time),
           model_year=model_year if model_year is not None else 1950,
           model_step=model_step if model_step is not None else jnp.int32(0))
 
     @classmethod
-    def ones(self, model_time=None, model_year=None, model_step=None):
-        return DateData(
+    def ones(cls, model_time=None, model_year=None, model_step=None):
+        return cls(
           tyear=fraction_of_year_elapsed(model_time) if model_time is not None else 1.0,
           model_year=model_year if model_year is not None else 1950,
           model_step=model_step if model_step is not None else jnp.int32(0))

--- a/jcm/geometry.py
+++ b/jcm/geometry.py
@@ -56,7 +56,7 @@ class Geometry:
     wvi: jnp.ndarray # Weights for vertical interpolation
 
     @classmethod
-    def from_coords(self, coords: CoordinateSystem=None):
+    def from_coords(cls, coords: CoordinateSystem=None):
         """
         Initializes all of the speedy model geometry variables from a dinosaur CoordinateSystem.
 
@@ -75,13 +75,13 @@ class Geometry:
         kx = coords.nodal_shape[0]
         hsg, fsg, dhs, sigl, grdsig, grdscp, wvi = _initialize_vertical(kx)
 
-        return Geometry(nodal_shape=coords.nodal_shape,
-                        radang=radang, sia=sia, coa=coa,
-                        hsg=hsg, fsg=fsg, dhs=dhs, sigl=sigl,
-                        grdsig=grdsig, grdscp=grdscp, wvi=wvi)
+        return cls(nodal_shape=coords.nodal_shape,
+                   radang=radang, sia=sia, coa=coa,
+                   hsg=hsg, fsg=fsg, dhs=dhs, sigl=sigl,
+                   grdsig=grdsig, grdscp=grdscp, wvi=wvi)
 
     @classmethod
-    def from_grid_shape(self, nodal_shape=None, node_levels=None):
+    def from_grid_shape(cls, nodal_shape=None, node_levels=None):
         """
         Initializes all of the speedy model geometry variables from grid dimensions (legacy code from speedy.f90).
 
@@ -107,7 +107,7 @@ class Geometry:
         kx = node_levels
         hsg, fsg, dhs, sigl, grdsig, grdscp, wvi = _initialize_vertical(kx)
         
-        return Geometry(nodal_shape=(node_levels,) + nodal_shape,
-                        radang=radang, sia=sia, coa=coa,
-                        hsg=hsg, fsg=fsg, dhs=dhs, sigl=sigl,
-                        grdsig=grdsig, grdscp=grdscp, wvi=wvi)
+        return cls(nodal_shape=(node_levels,) + nodal_shape,
+                   radang=radang, sia=sia, coa=coa,
+                   hsg=hsg, fsg=fsg, dhs=dhs, sigl=sigl,
+                   grdsig=grdsig, grdscp=grdscp, wvi=wvi)

--- a/jcm/physics/speedy/params.py
+++ b/jcm/physics/speedy/params.py
@@ -16,8 +16,8 @@ class ConvectionParameters:
     smf: jnp.ndarray # Ratio between secondary and primary mass flux at cloud-base
 
     @classmethod
-    def default(self):
-        return ConvectionParameters(
+    def default(cls):
+        return cls(
             psmin = jnp.array(0.8),
             trcnv = jnp.array(6.0),
             rhil = jnp.array(0.7),
@@ -35,8 +35,8 @@ class ForcingParameters:
     co2_year_ref: jnp.int32 # Time of relaxation (in hours) towards reference state
 
     @classmethod
-    def default(self):
-        return ForcingParameters(
+    def default(cls):
+        return cls(
             increase_co2 = True,
             co2_year_ref = 1950,
         )
@@ -54,8 +54,8 @@ class CondensationParameters:
     rhblsc: jnp.ndarray # Relative humidity threshold for boundary layer
 
     @classmethod
-    def default(self):
-        return CondensationParameters(
+    def default(cls):
+        return cls(
             trlsc = jnp.array(4.0),
             rhlsc = jnp.array(0.9),
             drhlsc = jnp.array(0.1),
@@ -99,8 +99,8 @@ class ShortwaveRadiationParameters:
     gse_s1: jnp.ndarray  # Gradient of dry static energy corresponding to stratiform cloud cover = 1
 
     @classmethod
-    def default(self):
-        return ShortwaveRadiationParameters(
+    def default(cls):
+        return cls(
             albcl = jnp.array(0.43),
             albcls = jnp.array(0.50),
             absdry = jnp.array(0.033),
@@ -140,8 +140,8 @@ class ModRadConParameters:
     emisfc: jnp.ndarray  # Longwave surface emissivity
 
     @classmethod
-    def default(self):
-        return ModRadConParameters(
+    def default(cls):
+        return cls(
             albsea = jnp.array(0.07),
             albice = jnp.array(0.60),
             albsn = jnp.array(0.60),
@@ -183,8 +183,8 @@ class SurfaceFluxParameters:
     hdrag: jnp.ndarray # Height scale for orographic correction
 
     @classmethod
-    def default(self):
-        return SurfaceFluxParameters(
+    def default(cls):
+        return cls(
             fwind0 = jnp.array(0.95),
             ftemp0 = jnp.array(1.0),
             fhum0 = jnp.array(0.0),
@@ -218,8 +218,8 @@ class VerticalDiffusionParameters:
     segrad: jnp.ndarray  # Minimum gradient of dry static energy (d_DSE/d_phi)
 
     @classmethod
-    def default(self):
-        return VerticalDiffusionParameters(
+    def default(cls):
+        return cls(
             trshc = jnp.array(6.0),
             trvdi = jnp.array(24.0),
             trvds = jnp.array(6.0),
@@ -247,8 +247,8 @@ class LandModelParameters:
     hcapli: jnp.ndarray
 
     @classmethod
-    def default(self):
-        return LandModelParameters(
+    def default(cls):
+        return cls(
             sd2sc = jnp.array(60.0),
             swcap = jnp.array(0.30),
             swwil = jnp.array(0.17),
@@ -276,8 +276,8 @@ class Parameters:
     forcing: ForcingParameters
 
     @classmethod
-    def default(self):
-        return Parameters(
+    def default(cls):
+        return cls(
             convection = ConvectionParameters.default(),
             condensation = CondensationParameters.default(),
             shortwave_radiation = ShortwaveRadiationParameters.default(),

--- a/jcm/physics/speedy/physics_data.py
+++ b/jcm/physics/speedy/physics_data.py
@@ -11,15 +11,15 @@ class LWRadiationData:
     ftop: jnp.ndarray
 
     @classmethod
-    def zeros(self, nodal_shape, node_levels, dfabs=None, ftop=None):
-        return LWRadiationData(
+    def zeros(cls, nodal_shape, node_levels, dfabs=None, ftop=None):
+        return cls(
             dfabs = dfabs if dfabs is not None else jnp.zeros((node_levels,)+nodal_shape),
             ftop = ftop if ftop is not None else jnp.zeros(nodal_shape),
         )
     
     @classmethod
-    def ones(self, nodal_shape, node_levels, dfabs=None, ftop=None):
-        return LWRadiationData(
+    def ones(cls, nodal_shape, node_levels, dfabs=None, ftop=None):
+        return cls(
             dfabs = dfabs if dfabs is not None else jnp.ones((node_levels,)+nodal_shape),
             ftop = ftop if ftop is not None else jnp.ones(nodal_shape),
         )
@@ -52,8 +52,8 @@ class SWRadiationData:
     compute_shortwave: jnp.bool
 
     @classmethod
-    def zeros(self, nodal_shape, node_levels, qcloud=None, fsol=None, rsds=None, rsns=None, ozone=None, ozupp=None, zenit=None, stratz=None, gse=None, icltop=None, cloudc=None, cloudstr=None, ftop=None, dfabs=None, compute_shortwave=None):
-        return SWRadiationData(
+    def zeros(cls, nodal_shape, node_levels, qcloud=None, fsol=None, rsds=None, rsns=None, ozone=None, ozupp=None, zenit=None, stratz=None, gse=None, icltop=None, cloudc=None, cloudstr=None, ftop=None, dfabs=None, compute_shortwave=None):
+        return cls(
             qcloud = qcloud if qcloud is not None else jnp.zeros(nodal_shape),
             fsol = fsol if fsol is not None else jnp.zeros(nodal_shape),
             rsds = rsds if rsds is not None else jnp.zeros(nodal_shape),
@@ -72,8 +72,8 @@ class SWRadiationData:
         )
     
     @classmethod
-    def ones(self, nodal_shape, node_levels, qcloud=None, fsol=None, rsds=None, rsns=None, ozone=None, ozupp=None, zenit=None, stratz=None, gse=None, icltop=None, cloudc=None, cloudstr=None, ftop=None, dfabs=None, compute_shortwave=None):
-        return SWRadiationData(
+    def ones(cls, nodal_shape, node_levels, qcloud=None, fsol=None, rsds=None, rsns=None, ozone=None, ozupp=None, zenit=None, stratz=None, gse=None, icltop=None, cloudc=None, cloudstr=None, ftop=None, dfabs=None, compute_shortwave=None):
+        return cls(
             qcloud = qcloud if qcloud is not None else jnp.ones(nodal_shape),
             fsol = fsol if fsol is not None else jnp.ones(nodal_shape),
             rsds = rsds if rsds is not None else jnp.ones(nodal_shape),
@@ -132,8 +132,8 @@ class ModRadConData:
     flux: jnp.ndarray         # Radiative flux in different spectral bands
 
     @classmethod
-    def zeros(self, nodal_shape, node_levels, ablco2=None, alb_l=None,alb_s=None,albsfc=None,snowc=None,tau2=None,st4a=None,stratc=None,flux=None):
-        return ModRadConData(
+    def zeros(cls, nodal_shape, node_levels, ablco2=None, alb_l=None,alb_s=None,albsfc=None,snowc=None,tau2=None,st4a=None,stratc=None,flux=None):
+        return cls(
             ablco2 = ablco2 if ablco2 is not None else ablco2_ref,
             alb_l = alb_l if alb_l is not None else jnp.zeros(nodal_shape),
             alb_s = alb_s if alb_s is not None else jnp.zeros(nodal_shape),
@@ -146,8 +146,8 @@ class ModRadConData:
         )
     
     @classmethod
-    def ones(self, nodal_shape, node_levels, ablco2=None, alb_l=None,alb_s=None,albsfc=None,snowc=None,tau2=None,st4a=None,stratc=None,flux=None):
-        return ModRadConData(
+    def ones(cls, nodal_shape, node_levels, ablco2=None, alb_l=None,alb_s=None,albsfc=None,snowc=None,tau2=None,st4a=None,stratc=None,flux=None):
+        return cls(
             ablco2 = ablco2 if ablco2 is not None else ablco2_ref,
             alb_l = alb_l if alb_l is not None else jnp.ones(nodal_shape),
             alb_s = alb_s if alb_s is not None else jnp.ones(nodal_shape),
@@ -182,16 +182,16 @@ class CondensationData:
     dqlsc: jnp.ndarray
 
     @classmethod
-    def zeros(self, nodal_shape, node_levels, precls=None, dtlsc=None, dqlsc=None):
-        return CondensationData(
+    def zeros(cls, nodal_shape, node_levels, precls=None, dtlsc=None, dqlsc=None):
+        return cls(
             precls = precls if precls is not None else jnp.zeros(nodal_shape),
             dtlsc = dtlsc if dtlsc is not None else jnp.zeros((node_levels,)+nodal_shape),
             dqlsc = dqlsc if dqlsc is not None else jnp.zeros((node_levels,)+nodal_shape),
         )
     
     @classmethod
-    def ones(self, nodal_shape, node_levels, precls=None, dtlsc=None, dqlsc=None):
-        return CondensationData(
+    def ones(cls, nodal_shape, node_levels, precls=None, dtlsc=None, dqlsc=None):
+        return cls(
             precls = precls if precls is not None else jnp.ones(nodal_shape),
             dtlsc = dtlsc if dtlsc is not None else jnp.ones((node_levels,)+nodal_shape),
             dqlsc = dqlsc if dqlsc is not None else jnp.ones((node_levels,)+nodal_shape),
@@ -215,8 +215,8 @@ class ConvectionData:
     precnv: jnp.ndarray # Convective precipitation [g/(m^2 s)]
 
     @classmethod
-    def zeros(self, nodal_shape, node_levels, se=None, iptop=None, cbmf=None, precnv=None):
-        return ConvectionData(
+    def zeros(cls, nodal_shape, node_levels, se=None, iptop=None, cbmf=None, precnv=None):
+        return cls(
             se = se if se is not None else jnp.zeros((node_levels,)+nodal_shape),
             iptop = iptop if iptop is not None else jnp.zeros((nodal_shape),dtype=int),
             cbmf = cbmf if cbmf is not None else jnp.zeros(nodal_shape),
@@ -224,8 +224,8 @@ class ConvectionData:
         )
     
     @classmethod
-    def ones(self, nodal_shape, node_levels, se=None, iptop=None, cbmf=None, precnv=None):
-        return ConvectionData(
+    def ones(cls, nodal_shape, node_levels, se=None, iptop=None, cbmf=None, precnv=None):
+        return cls(
             se = se if se is not None else jnp.ones((node_levels,)+nodal_shape),
             iptop = iptop if iptop is not None else jnp.ones((nodal_shape),dtype=int),
             cbmf = cbmf if cbmf is not None else jnp.ones(nodal_shape),
@@ -253,15 +253,15 @@ class HumidityData:
     qsat: jnp.ndarray # saturation specific humidity
 
     @classmethod
-    def zeros(self, nodal_shape, node_levels, rh=None, qsat=None):
-        return HumidityData(
+    def zeros(cls, nodal_shape, node_levels, rh=None, qsat=None):
+        return cls(
             rh = rh if rh is not None else jnp.zeros((node_levels,)+nodal_shape),
             qsat = qsat if qsat is not None else jnp.zeros((node_levels,)+nodal_shape)
         )
     
     @classmethod
-    def ones(self, nodal_shape, node_levels, rh=None, qsat=None):
-        return HumidityData(
+    def ones(cls, nodal_shape, node_levels, rh=None, qsat=None):
+        return cls(
             rh = rh if rh is not None else jnp.ones((node_levels,)+nodal_shape),
             qsat = qsat if qsat is not None else jnp.ones((node_levels,)+nodal_shape)
         )
@@ -292,8 +292,8 @@ class SurfaceFluxData:
     t0: jnp.ndarray # Near-surface temperature
 
     @classmethod
-    def zeros(self, nodal_shape, ustr=None, vstr=None, shf=None, evap=None, rlus=None, rlds=None, rlns=None, hfluxn=None, tsfc=None, tskin=None, u0=None, v0=None, t0=None):
-        return SurfaceFluxData(
+    def zeros(cls, nodal_shape, ustr=None, vstr=None, shf=None, evap=None, rlus=None, rlds=None, rlns=None, hfluxn=None, tsfc=None, tskin=None, u0=None, v0=None, t0=None):
+        return cls(
             ustr = ustr if ustr is not None else jnp.zeros((nodal_shape)+(3,)),
             vstr = vstr if vstr is not None else jnp.zeros((nodal_shape)+(3,)),
             shf = shf if shf is not None else jnp.zeros((nodal_shape)+(3,)),
@@ -310,8 +310,8 @@ class SurfaceFluxData:
         )
     
     @classmethod
-    def ones(self, nodal_shape, ustr=None, vstr=None, shf=None, evap=None, rlus=None, rlds=None, rlns=None, hfluxn=None, tsfc=None, tskin=None, u0=None, v0=None, t0=None):
-        return SurfaceFluxData(
+    def ones(cls, nodal_shape, ustr=None, vstr=None, shf=None, evap=None, rlus=None, rlds=None, rlns=None, hfluxn=None, tsfc=None, tskin=None, u0=None, v0=None, t0=None):
+        return cls(
             ustr = ustr if ustr is not None else jnp.ones((nodal_shape)+(3,)),
             vstr = vstr if vstr is not None else jnp.ones((nodal_shape)+(3,)),
             shf = shf if shf is not None else jnp.ones((nodal_shape)+(3,)),
@@ -353,15 +353,15 @@ class LandModelData:
     stl_am: jnp.ndarray
     
     @classmethod
-    def zeros(self, nodal_shape, stl_lm=None, stl_am=None):
-        return LandModelData(
+    def zeros(cls, nodal_shape, stl_lm=None, stl_am=None):
+        return cls(
             stl_am = stl_am if stl_am is not None else jnp.full((nodal_shape), 288.0),
             stl_lm = stl_lm if stl_lm is not None else jnp.full((nodal_shape), 288.0)
         )
     
     @classmethod
-    def ones(self, nodal_shape, stl_lm=None, stl_am=None):
-        return LandModelData(
+    def ones(cls, nodal_shape, stl_lm=None, stl_am=None):
+        return cls(
             stl_am = stl_am if stl_am is not None else jnp.ones(nodal_shape),
             stl_lm = stl_lm if stl_lm is not None else jnp.ones(nodal_shape)
         )
@@ -389,8 +389,8 @@ class PhysicsData:
     land_model: LandModelData
 
     @classmethod
-    def zeros(self, nodal_shape, node_levels, shortwave_rad=None,longwave_rad=None, convection=None, mod_radcon=None, humidity=None, condensation=None, surface_flux=None, date=None, land_model=None):
-        return PhysicsData(
+    def zeros(cls, nodal_shape, node_levels, shortwave_rad=None,longwave_rad=None, convection=None, mod_radcon=None, humidity=None, condensation=None, surface_flux=None, date=None, land_model=None):
+        return cls(
             longwave_rad = longwave_rad if longwave_rad is not None else LWRadiationData.zeros(nodal_shape, node_levels),
             shortwave_rad = shortwave_rad if shortwave_rad is not None else SWRadiationData.zeros(nodal_shape, node_levels),
             convection = convection if convection is not None else ConvectionData.zeros(nodal_shape, node_levels),
@@ -403,8 +403,8 @@ class PhysicsData:
         )
     
     @classmethod
-    def ones(self, nodal_shape, node_levels, shortwave_rad=None, longwave_rad=None, convection=None, mod_radcon=None, humidity=None, condensation=None, surface_flux=None, date=None, land_model=None):
-        return PhysicsData(
+    def ones(cls, nodal_shape, node_levels, shortwave_rad=None, longwave_rad=None, convection=None, mod_radcon=None, humidity=None, condensation=None, surface_flux=None, date=None, land_model=None):
+        return cls(
             longwave_rad = longwave_rad if longwave_rad is not None else LWRadiationData.ones(nodal_shape, node_levels),
             shortwave_rad = shortwave_rad if shortwave_rad is not None else SWRadiationData.ones(nodal_shape, node_levels),
             convection = convection if convection is not None else ConvectionData.ones(nodal_shape, node_levels),

--- a/jcm/physics_interface.py
+++ b/jcm/physics_interface.py
@@ -28,8 +28,8 @@ class PhysicsState:
     surface_pressure: jnp.ndarray  # normalized surface pressure (normalized by p0)
 
     @classmethod
-    def zeros(self, shape, u_wind=None, v_wind=None, temperature=None, specific_humidity=None, geopotential=None, surface_pressure=None):
-        return PhysicsState(
+    def zeros(cls, shape, u_wind=None, v_wind=None, temperature=None, specific_humidity=None, geopotential=None, surface_pressure=None):
+        return cls(
             u_wind if u_wind is not None else jnp.zeros(shape),
             v_wind if v_wind is not None else jnp.zeros(shape),
             temperature if temperature is not None else jnp.zeros(shape),
@@ -39,8 +39,8 @@ class PhysicsState:
         )
 
     @classmethod
-    def ones(self, shape, u_wind=None, v_wind=None, temperature=None, specific_humidity=None, geopotential=None, surface_pressure=None):
-        return PhysicsState(
+    def ones(cls, shape, u_wind=None, v_wind=None, temperature=None, specific_humidity=None, geopotential=None, surface_pressure=None):
+        return cls(
             u_wind if u_wind is not None else jnp.ones(shape),
             v_wind if v_wind is not None else jnp.ones(shape),
             temperature if temperature is not None else jnp.ones(shape),
@@ -73,8 +73,8 @@ class PhysicsTendency:
     specific_humidity: jnp.ndarray
 
     @classmethod
-    def zeros(self,shape,u_wind=None,v_wind=None,temperature=None,specific_humidity=None):
-        return PhysicsTendency(
+    def zeros(cls,shape,u_wind=None,v_wind=None,temperature=None,specific_humidity=None):
+        return cls(
             u_wind if u_wind is not None else jnp.zeros(shape),
             v_wind if v_wind is not None else jnp.zeros(shape),
             temperature if temperature is not None else jnp.zeros(shape),
@@ -82,8 +82,8 @@ class PhysicsTendency:
         )
 
     @classmethod
-    def ones(self,shape,u_wind=None,v_wind=None,temperature=None,specific_humidity=None):
-        return PhysicsTendency(
+    def ones(cls,shape,u_wind=None,v_wind=None,temperature=None,specific_humidity=None):
+        return cls(
             u_wind if u_wind is not None else jnp.ones(shape),
             v_wind if v_wind is not None else jnp.ones(shape),
             temperature if temperature is not None else jnp.ones(shape),


### PR DESCRIPTION
Using `cls` allows classmethods to function properly wrt inheritance/polymorphism, `self` is incorrect