### PR TITLE
Enable command-line arguments for non-interactive Docker runs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,84 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install jcm and dependencies
+RUN pip install --upgrade pip && \
+    pip install jcm hydra-core omegaconf
+
+# Create config directory and config file
+RUN mkdir -p /app/config && \
+    cat > /app/config/config.yaml << 'EOF'
+model:
+  time_step: 10
+  save_interval: 10
+  total_time: 10
+  start_date: "2026-02-01"
+
+hydra:
+  run:
+    dir: outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
+EOF
+
+# Create custom main script
+RUN cat > /app/run_model.py << 'EOF'
+import hydra
+from omegaconf import DictConfig, OmegaConf
+from jcm.model import Model
+from hydra.core.hydra_config import HydraConfig
+from pathlib import Path
+import jax_datetime as jdt
+
+@hydra.main(version_base=None, config_path="config", config_name="config")
+def main(cfg: DictConfig):
+    """Run JCM Model with adjustable parameters"""
+    
+    # Allow command-line overrides
+    OmegaConf.set_struct(cfg, False)
+    
+    # Convert string date to jax_datetime.Datetime
+    start_date = jdt.to_datetime(cfg.model.start_date)
+    
+    print(f"🚀 Starting JCM simulation with:")
+    print(f"   Time step: {cfg.model.time_step} minutes")
+    print(f"   Save interval: {cfg.model.save_interval} days")
+    print(f"   Total time: {cfg.model.total_time} days")
+    print(f"   Start date: {cfg.model.start_date}")
+    print()
+    
+    model = Model(
+        time_step=cfg.model.time_step,
+        start_date=start_date
+    )
+    
+    predictions = model.run(
+        save_interval=cfg.model.save_interval,
+        total_time=cfg.model.total_time
+    )
+    
+    ds = predictions.to_xarray()
+    hydra_cfg = HydraConfig.get()
+    base_dir = Path('outputs') / hydra_cfg.run.dir.split('outputs/')[-1]
+    
+    if str(hydra_cfg.mode) == "RunMode.MULTIRUN":
+        output_dir = base_dir / 'multirun' / str(hydra_cfg.job.num)
+    else:
+        output_dir = base_dir
+    
+    filename = "model_state.nc"
+    output_path = output_dir / filename
+    
+    output_dir.mkdir(parents=True, exist_ok=True)
+    ds.to_netcdf(str(output_path))
+    
+    print()
+    print(f"✅ Simulation complete!")
+    print(f"📁 Output saved to: {output_path}")
+
+if __name__ == "__main__":
+    main()
+EOF
+
+# Set the custom script as the entry point
+ENTRYPOINT ["python", "/app/run_model.py"]
+CMD []

