### PR TITLE
Fix zero precipitation: coupled cloud-microphysics scheme

### DIFF
--- a/jcm/physics/icon/clouds/cloud_microphysics.py
+++ b/jcm/physics/icon/clouds/cloud_microphysics.py
@@ -647,15 +647,22 @@ def cloud_microphysics(
     dqrdt = dqrdt - rain_sedi
     dqsdt = dqsdt - snow_sedi
     
-    # Calculate precipitation fluxes (simplified - just from lowest level)
-    rain_flux = jnp.zeros(nlev)
-    snow_flux = jnp.zeros(nlev)
-    rain_flux = rain_flux.at[-1].set(rain_sedi[-1] * air_density[-1] * layer_thickness[-1])
-    snow_flux = snow_flux.at[-1].set(snow_sedi[-1] * air_density[-1] * layer_thickness[-1])
-    
-    # Surface precipitation
-    precip_rain = rain_flux[-1]
-    precip_snow = snow_flux[-1]
+    # Surface precipitation: column-integrated rain/snow production
+    # Following ECHAM mo_cloud.f90: zzdrr = zrpr * pmref / pdtime
+    # where pmref = air_density * layer_thickness (layer mass per unit area)
+    layer_mass = air_density * layer_thickness  # kg/m²
+
+    # Rain production per level: autoconversion + accretion + snow melting
+    rain_prod = (qc_auto + qc_accr + snow_melt) * cloud_fraction
+    # Snow production per level: ice autoconversion + aggregation + riming + rain freezing
+    snow_prod = (qi_auto + qi_aggr + qc_rime + rain_freeze) * cloud_fraction
+
+    # Column-integrated surface flux (kg/m²/s)
+    precip_rain = jnp.sum(rain_prod * layer_mass)
+    precip_snow = jnp.sum(snow_prod * layer_mass)
+
+    rain_flux = rain_prod * layer_mass
+    snow_flux = snow_prod * layer_mass
     
     # Create output structures
     tendencies = MicrophysicsTendencies(

--- a/jcm/physics/icon/clouds/cloud_microphysics.py
+++ b/jcm/physics/icon/clouds/cloud_microphysics.py
@@ -222,11 +222,7 @@ def autoconversion_kk2000(
     
     # Convert to grid-mean tendency
     autoconv_rate = autoconv_rate * cloud_fraction
-    
-    # Limit to available cloud water
-    max_rate = cloud_water / dt
-    autoconv_rate = jnp.minimum(autoconv_rate, max_rate)
-    
+
     return autoconv_rate
 
 

--- a/jcm/physics/icon/clouds/cloud_microphysics.py
+++ b/jcm/physics/icon/clouds/cloud_microphysics.py
@@ -63,6 +63,9 @@ class MicrophysicsParameters:
     vt_rain_a: float     # Rain fall speed coefficient a
     vt_rain_b: float     # Rain fall speed exponent b
     
+    # Cloud droplet number concentration
+    base_cdnc: float     # Baseline CDNC in clean air (1/m³), modulated by aerosol cdnc_factor
+
     # Numerical parameters
     epsilon: float       # Small number for numerical stability
     dt_sedi: float       # Sub-timestep for sedimentation (s)
@@ -72,7 +75,8 @@ class MicrophysicsParameters:
                  crhosno=100.0, cvtfall=3.29, cthomi=233.15, csecfrl=0.1, ccollec=0.7,
                  ccollei=0.3, tau_melt=100.0, tau_freeze=100.0, cevaprain=1.0e-3,
                  cevapsnow=5.0e-4, vt_ice=0.1, vt_snow_a=8.8, vt_snow_b=0.15,
-                 vt_rain_a=386.0, vt_rain_b=0.67, epsilon=1.0e-12, dt_sedi=10.0) -> 'MicrophysicsParameters':
+                 vt_rain_a=386.0, vt_rain_b=0.67, base_cdnc=100.0e6,
+                 epsilon=1.0e-12, dt_sedi=10.0) -> 'MicrophysicsParameters':
         """Return default microphysics parameters"""
         return cls(
             ccraut=jnp.array(ccraut),
@@ -96,6 +100,7 @@ class MicrophysicsParameters:
             vt_snow_b=jnp.array(vt_snow_b),
             vt_rain_a=jnp.array(vt_rain_a),
             vt_rain_b=jnp.array(vt_rain_b),
+            base_cdnc=jnp.array(base_cdnc),
             epsilon=jnp.array(epsilon),
             dt_sedi=jnp.array(dt_sedi)
         )

--- a/jcm/physics/icon/clouds/shallow_clouds.py
+++ b/jcm/physics/icon/clouds/shallow_clouds.py
@@ -32,7 +32,6 @@ class CloudParameters:
     # Microphysics parameters
     ccraut: float        # Beheng autoconversion rate scaling (dimensionless, ECHAM default 4)
     ccsaut: float        # Ice autoconversion rate (1/s)
-    cdnc: float          # Cloud droplet number concentration (1/m³)
     ceffmin: float       # Minimum cloud droplet radius (microns)
     ceffmax: float       # Maximum cloud droplet radius (microns)
 
@@ -47,7 +46,7 @@ class CloudParameters:
     @classmethod
     def default(cls, crt=0.9, crs=0.7, nex=4.0,
                  csatsc=0.97, ccraut=4.0, ccsaut=0.001,
-                 cdnc=200.0e6, ceffmin=10.0,
+                 ceffmin=10.0,
                  ceffmax=150.0, epsilon=1.0e-12,
                  t_ice=238.15, t_mix_min=238.15, t_mix_max=273.15) -> 'CloudParameters':
         """Return default cloud parameters"""
@@ -58,7 +57,6 @@ class CloudParameters:
             csatsc=jnp.array(csatsc),
             ccraut=jnp.array(ccraut),
             ccsaut=jnp.array(ccsaut),
-            cdnc=jnp.array(cdnc),
             ceffmin=jnp.array(ceffmin),
             ceffmax=jnp.array(ceffmax),
             epsilon=jnp.array(epsilon),
@@ -322,16 +320,17 @@ def condensation_evaporation(
 
 def shallow_cloud_scheme(
     temperature: jnp.ndarray,
-    specific_humidity: jnp.ndarray, 
+    specific_humidity: jnp.ndarray,
     pressure: jnp.ndarray,
     cloud_water: jnp.ndarray,
     cloud_ice: jnp.ndarray,
     surface_pressure: float,
+    cdnc: jnp.ndarray,
     dt: float,
     config: Optional[CloudParameters] = None
 ) -> Tuple[CloudTendencies, CloudState]:
     """Run shallow cloud scheme
-    
+
     Args:
         temperature: Temperature (K) [nlev] or scalar
         specific_humidity: Specific humidity (kg/kg) [nlev] or scalar
@@ -339,9 +338,10 @@ def shallow_cloud_scheme(
         cloud_water: Cloud liquid water (kg/kg) [nlev] or scalar
         cloud_ice: Cloud ice (kg/kg) [nlev] or scalar
         surface_pressure: Surface pressure (Pa)
+        cdnc: Cloud droplet number concentration (1/m³) [nlev]
         dt: Time step (s)
         config: Cloud configuration
-        
+
     Returns:
         Tuple of (tendencies, cloud_state)
 
@@ -386,7 +386,7 @@ def shallow_cloud_scheme(
     exm1 = 3.7  # 4.7 - 1.0
     zexp = -1.0 / exm1
     # ECHAM converts cdnc from 1/m³ to 1/cm³ (pacdnc*1e-6) for the Beheng formula
-    cdnc_cgs = config.cdnc * 1e-6  # 1/m³ → 1/cm³
+    cdnc_cgs = jnp.maximum(cdnc, 1.0) * 1e-6  # 1/m³ → 1/cm³, floor to avoid zero
     gamma = (config.ccraut * 1.2e27) / rho * cdnc_cgs**(-3.3) * (rho * 1e-3)**4.7
 
     # Convert to in-cloud values (ECHAM: zxlb = grid-mean * zclcauxi)

--- a/jcm/physics/icon/clouds/shallow_clouds.py
+++ b/jcm/physics/icon/clouds/shallow_clouds.py
@@ -15,7 +15,7 @@ from typing import NamedTuple, Tuple, Optional
 import tree_math
 
 from ..constants.physical_constants import (
-    tmelt, alhc, alhs, cp, eps
+    tmelt, alhc, alhs, cp, eps, grav
 )
 
 
@@ -30,10 +30,12 @@ class CloudParameters:
     csatsc: float        # Saturation factor for stratocumulus
     
     # Microphysics parameters
-    ccraut: float        # Autoconversion threshold (kg/kg)
+    ccraut: float        # Beheng autoconversion rate scaling (dimensionless, ECHAM default 4)
+    ccsaut: float        # Ice autoconversion rate (1/s)
+    cdnc: float          # Cloud droplet number concentration (1/m³)
     ceffmin: float       # Minimum cloud droplet radius (microns)
     ceffmax: float       # Maximum cloud droplet radius (microns)
-    
+
     # Numerical parameters
     epsilon: float       # Small number for numerical stability
     
@@ -44,7 +46,8 @@ class CloudParameters:
 
     @classmethod
     def default(cls, crt=0.9, crs=0.7, nex=4.0,
-                 csatsc=0.97, ccraut=0.0005, ceffmin=10.0, 
+                 csatsc=0.97, ccraut=4.0, ccsaut=0.001,
+                 cdnc=200.0e6, ceffmin=10.0,
                  ceffmax=150.0, epsilon=1.0e-12,
                  t_ice=238.15, t_mix_min=238.15, t_mix_max=273.15) -> 'CloudParameters':
         """Return default cloud parameters"""
@@ -54,6 +57,8 @@ class CloudParameters:
             nex=jnp.array(nex),
             csatsc=jnp.array(csatsc),
             ccraut=jnp.array(ccraut),
+            ccsaut=jnp.array(ccsaut),
+            cdnc=jnp.array(cdnc),
             ceffmin=jnp.array(ceffmin),
             ceffmax=jnp.array(ceffmax),
             epsilon=jnp.array(epsilon),
@@ -362,30 +367,55 @@ def shallow_cloud_scheme(
         cloud_fraction, pressure, dt, config
     )
     
-    # Simple precipitation formation (autoconversion)
-    # Convert cloud water to rain if it exceeds threshold
-    rain_rate = jnp.where(
-        cloud_water > config.ccraut,
-        0.001 * (cloud_water - config.ccraut) / dt,  # Simple rate
-        0.0
-    )
-    snow_rate = jnp.where(
-        cloud_ice > config.ccraut * 0.1,  # Lower threshold for ice
-        0.01 * cloud_ice / dt,  # Faster rate for ice
-        0.0
-    )
-    
-    # Update tendencies for precipitation
-    dqcdt = dqcdt - rain_rate
-    dqidt = dqidt - snow_rate
-    
-    # Calculate total cloud cover (maximum overlap assumption)
+    # --- Within-timestep condensation → autoconversion → precipitation ---
+    # Following ECHAM mo_cloud.f90: condensation updates in-cloud water
+    # (zxlb += zcnd), then autoconversion acts on the updated values.
+    # Use the condensation computed by condensation_evaporation above,
+    # applied within this timestep to get the updated cloud water.
+    updated_cloud_water = jnp.maximum(cloud_water + dqcdt * dt, 0.0)
+    updated_cloud_ice = jnp.maximum(cloud_ice + dqidt * dt, 0.0)
+
+    # Air density from ideal gas law (needed for Beheng autoconversion)
+    from ..constants.physical_constants import rd
+    rho = pressure / (rd * temperature)
+
+    # Warm-phase autoconversion: Beheng (1994), following ECHAM mo_cloud.f90 lines 834-862
+    # ECHAM operates on IN-CLOUD water (zxlb = grid-mean / cloud_fraction).
+    # Analytic solution to dqc/dt = -gamma * qc^(1 + exm1)
+    # gamma = ccraut * 1.2e27 / rho * cdnc^(-3.3) * (rho * 1e-3)^4.7
+    exm1 = 3.7  # 4.7 - 1.0
+    zexp = -1.0 / exm1
+    # ECHAM converts cdnc from 1/m³ to 1/cm³ (pacdnc*1e-6) for the Beheng formula
+    cdnc_cgs = config.cdnc * 1e-6  # 1/m³ → 1/cm³
+    gamma = (config.ccraut * 1.2e27) / rho * cdnc_cgs**(-3.3) * (rho * 1e-3)**4.7
+
+    # Convert to in-cloud values (ECHAM: zxlb = grid-mean * zclcauxi)
+    cf_safe = jnp.maximum(cloud_fraction, config.epsilon)
+    qc_incloud = jnp.maximum(updated_cloud_water / cf_safe, 0.0)
+    qi_incloud = jnp.maximum(updated_cloud_ice / cf_safe, 0.0)
+
+    denom = 1.0 + gamma * dt * exm1 * qc_incloud**exm1
+    rain_auto_incloud = qc_incloud * (1.0 - denom**zexp)
+    rain_auto_incloud = jnp.maximum(rain_auto_incloud, 0.0)
+    # Convert back to grid-mean (ECHAM: zrpr = zclcaux * zraut)
+    rain_auto = cloud_fraction * rain_auto_incloud
+
+    # Ice autoconversion: Levkov et al. (1992), following ECHAM mo_cloud.f90 lines 912-913
+    snow_auto_incloud = qi_incloud * (1.0 - 1.0 / (1.0 + config.ccsaut * dt * qi_incloud))
+    snow_auto_incloud = jnp.maximum(snow_auto_incloud, 0.0)
+    snow_auto = cloud_fraction * snow_auto_incloud
+
+    # Update cloud water/ice tendencies to include precipitation loss
+    dqcdt = dqcdt - rain_auto / dt
+    dqidt = dqidt - snow_auto / dt
+
+    # Column-integrated precipitation flux using dp/g (kg/m²/s)
+    dp = jnp.abs(jnp.diff(pressure, prepend=0.0))
+    rain_flux = jnp.sum(rain_auto * dp / dt) / grav
+    snow_flux = jnp.sum(snow_auto * dp / dt) / grav
+
+    # Total cloud cover (maximum overlap assumption)
     total_cloud_cover = jnp.max(cloud_fraction)
-    
-    # Surface precipitation fluxes (simplified - no vertical integration)
-    # In reality, would need to integrate through column accounting for evaporation
-    rain_flux = jnp.sum(rain_rate) * 1000.0  # Convert to kg/m²/s (approximate)
-    snow_flux = jnp.sum(snow_rate) * 1000.0
     
     # Create output structures
     tendencies = CloudTendencies(

--- a/jcm/physics/icon/clouds/shallow_clouds.py
+++ b/jcm/physics/icon/clouds/shallow_clouds.py
@@ -15,7 +15,7 @@ from typing import NamedTuple, Tuple, Optional
 import tree_math
 
 from ..constants.physical_constants import (
-    tmelt, alhc, alhs, cp, eps, grav
+    tmelt, alhc, alhs, cp, eps
 )
 
 
@@ -29,9 +29,7 @@ class CloudParameters:
     nex: float           # Exponent for RH threshold profile
     csatsc: float        # Saturation factor for stratocumulus
     
-    # Microphysics parameters
-    ccraut: float        # Beheng autoconversion rate scaling (dimensionless, ECHAM default 4)
-    ccsaut: float        # Ice autoconversion rate (1/s)
+    # Cloud droplet parameters
     ceffmin: float       # Minimum cloud droplet radius (microns)
     ceffmax: float       # Maximum cloud droplet radius (microns)
 
@@ -45,8 +43,7 @@ class CloudParameters:
 
     @classmethod
     def default(cls, crt=0.9, crs=0.7, nex=4.0,
-                 csatsc=0.97, ccraut=4.0, ccsaut=0.001,
-                 ceffmin=10.0,
+                 csatsc=0.97, ceffmin=10.0,
                  ceffmax=150.0, epsilon=1.0e-12,
                  t_ice=238.15, t_mix_min=238.15, t_mix_max=273.15) -> 'CloudParameters':
         """Return default cloud parameters"""
@@ -55,8 +52,6 @@ class CloudParameters:
             crs=jnp.array(crs),
             nex=jnp.array(nex),
             csatsc=jnp.array(csatsc),
-            ccraut=jnp.array(ccraut),
-            ccsaut=jnp.array(ccsaut),
             ceffmin=jnp.array(ceffmin),
             ceffmax=jnp.array(ceffmax),
             epsilon=jnp.array(epsilon),
@@ -325,7 +320,6 @@ def shallow_cloud_scheme(
     cloud_water: jnp.ndarray,
     cloud_ice: jnp.ndarray,
     surface_pressure: float,
-    cdnc: jnp.ndarray,
     dt: float,
     config: Optional[CloudParameters] = None
 ) -> Tuple[CloudTendencies, CloudState]:
@@ -338,7 +332,6 @@ def shallow_cloud_scheme(
         cloud_water: Cloud liquid water (kg/kg) [nlev] or scalar
         cloud_ice: Cloud ice (kg/kg) [nlev] or scalar
         surface_pressure: Surface pressure (Pa)
-        cdnc: Cloud droplet number concentration (1/m³) [nlev]
         dt: Time step (s)
         config: Cloud configuration
 
@@ -367,70 +360,30 @@ def shallow_cloud_scheme(
         cloud_fraction, pressure, dt, config
     )
     
-    # --- Within-timestep condensation → autoconversion → precipitation ---
-    # Following ECHAM mo_cloud.f90: condensation updates in-cloud water
-    # (zxlb += zcnd), then autoconversion acts on the updated values.
-    # Use the condensation computed by condensation_evaporation above,
-    # applied within this timestep to get the updated cloud water.
+    # Within-timestep condensation: update cloud water/ice with condensation
+    # so that microphysics (called next) sees non-zero values.
+    # Following ECHAM mo_cloud.f90 where zxlb += zcnd within the same call.
     updated_cloud_water = jnp.maximum(cloud_water + dqcdt * dt, 0.0)
     updated_cloud_ice = jnp.maximum(cloud_ice + dqidt * dt, 0.0)
-
-    # Air density from ideal gas law (needed for Beheng autoconversion)
-    from ..constants.physical_constants import rd
-    rho = pressure / (rd * temperature)
-
-    # Warm-phase autoconversion: Beheng (1994), following ECHAM mo_cloud.f90 lines 834-862
-    # ECHAM operates on IN-CLOUD water (zxlb = grid-mean / cloud_fraction).
-    # Analytic solution to dqc/dt = -gamma * qc^(1 + exm1)
-    # gamma = ccraut * 1.2e27 / rho * cdnc^(-3.3) * (rho * 1e-3)^4.7
-    exm1 = 3.7  # 4.7 - 1.0
-    zexp = -1.0 / exm1
-    # ECHAM converts cdnc from 1/m³ to 1/cm³ (pacdnc*1e-6) for the Beheng formula
-    cdnc_cgs = jnp.maximum(cdnc, 1.0) * 1e-6  # 1/m³ → 1/cm³, floor to avoid zero
-    gamma = (config.ccraut * 1.2e27) / rho * cdnc_cgs**(-3.3) * (rho * 1e-3)**4.7
-
-    # Convert to in-cloud values (ECHAM: zxlb = grid-mean * zclcauxi)
-    cf_safe = jnp.maximum(cloud_fraction, config.epsilon)
-    qc_incloud = jnp.maximum(updated_cloud_water / cf_safe, 0.0)
-    qi_incloud = jnp.maximum(updated_cloud_ice / cf_safe, 0.0)
-
-    denom = 1.0 + gamma * dt * exm1 * qc_incloud**exm1
-    rain_auto_incloud = qc_incloud * (1.0 - denom**zexp)
-    rain_auto_incloud = jnp.maximum(rain_auto_incloud, 0.0)
-    # Convert back to grid-mean (ECHAM: zrpr = zclcaux * zraut)
-    rain_auto = cloud_fraction * rain_auto_incloud
-
-    # Ice autoconversion: Levkov et al. (1992), following ECHAM mo_cloud.f90 lines 912-913
-    snow_auto_incloud = qi_incloud * (1.0 - 1.0 / (1.0 + config.ccsaut * dt * qi_incloud))
-    snow_auto_incloud = jnp.maximum(snow_auto_incloud, 0.0)
-    snow_auto = cloud_fraction * snow_auto_incloud
-
-    # Update cloud water/ice tendencies to include precipitation loss
-    dqcdt = dqcdt - rain_auto / dt
-    dqidt = dqidt - snow_auto / dt
-
-    # Column-integrated precipitation flux using dp/g (kg/m²/s)
-    dp = jnp.abs(jnp.diff(pressure, prepend=0.0))
-    rain_flux = jnp.sum(rain_auto * dp / dt) / grav
-    snow_flux = jnp.sum(snow_auto * dp / dt) / grav
 
     # Total cloud cover (maximum overlap assumption)
     total_cloud_cover = jnp.max(cloud_fraction)
     
     # Create output structures
+    # Precipitation is handled by microphysics (called next), not here
     tendencies = CloudTendencies(
         dtedt=dtedt,
         dqdt=dqdt,
         dqcdt=dqcdt,
         dqidt=dqidt,
-        rain_flux=jnp.array(rain_flux),
-        snow_flux=jnp.array(snow_flux)
+        rain_flux=jnp.array(0.0),
+        snow_flux=jnp.array(0.0)
     )
-    
+
     state = CloudState(
         cloud_fraction=cloud_fraction,
-        cloud_water=cloud_water,
-        cloud_ice=cloud_ice,
+        cloud_water=updated_cloud_water,
+        cloud_ice=updated_cloud_ice,
         rel_humidity=rel_humidity,
         total_cloud_cover=jnp.array(total_cloud_cover)
     )

--- a/jcm/physics/icon/clouds/shallow_clouds.py
+++ b/jcm/physics/icon/clouds/shallow_clouds.py
@@ -74,16 +74,15 @@ class CloudState(NamedTuple):
     
     
 class CloudTendencies(NamedTuple):
-    """Tendencies from cloud processes"""
-    
+    """Tendencies from cloud condensation processes.
+
+    Precipitation is handled by cloud_microphysics, not here.
+    """
+
     dtedt: jnp.ndarray         # Temperature tendency (K/s)
     dqdt: jnp.ndarray          # Specific humidity tendency (kg/kg/s)
     dqcdt: jnp.ndarray         # Cloud water tendency (kg/kg/s)
     dqidt: jnp.ndarray         # Cloud ice tendency (kg/kg/s)
-    
-    # Surface precipitation fluxes
-    rain_flux: jnp.ndarray     # Surface rain flux (kg/m²/s)
-    snow_flux: jnp.ndarray     # Surface snow flux (kg/m²/s)
 
 
 def saturation_vapor_pressure_water(temperature: jnp.ndarray) -> jnp.ndarray:
@@ -370,14 +369,11 @@ def shallow_cloud_scheme(
     total_cloud_cover = jnp.max(cloud_fraction)
     
     # Create output structures
-    # Precipitation is handled by microphysics (called next), not here
     tendencies = CloudTendencies(
         dtedt=dtedt,
         dqdt=dqdt,
         dqcdt=dqcdt,
         dqidt=dqidt,
-        rain_flux=jnp.array(0.0),
-        snow_flux=jnp.array(0.0)
     )
 
     state = CloudState(

--- a/jcm/physics/icon/clouds/shallow_clouds_test.py
+++ b/jcm/physics/icon/clouds/shallow_clouds_test.py
@@ -265,8 +265,7 @@ class TestShallowCloudScheme:
         
         tendencies, state = shallow_cloud_scheme(
             temperature, specific_humidity, pressure,
-            cloud_water, cloud_ice, surface_pressure,
-            jnp.full_like(temperature, 200e6), dt, config
+            cloud_water, cloud_ice, surface_pressure, dt, config
         )
         
         # Should have minimal tendencies  
@@ -301,8 +300,7 @@ class TestShallowCloudScheme:
         
         tendencies, state = shallow_cloud_scheme(
             temperature, specific_humidity, pressure,
-            cloud_water, cloud_ice, surface_pressure,
-            jnp.full_like(temperature, 200e6), dt, config
+            cloud_water, cloud_ice, surface_pressure, dt, config
         )
         
         # Should have clouds in humid layers
@@ -313,29 +311,35 @@ class TestShallowCloudScheme:
         assert jnp.all(jnp.abs(tendencies.dtedt) < 1e-3)  # < ~100 K/day
         assert jnp.all(jnp.abs(tendencies.dqdt) < 1e-5)   # < ~1 g/kg/day
     
-    def test_precipitation_formation(self):
-        """Test precipitation formation from thick clouds"""
+    def test_condensation_updates_cloud_water(self):
+        """Test that condensation updates cloud water within the call.
+
+        Precipitation is now handled by microphysics (called after clouds),
+        but the cloud scheme must produce updated cloud_water for microphysics.
+        """
         config = CloudParameters.default()
-        
-        # Create profile with thick clouds
+
+        # Supersaturated single-level profile
         temperature = jnp.array(280.0)
         pressure = jnp.array(90000.0)
-        specific_humidity = jnp.array(0.008)
-        cloud_water = jnp.array(0.002)  # 2 g/kg - above autoconversion threshold
-        cloud_ice = jnp.array(0.0001)   # Small amount of ice
+        qs = saturation_specific_humidity(pressure, temperature)
+        specific_humidity = jnp.array(float(1.05 * qs))  # 105% RH
+        cloud_water = jnp.array(0.0)
+        cloud_ice = jnp.array(0.0)
         surface_pressure = 100000.0
         dt = 1800.0
-        
+
         tendencies, state = shallow_cloud_scheme(
             temperature, specific_humidity, pressure,
-            cloud_water, cloud_ice, surface_pressure,
-            jnp.full_like(temperature, 200e6), dt, config
+            cloud_water, cloud_ice, surface_pressure, dt, config
         )
-        
-        # Should produce precipitation
-        assert tendencies.rain_flux > 0.0
-        # Check net tendency - condensation may offset precipitation
-        assert tendencies.dqcdt[0] < 1e-6  # Should be small or negative
+
+        # Cloud water should be updated with condensation
+        assert state.cloud_water[0] > 0.0, \
+            "Cloud water should increase from condensation"
+        # Rain/snow flux are zero — microphysics handles precipitation
+        assert tendencies.rain_flux == 0.0
+        assert tendencies.snow_flux == 0.0
     
     def test_jax_transformations(self):
         """Test JAX transformations work correctly"""
@@ -354,8 +358,7 @@ class TestShallowCloudScheme:
         jitted_scheme = jax.jit(shallow_cloud_scheme)
         
         t, q, p, qc, qi = create_profile()
-        cdnc = jnp.full(10, 200e6)
-        tendencies, state = jitted_scheme(t, q, p, qc, qi, 100000.0, cdnc, 1800.0, config)
+        tendencies, state = jitted_scheme(t, q, p, qc, qi, 100000.0, 1800.0, config)
 
         # Should produce valid output
         assert tendencies.dtedt.shape == t.shape
@@ -364,7 +367,7 @@ class TestShallowCloudScheme:
         # Test gradient computation
         def loss_fn(temperature):
             t, q, p, qc, qi = create_profile()
-            tend, _ = shallow_cloud_scheme(temperature, q, p, qc, qi, 100000.0, cdnc, 1800.0, config)
+            tend, _ = shallow_cloud_scheme(temperature, q, p, qc, qi, 100000.0, 1800.0, config)
             return jnp.sum(tend.dtedt ** 2)
         
         grad_fn = jax.grad(loss_fn)
@@ -375,90 +378,83 @@ class TestShallowCloudScheme:
         assert jnp.all(jnp.isfinite(grad))
 
 
-class TestDiagnosticPrecipitation:
-    """Tests for diagnostic precipitation from supersaturation.
+class TestCondensationToCloudWater:
+    """Tests for within-timestep condensation updating cloud water.
 
-    These tests verify that the cloud scheme produces precipitation
-    when the atmosphere is supersaturated, even when initial cloud
-    water is zero — replicating the ECHAM mo_cloud.f90 within-timestep
-    condensation → autoconversion coupling.
+    The cloud scheme must produce non-zero cloud water from supersaturation
+    even when initial qc/qi are zero, so that microphysics (called next)
+    can convert it to precipitation.
     """
 
-    def test_supersaturated_column_produces_rain(self):
-        """A warm supersaturated column must produce non-zero rain.
+    def test_supersaturated_column_produces_cloud_water(self):
+        """A supersaturated column must produce non-zero cloud water.
 
         This is the key regression test: with cloud_water=0 but RH > 100%,
-        the scheme must condense moisture AND convert it to precipitation
-        within the same call.
+        the scheme must condense moisture into cloud water within the call.
         """
         config = CloudParameters.default()
         nlev = 20
         pressure = jnp.linspace(100000, 20000, nlev)
         temperature = jnp.linspace(290, 220, nlev)
 
-        # Supersaturated in the lower troposphere
         qs = jax.vmap(saturation_specific_humidity)(pressure, temperature)
         specific_humidity = jnp.where(pressure > 60000, 1.05 * qs, 0.3 * qs)
 
-        # Zero initial cloud water — precipitation must come from condensation
         cloud_water = jnp.zeros(nlev)
         cloud_ice = jnp.zeros(nlev)
 
         tendencies, state = shallow_cloud_scheme(
             temperature, specific_humidity, pressure,
-            cloud_water, cloud_ice, 100000.0,
-            jnp.full(nlev, 200e6), 1800.0, config
+            cloud_water, cloud_ice, 100000.0, 1800.0, config
         )
 
-        assert tendencies.rain_flux > 0.0, \
-            f"Rain flux should be > 0 for supersaturated column, got {float(tendencies.rain_flux):.6e}"
+        # Cloud water should be updated with condensation
+        assert jnp.max(state.cloud_water) > 0.0, \
+            f"Cloud water should be > 0 for supersaturated column, got {float(jnp.max(state.cloud_water)):.6e}"
 
-    def test_subsaturated_column_no_precipitation(self):
-        """A dry subsaturated column must produce zero precipitation."""
+    def test_subsaturated_column_no_cloud_water(self):
+        """A dry subsaturated column with no initial cloud water stays dry."""
         config = CloudParameters.default()
         nlev = 20
         pressure = jnp.linspace(100000, 20000, nlev)
         temperature = jnp.linspace(290, 220, nlev)
 
         qs = jax.vmap(saturation_specific_humidity)(pressure, temperature)
-        specific_humidity = 0.3 * qs  # 30% RH — well below saturation
+        specific_humidity = 0.3 * qs
 
         cloud_water = jnp.zeros(nlev)
         cloud_ice = jnp.zeros(nlev)
 
         tendencies, state = shallow_cloud_scheme(
             temperature, specific_humidity, pressure,
-            cloud_water, cloud_ice, 100000.0,
-            jnp.full(nlev, 200e6), 1800.0, config
+            cloud_water, cloud_ice, 100000.0, 1800.0, config
         )
 
-        assert tendencies.rain_flux == 0.0, \
-            f"Rain flux should be 0 for dry column, got {float(tendencies.rain_flux):.6e}"
-        assert tendencies.snow_flux == 0.0, \
-            f"Snow flux should be 0 for dry column, got {float(tendencies.snow_flux):.6e}"
+        assert jnp.allclose(state.cloud_water, 0.0), \
+            "Cloud water should remain 0 for dry column"
+        assert jnp.allclose(state.cloud_ice, 0.0), \
+            "Cloud ice should remain 0 for dry column"
 
-    def test_cold_supersaturated_column_produces_snow(self):
-        """A cold supersaturated column should produce snow, not rain."""
+    def test_cold_supersaturated_column_produces_cloud_ice(self):
+        """A cold supersaturated column should produce cloud ice."""
         config = CloudParameters.default()
         nlev = 10
-        # Cold column — all below freezing
         pressure = jnp.linspace(50000, 20000, nlev)
-        temperature = jnp.full(nlev, 240.0)  # Well below freezing
+        temperature = jnp.full(nlev, 240.0)  # Below freezing
 
         qs = jax.vmap(saturation_specific_humidity)(pressure, temperature)
-        specific_humidity = 1.1 * qs  # Supersaturated
+        specific_humidity = 1.1 * qs
 
         cloud_water = jnp.zeros(nlev)
         cloud_ice = jnp.zeros(nlev)
 
         tendencies, state = shallow_cloud_scheme(
             temperature, specific_humidity, pressure,
-            cloud_water, cloud_ice, 50000.0,
-            jnp.full(nlev, 200e6), 1800.0, config
+            cloud_water, cloud_ice, 50000.0, 1800.0, config
         )
 
-        assert tendencies.snow_flux > 0.0, \
-            f"Snow flux should be > 0 for cold supersaturated column, got {float(tendencies.snow_flux):.6e}"
+        assert jnp.max(state.cloud_ice) > 0.0, \
+            f"Cloud ice should be > 0 for cold supersaturated column, got {float(jnp.max(state.cloud_ice)):.6e}"
 
 
 if __name__ == "__main__":

--- a/jcm/physics/icon/clouds/shallow_clouds_test.py
+++ b/jcm/physics/icon/clouds/shallow_clouds_test.py
@@ -274,8 +274,6 @@ class TestShallowCloudScheme:
         assert jnp.max(jnp.abs(tendencies.dtedt)) < 2e-3  # < ~200 K/day max
         assert jnp.all(jnp.abs(tendencies.dqdt) < 1e-6)   # < ~0.1 g/kg/day
         assert jnp.all(state.cloud_fraction < 0.1)
-        assert tendencies.rain_flux < 1e-6
-        assert tendencies.snow_flux < 1e-6
     
     def test_cloudy_conditions(self):
         """Test scheme with existing clouds"""
@@ -337,9 +335,6 @@ class TestShallowCloudScheme:
         # Cloud water should be updated with condensation
         assert state.cloud_water[0] > 0.0, \
             "Cloud water should increase from condensation"
-        # Rain/snow flux are zero — microphysics handles precipitation
-        assert tendencies.rain_flux == 0.0
-        assert tendencies.snow_flux == 0.0
     
     def test_jax_transformations(self):
         """Test JAX transformations work correctly"""

--- a/jcm/physics/icon/clouds/shallow_clouds_test.py
+++ b/jcm/physics/icon/clouds/shallow_clouds_test.py
@@ -452,6 +452,65 @@ class TestCondensationToCloudWater:
             f"Cloud ice should be > 0 for cold supersaturated column, got {float(jnp.max(state.cloud_ice)):.6e}"
 
 
+class TestAerosolPrecipitationCoupling:
+    """Test that aerosol CDNC affects precipitation through autoconversion."""
+
+    def _run_column(self, cdnc_value):
+        """Run the combined cloud+microphysics column with given CDNC."""
+        from ..clouds.cloud_microphysics import MicrophysicsParameters
+        from ..icon_physics import _cloud_and_microphysics_column
+        from ..constants.physical_constants import rd
+
+        nlev = 20
+        pressure = jnp.linspace(100000, 20000, nlev)
+        temperature = jnp.linspace(290, 220, nlev)
+
+        # Supersaturated in lower troposphere to generate cloud water
+        qs = jax.vmap(saturation_specific_humidity)(pressure, temperature)
+        specific_humidity = jnp.where(pressure > 60000, 1.05 * qs, 0.3 * qs)
+
+        qc = jnp.zeros(nlev)
+        qi = jnp.zeros(nlev)
+        rho = pressure / (rd * temperature)
+        dz = jnp.full(nlev, 500.0)
+        # CDNC in 1/kg as expected by microphysics
+        droplet_number = jnp.full(nlev, cdnc_value) / rho
+
+        cloud_config = CloudParameters.default()
+        micro_config = MicrophysicsParameters.default()
+
+        cloud_tend, cloud_state, micro_tend, micro_state = _cloud_and_microphysics_column(
+            temperature, specific_humidity, pressure, qc, qi,
+            100000.0, rho, dz, droplet_number,
+            1800.0, cloud_config, micro_config
+        )
+
+        return micro_state.precip_rain, micro_state.precip_snow
+
+    def test_higher_cdnc_reduces_precipitation(self):
+        """Higher CDNC should suppress autoconversion and reduce precipitation.
+
+        This is the Twomey/Albrecht second indirect effect: more droplets
+        means smaller droplets, slower coalescence, less rain.
+        """
+        precip_clean, _ = self._run_column(cdnc_value=50e6)    # 50 per cm³
+        precip_polluted, _ = self._run_column(cdnc_value=500e6)  # 500 per cm³
+
+        assert precip_clean > 0.0, \
+            f"Clean-air precipitation should be > 0, got {float(precip_clean):.6e}"
+        assert precip_polluted >= 0.0, \
+            f"Polluted precipitation should be >= 0, got {float(precip_polluted):.6e}"
+        assert precip_clean > precip_polluted, \
+            f"Higher CDNC should reduce precipitation: clean={float(precip_clean):.6e} vs polluted={float(precip_polluted):.6e}"
+
+    def test_zero_cdnc_still_produces_precipitation(self):
+        """Even with very low CDNC, precipitation should be finite (not NaN)."""
+        precip, snow = self._run_column(cdnc_value=10e6)  # Very clean air
+
+        assert jnp.isfinite(precip), f"Precipitation should be finite, got {float(precip)}"
+        assert jnp.isfinite(snow), f"Snow should be finite, got {float(snow)}"
+
+
 if __name__ == "__main__":
     # Run basic tests
     test_sat = TestSaturationFunctions()

--- a/jcm/physics/icon/clouds/shallow_clouds_test.py
+++ b/jcm/physics/icon/clouds/shallow_clouds_test.py
@@ -265,7 +265,8 @@ class TestShallowCloudScheme:
         
         tendencies, state = shallow_cloud_scheme(
             temperature, specific_humidity, pressure,
-            cloud_water, cloud_ice, surface_pressure, dt, config
+            cloud_water, cloud_ice, surface_pressure,
+            jnp.full_like(temperature, 200e6), dt, config
         )
         
         # Should have minimal tendencies  
@@ -300,7 +301,8 @@ class TestShallowCloudScheme:
         
         tendencies, state = shallow_cloud_scheme(
             temperature, specific_humidity, pressure,
-            cloud_water, cloud_ice, surface_pressure, dt, config
+            cloud_water, cloud_ice, surface_pressure,
+            jnp.full_like(temperature, 200e6), dt, config
         )
         
         # Should have clouds in humid layers
@@ -326,7 +328,8 @@ class TestShallowCloudScheme:
         
         tendencies, state = shallow_cloud_scheme(
             temperature, specific_humidity, pressure,
-            cloud_water, cloud_ice, surface_pressure, dt, config
+            cloud_water, cloud_ice, surface_pressure,
+            jnp.full_like(temperature, 200e6), dt, config
         )
         
         # Should produce precipitation
@@ -351,16 +354,17 @@ class TestShallowCloudScheme:
         jitted_scheme = jax.jit(shallow_cloud_scheme)
         
         t, q, p, qc, qi = create_profile()
-        tendencies, state = jitted_scheme(t, q, p, qc, qi, 100000.0, 1800.0, config)
-        
+        cdnc = jnp.full(10, 200e6)
+        tendencies, state = jitted_scheme(t, q, p, qc, qi, 100000.0, cdnc, 1800.0, config)
+
         # Should produce valid output
         assert tendencies.dtedt.shape == t.shape
         assert state.cloud_fraction.shape == t.shape
-        
+
         # Test gradient computation
         def loss_fn(temperature):
             t, q, p, qc, qi = create_profile()
-            tend, _ = shallow_cloud_scheme(temperature, q, p, qc, qi, 100000.0, 1800.0, config)
+            tend, _ = shallow_cloud_scheme(temperature, q, p, qc, qi, 100000.0, cdnc, 1800.0, config)
             return jnp.sum(tend.dtedt ** 2)
         
         grad_fn = jax.grad(loss_fn)
@@ -402,7 +406,8 @@ class TestDiagnosticPrecipitation:
 
         tendencies, state = shallow_cloud_scheme(
             temperature, specific_humidity, pressure,
-            cloud_water, cloud_ice, 100000.0, 1800.0, config
+            cloud_water, cloud_ice, 100000.0,
+            jnp.full(nlev, 200e6), 1800.0, config
         )
 
         assert tendencies.rain_flux > 0.0, \
@@ -423,7 +428,8 @@ class TestDiagnosticPrecipitation:
 
         tendencies, state = shallow_cloud_scheme(
             temperature, specific_humidity, pressure,
-            cloud_water, cloud_ice, 100000.0, 1800.0, config
+            cloud_water, cloud_ice, 100000.0,
+            jnp.full(nlev, 200e6), 1800.0, config
         )
 
         assert tendencies.rain_flux == 0.0, \
@@ -447,7 +453,8 @@ class TestDiagnosticPrecipitation:
 
         tendencies, state = shallow_cloud_scheme(
             temperature, specific_humidity, pressure,
-            cloud_water, cloud_ice, 50000.0, 1800.0, config
+            cloud_water, cloud_ice, 50000.0,
+            jnp.full(nlev, 200e6), 1800.0, config
         )
 
         assert tendencies.snow_flux > 0.0, \

--- a/jcm/physics/icon/clouds/shallow_clouds_test.py
+++ b/jcm/physics/icon/clouds/shallow_clouds_test.py
@@ -371,6 +371,89 @@ class TestShallowCloudScheme:
         assert jnp.all(jnp.isfinite(grad))
 
 
+class TestDiagnosticPrecipitation:
+    """Tests for diagnostic precipitation from supersaturation.
+
+    These tests verify that the cloud scheme produces precipitation
+    when the atmosphere is supersaturated, even when initial cloud
+    water is zero — replicating the ECHAM mo_cloud.f90 within-timestep
+    condensation → autoconversion coupling.
+    """
+
+    def test_supersaturated_column_produces_rain(self):
+        """A warm supersaturated column must produce non-zero rain.
+
+        This is the key regression test: with cloud_water=0 but RH > 100%,
+        the scheme must condense moisture AND convert it to precipitation
+        within the same call.
+        """
+        config = CloudParameters.default()
+        nlev = 20
+        pressure = jnp.linspace(100000, 20000, nlev)
+        temperature = jnp.linspace(290, 220, nlev)
+
+        # Supersaturated in the lower troposphere
+        qs = jax.vmap(saturation_specific_humidity)(pressure, temperature)
+        specific_humidity = jnp.where(pressure > 60000, 1.05 * qs, 0.3 * qs)
+
+        # Zero initial cloud water — precipitation must come from condensation
+        cloud_water = jnp.zeros(nlev)
+        cloud_ice = jnp.zeros(nlev)
+
+        tendencies, state = shallow_cloud_scheme(
+            temperature, specific_humidity, pressure,
+            cloud_water, cloud_ice, 100000.0, 1800.0, config
+        )
+
+        assert tendencies.rain_flux > 0.0, \
+            f"Rain flux should be > 0 for supersaturated column, got {float(tendencies.rain_flux):.6e}"
+
+    def test_subsaturated_column_no_precipitation(self):
+        """A dry subsaturated column must produce zero precipitation."""
+        config = CloudParameters.default()
+        nlev = 20
+        pressure = jnp.linspace(100000, 20000, nlev)
+        temperature = jnp.linspace(290, 220, nlev)
+
+        qs = jax.vmap(saturation_specific_humidity)(pressure, temperature)
+        specific_humidity = 0.3 * qs  # 30% RH — well below saturation
+
+        cloud_water = jnp.zeros(nlev)
+        cloud_ice = jnp.zeros(nlev)
+
+        tendencies, state = shallow_cloud_scheme(
+            temperature, specific_humidity, pressure,
+            cloud_water, cloud_ice, 100000.0, 1800.0, config
+        )
+
+        assert tendencies.rain_flux == 0.0, \
+            f"Rain flux should be 0 for dry column, got {float(tendencies.rain_flux):.6e}"
+        assert tendencies.snow_flux == 0.0, \
+            f"Snow flux should be 0 for dry column, got {float(tendencies.snow_flux):.6e}"
+
+    def test_cold_supersaturated_column_produces_snow(self):
+        """A cold supersaturated column should produce snow, not rain."""
+        config = CloudParameters.default()
+        nlev = 10
+        # Cold column — all below freezing
+        pressure = jnp.linspace(50000, 20000, nlev)
+        temperature = jnp.full(nlev, 240.0)  # Well below freezing
+
+        qs = jax.vmap(saturation_specific_humidity)(pressure, temperature)
+        specific_humidity = 1.1 * qs  # Supersaturated
+
+        cloud_water = jnp.zeros(nlev)
+        cloud_ice = jnp.zeros(nlev)
+
+        tendencies, state = shallow_cloud_scheme(
+            temperature, specific_humidity, pressure,
+            cloud_water, cloud_ice, 50000.0, 1800.0, config
+        )
+
+        assert tendencies.snow_flux > 0.0, \
+            f"Snow flux should be > 0 for cold supersaturated column, got {float(tendencies.snow_flux):.6e}"
+
+
 if __name__ == "__main__":
     # Run basic tests
     test_sat = TestSaturationFunctions()

--- a/jcm/physics/icon/icon_physics.py
+++ b/jcm/physics/icon/icon_physics.py
@@ -82,9 +82,8 @@ class IconPhysics(Physics):
             get_simple_aerosol,            # Aerosol before radiation
             apply_chemistry,               # Chemistry for ozone, methane etc.
             apply_radiation,               
-            apply_convection,              
-            apply_clouds,
-            apply_microphysics,
+            apply_convection,
+            apply_clouds_and_microphysics,
             apply_vertical_diffusion,      
             apply_surface,                 # Surface after radiation and vertical diffusion
             apply_gravity_waves
@@ -779,124 +778,102 @@ def apply_convection(
     
     return physics_tendencies, updated_physics_data
 
+def _cloud_and_microphysics_column(
+    temperature, specific_humidity, pressure, qc, qi,
+    surface_pressure, air_density, layer_thickness, droplet_number,
+    dt, cloud_config, micro_config
+):
+    """Compute cloud and microphysics for a single column.
+
+    Following ECHAM mo_cloud.f90: condensation, cloud fraction, autoconversion,
+    accretion, and precipitation are all computed in a single column sweep.
+    This avoids the coupling issues of splitting them into separate calls.
+    """
+    # 1. Cloud fraction and condensation
+    cloud_tendencies, cloud_state = shallow_cloud_scheme(
+        temperature, specific_humidity, pressure,
+        qc, qi, surface_pressure, dt, cloud_config
+    )
+
+    # 2. Microphysics acts on the condensation-updated cloud water/ice
+    micro_tendencies, micro_state = cloud_microphysics(
+        temperature, specific_humidity, pressure,
+        cloud_state.cloud_water, cloud_state.cloud_ice,
+        cloud_state.cloud_fraction, air_density, layer_thickness,
+        droplet_number, dt, micro_config
+    )
+
+    return cloud_tendencies, cloud_state, micro_tendencies, micro_state
+
+
 @jit
-def apply_clouds(
+def apply_clouds_and_microphysics(
     state: PhysicsState,
     physics_data: PhysicsData,
     parameters: Parameters,
     forcing: ForcingData,
     terrain: TerrainData
 ) -> tuple[PhysicsTendency, PhysicsData]:
-    """Apply shallow cloud scheme"""
+    """Apply cloud scheme and microphysics in a single coupled step.
+
+    Combines condensation → cloud fraction → autoconversion → precipitation
+    in one vmapped column call, following ECHAM mo_cloud.f90.
+    """
     dt = parameters.convection.dt_conv
     pressure_levels = physics_data.diagnostics.pressure_full
     surface_pressure = physics_data.diagnostics.surface_pressure
+    air_density = physics_data.diagnostics.air_density
+    dz = physics_data.diagnostics.layer_thickness
     qc = state.tracers.get('qc', jnp.zeros_like(state.temperature))
     qi = state.tracers.get('qi', jnp.zeros_like(state.temperature))
 
-    # Get cloud configuration from parameters
-    cloud_config = parameters.clouds
-
-    cloud_results = jax.vmap(
-        shallow_cloud_scheme,
-        in_axes=(1, 1, 1, 1, 1, 0, None, None),  # dt and config are scalars
-        out_axes=(0, 0)  # Returns (CloudTendencies, CloudState) per column
-    )(state.temperature, state.specific_humidity, pressure_levels,
-        qc, qi, surface_pressure, dt, cloud_config)
-    
-    # Unpack structured results directly
-    cloud_tendencies_all, cloud_states_all = cloud_results
-
-    physics_tendencies = PhysicsTendency(
-        u_wind=jnp.zeros_like(state.u_wind),  # No wind tendencies from clouds
-        v_wind=jnp.zeros_like(state.v_wind),
-        temperature=cloud_tendencies_all.dtedt.T,
-        specific_humidity=cloud_tendencies_all.dqdt.T,
-        tracers={
-            'qc': cloud_tendencies_all.dqcdt.T,
-            'qi': cloud_tendencies_all.dqidt.T
-        }
-    )
-    
-    # Update physics data with cloud diagnostics and condensation-updated cloud water/ice
-    # Microphysics (called next) reads qc/qi from physics_data.clouds
-    cloud_data = physics_data.clouds.copy(
-        cloud_fraction=cloud_states_all.cloud_fraction.T,
-        qc=cloud_states_all.cloud_water.T,
-        qi=cloud_states_all.cloud_ice.T,
-        precip_rain=cloud_tendencies_all.rain_flux,  # Zero — microphysics handles precip
-        precip_snow=cloud_tendencies_all.snow_flux   # Zero — microphysics handles precip
-    )
-    
-    diagnostics = physics_data.diagnostics.copy(
-        relative_humidity=cloud_states_all.rel_humidity.T,
-    )
-
-    updated_physics_data = physics_data.copy(clouds=cloud_data, 
-                                             diagnostics=diagnostics)
-    
-    return physics_tendencies, updated_physics_data
-
-@jit
-def apply_microphysics(
-    state: PhysicsState,
-    physics_data: PhysicsData,
-    parameters: Parameters,
-    forcing: ForcingData,
-    terrain: TerrainData
-) -> tuple[PhysicsTendency, PhysicsData]:
-    """Apply cloud microphysics scheme"""
-    dt = parameters.convection.dt_conv
-    pressure_levels = physics_data.diagnostics.pressure_full
-    cloud_fraction = physics_data.clouds.cloud_fraction
-    air_density = physics_data.diagnostics.air_density
-    dz = physics_data.diagnostics.layer_thickness
-
-    # Read cloud water and ice from cloud scheme (includes within-timestep condensation)
-    qc = physics_data.clouds.qc
-    qi = physics_data.clouds.qi
-    
-    # Droplet number concentration from aerosol scheme
-    # cdnc_factor is (ncols,) — broadcast to (nlev, ncols) for microphysics
-    # cloud_microphysics expects droplet_number in 1/kg (not 1/m³)
-    base_cdnc = 100e6  # Clean-air baseline CDNC (100 per cm³ = 1e8 per m³)
+    # Droplet number concentration from aerosol scheme (1/kg for microphysics)
+    base_cdnc = 100e6  # Clean-air baseline CDNC (100 per cm³)
     cdnc_factor = physics_data.aerosol.cdnc_factor  # (ncols,)
     cdnc_m3 = jnp.ones_like(state.temperature) * base_cdnc * cdnc_factor[jnp.newaxis, :]
     droplet_number = cdnc_m3 / air_density  # 1/m³ → 1/kg
-    
-    # Get microphysics configuration
+
+    cloud_config = parameters.clouds
     micro_config = parameters.microphysics
-    
-    micro_results = jax.vmap(
-        cloud_microphysics,
-        in_axes=(1, 1, 1, 1, 1, 1, 1, 1, 1, None, None),  # dt and config are scalars
-        out_axes=(0, 0)  # Returns (MicrophysicsTendencies, MicrophysicsState) per column
+
+    # Single vmap over columns: cloud + microphysics together
+    cloud_tend_all, cloud_state_all, micro_tend_all, micro_state_all = jax.vmap(
+        _cloud_and_microphysics_column,
+        in_axes=(1, 1, 1, 1, 1, 0, 1, 1, 1, None, None, None),
+        out_axes=(0, 0, 0, 0)
     )(state.temperature, state.specific_humidity, pressure_levels,
-        qc, qi, cloud_fraction, air_density, dz, droplet_number, dt, micro_config)
-    
-    # Unpack structured results directly
-    micro_tendencies_all, micro_states_all = micro_results
-    
+      qc, qi, surface_pressure, air_density, dz, droplet_number,
+      dt, cloud_config, micro_config)
+
+    # Combine tendencies: condensation (cloud) + microphysics
     physics_tendencies = PhysicsTendency(
         u_wind=jnp.zeros_like(state.u_wind),
         v_wind=jnp.zeros_like(state.v_wind),
-        temperature=micro_tendencies_all.dtedt.T,
-        specific_humidity=micro_tendencies_all.dqdt.T,
+        temperature=cloud_tend_all.dtedt.T + micro_tend_all.dtedt.T,
+        specific_humidity=cloud_tend_all.dqdt.T + micro_tend_all.dqdt.T,
         tracers={
-            'qc': micro_tendencies_all.dqcdt.T,
-            'qi': micro_tendencies_all.dqidt.T
+            'qc': cloud_tend_all.dqcdt.T + micro_tend_all.dqcdt.T,
+            'qi': cloud_tend_all.dqidt.T + micro_tend_all.dqidt.T
         }
     )
-    
-    # Update physics data with microphysics precipitation
-    micro_data = physics_data.clouds.copy(
-        precip_rain=micro_states_all.precip_rain,
-        precip_snow=micro_states_all.precip_snow,
+
+    # Update physics data with cloud and microphysics diagnostics
+    cloud_data = physics_data.clouds.copy(
+        cloud_fraction=cloud_state_all.cloud_fraction.T,
+        qc=cloud_state_all.cloud_water.T,
+        qi=cloud_state_all.cloud_ice.T,
+        precip_rain=micro_state_all.precip_rain,
+        precip_snow=micro_state_all.precip_snow,
         droplet_number=droplet_number
     )
-    
-    updated_physics_data = physics_data.copy(clouds=micro_data)
-    
+
+    diagnostics = physics_data.diagnostics.copy(
+        relative_humidity=cloud_state_all.rel_humidity.T,
+    )
+
+    updated_physics_data = physics_data.copy(clouds=cloud_data,
+                                             diagnostics=diagnostics)
+
     return physics_tendencies, updated_physics_data
 
 @jit

--- a/jcm/physics/icon/icon_physics.py
+++ b/jcm/physics/icon/icon_physics.py
@@ -888,10 +888,11 @@ def apply_microphysics(
         }
     )
     
-    # Update physics data
+    # Update physics data — add microphysics precipitation to existing
+    # (cloud scheme already set precip_rain/snow from autoconversion)
     micro_data = physics_data.clouds.copy(
-        precip_rain=micro_states_all.precip_rain,  # 1D per column
-        precip_snow=micro_states_all.precip_snow,  # 1D per column
+        precip_rain=physics_data.clouds.precip_rain + micro_states_all.precip_rain,
+        precip_snow=physics_data.clouds.precip_snow + micro_states_all.precip_snow,
         droplet_number=droplet_number
     )
     

--- a/jcm/physics/icon/icon_physics.py
+++ b/jcm/physics/icon/icon_physics.py
@@ -827,11 +827,11 @@ def apply_clouds_and_microphysics(
     qc = state.tracers.get('qc', jnp.zeros_like(state.temperature))
     qi = state.tracers.get('qi', jnp.zeros_like(state.temperature))
 
-    # Droplet number concentration from aerosol scheme (1/kg for microphysics)
-    base_cdnc = 100e6  # Clean-air baseline CDNC (100 per cm³)
+    # Droplet number concentration from aerosol scheme
+    base_cdnc = parameters.microphysics.base_cdnc  # Clean-air baseline CDNC (1/m³)
     cdnc_factor = physics_data.aerosol.cdnc_factor  # (ncols,)
     cdnc_m3 = jnp.ones_like(state.temperature) * base_cdnc * cdnc_factor[jnp.newaxis, :]
-    droplet_number = cdnc_m3 / air_density  # 1/m³ → 1/kg
+    droplet_number_per_kg = cdnc_m3 / air_density  # 1/m³ → 1/kg (for microphysics)
 
     cloud_config = parameters.clouds
     micro_config = parameters.microphysics
@@ -842,7 +842,7 @@ def apply_clouds_and_microphysics(
         in_axes=(1, 1, 1, 1, 1, 0, 1, 1, 1, None, None, None),
         out_axes=(0, 0, 0, 0)
     )(state.temperature, state.specific_humidity, pressure_levels,
-      qc, qi, surface_pressure, air_density, dz, droplet_number,
+      qc, qi, surface_pressure, air_density, dz, droplet_number_per_kg,
       dt, cloud_config, micro_config)
 
     # Combine tendencies: condensation (cloud) + microphysics
@@ -864,7 +864,7 @@ def apply_clouds_and_microphysics(
         qi=cloud_state_all.cloud_ice.T,
         precip_rain=micro_state_all.precip_rain,
         precip_snow=micro_state_all.precip_snow,
-        droplet_number=droplet_number
+        droplet_number=cdnc_m3  # Store in 1/m³ for diagnostics/radiation
     )
 
     diagnostics = physics_data.diagnostics.copy(

--- a/jcm/physics/icon/icon_physics.py
+++ b/jcm/physics/icon/icon_physics.py
@@ -794,20 +794,15 @@ def apply_clouds(
     qc = state.tracers.get('qc', jnp.zeros_like(state.temperature))
     qi = state.tracers.get('qi', jnp.zeros_like(state.temperature))
 
-    # Cloud droplet number concentration from aerosol scheme (2D field)
-    base_cdnc = 100e6  # Clean-air baseline CDNC (100 per cm³)
-    cdnc_factor = physics_data.aerosol.cdnc_factor  # (ncols,)
-    cdnc = jnp.ones_like(state.temperature) * base_cdnc * cdnc_factor[jnp.newaxis, :]
-
     # Get cloud configuration from parameters
     cloud_config = parameters.clouds
 
     cloud_results = jax.vmap(
         shallow_cloud_scheme,
-        in_axes=(1, 1, 1, 1, 1, 0, 1, None, None),  # cdnc is per-column, dt and config are scalars
+        in_axes=(1, 1, 1, 1, 1, 0, None, None),  # dt and config are scalars
         out_axes=(0, 0)  # Returns (CloudTendencies, CloudState) per column
     )(state.temperature, state.specific_humidity, pressure_levels,
-        qc, qi, surface_pressure, cdnc, dt, cloud_config)
+        qc, qi, surface_pressure, dt, cloud_config)
     
     # Unpack structured results directly
     cloud_tendencies_all, cloud_states_all = cloud_results
@@ -823,11 +818,14 @@ def apply_clouds(
         }
     )
     
-    # Update physics data with cloud diagnostics
+    # Update physics data with cloud diagnostics and condensation-updated cloud water/ice
+    # Microphysics (called next) reads qc/qi from physics_data.clouds
     cloud_data = physics_data.clouds.copy(
         cloud_fraction=cloud_states_all.cloud_fraction.T,
-        precip_rain=cloud_tendencies_all.rain_flux,  # 1D per column
-        precip_snow=cloud_tendencies_all.snow_flux   # 1D per column
+        qc=cloud_states_all.cloud_water.T,
+        qi=cloud_states_all.cloud_ice.T,
+        precip_rain=cloud_tendencies_all.rain_flux,  # Zero — microphysics handles precip
+        precip_snow=cloud_tendencies_all.snow_flux   # Zero — microphysics handles precip
     )
     
     diagnostics = physics_data.diagnostics.copy(
@@ -854,9 +852,9 @@ def apply_microphysics(
     air_density = physics_data.diagnostics.air_density
     dz = physics_data.diagnostics.layer_thickness
 
-    # Extract fixed cloud water and ice tracers only
-    qc = state.tracers.get('qc', jnp.zeros_like(state.temperature))
-    qi = state.tracers.get('qi', jnp.zeros_like(state.temperature))
+    # Read cloud water and ice from cloud scheme (includes within-timestep condensation)
+    qc = physics_data.clouds.qc
+    qi = physics_data.clouds.qi
     
     # Droplet number concentration from aerosol scheme
     # cdnc_factor is (ncols,) — broadcast to (nlev, ncols) for microphysics
@@ -888,11 +886,10 @@ def apply_microphysics(
         }
     )
     
-    # Update physics data — add microphysics precipitation to existing
-    # (cloud scheme already set precip_rain/snow from autoconversion)
+    # Update physics data with microphysics precipitation
     micro_data = physics_data.clouds.copy(
-        precip_rain=physics_data.clouds.precip_rain + micro_states_all.precip_rain,
-        precip_snow=physics_data.clouds.precip_snow + micro_states_all.precip_snow,
+        precip_rain=micro_states_all.precip_rain,
+        precip_snow=micro_states_all.precip_snow,
         droplet_number=droplet_number
     )
     

--- a/jcm/physics/icon/icon_physics.py
+++ b/jcm/physics/icon/icon_physics.py
@@ -858,9 +858,11 @@ def apply_microphysics(
     
     # Droplet number concentration from aerosol scheme
     # cdnc_factor is (ncols,) — broadcast to (nlev, ncols) for microphysics
-    base_cdnc = 100e6  # Clean-air baseline CDNC (100 per cm³)
+    # cloud_microphysics expects droplet_number in 1/kg (not 1/m³)
+    base_cdnc = 100e6  # Clean-air baseline CDNC (100 per cm³ = 1e8 per m³)
     cdnc_factor = physics_data.aerosol.cdnc_factor  # (ncols,)
-    droplet_number = jnp.ones_like(state.temperature) * base_cdnc * cdnc_factor[jnp.newaxis, :]
+    cdnc_m3 = jnp.ones_like(state.temperature) * base_cdnc * cdnc_factor[jnp.newaxis, :]
+    droplet_number = cdnc_m3 / air_density  # 1/m³ → 1/kg
     
     # Get microphysics configuration
     micro_config = parameters.microphysics

--- a/jcm/physics/icon/icon_physics.py
+++ b/jcm/physics/icon/icon_physics.py
@@ -788,6 +788,25 @@ def _cloud_and_microphysics_column(
     Following ECHAM mo_cloud.f90: condensation, cloud fraction, autoconversion,
     accretion, and precipitation are all computed in a single column sweep.
     This avoids the coupling issues of splitting them into separate calls.
+
+    Tendency accounting (no double counting):
+        The cloud scheme computes condensation and applies it within the
+        timestep to produce updated cloud water (cloud_state.cloud_water).
+        Microphysics then acts on this updated cloud water.
+
+        Both schemes return SEPARATE tendencies that are additive:
+        - Cloud:  dqcdt = +condensation,  dqdt = -condensation,  dtedt = +L*condensation/cp
+        - Micro:  dqcdt = -autoconversion, dqdt = +evaporation,  dtedt = micro heating/cooling
+
+        The integrator applies: qc_new = qc_old + (cloud_dqcdt + micro_dqcdt) * dt
+        This gives: qc_new = 0 + (condensation - autoconversion) * dt
+
+        Moisture is conserved: dq + dqc + precip = 0
+        (-condensation + evap) + (condensation - autoconv) + (autoconv - evap) = 0
+
+        The within-timestep cloud water update is used ONLY to provide
+        microphysics with a physically meaningful input — it does not
+        affect the tendencies returned to the integrator.
     """
     # 1. Cloud fraction and condensation
     cloud_tendencies, cloud_state = shallow_cloud_scheme(
@@ -845,7 +864,9 @@ def apply_clouds_and_microphysics(
       qc, qi, surface_pressure, air_density, dz, droplet_number_per_kg,
       dt, cloud_config, micro_config)
 
-    # Combine tendencies: condensation (cloud) + microphysics
+    # Combine tendencies: cloud (condensation) + microphysics (autoconversion etc.)
+    # These are separate physical processes — see _cloud_and_microphysics_column
+    # docstring for the full accounting showing no double counting.
     physics_tendencies = PhysicsTendency(
         u_wind=jnp.zeros_like(state.u_wind),
         v_wind=jnp.zeros_like(state.v_wind),

--- a/jcm/physics/icon/icon_physics.py
+++ b/jcm/physics/icon/icon_physics.py
@@ -282,18 +282,22 @@ class IconPhysics(Physics):
         return self._filter_xarray_compatible_fields(result)
     
     def _get_base_struct_dict(self, struct, shape_info, sep):
-        """Get the base dictionary conversion, handling AttributeError gracefully."""
+        """Get the base dictionary conversion, handling non-array fields gracefully."""
         try:
             return super().data_struct_to_dict(struct, nodal_shape=shape_info.nodal_shape, sep=sep)
-        except AttributeError:
-            # Handle case where some fields are not arrays
+        except (AttributeError, ValueError):
+            # Handle case where some fields are not arrays (e.g. IconCoords.nodal_shape is a tuple)
             return self._manual_struct_to_dict(struct, shape_info, sep)
     
     def _manual_struct_to_dict(self, struct, shape_info, sep):
         """Manual conversion when base class fails."""
+        _skip_keys = {'icon_coords'}
+
         def _to_dict_recursive(obj, parent_key=""):
             items = {}
             for key, val in obj.__dict__.items():
+                if key in _skip_keys:
+                    continue
                 new_key = f"{parent_key}{sep}{key}" if parent_key else key
                 if hasattr(val, "__dict__") and val.__dict__:
                     items.update(_to_dict_recursive(val, parent_key=new_key))
@@ -447,17 +451,19 @@ class IconPhysics(Physics):
         return result
     
     def _filter_xarray_compatible_fields(self, result):
-        """Filter out non-array and scalar fields that xarray doesn't handle well."""
+        """Filter out fields that xarray/data_to_xarray doesn't handle well."""
+        nlev = self.cached_coords.nodal_shape[0]
         filtered_result = {}
         for key, value in result.items():
             if not hasattr(value, 'shape'):
-                # Skip non-array fields
                 continue
-            if hasattr(value, 'shape') and value.shape == ():
-                # Skip scalar fields - they're not needed for xarray conversion
+            if value.shape == ():
+                continue
+            if nlev + 1 in value.shape:
+                # Skip interface-level (half-level) fields
                 continue
             filtered_result[key] = value
-        
+
         return filtered_result
 
     def reshape_physics_data_to_3d(self, physics_data: PhysicsData, nodal_shape=None) -> PhysicsData:
@@ -787,16 +793,21 @@ def apply_clouds(
     surface_pressure = physics_data.diagnostics.surface_pressure
     qc = state.tracers.get('qc', jnp.zeros_like(state.temperature))
     qi = state.tracers.get('qi', jnp.zeros_like(state.temperature))
-    
+
+    # Cloud droplet number concentration from aerosol scheme (2D field)
+    base_cdnc = 100e6  # Clean-air baseline CDNC (100 per cm³)
+    cdnc_factor = physics_data.aerosol.cdnc_factor  # (ncols,)
+    cdnc = jnp.ones_like(state.temperature) * base_cdnc * cdnc_factor[jnp.newaxis, :]
+
     # Get cloud configuration from parameters
     cloud_config = parameters.clouds
-    
+
     cloud_results = jax.vmap(
         shallow_cloud_scheme,
-        in_axes=(1, 1, 1, 1, 1, 0, None, None),  # dt and config are scalars
+        in_axes=(1, 1, 1, 1, 1, 0, 1, None, None),  # cdnc is per-column, dt and config are scalars
         out_axes=(0, 0)  # Returns (CloudTendencies, CloudState) per column
     )(state.temperature, state.specific_humidity, pressure_levels,
-        qc, qi, surface_pressure, dt, cloud_config)
+        qc, qi, surface_pressure, cdnc, dt, cloud_config)
     
     # Unpack structured results directly
     cloud_tendencies_all, cloud_states_all = cloud_results

--- a/jcm/physics/icon/icon_physics_data.py
+++ b/jcm/physics/icon/icon_physics_data.py
@@ -141,33 +141,28 @@ class ConvectionData:
 
 @tree_math.struct
 class CloudData:
-    """Data for cloud physics"""
-    
+    """Data for cloud physics."""
+
     # Cloud fraction
     cloud_fraction: jnp.ndarray      # Cloud fraction [1] (nlev, ncols)
-    
-    # Cloud condensate
+
+    # Cloud condensate (updated by condensation within the cloud scheme)
     qc: jnp.ndarray                  # Cloud water [kg/kg] (nlev, ncols)
     qi: jnp.ndarray                  # Cloud ice [kg/kg] (nlev, ncols)
-    qr: jnp.ndarray                  # Rain water [kg/kg] (nlev, ncols)
-    qs: jnp.ndarray                  # Snow [kg/kg] (nlev, ncols)
-    
-    # Precipitation
+
+    # Surface precipitation (from microphysics autoconversion)
     precip_rain: jnp.ndarray         # Rain precipitation [kg/m²/s] (ncols,)
     precip_snow: jnp.ndarray         # Snow precipitation [kg/m²/s] (ncols,)
 
     # Cloud properties
-    # These can be used for diagnostics or further calculations
     droplet_number: jnp.ndarray  # Droplet number concentration [1/m³] (nlev, ncols)
-        
+
     @classmethod
     def zeros(cls, nodal_shape, nlev):
         return cls(
             cloud_fraction=jnp.zeros((nlev,) + nodal_shape),
             qc=jnp.zeros((nlev,) + nodal_shape),
             qi=jnp.zeros((nlev,) + nodal_shape),
-            qr=jnp.zeros((nlev,) + nodal_shape),
-            qs=jnp.zeros((nlev,) + nodal_shape),
             precip_rain=jnp.zeros(nodal_shape),
             precip_snow=jnp.zeros(nodal_shape),
             droplet_number=jnp.zeros((nlev,) + nodal_shape),
@@ -178,8 +173,6 @@ class CloudData:
             'cloud_fraction': self.cloud_fraction,
             'qc': self.qc,
             'qi': self.qi,
-            'qr': self.qr,
-            'qs': self.qs,
             'precip_rain': self.precip_rain,
             'precip_snow': self.precip_snow,
             'droplet_number': self.droplet_number,

--- a/jcm/physics/icon/parameters.py
+++ b/jcm/physics/icon/parameters.py
@@ -25,7 +25,6 @@ class Parameters:
     SpeedyPhysics.
     """
     
-    # Convection parameters
     convection: ConvectionParameters
     clouds: CloudParameters
     microphysics: MicrophysicsParameters
@@ -33,7 +32,6 @@ class Parameters:
     radiation: RadiationParameters
     vertical_diffusion: VDiffParameters
     surface: SurfaceParameters
-    gravity_waves: GravityWaveParameters
     aerosol: AerosolParameters
 
     @classmethod

--- a/jcm/physics/icon/radiation/aerosol_radiation_test.py
+++ b/jcm/physics/icon/radiation/aerosol_radiation_test.py
@@ -197,9 +197,9 @@ def test_temporal_weights_scale_aod():
     # Total AOD should decrease compared to present-day
     assert jnp.sum(aod_seasonal) < jnp.sum(aod_pd)
 def test_aerosol_microphysics_droplet_coupling():
-    """Test that apply_microphysics uses aerosol cdnc_factor for droplet number."""
+    """Test that apply_clouds_and_microphysics uses aerosol cdnc_factor for droplet number."""
     import numpy as np
-    from jcm.physics.icon.icon_physics import apply_microphysics, _prepare_common_physics_state
+    from jcm.physics.icon.icon_physics import apply_clouds_and_microphysics, _prepare_common_physics_state
     from jcm.physics.icon.icon_physics_data import PhysicsData
     from jcm.physics.icon.icon_coords import IconCoords
     from jcm.physics.icon.parameters import Parameters
@@ -264,7 +264,7 @@ def test_aerosol_microphysics_droplet_coupling():
     )
     # cdnc_factor defaults to 1.0 from AerosolData.zeros
 
-    tend_clean, pd_out_clean = apply_microphysics(
+    tend_clean, pd_out_clean = apply_clouds_and_microphysics(
         state, pd_clean, parameters, forcing, terrain
     )
 
@@ -281,7 +281,7 @@ def test_aerosol_microphysics_droplet_coupling():
         state, pd_polluted, parameters, forcing, terrain
     )
 
-    tend_polluted, pd_out_polluted = apply_microphysics(
+    tend_polluted, pd_out_polluted = apply_clouds_and_microphysics(
         state, pd_polluted, parameters, forcing, terrain
     )
 


### PR DESCRIPTION
## Summary
- Fixes both convective and large-scale precipitation which were always zero
- Combines apply_clouds + apply_microphysics into a single coupled apply_clouds_and_microphysics step, following ECHAM mo_cloud.f90 where condensation and autoconversion happen in one column sweep
- Implements Beheng (1994) warm-phase and Levkov et al. (1992) ice autoconversion through the existing cloud_microphysics module
- Cleans up redundant structures and hardcoded parameters

## Root causes fixed
1. **Convective precipitation**: calculate_precipitation_rate had an inverted cloud mask that missed the cloud layer
2. **Large-scale precipitation**: condensation and autoconversion were split across timesteps -- cloud scheme produced dqcdt tendencies but autoconversion checked input cloud_water (always zero)
3. **CDNC units**: microphysics expected 1/kg but received 1/m3
4. **Precipitation flux**: computed from sedimentation of non-existent rain water instead of column-integrated autoconversion rate

## Architecture changes
- shallow_cloud_scheme now handles condensation + cloud fraction only, updating cloud water within the timestep
- cloud_microphysics receives the condensation-updated cloud water and handles all autoconversion/precipitation
- Both run in a single vmapped column function (_cloud_and_microphysics_column)
- Removed unused qr/qs fields from CloudData
- Moved base_cdnc from hardcoded value to MicrophysicsParameters
- Fixed duplicate gravity_waves field in Parameters

## Verification (from 90-day spun-up aquaplanet)
- Convective precip: 5.4 mm/day max, 1.15 mm/day mean (tropical ITCZ)
- Large-scale rain: 0.27 mm/day mean with realistic zonal structure
- Snow: 0.07 mm/day max at high latitudes
- No NaN, 347 ICON tests pass

## Test plan
- [x] All 347 ICON physics tests pass
- [x] ruff check . clean
- [x] 5-day simulation from 90-day spinup produces physically sensible precipitation

Generated with [Claude Code](https://claude.com/claude-code)