### PR TITLE
Add Angstrom spectral scaling and temporal forcing to MACv2-SP

### DIFF
--- a/jcm/forcing.py
+++ b/jcm/forcing.py
@@ -15,10 +15,16 @@ class ForcingData:
     stl_am: jnp.ndarray # temperature over land
     sea_surface_temperature: jnp.ndarray # SST, should come from sea_model.py or some default value
 
+    # Aerosol temporal forcing (MACv2-SP plume weights)
+    aerosol_year_weight: jnp.ndarray  # Per-plume year-specific emission weight (nplumes,)
+    aerosol_ann_cycle: jnp.ndarray    # Per-plume annual cycle weight (nplumes,)
+
     @classmethod
     def zeros(cls,nodal_shape,
               alb0=None,sice_am=None,snowc_am=None,
-              soilw_am=None,stl_am=None,sea_surface_temperature=None):
+              soilw_am=None,stl_am=None,sea_surface_temperature=None,
+              aerosol_year_weight=None,aerosol_ann_cycle=None,
+              nplumes=9):
         return cls(
             alb0=alb0 if alb0 is not None else jnp.zeros((nodal_shape)),
             sice_am=sice_am if sice_am is not None else jnp.zeros((nodal_shape)),
@@ -26,12 +32,16 @@ class ForcingData:
             soilw_am=soilw_am if soilw_am is not None else jnp.zeros((nodal_shape)),
             stl_am =stl_am if stl_am is not None else jnp.zeros((nodal_shape)),
             sea_surface_temperature=sea_surface_temperature if sea_surface_temperature is not None else jnp.zeros((nodal_shape)),
+            aerosol_year_weight=aerosol_year_weight if aerosol_year_weight is not None else jnp.ones(nplumes),
+            aerosol_ann_cycle=aerosol_ann_cycle if aerosol_ann_cycle is not None else jnp.ones(nplumes),
         )
 
     @classmethod
     def ones(cls,nodal_shape,
              alb0=None,sice_am=None,snowc_am=None,
-             soilw_am=None,stl_am=None,sea_surface_temperature=None):
+             soilw_am=None,stl_am=None,sea_surface_temperature=None,
+             aerosol_year_weight=None,aerosol_ann_cycle=None,
+             nplumes=9):
         return cls(
             alb0=alb0 if alb0 is not None else jnp.ones((nodal_shape)),
             sice_am=sice_am if sice_am is not None else jnp.ones((nodal_shape)),
@@ -39,6 +49,8 @@ class ForcingData:
             soilw_am=soilw_am if soilw_am is not None else jnp.ones((nodal_shape)),
             stl_am =stl_am if stl_am is not None else jnp.ones((nodal_shape)),
             sea_surface_temperature=sea_surface_temperature if sea_surface_temperature is not None else jnp.ones((nodal_shape)),
+            aerosol_year_weight=aerosol_year_weight if aerosol_year_weight is not None else jnp.ones(nplumes),
+            aerosol_ann_cycle=aerosol_ann_cycle if aerosol_ann_cycle is not None else jnp.ones(nplumes),
         )
     
     @classmethod
@@ -110,7 +122,8 @@ class ForcingData:
 
     def copy(self,alb0=None,
              sice_am=None,snowc_am=None,soilw_am=None, stl_am=None,
-             sea_surface_temperature=None):
+             sea_surface_temperature=None,
+             aerosol_year_weight=None,aerosol_ann_cycle=None):
         return ForcingData(
             alb0=alb0 if alb0 is not None else self.alb0,
             sice_am=sice_am if sice_am is not None else self.sice_am,
@@ -118,6 +131,8 @@ class ForcingData:
             soilw_am = soilw_am if soilw_am is not None else self.soilw_am,
             stl_am =stl_am if stl_am is not None else self.stl_am,
             sea_surface_temperature=sea_surface_temperature if sea_surface_temperature is not None else self.sea_surface_temperature,
+            aerosol_year_weight=aerosol_year_weight if aerosol_year_weight is not None else self.aerosol_year_weight,
+            aerosol_ann_cycle=aerosol_ann_cycle if aerosol_ann_cycle is not None else self.aerosol_ann_cycle,
         )
 
     def isnan(self):

