### PR TITLE
Modify pytest logic to avoid skipping steps in build job

### DIFF
--- a/.github/workflows/run_test.yaml
+++ b/.github/workflows/run_test.yaml
@@ -7,7 +7,7 @@ on:
 concurrency:
   # For pull requests: group by PR number
   # For branch pushes: group by branch name
-  group: ${{ github.event_name == 'pull_request' && github.workflow + '-pr-' + github.event.pull_request.number || github.workflow + '-' + github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This will fix the issue of PR checks showing up as failing