--- a/README.md
+++ b/README.md
@@ -1,0 +1,257 @@
+# JAX-GCM (JCM)
+
+<img src="logo.png" alt="Logo" width="200">
+
+A fully differentiable General Circulation Model (GCM) for climate science and machine learning applications, written entirely in JAX.
+
+## Overview
+
+JCM is a physical climate model that combines the [Dinosaur](https://github.com/google-research/dinosaur) dynamical core with JAX implementations of atmospheric physics parameterizations. The entire model is differentiable, enabling gradient-based optimization, data assimilation, and ML-enhanced climate modeling.
+
+### Key Features
+
+- **Fully Differentiable**: Automatic differentiation through the entire model using JAX
+- **GPU/TPU Accelerated**: JIT compilation and hardware acceleration via JAX
+- **Modular Physics**: SPEEDY physics package with radiation, convection, clouds, and surface processes
+- **Flexible Grids**: Spectral dynamical core supporting multiple resolutions (T21 to T425)
+- **ML-Ready**: Designed for hybrid physics-ML workflows and parameter optimization
+
+## Installation
+
+Clone the repository and install in development mode:
+```bash
+git clone https://github.com/yourusername/jax-gcm.git
+cd jax-gcm
+pip install -e .
+```
+
+### Requirements
+
+- Python ≥ 3.11
+- JAX
+- [Dinosaur](https://github.com/google-research/dinosaur) (dynamical core)
+- XArray (for I/O and data handling)
+
+See `requirements.txt` for the complete list of dependencies.
+
+## Quick Start
+
+Run a simple aquaplanet simulation:
+```python
+from jcm.model import Model
+
+# Create a model with default configuration
+model = Model(
+    time_step=30.0,          # minutes
+    layers=8,                 # vertical levels
+    horizontal_resolution=31  # T31 spectral grid
+)
+
+# Run a 120-day simulation
+predictions = model.run(
+    save_interval=10.0,  # save every 10 days
+    total_time=120.0     # total simulation time in days
+)
+
+# Convert output to xarray Dataset for analysis
+ds = predictions.to_xarray()
+print(ds)
+```
+
+## Examples
+
+Example notebooks are available in the `notebooks/` directory:
+
+- **`run-speedy.ipynb`**: Basic model simulation with SPEEDY physics
+- **`run-speedy-gradients.ipynb`**: Computing gradients through the model
+- **`optimization_example.ipynb`**: Parameter optimization examples
+- **`autodiff_userguide.ipynb`**: Guide to automatic differentiation features
+
+## Physics Packages
+
+### SPEEDY Physics
+
+The SPEEDY (Simplified Parameterizations, primitivE-Equation DYnamics) physics package includes:
+
+- Convection (simplified mass-flux scheme)
+- Large-scale condensation
+- Shortwave and longwave radiation
+- Surface fluxes (land, ocean, sea ice)
+- Vertical diffusion
+- Orographic drag
+
+> **Note**: ICON atmospheric physics is currently under development but not yet available in released versions.
+
+## Documentation
+
+For more details, see the [documentation](https://jax-gcm.readthedocs.io) (or build locally):
+```bash
+cd docs
+make html
+```
+
+Then open `docs/build/html/index.html` in your browser.
+
+## Testing
+
+Run the test suite with pytest:
+```bash
+# Run all tests
+pytest
+
+# Run specific test file
+pytest jcm/model_test.py
+
+# Run with verbose output
+pytest -v
+```
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit issues or pull requests.
+
+## Citation
+
+If you use JAX-GCM in your research, please cite:
+```bibtex
+@software{jax_gcm,
+  title = {JAX-GCM: A Differentiable General Circulation Model},
+  author = {J. Madan, E. Davenport, et al.},
+  year = {2025},
+  url = {https://github.com/climate-analytics-lab/jax-gcm}
+}
+```
+
+## License
+
+This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
+
+## Acknowledgments
+
+- **Dinosaur**: JAX-GCM builds on the [Dinosaur](https://github.com/google-research/dinosaur) dynamical core developed by Google Research
+- **SPEEDY**: Physics parameterizations adapted from the [SPEEDY](https://users.ictp.it/~kucharsk/speedy-net.html) model by F. Molteni
+- **SPEEDY.f90**: We referenced the [Fortran 90 version](https://github.com/samhatfield/speedy.f90) of SPEEDY by Sam Hatfield and Leo Saffin for our specific implementation.
+
+## Contact
+
+For questions or collaboration inquiries, please open an issue or contact dwatsonparris@ucsd.edu.
+
+## Running Non-Interactive Simulations in Docker
+
+The Docker image supports passing command-line arguments for non-interactive runs using Hydra configuration.
+
+### Building the Docker Image
+```bash
+docker build -t jcm-test .
+```
+
+### Docker Examples
+
+**Basic run with default settings:**
+```bash
+docker run --rm -v $(pwd)/outputs:/app/outputs jcm-test
+```
+
+**Override start date:**
+```bash
+docker run --rm -v $(pwd)/outputs:/app/outputs jcm-test model.start_date=2026-02-07
+```
+
+**Override multiple parameters:**
+```bash
+docker run --rm -v $(pwd)/outputs:/app/outputs jcm-test \
+  model.time_step=60 \
+  model.save_interval=20 \
+  model.total_time=100
+```
+
+**Full custom configuration:**
+```bash
+docker run --rm -v $(pwd)/outputs:/app/outputs jcm-test \
+  model.time_step=30 \
+  model.save_interval=10 \
+  model.total_time=100 \
+  model.start_date=2026-01-15
+```
+
+### Kubernetes Example
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: jcm-simulation
+spec:
+  containers:
+  - name: jcm-container
+    image: your-registry/jcm-test:latest
+    args: 
+      - "model.start_date=2026-02-06"
+      - "model.time_step=30"
+      - "model.save_interval=20"
+    volumeMounts:
+      - name: output-storage
+        mountPath: /app/outputs
+  volumes:
+  - name: output-storage
+    persistentVolumeClaim:
+      claimName: jcm-outputs
+```
+
+### Available Parameters
+
+All parameters are under the `model` namespace:
+
+- `model.time_step` - Model time step in minutes (default: 10)
+- `model.save_interval` - Save interval in days (default: 10)
+- `model.total_time` - Total simulation time in days (default: 10)
+- `model.start_date` - Simulation start date in YYYY-MM-DD format (default: "2026-02-01")
+
+### Output Files
+
+The simulation generates a NetCDF file (`model_state.nc`) in the outputs directory:
+```bash
+# Run simulation and access outputs
+docker run --rm -v $(pwd)/outputs:/app/outputs jcm-test model.total_time=50
+
+# Outputs will be in:
+# ./outputs/YYYY-MM-DD/HH-MM-SS/model_state.nc
+```
+
+### Advanced Usage
+
+**Run multiple simulations with different parameters:**
+```bash
+# Simulation 1
+docker run --rm -v $(pwd)/outputs:/app/outputs jcm-test \
+  model.time_step=15 model.total_time=50
+
+# Simulation 2
+docker run --rm -v $(pwd)/outputs:/app/outputs jcm-test \
+  model.time_step=30 model.total_time=100
+```
+
+**Interactive shell for debugging:**
+```bash
+docker run --rm -it -v $(pwd)/outputs:/app/outputs jcm-test bash
+```
+
+### Troubleshooting
+
+If you encounter issues:
+
+1. **Check outputs directory exists:**
+```bash
+   mkdir -p outputs
+```
+
+2. **Run with verbose Hydra logging:**
+```bash
+   docker run --rm -v $(pwd)/outputs:/app/outputs jcm-test \
+     model.time_step=30 hydra.verbose=true
+```
+
+3. **View full error stack trace:**
+```bash
+   docker run --rm -v $(pwd)/outputs:/app/outputs \
+     -e HYDRA_FULL_ERROR=1 jcm-test model.time_step=30
+```


### PR DESCRIPTION
## Describe your changes
This PR updates the Dockerfile to support passing command-line arguments to JCM simulations.

The Docker image now uses the ENTRYPOINT + CMD pattern, allowing arguments to be overridden at runtime.  
Documentation has also been updated with Docker and Kubernetes usage examples to enable non-interactive execution.

## Issue ticket number and link
Fixes #376  
https://github.com/VanshikaSalekar/jax-gcm/issues/376

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes