### PR TITLE
Fix downdraft LFS criteria to use cmfdeps (#337)

### DIFF
--- a/jcm/physics/icon/convection/convection_units_test.py
+++ b/jcm/physics/icon/convection/convection_units_test.py
@@ -394,6 +394,37 @@ def default_config():
     return ConvectionParameters.default()
 
 
+class TestDowndraftLFS:
+    """Test downdraft level of free sinking criteria."""
+
+    def test_cmfdeps_parameter_exists(self):
+        """Verify cmfdeps parameter exists with default value ~0.33."""
+        config = ConvectionParameters.default()
+        assert hasattr(config, 'cmfdeps'), "Should have cmfdeps parameter"
+        assert float(config.cmfdeps) == pytest.approx(0.33)
+
+    def test_cmfdeps_used_in_lfs_threshold(self):
+        """LFS threshold should use cmfdeps (not cmfcmin) times base mass flux.
+
+        The Fortran reference computes zmftop = -cmfdeps*pmfub where cmfdeps~0.33,
+        giving a meaningful fraction of the updraft mass flux. Using cmfcmin (~1e-10)
+        would make the threshold effectively zero.
+        """
+        config = ConvectionParameters.default()
+        base_mf = 0.1  # Typical cloud base mass flux (kg/m²/s)
+
+        # Correct threshold using cmfdeps
+        threshold_correct = float(config.cmfdeps) * base_mf
+        assert threshold_correct == pytest.approx(0.033, rel=0.01)
+
+        # Old (wrong) threshold using cmfcmin would be negligible
+        threshold_wrong = float(config.cmfcmin) * base_mf
+        assert threshold_wrong < 1e-9, "cmfcmin threshold should be negligible"
+
+        # The correct threshold should be orders of magnitude larger
+        assert threshold_correct > threshold_wrong * 1e6
+
+
 if __name__ == "__main__":
     # Run tests with pytest
     pytest.main([__file__, "-v"])

--- a/jcm/physics/icon/convection/downdraft.py
+++ b/jcm/physics/icon/convection/downdraft.py
@@ -126,8 +126,8 @@ def find_lfs(
         # Condensation in downdraft
         condensation = humidity[k] - qwb
         
-        # Minimum mass flux threshold
-        min_flux = config.cmfcmin * updraft_mf[kbase]
+        # Minimum mass flux threshold (Fortran: zmftop = -cmfdeps*pmfub)
+        min_flux = config.cmfdeps * updraft_mf[kbase]
         
         # Check LFS criteria:
         # 1. Negative buoyancy

--- a/jcm/physics/icon/convection/tiedtke_nordeng.py
+++ b/jcm/physics/icon/convection/tiedtke_nordeng.py
@@ -70,11 +70,14 @@ class ConvectionParameters:
     # Momentum transport
     cmfctop: float           # Mass flux fraction at cloud top
 
+    # Downdraft parameters
+    cmfdeps: float           # Downdraft mass flux fraction for LFS threshold
+
     @classmethod
     def default(cls, dt_conv=3600.0, entrpen=1.0e-4, entrscv=3.0e-3, entrmid=1.0e-4, # FIXME: validate dt_conv
                  tau=7200.0, cmfcmax=1.0, cmfcmin=1.0e-10, cprcon=1.4e-3,
                  cevapcu=2.0e-5, epsilon=1.0e-12, rlcrit=8.0e-4, rhcrit=0.9,
-                 cmfctop=0.33) -> 'ConvectionParameters':
+                 cmfctop=0.33, cmfdeps=0.33) -> 'ConvectionParameters':
         """Return default convection parameters"""
         return cls(
             dt_conv=jnp.array(dt_conv),
@@ -89,7 +92,8 @@ class ConvectionParameters:
             epsilon=jnp.array(epsilon),
             rlcrit=jnp.array(rlcrit),
             rhcrit=jnp.array(rhcrit),
-            cmfctop=jnp.array(cmfctop)
+            cmfctop=jnp.array(cmfctop),
+            cmfdeps=jnp.array(cmfdeps)
         )
 
 


### PR DESCRIPTION
## Summary
- LFS mass flux threshold was using `cmfcmin` (~1e-10), making the precipitation condition effectively zero and allowing downdrafts to form at incorrect levels
- Now uses new `cmfdeps` parameter (0.33) to match the Fortran reference (`zmftop = -cmfdeps*pmfub`), giving a meaningful fraction of cloud base updraft mass flux
- Added `cmfdeps` to `ConvectionParameters` with default value 0.33

## Test plan
- [x] All 55 convection tests pass
- [x] New tests verify `cmfdeps` parameter exists and produces correct threshold magnitude
- [x] Ruff lint clean

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)