### PR TITLE
Couple aerosol CDNC factor to cloud microphysics

### DIFF
--- a/jcm/physics/icon/icon_physics.py
+++ b/jcm/physics/icon/icon_physics.py
@@ -845,8 +845,11 @@ def apply_microphysics(
     qc = state.tracers.get('qc', jnp.zeros_like(state.temperature))
     qi = state.tracers.get('qi', jnp.zeros_like(state.temperature))
     
-    # Droplet number concentration (simple profile)
-    droplet_number = jnp.ones_like(state.temperature) * 100e6  # 100 per cm³
+    # Droplet number concentration from aerosol scheme
+    # cdnc_factor is (ncols,) — broadcast to (nlev, ncols) for microphysics
+    base_cdnc = 100e6  # Clean-air baseline CDNC (100 per cm³)
+    cdnc_factor = physics_data.aerosol.cdnc_factor  # (ncols,)
+    droplet_number = jnp.ones_like(state.temperature) * base_cdnc * cdnc_factor[jnp.newaxis, :]
     
     # Get microphysics configuration
     micro_config = parameters.microphysics

--- a/jcm/physics/icon/radiation/aerosol_radiation_test.py
+++ b/jcm/physics/icon/radiation/aerosol_radiation_test.py
@@ -110,13 +110,63 @@ def test_radiation_scheme_with_without_aerosols():
         return
 
 
+def test_aerosol_microphysics_droplet_coupling():
+    """Test that aerosol cdnc_factor scales droplet number for microphysics"""
+    base_cdnc = 100e6  # Clean-air baseline (100 per cm³)
+
+    # Clean case: cdnc_factor = 1.0
+    cdnc_clean = jnp.array([1.0, 1.0])
+    droplet_clean = jnp.ones((3, 2)) * base_cdnc * cdnc_clean[jnp.newaxis, :]
+    assert jnp.allclose(droplet_clean, base_cdnc)
+
+    # Polluted case: cdnc_factor = 2.5
+    cdnc_polluted = jnp.array([2.5, 1.0])
+    droplet_polluted = jnp.ones((3, 2)) * base_cdnc * cdnc_polluted[jnp.newaxis, :]
+    # Column 0 should be scaled up, column 1 unchanged
+    assert jnp.allclose(droplet_polluted[:, 0], base_cdnc * 2.5)
+    assert jnp.allclose(droplet_polluted[:, 1], base_cdnc)
+
+
+def test_higher_cdnc_reduces_autoconversion():
+    """Test physical effect: more droplets → smaller drops → less autoconversion"""
+    from jcm.physics.icon.clouds.cloud_microphysics import (
+        autoconversion_kk2000, MicrophysicsParameters
+    )
+
+    config = MicrophysicsParameters.default()
+    cloud_water = jnp.array(1e-3)
+    cloud_fraction = jnp.array(0.8)
+    air_density = jnp.array(1.0)
+    dt = 1.0
+
+    # Clean air: fewer, larger droplets
+    nc_clean = jnp.array(100e6)
+    rate_clean = autoconversion_kk2000(
+        cloud_water, cloud_fraction, air_density, nc_clean, dt, config
+    )
+
+    # Polluted air: more, smaller droplets
+    nc_polluted = jnp.array(300e6)
+    rate_polluted = autoconversion_kk2000(
+        cloud_water, cloud_fraction, air_density, nc_polluted, dt, config
+    )
+
+    # Higher CDNC should suppress autoconversion (second indirect effect)
+    assert rate_clean > rate_polluted, (
+        f"Expected less autoconversion with more droplets: "
+        f"clean={rate_clean}, polluted={rate_polluted}"
+    )
+
+
 if __name__ == "__main__":
     print("Testing aerosol-radiation integration...")
     print("=" * 50)
-    
+
     test_aerosol_cloud_interaction()
-    test_optical_property_combination() 
+    test_optical_property_combination()
     test_radiation_scheme_with_without_aerosols()
-    
+    test_aerosol_microphysics_droplet_coupling()
+    test_higher_cdnc_reduces_autoconversion()
+
     print("\\n" + "=" * 50)
     print("All tests completed!")

--- a/jcm/physics/icon/radiation/aerosol_radiation_test.py
+++ b/jcm/physics/icon/radiation/aerosol_radiation_test.py
@@ -111,20 +111,114 @@ def test_radiation_scheme_with_without_aerosols():
 
 
 def test_aerosol_microphysics_droplet_coupling():
-    """Test that aerosol cdnc_factor scales droplet number for microphysics"""
-    base_cdnc = 100e6  # Clean-air baseline (100 per cm³)
+    """Test that apply_microphysics uses aerosol cdnc_factor for droplet number."""
+    import numpy as np
+    from jcm.physics.icon.icon_physics import apply_microphysics, _prepare_common_physics_state
+    from jcm.physics.icon.icon_physics_data import PhysicsData
+    from jcm.physics.icon.icon_coords import IconCoords
+    from jcm.physics.icon.parameters import Parameters
+    from jcm.physics_interface import PhysicsState
+    from jcm.date import DateData
+    from jcm.forcing import ForcingData
+    from jcm.terrain import TerrainData
+    from jcm.utils import get_coords
 
-    # Clean case: cdnc_factor = 1.0
-    cdnc_clean = jnp.array([1.0, 1.0])
-    droplet_clean = jnp.ones((3, 2)) * base_cdnc * cdnc_clean[jnp.newaxis, :]
-    assert jnp.allclose(droplet_clean, base_cdnc)
+    nlev, nlat, nlon = 40, 32, 64
+    ncols = nlat * nlon
+    sigma_boundaries = np.linspace(0, 1, nlev + 1)
+    coords = get_coords(sigma_boundaries, nodal_shape=(nlon, nlat))
+    icon_coords = IconCoords.from_coordinate_system(coords)
 
-    # Polluted case: cdnc_factor = 2.5
-    cdnc_polluted = jnp.array([2.5, 1.0])
-    droplet_polluted = jnp.ones((3, 2)) * base_cdnc * cdnc_polluted[jnp.newaxis, :]
-    # Column 0 should be scaled up, column 1 unchanged
-    assert jnp.allclose(droplet_polluted[:, 0], base_cdnc * 2.5)
-    assert jnp.allclose(droplet_polluted[:, 1], base_cdnc)
+    # Build a warm profile with cloud water so microphysics has work to do
+    sigma_mid = (sigma_boundaries[:-1] + sigma_boundaries[1:]) / 2
+    temp_profile = 290.0 * (sigma_mid ** 0.19)
+    temperature = jnp.broadcast_to(
+        jnp.array(temp_profile)[:, jnp.newaxis], (nlev, ncols)
+    )
+    q_profile = 0.01 * sigma_mid ** 3
+    specific_hum = jnp.broadcast_to(
+        jnp.array(q_profile)[:, jnp.newaxis], (nlev, ncols)
+    )
+
+    # Cloud water in mid-levels to trigger autoconversion
+    qc = jnp.zeros((nlev, ncols))
+    qc = qc.at[15:25, :].set(1e-3)
+
+    from jcm.physics.icon.constants import physical_constants as pc
+    height_profile = -pc.rd * 290.0 / pc.grav * np.log(sigma_mid)
+    geopotential = jnp.broadcast_to(
+        jnp.array(height_profile * pc.grav)[:, jnp.newaxis], (nlev, ncols)
+    )
+
+    state = PhysicsState(
+        temperature=temperature,
+        specific_humidity=specific_hum,
+        u_wind=jnp.ones((nlev, ncols)) * 5.0,
+        v_wind=jnp.zeros((nlev, ncols)),
+        geopotential=geopotential,
+        normalized_surface_pressure=jnp.ones(ncols),
+        tracers={'qc': qc, 'qi': jnp.zeros((nlev, ncols))},
+    )
+
+    date = DateData.zeros()
+    terrain = TerrainData.aquaplanet(coords)
+    # Use short timestep so autoconversion rate limiter doesn't mask the
+    # droplet-number sensitivity (default dt_conv=3600s clamps both cases)
+    parameters = Parameters.default().with_timestep(1.0)
+    forcing = ForcingData.zeros(coords.horizontal.nodal_shape)
+
+    # --- Run with clean air (cdnc_factor = 1.0) ---
+    pd_clean = PhysicsData.zeros((ncols,), nlev, icon_coords=icon_coords, date=date)
+    cloud_data_clean = pd_clean.clouds.copy(
+        cloud_fraction=jnp.where(qc > 0, 0.8, 0.0),
+    )
+    pd_clean = pd_clean.copy(clouds=cloud_data_clean)
+    _, pd_clean = _prepare_common_physics_state(
+        state, pd_clean, parameters, forcing, terrain
+    )
+    # cdnc_factor defaults to 1.0 from AerosolData.zeros
+
+    tend_clean, pd_out_clean = apply_microphysics(
+        state, pd_clean, parameters, forcing, terrain
+    )
+
+    # --- Run with polluted air (cdnc_factor = 3.0) ---
+    pd_polluted = PhysicsData.zeros((ncols,), nlev, icon_coords=icon_coords, date=date)
+    cloud_data_polluted = pd_polluted.clouds.copy(
+        cloud_fraction=jnp.where(qc > 0, 0.8, 0.0),
+    )
+    aerosol_polluted = pd_polluted.aerosol.copy(
+        cdnc_factor=jnp.ones(ncols) * 3.0,
+    )
+    pd_polluted = pd_polluted.copy(clouds=cloud_data_polluted, aerosol=aerosol_polluted)
+    _, pd_polluted = _prepare_common_physics_state(
+        state, pd_polluted, parameters, forcing, terrain
+    )
+
+    tend_polluted, pd_out_polluted = apply_microphysics(
+        state, pd_polluted, parameters, forcing, terrain
+    )
+
+    # Droplet number stored in output should reflect cdnc_factor
+    assert jnp.allclose(pd_out_clean.clouds.droplet_number, 100e6), (
+        "Clean-air droplet number should be 100e6"
+    )
+    assert jnp.allclose(pd_out_polluted.clouds.droplet_number, 300e6), (
+        "Polluted droplet number should be 3x baseline = 300e6"
+    )
+
+    # Higher CDNC suppresses autoconversion → less cloud water removal
+    # (less negative qc tendency in polluted case)
+    dqc_clean = tend_clean.tracers['qc']
+    dqc_polluted = tend_polluted.tracers['qc']
+    # In cloud layers, clean air should lose more cloud water
+    cloud_mask = qc > 0
+    mean_dqc_clean = float(jnp.mean(jnp.where(cloud_mask, dqc_clean, 0.0)))
+    mean_dqc_polluted = float(jnp.mean(jnp.where(cloud_mask, dqc_polluted, 0.0)))
+    assert mean_dqc_clean < mean_dqc_polluted, (
+        f"Clean air should lose more cloud water (dqc_clean={mean_dqc_clean:.2e}) "
+        f"than polluted air (dqc_polluted={mean_dqc_polluted:.2e})"
+    )
 
 
 def test_higher_cdnc_reduces_autoconversion():


### PR DESCRIPTION
## Summary
- Replace hardcoded `droplet_number = 100e6` in `apply_microphysics` with aerosol-derived CDNC using `physics_data.aerosol.cdnc_factor`
- Completes the aerosol indirect effect pathway: aerosol → CDNC → droplet number → autoconversion → cloud lifetime
- The direct effect (aerosol → radiation) and first indirect/Twomey effect (aerosol → cloud effective radius) were already working; this fixes the missing second indirect effect (aerosol → cloud microphysics)

## Test plan
- [x] `test_aerosol_microphysics_droplet_coupling` — verifies cdnc_factor broadcast and scaling
- [x] `test_higher_cdnc_reduces_autoconversion` — verifies physical effect (more droplets → less autoconversion)
- [x] All existing aerosol-radiation tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)