### PR TITLE
Fix bugs that occur when running with jit disabled

### DIFF
--- a/jcm/model.py
+++ b/jcm/model.py
@@ -344,7 +344,7 @@ class Model:
     def _date_from_sim_time(self, sim_time) -> DateData:
         return DateData.set_date(
             model_time=self.start_date + jdt.Timedelta(seconds=jnp.round(sim_time).astype(jnp.int32)),
-            model_step=(sim_time / self.dt_si.m).astype(jnp.int32),
+            model_step=jnp.int32(sim_time / self.dt_si.m),
             dt_seconds=self.dt_si.m
         )
 

--- a/jcm/utils.py
+++ b/jcm/utils.py
@@ -111,7 +111,7 @@ def _index_if_3d(arr, key):
     return arr[:, :, key] if arr.ndim > 2 else arr
 
 def tree_index_3d(tree, key):
-    return tree_map(lambda arr: _index_if_3d(arr, key), tree)
+    return tree_map(lambda arr: _index_if_3d(jnp.array(arr), key), tree)
 
 def _check_type_ones_like_tangent(x):
         if jnp.result_type(x) == jnp.float32:


### PR DESCRIPTION
I think the type checker or something is more particular when jit is disabled, so a couple of lines were causing errors. I made sure these fixes shouldn't change the behavior when jit is enabled.