### PR TITLE
Add correction to conserve global mean pressure

### DIFF
--- a/jcm/model.py
+++ b/jcm/model.py
@@ -141,11 +141,15 @@ class Model:
         
         self.primitive_with_speedy = dinosaur.time_integration.compose_equations([self.primitive, physics_forcing_eqn])
         step_fn = dinosaur.time_integration.imex_rk_sil3(self.primitive_with_speedy, self.dt)
-        filters = [
-            lambda u, u_next: u_next.replace(
+        
+        def conserve_global_mean_surface_pressure(u, u_next):
+            return u_next.replace(
                 # prevent global mean (0th spectral component) surface pressure drift by setting it to its value before timestep
-                log_surface_pressure=u_next.log_surface_pressure.at[0,0,0].set(u.log_surface_pressure[0,0,0])
-            ),
+                log_surface_pressure=u_next.log_surface_pressure.at[0, 0, 0].set(u.log_surface_pressure[0, 0, 0])
+            )
+        
+        filters = [
+            conserve_global_mean_surface_pressure,
             dinosaur.time_integration.exponential_step_filter(
                 self.coords.horizontal, self.dt, tau=0.0087504, order=1.5, cutoff=0.8
             ),


### PR DESCRIPTION
Just a first draft of this fix--we could pop it out into a second verify_tendencies function or something. Setting 0th spectral component to zero is equivalent to multiplying the normalized pressure field by a constant factor to bring it back to a mean of 1. Without this fix, global mean surface pressure decays (half life of a few months) when realistic boundary conditions are used. Pressure doesn't decay in the aquaplanet setup, presumably it's the orography that causes problems.