--- a/jcm/physics/icon/aerosol/aerosol_params.py
+++ b/jcm/physics/icon/aerosol/aerosol_params.py
@@ -53,10 +53,6 @@ class AerosolParameters:
     # Natural background AOD
     background_aod: jnp.ndarray   # Background AOD at 550nm (scalar)
     
-    # Time variation parameters
-    ann_cycle: jnp.ndarray        # (nplumes,) Annual cycle weights
-    year_weight: jnp.ndarray      # (nplumes,) Year-specific weights
-    
     @classmethod
     def default(cls, background_aod=0.02) -> 'AerosolParameters':
         """Create default MACv2-SP aerosol parameters
@@ -183,10 +179,6 @@ class AerosolParameters:
             [0.8, 0.2]     # Middle East
         ]).T
         
-        # Time variation parameters (simplified for now)
-        ann_cycle = jnp.ones(nplumes)  # No seasonal variation
-        year_weight = jnp.ones(nplumes)  # Present-day emissions
-        
         return cls(
             nplumes=nplumes,
             nfeatures=nfeatures,
@@ -206,8 +198,6 @@ class AerosolParameters:
             theta=theta,
             ftr_weight=ftr_weight,
             background_aod=jnp.array(background_aod),
-            ann_cycle=ann_cycle,
-            year_weight=year_weight
         )
     
     def isnan(self):

--- a/jcm/physics/icon/aerosol/simple_aerosol.py
+++ b/jcm/physics/icon/aerosol/simple_aerosol.py
@@ -48,9 +48,13 @@ def get_simple_aerosol(
     ssa_profile = jnp.zeros((nlev, ncols))
     asy_profile = jnp.zeros((nlev, ncols))
     
+    # Get temporal weights from forcing data (allows time-varying emissions)
+    year_weight = forcing.aerosol_year_weight
+    ann_cycle = forcing.aerosol_ann_cycle
+
     # Calculate anthropogenic and background AOD using vectorized operations
-    aod_anthropogenic = get_anthropogenic_aod(lats, lons, aerosol_params)
-    aod_background = get_background_aod(lats, lons, aerosol_params)
+    aod_anthropogenic = get_anthropogenic_aod(lats, lons, aerosol_params, year_weight, ann_cycle)
+    aod_background = get_background_aod(lats, lons, aerosol_params, ann_cycle)
     
     # Calculate vertical profiles for each plume using vectorized operations
     plume_profiles = get_vertical_profiles(height_full, aerosol_params)
@@ -77,16 +81,16 @@ def get_simple_aerosol(
     aod_profile = plume_contribution + bg_contribution
     
     # Calculate optical properties using weighted averages
-    ssa_profile, asy_profile = get_optical_properties(
+    ssa_profile, asy_profile, angstrom = get_optical_properties(
         aod_profile, spatial_dist, aerosol_params
     )
-    
+
     # Calculate total column AOD
     aod_total = jnp.sum(aod_profile, axis=0)
-    
+
     # Calculate Twomey effect using proper CDNC relationship
     cdnc_factor = get_CDNC(aod_anthropogenic) / get_CDNC(jnp.zeros_like(aod_anthropogenic))
-    
+
     # Update aerosol data
     aerosol_data = physics_data.aerosol.copy(
         aod_profile=aod_profile,
@@ -95,7 +99,8 @@ def get_simple_aerosol(
         aod_total=aod_total,
         aod_anthropogenic=aod_anthropogenic,
         aod_background=aod_background,
-        cdnc_factor=cdnc_factor
+        cdnc_factor=cdnc_factor,
+        angstrom=angstrom
     )
     
     physics_data = physics_data.copy(aerosol=aerosol_data)
@@ -175,26 +180,24 @@ def get_plume_spatial_distribution(lats, lons, parameters):
     return jnp.sum(weighted_gaussian, axis=0)  # (nplumes, ncols)
 
 
-def get_background_aod(lats, lons, parameters, constant_background=0.02):
+def get_background_aod(lats, lons, parameters, ann_cycle, constant_background=0.02):
     """Calculate background (pre-industrial) aerosol optical depth
-    
+
     Args:
         lats: Array of latitudes [degrees]
         lons: Array of longitudes [degrees]
         parameters: AerosolParameters object
+        ann_cycle: Annual cycle weights (nplumes,) from forcing data
         constant_background: Constant background AOD value
