### PR TITLE
Fix coverage error

### DIFF
--- a/.github/workflows/run_test.yaml
+++ b/.github/workflows/run_test.yaml
@@ -34,10 +34,10 @@ jobs:
       - name: Test with pytest (no slow tests on push)
         if: github.event_name == 'push'
         run: |
-          pytest -v -s -m "not slow" --cov-fail-under=90
+          pytest -v -s -m "not slow" --cov --cov-fail-under=90
 
       # run slow tests when triggered by a push to an open PR
       - name: Test with pytest (include slow tests on PR)
         if: github.event_name == 'pull_request'
         run: |
-          pytest -v -s --cov-fail-under=90
+          pytest -v -s --cov --cov-fail-under=90


### PR DESCRIPTION
Removes (redundant?) generate coverage report step which was broken.

To keep the coverage threshold working, added `--cov` to the pytest command and didn't feed it to `coverage`.

Apparently `coverage` and `pytest` don't always work well together. I think pytest on its own has some nice options for whatever we'd want to do (such as showing which lines aren't covered).