### PR TITLE
Fix concurrency logic for CI jobs

### DIFF
--- a/.github/workflows/run_test.yaml
+++ b/.github/workflows/run_test.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11"]
-
+    if: github.event_name == 'pull_request' || github.event.pull_request == null
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
PRs and pushes should be in separate concurrency groups