### PR TITLE
Fix ocean surface fluxes in aquaplanet simulations

### DIFF
--- a/jcm/physics/speedy/surface_flux.py
+++ b/jcm/physics/speedy/surface_flux.py
@@ -88,41 +88,60 @@ def get_surface_fluxes(
 
     u0 = parameters.surface_flux.fwind0*ua[kx-1]
     v0 = parameters.surface_flux.fwind0*va[kx-1]
+
+    def compute_evap_true(operand):
+        q1, qsat0, idx = operand
+        q1_val, qsat0_val = rel_hum_to_spec_hum(t1[:, :, idx], psa, 1.0, rh[kx-1])
+        q1 = q1.at[:, :, idx].set(parameters.surface_flux.fhum0*q1_val + ghum0*qa[kx-1])
+        qsat0 = qsat0.at[:, :, idx].set(qsat0_val)
+        return q1, qsat0
+    
+    def compute_evap_false(operand):
+        q1, qsat0, idx = operand
+        q1 = q1.at[:, :, idx].set(qa[kx-1])
+        return q1, qsat0
+    
+    rdth  = parameters.surface_flux.fstab / parameters.surface_flux.dtheta
+
+    astab = jax.lax.cond(parameters.surface_flux.lscasym, lambda _: jnp.array(0.5), lambda _: jnp.array(1.0), operand=None)
+
+    # 1.1 Wind components
+    rcp = 1.0/cp
+    nl1 = kx-1
+    gtemp0 = 1.0 - parameters.surface_flux.ftemp0
+
+    # substituting the for loop at line 109
+    # Temperature difference between lowest level and sfc
+    # line 112
+    dt1 = geometry.wvi[kx-1, 1, jnp.newaxis, jnp.newaxis]*(ta[kx-1] - ta[nl1-1])
+    
+    # Extrapolated temperature using actual lapse rate (0:land, 1:sea)
+    # line 115 - 116
+    t1 = t1.at[:, :, 0].add(ta[kx-1] + dt1)
+    t1 = t1.at[:, :, 1].set(t1[:, :, 0] - phi0*dt1/(rgas*288.0*geometry.sigl[kx-1]))
+
+    # Extrapolated temperature using dry-adiab. lapse rate (0:land, 1:sea)
+    # line 119 - 120
+    t2 = t2.at[:, :, 1].set(ta[kx-1] + rcp*phi[kx-1])
+    t2 = t2.at[:, :, 0].set(t2[:, :, 1] - rcp*phi0)
+
+    # lines 124 - 137
+    t1 = jnp.where((ta[kx-1] > ta[nl1-1])[:, :, jnp.newaxis],
+                parameters.surface_flux.ftemp0*t1 + gtemp0*t2,
+                ta[kx-1][:, :, jnp.newaxis])
+    
+    t0 = t1[:, :, 1] + fmask * (t1[:, :, 0] - t1[:, :, 1])
+
+    # 1.3 Density * wind speed (including gustiness factor)
+    denvvs = denvvs.at[:, :, 0].set((p0*psa/(rgas*t0))*jnp.sqrt(u0**2 + v0**2 + parameters.surface_flux.vgust**2))
+
+
     ##########################################################
     # Land surface
     ##########################################################
 
     def land_fluxes(operand):
         u0,v0,ustr,vstr,shf,evap,rlus,hfluxn,t1,q1,t2,qsat0,denvvs,parameters,tskin = operand
-        # 1.1 Wind components
-        rcp = 1.0/cp
-        nl1 = kx-1
-        gtemp0 = 1.0 - parameters.surface_flux.ftemp0
-
-        # substituting the for loop at line 109
-        # Temperature difference between lowest level and sfc
-        # line 112
-        dt1 = geometry.wvi[kx-1, 1, jnp.newaxis, jnp.newaxis]*(ta[kx-1] - ta[nl1-1])
-        
-        # Extrapolated temperature using actual lapse rate (0:land, 1:sea)
-        # line 115 - 116
-        t1 = t1.at[:, :, 0].add(ta[kx-1] + dt1)
-        t1 = t1.at[:, :, 1].set(t1[:, :, 0] - phi0*dt1/(rgas*288.0*geometry.sigl[kx-1]))
-
-        # Extrapolated temperature using dry-adiab. lapse rate (0:land, 1:sea)
-        # line 119 - 120
-        t2 = t2.at[:, :, 1].set(ta[kx-1] + rcp*phi[kx-1])
-        t2 = t2.at[:, :, 0].set(t2[:, :, 1] - rcp*phi0)
-
-        # lines 124 - 137
-        t1 = jnp.where((ta[kx-1] > ta[nl1-1])[:, :, jnp.newaxis],
-                    parameters.surface_flux.ftemp0*t1 + gtemp0*t2,
-                    ta[kx-1][:, :, jnp.newaxis])
-        
-        t0 = t1[:, :, 1] + fmask * (t1[:, :, 0] - t1[:, :, 1])
-
-        # 1.3 Density * wind speed (including gustiness factor)
-        denvvs = denvvs.at[:, :, 0].set((p0*psa/(rgas*t0))*jnp.sqrt(u0**2 + v0**2 + parameters.surface_flux.vgust**2))
 
         # 2. Using Presribed Skin Temperature to Compute Land Surface Fluxes
         # 2.1 Compensating for non-linearity of Heat/Moisture Fluxes by definig effective skin temperature
@@ -131,9 +150,6 @@ def get_surface_fluxes(
         tskin = stl_am + parameters.surface_flux.ctday * jnp.sqrt(geometry.coa) * rsds * (1.0 - alb_l) * psa
 
         # 2.2 Stability Correlation
-        rdth  = parameters.surface_flux.fstab / parameters.surface_flux.dtheta
-
-        astab = jax.lax.cond(parameters.surface_flux.lscasym, lambda _: jnp.array(0.5), lambda _: jnp.array(1.0), operand=None)
 
         dthl = jnp.where(
             tskin > t2[:, :, 0],
@@ -154,18 +170,7 @@ def get_surface_fluxes(
         shf = shf.at[:, :, 0].set(chlcp * denvvs[:, :, 1] * (tskin - t1[:, :, 0]))
         
         # 2.5 Computing Evaporation
-        def compute_evap_true(operand):
-            q1, qsat0, idx = operand
-            q1_val, qsat0_val = rel_hum_to_spec_hum(t1[:, :, idx], psa, 1.0, rh[kx-1])
-            q1 = q1.at[:, :, idx].set(parameters.surface_flux.fhum0*q1_val + ghum0*qa[kx-1])
-            qsat0 = qsat0.at[:, :, idx].set(qsat0_val)
-            return q1, qsat0
-        
-        def compute_evap_false(operand):
-            q1, qsat0, idx = operand
-            q1 = q1.at[:, :, idx].set(qa[kx-1])
-            return q1, qsat0
-        
+
         q1, qsat0 = jax.lax.cond(parameters.surface_flux.fhum0 > 0.0, compute_evap_true, compute_evap_false, operand=(q1, qsat0, 0))
 
         qsat0 = qsat0.at[:, :, 0].set(get_qsat(tskin, psa, 1.0))
@@ -219,23 +224,6 @@ def get_surface_fluxes(
             parameters.surface_flux.lskineb, skin_temp, pass_fn, operand=(hfluxn, rlus, evap, shf, tskin, qsat0)
         )
 
-        dths = jnp.where(
-            forcing.sea_surface_temperature > t2[:, :, 1],
-            jnp.minimum(parameters.surface_flux.dtheta, forcing.sea_surface_temperature - t2[:, :, 1]),
-            jnp.maximum(-parameters.surface_flux.dtheta, astab * (forcing.sea_surface_temperature - t2[:, :, 1]))
-        )
-        
-        denvvs = denvvs.at[:, :, 2].set(denvvs[:, :, 0] * (1.0 + dths * rdth))
-
-        q1, qsat0 = jax.lax.cond(parameters.surface_flux.fhum0 > 0.0, compute_evap_true, compute_evap_false, operand=(q1, qsat0, 1))
-
-        # 4.2 Wind Stress
-        ks = 2
-
-        cdsdv = parameters.surface_flux.cds * denvvs[:, :, ks]
-        ustr = ustr.at[:, :, 1].set(-cdsdv * ua[kx-1])
-        vstr = vstr.at[:, :, 1].set(-cdsdv * va[kx-1])
-
         return (u0, v0, ustr, vstr, shf, evap, rlus, hfluxn, t1, q1, t2, qsat0, denvvs, parameters, tskin)
     
     tskin = jnp.zeros_like(stl_am)
@@ -246,7 +234,22 @@ def get_surface_fluxes(
     # Sea Surface
     ##########################################################
 
+    dths = jnp.where(
+        forcing.sea_surface_temperature > t2[:, :, 1],
+        jnp.minimum(parameters.surface_flux.dtheta, forcing.sea_surface_temperature - t2[:, :, 1]),
+        jnp.maximum(-parameters.surface_flux.dtheta, astab * (forcing.sea_surface_temperature - t2[:, :, 1]))
+    )
+    
+    denvvs = denvvs.at[:, :, 2].set(denvvs[:, :, 0] * (1.0 + dths * rdth))
+
+    q1, qsat0 = jax.lax.cond(parameters.surface_flux.fhum0 > 0.0, compute_evap_true, compute_evap_false, operand=(q1, qsat0, 1))
+
+    # 4.2 Wind Stress
     ks = 2
+
+    cdsdv = parameters.surface_flux.cds * denvvs[:, :, ks]
+    ustr = ustr.at[:, :, 1].set(-cdsdv * ua[kx-1])
+    vstr = vstr.at[:, :, 1].set(-cdsdv * va[kx-1])
 
     # 4.3 Sensible heat flux
     shf = shf.at[:, :, 1].set(parameters.surface_flux.chs * cp * denvvs[:, :, ks] * (forcing.sea_surface_temperature - t1[:, :, 1]))
@@ -262,27 +265,16 @@ def get_surface_fluxes(
     # Weighted average of surface fluxes and temperatures according to land-sea mask
     weighted_average = lambda var: var[:, :, 1] + fmask * (var[:, :, 0] - var[:, :, 1])
 
-    def weight_avg_landfluxes(operand):
+    ustr = ustr.at[:, :, 2].set(weighted_average(ustr))
+    vstr = vstr.at[:, :, 2].set(weighted_average(vstr))
+    shf = shf.at[:, :, 2].set(weighted_average(shf))
+    evap = evap.at[:, :, 2].set(weighted_average(evap))
+    rlus = rlus.at[:, :, 2].set(weighted_average(rlus))
 
-        ustr, vstr, shf, evap, rlus, t1, t0, tsfc, tskin = operand
-        ustr = ustr.at[:, :, 2].set(weighted_average(ustr))
-        vstr = vstr.at[:, :, 2].set(weighted_average(vstr))
-        shf = shf.at[:, :, 2].set(weighted_average(shf))
-        evap = evap.at[:, :, 2].set(weighted_average(evap))
-        rlus = rlus.at[:, :, 2].set(weighted_average(rlus))
+    t0 = weighted_average(t1)
 
-        t0 = weighted_average(t1)
-
-        tsfc  = forcing.sea_surface_temperature + fmask * (stl_am - forcing.sea_surface_temperature)
-        tskin = forcing.sea_surface_temperature + fmask * (tskin  - forcing.sea_surface_temperature)
-
-        return (ustr, vstr, shf, evap, rlus, t1, t0, tsfc, tskin)
-    
-    t0 = jnp.zeros_like(t1[:,:,0])
-    tsfc = jnp.zeros_like(stl_am)
-    ustr, vstr, shf, evap, rlus, t1, t0, tsfc, tskin = jax.lax.cond(
-        lfluxland, weight_avg_landfluxes, pass_fn, operand=(ustr, vstr, shf, evap, rlus, t1, t0, tsfc, tskin)
-    )
+    tsfc  = forcing.sea_surface_temperature + fmask * (stl_am - forcing.sea_surface_temperature)
+    tskin = forcing.sea_surface_temperature + fmask * (tskin  - forcing.sea_surface_temperature)
 
     surface_flux_out = physics_data.surface_flux.copy(ustr=ustr, vstr=vstr, shf=shf, evap=evap, rlus=rlus,
                                                       hfluxn=hfluxn, tsfc=tsfc, tskin=tskin, u0=u0, v0=v0, t0=t0)

--- a/jcm/physics/speedy/surface_flux_test.py
+++ b/jcm/physics/speedy/surface_flux_test.py
@@ -427,8 +427,185 @@ class TestSurfaceFluxesUnit(unittest.TestCase):
         f_jvp = functools.partial(jax.jvp, f)
         f_vjp = functools.partial(jax.vjp, f)  
 
-        check_vjp(f, f_vjp, args = (phi0, parameters.surface_flux.hdrag), 
+        check_vjp(f, f_vjp, args = (phi0, parameters.surface_flux.hdrag),
                                 atol=None, rtol=1, eps=0.00001)
-        check_jvp(f, f_jvp, args = (phi0, parameters.surface_flux.hdrag), 
+        check_jvp(f, f_jvp, args = (phi0, parameters.surface_flux.hdrag),
                                 atol=None, rtol=1, eps=0.000001)
+
+
+class TestAquaplanetSurfaceFluxes(unittest.TestCase):
+    """Tests for aquaplanet configuration (lfluxland=False, fmask=0).
+
+    These tests verify that ocean surface fluxes are correctly computed
+    when there is no land in the simulation (pure aquaplanet).
+    """
+
+    def setUp(self):
+        global ix, il, kx
+        ix, il, kx = 96, 48, 8
+
+        global ForcingData, SurfaceFluxData, HumidityData, ConvectionData, SWRadiationData, LWRadiationData, PhysicsData, \
+               PhysicsState, get_surface_fluxes, PhysicsTendency, parameters, Geometry, convert_to_speedy_latitudes, grav
+        from jcm.forcing import ForcingData
+        from jcm.physics.speedy.physics_data import SurfaceFluxData, HumidityData, ConvectionData, SWRadiationData, LWRadiationData, PhysicsData
+        from jcm.physics_interface import PhysicsState, PhysicsTendency
+        from jcm.physics.speedy.params import Parameters
+        from jcm.geometry import Geometry
+        from jcm.physics.speedy.test_utils import convert_to_speedy_latitudes
+        from jcm.constants import grav
+        parameters = Parameters.default()
+
+        from jcm.physics.speedy.surface_flux import get_surface_fluxes
+
+    def test_aquaplanet_ocean_evaporation_nonzero(self):
+        """Test that ocean evaporation is computed when lfluxland=False.
+
+        This test catches the bug where sea surface fluxes were zero in aquaplanet
+        simulations because denvvs[:,:,2], t1[:,:,1], and q1[:,:,1] were only
+        computed inside the land_fluxes conditional branch.
+        """
+        xy = (ix, il)
+        zxy = (kx, ix, il)
+
+        # Pure ocean setup - no land
+        fmask = jnp.zeros((ix, il))  # All ocean
+        phi0 = jnp.zeros((ix, il))   # No orography
+
+        # Atmospheric state
+        psa = jnp.ones((ix, il))
+        ua = 5.0 * jnp.ones(zxy)
+        va = 2.0 * jnp.ones(zxy)
+        ta = 280.0 * jnp.ones(zxy)  # Cool atmosphere
+        qa = 5.0 * jnp.ones(zxy)    # Some humidity
+        rh = 0.7 * jnp.ones(zxy)
+        phi = 5000.0 * jnp.ones(zxy)
+
+        # Warm ocean - should drive evaporation
+        sea_surface_temperature = 300.0 * jnp.ones((ix, il))
+        rsds = 400.0 * jnp.ones((ix, il))
+        rlds = 350.0 * jnp.ones((ix, il))
+
+        state = PhysicsState.zeros(zxy, ua, va, ta, qa, phi, psa)
+        sflux_data = SurfaceFluxData.zeros(xy, rlds=rlds)
+        hum_data = HumidityData.zeros(xy, kx, rh=rh)
+        conv_data = ConvectionData.zeros(xy, kx)
+        sw_rad = SWRadiationData.zeros(xy, kx, rsds=rsds)
+        lw_rad = LWRadiationData.zeros(xy, kx)
+        physics_data = PhysicsData.zeros(xy, kx, convection=conv_data, humidity=hum_data,
+                                          surface_flux=sflux_data, shortwave_rad=sw_rad, longwave_rad=lw_rad)
+        geometry = convert_to_speedy_latitudes(
+            Geometry.from_grid_shape(nodal_shape=(ix, il), num_levels=kx, orography=phi0/grav, fmask=fmask)
+        )
+
+        # Key: lfluxland=False for aquaplanet
+        forcing = ForcingData.zeros(xy, sea_surface_temperature=sea_surface_temperature, lfluxland=False)
+
+        tendencies, physics_data = get_surface_fluxes(state, physics_data, parameters, forcing, geometry)
+        sflux_data = physics_data.surface_flux
+
+        # Verify no NaNs in outputs
+        self.assertFalse(jnp.any(jnp.isnan(sflux_data.evap)), "Evaporation contains NaNs")
+        self.assertFalse(jnp.any(jnp.isnan(sflux_data.shf)), "Sensible heat flux contains NaNs")
+        self.assertFalse(jnp.any(jnp.isnan(sflux_data.ustr)), "Wind stress contains NaNs")
+        self.assertFalse(jnp.any(jnp.isnan(tendencies.specific_humidity)), "Humidity tendency contains NaNs")
+
+        # Ocean evaporation (index 1) should be positive with warm SST and cool atmosphere
+        self.assertTrue(jnp.all(sflux_data.evap[:, :, 1] > 0),
+                        "Ocean evaporation should be positive with warm SST")
+
+        # Weighted evaporation (index 2) should equal ocean evaporation when fmask=0
+        self.assertTrue(jnp.allclose(sflux_data.evap[:, :, 2], sflux_data.evap[:, :, 1]),
+                        "Weighted evaporation should equal ocean evaporation for pure ocean")
+
+        # Humidity tendency should be positive (evaporation adds moisture)
+        self.assertTrue(jnp.all(tendencies.specific_humidity[-1] > 0),
+                        "Humidity tendency should be positive from ocean evaporation")
+
+    def test_aquaplanet_sensible_heat_flux(self):
+        """Test that ocean sensible heat flux is computed correctly in aquaplanet."""
+        xy = (ix, il)
+        zxy = (kx, ix, il)
+
+        fmask = jnp.zeros((ix, il))
+        phi0 = jnp.zeros((ix, il))
+
+        psa = jnp.ones((ix, il))
+        ua = 5.0 * jnp.ones(zxy)
+        va = 2.0 * jnp.ones(zxy)
+        ta = 280.0 * jnp.ones(zxy)
+        qa = 5.0 * jnp.ones(zxy)
+        rh = 0.7 * jnp.ones(zxy)
+        phi = 5000.0 * jnp.ones(zxy)
+
+        # Warm ocean relative to atmosphere
+        sea_surface_temperature = 300.0 * jnp.ones((ix, il))
+        rsds = 400.0 * jnp.ones((ix, il))
+        rlds = 350.0 * jnp.ones((ix, il))
+
+        state = PhysicsState.zeros(zxy, ua, va, ta, qa, phi, psa)
+        sflux_data = SurfaceFluxData.zeros(xy, rlds=rlds)
+        hum_data = HumidityData.zeros(xy, kx, rh=rh)
+        conv_data = ConvectionData.zeros(xy, kx)
+        sw_rad = SWRadiationData.zeros(xy, kx, rsds=rsds)
+        lw_rad = LWRadiationData.zeros(xy, kx)
+        physics_data = PhysicsData.zeros(xy, kx, convection=conv_data, humidity=hum_data,
+                                          surface_flux=sflux_data, shortwave_rad=sw_rad, longwave_rad=lw_rad)
+        geometry = convert_to_speedy_latitudes(
+            Geometry.from_grid_shape(nodal_shape=(ix, il), num_levels=kx, orography=phi0/grav, fmask=fmask)
+        )
+        forcing = ForcingData.zeros(xy, sea_surface_temperature=sea_surface_temperature, lfluxland=False)
+
+        tendencies, physics_data = get_surface_fluxes(state, physics_data, parameters, forcing, geometry)
+        sflux_data = physics_data.surface_flux
+
+        # Sensible heat flux should be positive (ocean warming atmosphere)
+        self.assertTrue(jnp.all(sflux_data.shf[:, :, 1] > 0),
+                        "Ocean sensible heat flux should be positive with warm SST")
+
+        # Temperature tendency should be positive at surface level
+        self.assertTrue(jnp.all(tendencies.temperature[-1] > 0),
+                        "Temperature tendency should be positive from warm ocean")
+
+    def test_aquaplanet_gradient_check(self):
+        """Test that gradients are valid for aquaplanet configuration."""
+        xy = (ix, il)
+        zxy = (kx, ix, il)
+
+        fmask = jnp.zeros((ix, il))
+        phi0 = jnp.zeros((ix, il))
+        psa = jnp.ones((ix, il))
+        ua = 5.0 * jnp.ones(zxy)
+        va = 2.0 * jnp.ones(zxy)
+        ta = 290.0 * jnp.ones(zxy)
+        qa = 5.0 * jnp.ones(zxy)
+        rh = 0.7 * jnp.ones(zxy)
+        phi = 5000.0 * jnp.ones(zxy)
+        sea_surface_temperature = 295.0 * jnp.ones((ix, il))
+        rsds = 400.0 * jnp.ones((ix, il))
+        rlds = 350.0 * jnp.ones((ix, il))
+
+        state = PhysicsState.zeros(zxy, ua, va, ta, qa, phi, psa)
+        sflux_data = SurfaceFluxData.zeros(xy, rlds=rlds)
+        hum_data = HumidityData.zeros(xy, kx, rh=rh)
+        conv_data = ConvectionData.zeros(xy, kx)
+        sw_rad = SWRadiationData.zeros(xy, kx, rsds=rsds)
+        lw_rad = LWRadiationData.zeros(xy, kx)
+        physics_data = PhysicsData.zeros(xy, kx, convection=conv_data, humidity=hum_data,
+                                          surface_flux=sflux_data, shortwave_rad=sw_rad, longwave_rad=lw_rad)
+        geometry = convert_to_speedy_latitudes(
+            Geometry.from_grid_shape(nodal_shape=(ix, il), num_levels=kx, orography=phi0/grav, fmask=fmask)
+        )
+        forcing = ForcingData.zeros(xy, sea_surface_temperature=sea_surface_temperature, lfluxland=False)
+
+        _, f_vjp = jax.vjp(get_surface_fluxes, state, physics_data, parameters, forcing, geometry)
+
+        tends = PhysicsTendency.ones(zxy)
+        datas = PhysicsData.ones(xy, kx)
+
+        df_dstate, df_ddatas, df_dparams, df_dforcing, df_dgeometry = f_vjp((tends, datas))
+
+        self.assertFalse(df_ddatas.isnan().any_true(), "Gradient w.r.t. physics_data contains NaNs")
+        self.assertFalse(df_dstate.isnan().any_true(), "Gradient w.r.t. state contains NaNs")
+        self.assertFalse(df_dparams.isnan().any_true(), "Gradient w.r.t. parameters contains NaNs")
+        self.assertFalse(df_dforcing.isnan().any_true(), "Gradient w.r.t. forcing contains NaNs")
 


### PR DESCRIPTION
Previously, sea surface fluxes (evaporation, sensible heat, wind stress) were zero when lfluxland=False because key variables (denvvs[:,:,2], t1[:,:,1], q1[:,:,1]) were only computed inside the land_fluxes conditional branch.

This fix moves the necessary calculations outside the lfluxland conditional:
- Temperature extrapolations (t1, t2, dt1)
- Base density calculation (denvvs[:,:,0])
- Sea surface stability correction and denvvs[:,:,2]
- Sea humidity q1[:,:,1]
- Weighted averaging (now unconditional)

Also adds aquaplanet-specific tests that verify ocean surface fluxes are correctly computed when lfluxland=False.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