-        
+
     Returns:
         Background AOD array of shape (ncols,)
 
     """
-    # Use annual cycle parameter for background
-    time_weight_bg = parameters.ann_cycle
-
     # Multiply the Gaussians through the grid
     spatial_dist = get_plume_spatial_distribution(lats, lons, parameters)
-    cw_bg = time_weight_bg[:, jnp.newaxis] * parameters.aod_fmbg[:, jnp.newaxis] * spatial_dist
-    
+    cw_bg = ann_cycle[:, jnp.newaxis] * parameters.aod_fmbg[:, jnp.newaxis] * spatial_dist
+
     # calculate contribution to plume from its different features, to get a column weight for the anthropogenic
     #   (cw_an) and the fine-mode background aerosol (cw_bg)
     aod_PI = jnp.sum(cw_bg, axis=0) + constant_background
@@ -202,20 +205,22 @@ def get_background_aod(lats, lons, parameters, constant_background=0.02):
     return aod_PI
 
 
-def get_anthropogenic_aod(lats, lons, parameters):
+def get_anthropogenic_aod(lats, lons, parameters, year_weight, ann_cycle):
     """Calculate anthropogenic aerosol optical depth
-    
+
     Args:
         lats: Array of latitudes [degrees]
         lons: Array of longitudes [degrees]
         parameters: AerosolParameters object
-        
+        year_weight: Year-specific emission weights (nplumes,) from forcing data
+        ann_cycle: Annual cycle weights (nplumes,) from forcing data
+
     Returns:
         Anthropogenic AOD array of shape (ncols,)
 
     """
     # Use time weights for anthropogenic emissions
-    time_weight = parameters.year_weight * parameters.ann_cycle
+    time_weight = year_weight * ann_cycle
 
     # Multiply the Gaussians through the grid
     spatial_dist = get_plume_spatial_distribution(lats, lons, parameters)
@@ -291,44 +296,49 @@ def get_background_vertical_profile(height_full):
 
 
 def get_optical_properties(aod_profile, spatial_dist, parameters):
-    """Calculate single scattering albedo and asymmetry parameter profiles
-    
+    """Calculate single scattering albedo, asymmetry parameter, and Angstrom exponent
+
     Args:
         aod_profile: AOD profile array of shape (nlev, ncols)
         spatial_dist: Spatial distribution array of shape (nplumes, ncols)
         parameters: AerosolParameters object
-        
+
     Returns:
-        Tuple of (ssa_profile, asy_profile) arrays of shape (nlev, ncols)
+        Tuple of (ssa_profile, asy_profile, angstrom) where profiles are
+        (nlev, ncols) and angstrom is (ncols,)
 
     """
     # Weight optical properties by AOD contribution from each plume
     # aod_profile: (nlev, ncols)
     # spatial_dist: (nplumes, ncols)
-    # parameters.ssa550, parameters.asy550: (nplumes,)
-    
+    # parameters.ssa550, parameters.asy550, parameters.angstrom: (nplumes,)
+
     # Calculate plume contributions to total AOD
     total_aod = jnp.sum(aod_profile, axis=0, keepdims=True)  # (1, ncols)
     total_aod = jnp.where(total_aod > 0, total_aod, 1.0)  # Avoid division by zero
-    
+
     # Weight by spatial distribution
     plume_weights = spatial_dist / jnp.sum(spatial_dist, axis=0, keepdims=True)
-    
+
     # Calculate weighted optical properties
     ssa_weighted = jnp.sum(
-        plume_weights * parameters.ssa550[:, jnp.newaxis], 
+        plume_weights * parameters.ssa550[:, jnp.newaxis],
         axis=0
     )
     asy_weighted = jnp.sum(
-        plume_weights * parameters.asy550[:, jnp.newaxis], 
+        plume_weights * parameters.asy550[:, jnp.newaxis],
         axis=0
     )
-    
+    angstrom_weighted = jnp.sum(
+        plume_weights * parameters.angstrom[:, jnp.newaxis],
+        axis=0
+    )
+
     # Expand to full vertical profile
     ssa_profile = jnp.ones_like(aod_profile) * ssa_weighted[jnp.newaxis, :]
     asy_profile = jnp.ones_like(aod_profile) * asy_weighted[jnp.newaxis, :]
-    
-    return ssa_profile, asy_profile
+
+    return ssa_profile, asy_profile, angstrom_weighted
 
 
 def get_CDNC(AOD, A=60, B=20):

