### PR TITLE
Avoid redundant jit compilation in integrate_fn

### DIFF
--- a/jcm/model.py
+++ b/jcm/model.py
@@ -407,17 +407,17 @@ class Model:
         trajectory_fn = averaged_trajectory_from_step if output_averages else dinosaur.time_integration.trajectory_from_step
 
         def _integrate_fn(state):
-            integrate_fn = jax.jit(trajectory_fn(
+            integrate_fn = trajectory_fn(
                 step_fn=step_fn,
                 outer_steps=outer_steps,
                 inner_steps=inner_steps,
                 **kwargs,
                 post_process_fn=post_process_fn
-            ))
-            
+            )
+
             # integrate_fn for avgs has different signature b/c empty physics data structure needed for DiagnosticsCollector initialization
             return integrate_fn(state, self.physics.get_empty_data(self.geometry)) if output_averages else integrate_fn(state)
-        
+
         return _integrate_fn
 
     @partial(jax.jit, static_argnums=(0, 3, 4, 5)) # Note: if model fields assumed to be static are changed, the changes will not be picked up here


### PR DESCRIPTION
* Inline jax.jit calls create compilation barriers--bad to have them inside a jitted function, because the compiler has to treat the inner jitted function as a black box when compiling the outer function
* jit decorators don't cause this problem, but in this case we don't even need one, the integration function will get traced when `run_from_state` is jit compiled
* I had Claude benchmark this change a bunch of times with n=30 runs at T21, it produced a statistically significant 4% speedup and 60% runtime variance reduction for 5-day runs, no observed speedup/variance reduction for 10-day runs, and then 3% speedup for 20 day runs with the variance again inconclusive.
* Nevertheless seems to reliably reduce compilation time by 1.5-6%

For a minute it was looking like this was reducing model runtime by 7%+, it turned out to be a smaller effect but I figured I should make the PR anyway