### PR TITLE
Allow moisture to condense in the top layer

### DIFF
--- a/jcm/physics/speedy/large_scale_condensation_test.py
+++ b/jcm/physics/speedy/large_scale_condensation_test.py
@@ -9,7 +9,7 @@ class TestLargeScaleCondensationUnit(unittest.TestCase):
         global ix, il, kx
         ix, il, kx = 1, 1, 8
 
-        global ConvectionData, HumidityData, PhysicsData, PhysicsState, PhysicsTendency, parameters, geometry, BoundaryData, get_large_scale_condensation_tendencies, p0, grav
+        global ConvectionData, HumidityData, PhysicsData, PhysicsState, PhysicsTendency, parameters, geometry, BoundaryData, get_large_scale_condensation_tendencies
         from jcm.physics.speedy.physics_data import ConvectionData, HumidityData, PhysicsData
         from jcm.physics_interface import PhysicsState, PhysicsTendency
         from jcm.physics.speedy.params import Parameters
@@ -18,7 +18,6 @@ class TestLargeScaleCondensationUnit(unittest.TestCase):
         geometry = Geometry.from_grid_shape((ix, il), kx)
         from jcm.boundaries import BoundaryData
         from jcm.physics.speedy.large_scale_condensation import get_large_scale_condensation_tendencies
-        from jcm.constants import p0, grav
 
     def test_get_large_scale_condensation_tendencies(self):
         xy = (ix,il)


### PR DESCRIPTION
The humidity blowup is possible because moisture was not able to condense in the top layer of the atmosphere. Allowing it to condense is a trivial fix that has minimal effects on model behavior because averting the exponential growth of humidity means the quantity in the top level is always very small.

Context:
* SPEEDY does not apply large-scale condensation to the stratosphere (the top layer). I'm not sure why--there's no explicit justification for this in any of the documentation I found. Presumably this was intended to match some feature of the ECMWF model speedy was based on. <img width="1170" height="824" alt="image" src="https://github.com/user-attachments/assets/04bc7082-5769-4e76-bfe0-bbdab229273f" />
* I assume that the lack of CCNs in the stratosphere, plus the fact that supersaturation with respect to ice formation is more stable than supersaturation with respect to water, means it might make sense to treat stratospheric condensation differently.
* Still, supersaturations over 150% are rare, chatgpt tells me the most extreme values observed are around 180%. <img width="930" height="714" alt="image" src="https://github.com/user-attachments/assets/982633ed-bb83-4158-bc31-8dfb3e21569a" />
* An approach taken in some models is to enforce condensation in overly supersaturated areas at the end of the physics routines, so it doesn't interfere with the cloud scheme and stuff. We could do this to avoid changing SPEEDY's large scale condensation module, but given that a) this is real physical condensation and b) it's a tiny amount of water, it seems more principled to keep it here.