### PR TITLE
Added yaml file necessary for ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,18 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 1
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.11"
+
+sphinx:
+   configuration: docs/conf.py
+
+python:
+   install:
+   - requirements: docs/requirements.txt
+        


### PR DESCRIPTION
## Describe your changes
This yaml file specifies The version of ReadTheDocs (which is 1), the build platform for sphinx, the sphinx configuration file, and the python install requirements. 

## Issue ticket number and link