--- a/jcm/physics/icon/aerosol/simple_aerosol_test.py
+++ b/jcm/physics/icon/aerosol/simple_aerosol_test.py
@@ -43,8 +43,6 @@ class TestAerosolParameters:
         assert params.sig_lat_W.shape == (2, 9)
         assert params.theta.shape == (2, 9)
         assert params.ftr_weight.shape == (2, 9)
-        assert params.ann_cycle.shape == (9,)
-        assert params.year_weight.shape == (9,)
         assert jnp.isscalar(params.background_aod)
     
     def test_parameter_ranges(self):
@@ -215,7 +213,7 @@ class TestAODCalculations:
         lats = jnp.linspace(-90, 90, ncols)
         lons = jnp.linspace(-180, 180, ncols)
         
-        aod_anth = get_anthropogenic_aod(lats, lons, params)
+        aod_anth = get_anthropogenic_aod(lats, lons, params, jnp.ones(params.nplumes), jnp.ones(params.nplumes))
         
         assert aod_anth.shape == (ncols,)
         assert jnp.all(aod_anth >= 0)
@@ -228,7 +226,7 @@ class TestAODCalculations:
         lats = jnp.linspace(-90, 90, ncols)
         lons = jnp.linspace(-180, 180, ncols)
         
-        aod_bg = get_background_aod(lats, lons, params)
+        aod_bg = get_background_aod(lats, lons, params, jnp.ones(params.nplumes))
         
         assert aod_bg.shape == (ncols,)
         assert jnp.all(aod_bg >= 0)
@@ -245,8 +243,10 @@ class TestAODCalculations:
         remote_lats = jnp.array([0.0, 0.0, 0.0])
         remote_lons = jnp.array([0.0, 90.0, 180.0])
         
-        aod_plume = get_anthropogenic_aod(plume_lats, plume_lons, params)
-        aod_remote = get_anthropogenic_aod(remote_lats, remote_lons, params)
+        year_weight = jnp.ones(params.nplumes)
+        ann_cycle = jnp.ones(params.nplumes)
+        aod_plume = get_anthropogenic_aod(plume_lats, plume_lons, params, year_weight, ann_cycle)
+        aod_remote = get_anthropogenic_aod(remote_lats, remote_lons, params, year_weight, ann_cycle)
         
         # AOD should be higher at plume centers
         assert jnp.all(aod_plume > aod_remote)
@@ -264,7 +264,7 @@ class TestOpticalProperties:
         aod_profile = jnp.ones((nlev, ncols)) * 0.1
         spatial_dist = jnp.ones((params.nplumes, ncols)) / params.nplumes
         
-        ssa_profile, asy_profile = get_optical_properties(aod_profile, spatial_dist, params)
+        ssa_profile, asy_profile, angstrom = get_optical_properties(aod_profile, spatial_dist, params)
         
         assert ssa_profile.shape == (nlev, ncols)
         assert asy_profile.shape == (nlev, ncols)
@@ -285,7 +285,7 @@ class TestOpticalProperties:
         spatial_dist = jnp.zeros((params.nplumes, ncols))
         spatial_dist = spatial_dist.at[0, :].set(1.0)  # Only first plume
         
-        ssa_profile, asy_profile = get_optical_properties(aod_profile, spatial_dist, params)
+        ssa_profile, asy_profile, angstrom = get_optical_properties(aod_profile, spatial_dist, params)
         
         # Should match first plume properties
         expected_ssa = params.ssa550[0]
@@ -378,7 +378,7 @@ class TestJAXCompatibility:
         params = AerosolParameters.default()
         
         def aod_sum(lats, lons):
-            return jnp.sum(get_anthropogenic_aod(lats, lons, params))
+            return jnp.sum(get_anthropogenic_aod(lats, lons, params, jnp.ones(params.nplumes), jnp.ones(params.nplumes)))
         
         ncols = 20
         lats = jnp.linspace(-90, 90, ncols)
@@ -412,8 +412,8 @@ class TestIntegration:
         height_full = jnp.repeat(height_full, ncols, axis=1)
         
         # Test individual functions work together
-        aod_anth = get_anthropogenic_aod(lats, lons, params)
-        aod_bg = get_background_aod(lats, lons, params)
+        aod_anth = get_anthropogenic_aod(lats, lons, params, jnp.ones(params.nplumes), jnp.ones(params.nplumes))
+        aod_bg = get_background_aod(lats, lons, params, jnp.ones(params.nplumes))
         
         assert aod_anth.shape == (ncols,)
         assert aod_bg.shape == (ncols,)
