### PR TITLE
Fix a couple operations that throw slow-compilation warnings

### DIFF
--- a/jcm/model.py
+++ b/jcm/model.py
@@ -20,7 +20,7 @@ from jcm.date import DateData
 from jcm.forcing import ForcingData, default_forcing
 from jcm.physics_interface import PhysicsState, Physics, get_physical_tendencies, dynamics_state_to_physics_state
 from jcm.physics.speedy.speedy_physics import SpeedyPhysics
-from jcm.utils import DYNAMICS_UNITS_TABLE_CSV_PATH, stack_trees, get_coords
+from jcm.utils import DYNAMICS_UNITS_TABLE_CSV_PATH, get_coords
 from jcm.diffusion import DiffusionFilter
 import pandas as pd
 from functools import partial
@@ -152,7 +152,11 @@ def averaged_trajectory_from_step(
     """
     def integrate(x_initial, empty_data):
         diagnostics_collector = DiagnosticsCollector(steps_to_average=inner_steps)
-        diagnostics_collector.data = nnx.Variable(stack_trees([empty_data] * outer_steps))
+        stacked_empty_data = tree_map(
+            lambda x: jnp.zeros((outer_steps,) + x.shape, dtype=jnp.float32),
+            empty_data
+        )
+        diagnostics_collector.data = nnx.Variable(stacked_empty_data)
         graphdef, init_diag_state = nnx.split(diagnostics_collector)
 
         empty_sum = tree_map(jnp.zeros_like, x_initial)

--- a/jcm/physics/speedy/longwave_radiation.py
+++ b/jcm/physics/speedy/longwave_radiation.py
@@ -214,13 +214,17 @@ def radset(temp, epslw):
 
     """
     jtemp = jnp.clip(temp, 200, 320) # To retain backwards compatibility with F90 code
-    
-    fband = jnp.stack((
-        jnp.zeros_like(jtemp),
+
+    fband_123 = jnp.stack((
         0.148 - 3.0e-6 * (jtemp - 247) ** 2,
         0.356 - 5.2e-6 * (jtemp - 282) ** 2,
         0.314 + 1.0e-5 * (jtemp - 315) ** 2,
     ), axis=-1)
-    fband = fband.at[..., 0].set(1. - fband.sum(axis=-1))
+    fband_0 = 1. - fband_123.sum(axis=-1)
+
+    fband = jnp.concatenate([
+        fband_0[..., jnp.newaxis],
+        fband_123
+    ], axis=-1)
     
     return (1. - epslw) * fband

--- a/jcm/utils.py
+++ b/jcm/utils.py
@@ -104,9 +104,6 @@ def pass_fn(operand):
 def ones_like(x):
     return tree_map(jnp.ones_like, x)
 
-def stack_trees(trees):
-    return tree_map(lambda *arrays: jnp.stack(arrays, axis=0).astype(jnp.float32), *trees)
-
 def _index_if_3d(arr, key):
     return arr[:, :, key] if arr.ndim > 2 else arr
 


### PR DESCRIPTION
* Fixes `E external/xla/xla/service/slow_operation_alarm.cc:65] Constant folding an instruction is taking > 1s` warning that would show up (at least for me) when running on higher resolutions.
* 2 of the above warnings popped up for runs a few months long at T85, so I would estimate the amount of compilation time this fix saves as ~2s for a few months at T85 with it scaling relative to that for other durations/resolutions.
* Does not change runtime of the model run itself