### PR TITLE
Make p1 nonzero

### DIFF
--- a/jcm/model.py
+++ b/jcm/model.py
@@ -244,6 +244,7 @@ class Model:
             coords=self.coords,
             physics_specs=self.physics_specs,
             p0=p0*units.pascal,
+            p1=0.01*p0*units.pascal,
         )
         
         self.physics = physics or SpeedyPhysics()


### PR DESCRIPTION
p1 needs to be nonzero for the random_seed argument to do anything. I made a quick plot (n=10 seeds) of what the variance between different seeds looks like over time, for different values of p1--TLDR, the value of p1 hardly matters. It can be very small without slowing down the physically realistic divergence between different seeds.
<img width="1029" height="547" alt="image" src="https://github.com/user-attachments/assets/84818fd5-3393-473b-9433-4676329dadc0" />
For completeness here's the variance over a longer duration (to get a sense of how large the initial noise perturbation is compared to the eventual internal variability).
<img width="1012" height="547" alt="image" src="https://github.com/user-attachments/assets/fbb8664e-d86f-47b6-99a0-ff6031b3dd10" />
Note that output_averages is off for these plots so the save_interval doesn't affect the variance between different seeds.