@@ -430,7 +430,7 @@ class TestIntegration:
         
         # Test optical properties
         aod_profile = jnp.ones((nlev, ncols)) * 0.1
-        ssa_profile, asy_profile = get_optical_properties(aod_profile, spatial_dist, params)
+        ssa_profile, asy_profile, angstrom = get_optical_properties(aod_profile, spatial_dist, params)
         
         assert ssa_profile.shape == (nlev, ncols)
         assert asy_profile.shape == (nlev, ncols)
@@ -443,20 +443,22 @@ class TestIntegration:
         """Test that individual functions can be JIT compiled"""
         params = AerosolParameters.default()
         ncols = 50
-        
+
         # Test JIT compilation of each function
         jit_spatial = jax.jit(get_plume_spatial_distribution)
         jit_aod_anth = jax.jit(get_anthropogenic_aod)
         jit_aod_bg = jax.jit(get_background_aod)
-        
+
         lats = jnp.linspace(-90, 90, ncols)
         lons = jnp.linspace(-180, 180, ncols)
-        
+        year_weight = jnp.ones(params.nplumes)
+        ann_cycle = jnp.ones(params.nplumes)
+
         # All should compile and run without errors
         spatial_dist = jit_spatial(lats, lons, params)
-        aod_anth = jit_aod_anth(lats, lons, params)
-        aod_bg = jit_aod_bg(lats, lons, params)
-        
+        aod_anth = jit_aod_anth(lats, lons, params, year_weight, ann_cycle)
+        aod_bg = jit_aod_bg(lats, lons, params, ann_cycle)
+
         assert spatial_dist.shape == (params.nplumes, ncols)
         assert aod_anth.shape == (ncols,)
         assert aod_bg.shape == (ncols,)
@@ -469,7 +471,7 @@ class TestIntegration:
         params = AerosolParameters.default()
         
         def total_aod(lats, lons):
-            return jnp.sum(get_anthropogenic_aod(lats, lons, params))
+            return jnp.sum(get_anthropogenic_aod(lats, lons, params, jnp.ones(params.nplumes), jnp.ones(params.nplumes)))
         
         ncols = 20
         lats = jnp.linspace(-90, 90, ncols)
@@ -512,7 +514,7 @@ class TestIntegration:
         spatial_dist = get_plume_spatial_distribution(lats, lons, params)
         
         aod_profile = jnp.ones((nlev, ncols)) * 0.1
-        ssa_profile, asy_profile = get_optical_properties(aod_profile, spatial_dist, params)
+        ssa_profile, asy_profile, angstrom = get_optical_properties(aod_profile, spatial_dist, params)
         
         # Should be within range of parameter values
         assert jnp.all(ssa_profile >= jnp.min(params.ssa550))

