### PR TITLE
create slow marker for pytests

### DIFF
--- a/.github/workflows/run_test.yaml
+++ b/.github/workflows/run_test.yaml
@@ -30,12 +30,13 @@ jobs:
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
-      # Run tests differently depending on event type
+      # run fast tests when triggered by a push *without* an open PR
       - name: Test with pytest (no slow tests on push)
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.event.pull_request.head.repo == null
         run: |
           coverage run -m pytest -v -s -m "not slow" --cov-fail-under=90
 
+      # run all tests when triggered by a push to an open PR
       - name: Test with pytest (include slow tests on PR)
         if: github.event_name == 'pull_request'
         run: |

--- a/.github/workflows/run_test.yaml
+++ b/.github/workflows/run_test.yaml
@@ -4,12 +4,6 @@ on:
   push:
   pull_request:
 
-concurrency:
-  # For pull requests: group by PR number
-  # For branch pushes: group by branch name
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/run_test.yaml
+++ b/.github/workflows/run_test.yaml
@@ -1,6 +1,8 @@
 name: Run Unit Tests via Pytest
 
-on: [push]
+on:
+  push:
+  pull_request:
 
 jobs:
   build:
@@ -11,18 +13,28 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-      - name: Test with pytest
+
+      # Run tests differently depending on event type
+      - name: Test with pytest (no slow tests on push)
+        if: github.event_name == 'push'
         run: |
-          coverage run -m pytest  -v -s --cov-fail-under=90
+          coverage run -m pytest -v -s -m "not slow" --cov-fail-under=90
+
+      - name: Test with pytest (include slow tests on PR)
+        if: github.event_name == 'pull_request'
+        run: |
+          coverage run -m pytest -v -s --cov-fail-under=90
+
       - name: Generate Coverage Report
         run: |
           coverage report -m
-      

--- a/.github/workflows/run_test.yaml
+++ b/.github/workflows/run_test.yaml
@@ -4,6 +4,12 @@ on:
   push:
   pull_request:
 
+concurrency:
+  # For pull requests: group by PR number
+  # For branch pushes: group by branch name
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -34,7 +40,7 @@ jobs:
       - name: Test with pytest (include slow tests on PR)
         if: github.event_name == 'pull_request'
         run: |
-          coverage run -m pytest -v -s -m "slow" --cov-fail-under=90
+          coverage run -m pytest -v -s --cov-fail-under=90
 
       - name: Generate Coverage Report
         run: |

--- a/.github/workflows/run_test.yaml
+++ b/.github/workflows/run_test.yaml
@@ -36,11 +36,11 @@ jobs:
         run: |
           coverage run -m pytest -v -s -m "not slow" --cov-fail-under=90
 
-      # run all tests when triggered by a push to an open PR
+      # run slow tests when triggered by a push to an open PR
       - name: Test with pytest (include slow tests on PR)
         if: github.event_name == 'pull_request'
         run: |
-          coverage run -m pytest -v -s --cov-fail-under=90
+          coverage run -m pytest -v -s -m "slow" --cov-fail-under=90
 
       - name: Generate Coverage Report
         run: |

--- a/.github/workflows/run_test.yaml
+++ b/.github/workflows/run_test.yaml
@@ -30,9 +30,9 @@ jobs:
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
-      # run fast tests when triggered by a push *without* an open PR
+      # run fast tests when triggered by a push 
       - name: Test with pytest (no slow tests on push)
-        if: github.event_name == 'push' && github.event.pull_request.head.repo == null
+        if: github.event_name == 'push'
         run: |
           coverage run -m pytest -v -s -m "not slow" --cov-fail-under=90
 

--- a/.github/workflows/run_test.yaml
+++ b/.github/workflows/run_test.yaml
@@ -4,6 +4,12 @@ on:
   push:
   pull_request:
 
+concurrency:
+  # For pull requests: group by PR number
+  # For branch pushes: group by branch name
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/jcm/model_test.py
+++ b/jcm/model_test.py
@@ -1,5 +1,6 @@
 import unittest
 import jax.tree_util as jtu
+import pytest
 
 class TestModelUnit(unittest.TestCase):
     def setUp(self):
@@ -96,7 +97,8 @@ class TestModelUnit(unittest.TestCase):
         self.assertTupleEqual(dynamics_predictions.specific_humidity.shape, nodal_tzxy)
         self.assertTupleEqual(dynamics_predictions.geopotential.shape, nodal_tzxy)
         self.assertTupleEqual(dynamics_predictions.normalized_surface_pressure.shape, (nodal_tzxy[0],) + nodal_tzxy[2:])
-        
+    
+    @pytest.mark.slow
     def test_speedy_model_gradients_isnan(self):
         import jax
         import jax.numpy as jnp
@@ -126,6 +128,7 @@ class TestModelUnit(unittest.TestCase):
         self.assertFalse(jnp.any(jnp.isnan(df_dstate[0].tracers['specific_humidity'])))
         # self.assertFalse(jnp.any(jnp.isnan(df_dstate[0].sim_time))) FIXME: this is ending up nan
 
+    @pytest.mark.slow
     def test_speedy_model_gradients_multiple_timesteps_isnan(self):
         import jax
         import jax.numpy as jnp
@@ -151,6 +154,7 @@ class TestModelUnit(unittest.TestCase):
         self.assertFalse(jnp.any(jnp.isnan(df_dstate[0].tracers['specific_humidity'])))
         # self.assertFalse(jnp.any(jnp.isnan(df_dstate[0].sim_time))) FIXME: this is ending up nan
 
+    @pytest.mark.slow
     def test_speedy_model_param_gradients_isnan_vjp(self):
         import jax
         from jcm.model import Model, get_coords
@@ -184,6 +188,7 @@ class TestModelUnit(unittest.TestCase):
 
         self.assertFalse(df_dparams[0].isnan().any_true())
     
+    @pytest.mark.slow
     def test_speedy_model_param_gradients_isnan_jvp(self):
         import jax
         import jax.numpy as jnp

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers = 
+    slow: marks tests as slow (deselect with '-m "not slow"')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 markers = 
-    slow: marks tests as slow (> 1 min) (deselect with '-m "not slow"')
+    slow: marks tests as slow (> 1 min, deselect with '-m "not slow"')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 markers = 
-    slow: marks tests as slow (deselect with '-m "not slow"')
+    slow: marks tests as slow (> 1 min) (deselect with '-m "not slow"')


### PR DESCRIPTION
## Describe your changes
test markers are now defined in pytest.ini (root directory). right now the only marker is "slow". the model gradient checks are now all marked as slow, and the github action for running unit tests is updated to only run slow tests on PRs.

## Issue ticket number and link
#256 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