--- a/jcm/physics/icon/icon_physics.py
+++ b/jcm/physics/icon/icon_physics.py
@@ -662,6 +662,7 @@ def apply_radiation(state: PhysicsState,
         aod_total=physics_data.aerosol.aod_total.reshape(ncols),  # (ncols,)
         aod_anthropogenic=physics_data.aerosol.aod_anthropogenic.reshape(ncols),  # (ncols,)
         aod_background=physics_data.aerosol.aod_background.reshape(ncols),  # (ncols,)
+        angstrom=physics_data.aerosol.angstrom.reshape(ncols),  # (ncols,)
     )
     
     radiation_results = jax.vmap(

--- a/jcm/physics/icon/icon_physics_data.py
+++ b/jcm/physics/icon/icon_physics_data.py
@@ -357,7 +357,10 @@ class AerosolData:
     
     # For Twomey effect (cloud-aerosol interactions)
     cdnc_factor: jnp.ndarray         # CDNC modification factor [1] (ncols,)
-    
+
+    # Spectral scaling
+    angstrom: jnp.ndarray            # Angstrom exponent [1] (ncols,)
+
     @classmethod
     def zeros(cls, nodal_shape, nlev):
         return cls(
@@ -368,8 +371,9 @@ class AerosolData:
             aod_anthropogenic=jnp.zeros(nodal_shape),
             aod_background=jnp.zeros(nodal_shape),
             cdnc_factor=jnp.ones(nodal_shape),  # Start with factor of 1.0
+            angstrom=jnp.ones(nodal_shape) * 1.5,  # Typical fine-mode aerosol
         )
-    
+
     def copy(self, **kwargs):
         new_data = {
             'aod_profile': self.aod_profile,
@@ -379,6 +383,7 @@ class AerosolData:
             'aod_anthropogenic': self.aod_anthropogenic,
             'aod_background': self.aod_background,
             'cdnc_factor': self.cdnc_factor,
+            'angstrom': self.angstrom,
         }
         new_data.update(kwargs)
         return AerosolData(**new_data)

--- a/jcm/physics/icon/radiation/aerosol_radiation_test.py
+++ b/jcm/physics/icon/radiation/aerosol_radiation_test.py
@@ -9,6 +9,11 @@ from jcm.physics.icon.radiation.radiation_scheme import (
 )
 from jcm.physics.icon.radiation.radiation_types import RadiationParameters, OpticalProperties
 from jcm.physics.icon.radiation.cloud_optics import effective_radius_liquid
+from jcm.physics.icon.aerosol.simple_aerosol import (
+    get_optical_properties,
+    get_anthropogenic_aod,
+)
+from jcm.physics.icon.aerosol.aerosol_params import AerosolParameters
 
 def test_aerosol_cloud_interaction():
     """Test that aerosols modify cloud effective radius"""
@@ -110,13 +115,99 @@ def test_radiation_scheme_with_without_aerosols():
         return
 
 
+def test_angstrom_spectral_scaling():
+    """Test that Angstrom exponent produces correct spectral AOD scaling"""
+    # AOD(λ) = AOD(550nm) * (λ/0.55)^(-α)
+    ref_wavelength = 0.55  # μm
+
+    # Test with known Angstrom exponent
+    alpha = 1.5
+    aod_550 = 0.3
+
+    # Shorter wavelength should have higher AOD (more scattering)
+    lambda_short = 0.4  # μm
+    lambda_long = 1.0   # μm
+
+    aod_short = aod_550 * (lambda_short / ref_wavelength) ** (-alpha)
+    aod_long = aod_550 * (lambda_long / ref_wavelength) ** (-alpha)
+
+    assert aod_short > aod_550, "AOD at shorter λ should be higher"
+    assert aod_long < aod_550, "AOD at longer λ should be lower"
+
+    # Check exact values
+    expected_short = aod_550 * (0.4 / 0.55) ** (-1.5)
+    expected_long = aod_550 * (1.0 / 0.55) ** (-1.5)
+    assert jnp.allclose(aod_short, expected_short, rtol=1e-6)
+    assert jnp.allclose(aod_long, expected_long, rtol=1e-6)
+
+
+def test_angstrom_weighted_average():
+    """Test that get_optical_properties returns proper Angstrom weighted average"""
+    params = AerosolParameters.default()
+    nlev, ncols = 10, 50
+
+    aod_profile = jnp.ones((nlev, ncols)) * 0.1
+
+    # Single plume dominating
+    spatial_dist = jnp.zeros((params.nplumes, ncols))
+    spatial_dist = spatial_dist.at[0, :].set(1.0)
+
+    _, _, angstrom = get_optical_properties(aod_profile, spatial_dist, params)
+
+    # Should match first plume's Angstrom exponent
+    assert jnp.allclose(angstrom, params.angstrom[0], rtol=1e-6)
+
+    # Equal-weight plumes
+    spatial_dist_equal = jnp.ones((params.nplumes, ncols)) / params.nplumes
+    _, _, angstrom_equal = get_optical_properties(aod_profile, spatial_dist_equal, params)
+
+    # Should be mean of all plume values
+    expected = jnp.mean(params.angstrom)
+    assert jnp.allclose(angstrom_equal[0], expected, rtol=1e-5)
+
+
+def test_temporal_weights_scale_aod():
+    """Test that temporal weights from forcing scale anthropogenic AOD"""
+    params = AerosolParameters.default()
+    ncols = 100
+    lats = jnp.linspace(-90, 90, ncols)
+    lons = jnp.linspace(-180, 180, ncols)
+
+    # Present-day: weights = 1
+    year_weight_pd = jnp.ones(params.nplumes)
+    ann_cycle = jnp.ones(params.nplumes)
+    aod_pd = get_anthropogenic_aod(lats, lons, params, year_weight_pd, ann_cycle)
+
+    # Pre-industrial: weights = 0
+    year_weight_pi = jnp.zeros(params.nplumes)
+    aod_pi = get_anthropogenic_aod(lats, lons, params, year_weight_pi, ann_cycle)
+
+    # Half emissions
+    year_weight_half = jnp.ones(params.nplumes) * 0.5
+    aod_half = get_anthropogenic_aod(lats, lons, params, year_weight_half, ann_cycle)
+
+    assert jnp.all(aod_pi == 0), "Pre-industrial AOD should be zero"
+    assert jnp.allclose(aod_half, aod_pd * 0.5, rtol=1e-6), "Half weights should give half AOD"
+
+    # Seasonal cycle: reduce one plume
+    ann_cycle_reduced = jnp.ones(params.nplumes)
+    ann_cycle_reduced = ann_cycle_reduced.at[0].set(0.5)
+    aod_seasonal = get_anthropogenic_aod(lats, lons, params, year_weight_pd, ann_cycle_reduced)
+
+    # Total AOD should decrease compared to present-day
+    assert jnp.sum(aod_seasonal) < jnp.sum(aod_pd)
+
+
 if __name__ == "__main__":
     print("Testing aerosol-radiation integration...")
     print("=" * 50)
-    
+
     test_aerosol_cloud_interaction()
-    test_optical_property_combination() 
+    test_optical_property_combination()
     test_radiation_scheme_with_without_aerosols()
-    
-    print("\\n" + "=" * 50)
+    test_angstrom_spectral_scaling()
+    test_angstrom_weighted_average()
+    test_temporal_weights_scale_aod()
+
+    print("\n" + "=" * 50)
     print("All tests completed!")

--- a/jcm/physics/icon/radiation/radiation_scheme.py
+++ b/jcm/physics/icon/radiation/radiation_scheme.py
@@ -228,40 +228,54 @@ def radiation_scheme(
 
     """
     nlev = temperature.shape[0]
-    
-    # For now, assume aerosol properties are spectrally uniform
-    # Expand aerosol profiles to radiation bands
+
+    # Expand aerosol profiles to radiation bands with Angstrom spectral scaling
+    # AOD(λ) = AOD(550nm) * (λ/0.55)^(-α)
     # Handle both 1D (single column from vmap) and 2D (full grid) aerosol data
     if aerosol_data.aod_profile.ndim == 1:
         # 1D case: single column from vmap
-        aerosol_aod_col = aerosol_data.aod_profile[:, None]  # Make it [nlev, 1]
-        aerosol_ssa_col = aerosol_data.ssa_profile[:, None]
-        aerosol_asy_col = aerosol_data.asy_profile[:, None]
+        aerosol_aod_col = aerosol_data.aod_profile  # [nlev]
+        aerosol_ssa_col = aerosol_data.ssa_profile
+        aerosol_asy_col = aerosol_data.asy_profile
+        angstrom = aerosol_data.angstrom  # scalar from vmap
     else:
         # 2D case: take first column
-        aerosol_aod_col = aerosol_data.aod_profile[:, 0:1]
-        aerosol_ssa_col = aerosol_data.ssa_profile[:, 0:1]
-        aerosol_asy_col = aerosol_data.asy_profile[:, 0:1]
-    
+        aerosol_aod_col = aerosol_data.aod_profile[:, 0]
+        aerosol_ssa_col = aerosol_data.ssa_profile[:, 0]
+        aerosol_asy_col = aerosol_data.asy_profile[:, 0]
+        angstrom = aerosol_data.angstrom[0]
+
     # SW bands - use fixed default values (2 SW bands, 3 LW bands)
-    # This is standard for ICON radiation and avoids tracer issues
     default_n_sw_bands = 2
     default_n_lw_bands = 3
-    
-    aerosol_tau_sw = jnp.tile(aerosol_aod_col, (1, default_n_sw_bands))
-    aerosol_ssa_sw = jnp.tile(aerosol_ssa_col, (1, default_n_sw_bands))
-    aerosol_asy_sw = jnp.tile(aerosol_asy_col, (1, default_n_sw_bands))
-    
-    # LW bands (pure absorption for aerosols)
-    aerosol_tau_lw = jnp.tile(aerosol_aod_col, (1, default_n_lw_bands))
-    aerosol_ssa_lw = jnp.zeros((nlev, default_n_lw_bands))  # Pure absorption
+
+    # Compute representative wavelengths (μm) from SW band limits (wavenumbers cm⁻¹)
+    # λ = 1e4 / ν_mid, where ν_mid is the midpoint wavenumber of the band
+    sw_band_limits = parameters.sw_band_limits  # [[4000, 14500], [14500, 50000]]
+    sw_wavelengths = 1e4 / ((sw_band_limits[:, 0] + sw_band_limits[:, 1]) / 2.0)
+
+    # Apply Angstrom scaling: AOD(λ) = AOD(550nm) * (λ/0.55)^(-α)
+    ref_wavelength = 0.55  # μm (550 nm reference)
+    sw_scaling = (sw_wavelengths / ref_wavelength) ** (-angstrom)  # [n_sw_bands]
+
+    aerosol_tau_sw = aerosol_aod_col[:, None] * sw_scaling[None, :]  # [nlev, n_sw_bands]
+    aerosol_ssa_sw = jnp.tile(aerosol_ssa_col[:, None], (1, default_n_sw_bands))
+    aerosol_asy_sw = jnp.tile(aerosol_asy_col[:, None], (1, default_n_sw_bands))
+
+    # LW bands: apply Angstrom scaling (gives very small AOD at long wavelengths)
+    lw_band_limits = parameters.lw_band_limits  # [[10, 350], [350, 500], [500, 2500]]
+    lw_wavelengths = 1e4 / ((lw_band_limits[:, 0] + lw_band_limits[:, 1]) / 2.0)
+    lw_scaling = (lw_wavelengths / ref_wavelength) ** (-angstrom)
+
+    aerosol_tau_lw = aerosol_aod_col[:, None] * lw_scaling[None, :]  # [nlev, n_lw_bands]
+    aerosol_ssa_lw = jnp.zeros((nlev, default_n_lw_bands))  # Pure absorption in LW
     aerosol_asy_lw = jnp.zeros((nlev, default_n_lw_bands))
-    
-    # For SW use scattering properties, for LW use absorption
+
+    # Concatenate SW and LW
     aerosol_optical_depth = jnp.concatenate([aerosol_tau_sw, aerosol_tau_lw], axis=1)
     aerosol_ssa = jnp.concatenate([aerosol_ssa_sw, aerosol_ssa_lw], axis=1)
     aerosol_asymmetry = jnp.concatenate([aerosol_asy_sw, aerosol_asy_lw], axis=1)
-    
+
     # Cloud droplet number concentration factor
     # Handle both 1D (single column from vmap) and 2D (full grid) cases
     if aerosol_data.cdnc_factor.ndim == 0:
@@ -269,7 +283,7 @@ def radiation_scheme(
         cdnc_factor = aerosol_data.cdnc_factor
     else:
         # 1D case: take first element
-        cdnc_factor = aerosol_data.cdnc_factor[0] 
+        cdnc_factor = aerosol_data.cdnc_factor[0]
     
     # Now perform the actual radiation calculation
     

--- a/jcm/physics/icon/radiation/radiation_scheme_test.py
+++ b/jcm/physics/icon/radiation/radiation_scheme_test.py
@@ -41,7 +41,8 @@ def create_default_aerosol_data(nlev=10, parameters=None, ncols=1):
         aod_total=aod_total,
         aod_anthropogenic=aod_anthropogenic,
         aod_background=aod_background,
-        cdnc_factor=cdnc_factor
+        cdnc_factor=cdnc_factor,
+        angstrom=jnp.ones(ncols) * 1.5,
     )
 
 


### PR DESCRIPTION
## Summary
- Apply Angstrom exponent spectral scaling to aerosol AOD across radiation bands (`AOD(λ) = AOD(550nm) * (λ/0.55)^(-α)`), replacing uniform tiling
- Compute plume-weighted average Angstrom exponent per column and store in `AerosolData`
- Move temporal variation weights (`year_weight`, `ann_cycle`) from `AerosolParameters` to `ForcingData`, enabling time-varying aerosol emissions through the forcing data system

## Test plan
- [x] 3 new tests: Angstrom formula correctness, weighted average computation, temporal weight AOD scaling
- [x] All 322 ICON physics tests pass
- [x] All 33 forcing tests pass
- [x] All 64 SPEEDY physics tests pass
- [x] Lint clean

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)