### PR TITLE
Add w-wind to output

### DIFF
--- a/jcm/constants.py
+++ b/jcm/constants.py
@@ -3,3 +3,5 @@
 p0 = 1e5 # Pressure normalization factor for PhysicsState (Pa)
 grav = 9.81 # Gravitational acceleration (m/s/s)
 cp = 1004.0 # Specific heat at constant pressure (J/K/kg)
+akap = 2.0/7.0 # 1 - 1/gamma where gamma is the heat capacity ratio of a perfect diatomic gas (7/5)
+rgas = akap * cp # Gas constant per unit mass for dry air (J/K/kg)

--- a/jcm/dynamics_units_table.csv
+++ b/jcm/dynamics_units_table.csv
@@ -1,6 +1,7 @@
 Variable,Units,Speedy,Description
 v_wind,m/s,va,V-wind
 u_wind,m/s,ua,U-wind
+w_wind,m/s,wa,W-wind
 specific_humidity,g/kg,qa,Specific humidity
 normalized_surface_pressure,1,psa,normalized surface pressure
 geopotential,m²/s²,phi,geopotential

--- a/jcm/model.py
+++ b/jcm/model.py
@@ -410,8 +410,12 @@ class Model:
         from jcm.physics_interface import verify_state
         jax.debug.callback(lambda t: logger.info("Post processing: %s simulated seconds", t), state.sim_time)
 
+        if output_averages:
+            dynamics_fn = jax.vmap(lambda s: dynamics_state_to_physics_state(s, self.primitive))
+        else:
+            dynamics_fn = lambda s: dynamics_state_to_physics_state(s, self.primitive)
         predictions = Predictions(
-            dynamics=dynamics_state_to_physics_state(state, self.primitive),
+            dynamics=dynamics_fn(state),
             physics=None,
             times=None
         )

--- a/jcm/physics/speedy/humidity_test.py
+++ b/jcm/physics/speedy/humidity_test.py
@@ -47,7 +47,7 @@ class TestHumidityUnit(unittest.TestCase):
 
         forcing = ForcingData.ones(xy,sea_surface_temperature=sea_surface_temperature)
             
-        state = PhysicsState.zeros(zxy,ua, va, ta, qa, phi, psa)
+        state = PhysicsState.zeros(zxy,u_wind=ua, v_wind=va, temperature=ta, specific_humidity=qa, geopotential=phi, normalized_surface_pressure=psa)
         sflux_data = SurfaceFluxData.zeros(xy, rlds=rlds)
         hum_data = HumidityData.zeros(xy,kx,rh=rh)
         conv_data = ConvectionData.zeros(xy,kx)

--- a/jcm/physics/speedy/longwave_radiation_test.py
+++ b/jcm/physics/speedy/longwave_radiation_test.py
@@ -120,7 +120,7 @@ class TestLongwave(unittest.TestCase):
         tau2 = jnp.ones((kx, ix, il, 4)) + jnp.arange(kx)[:, jnp.newaxis, jnp.newaxis, jnp.newaxis] * .1
         stratc = jnp.ones((ix, il, 2))
 
-        state = PhysicsState.zeros((ix, il), kx).copy(temperature=ta)
+        state = PhysicsState.zeros((kx, ix, il)).copy(temperature=ta)
         input_physics_data = PhysicsData.zeros((ix, il), kx, speedy_coords=speedy_coords).copy(
             longwave_rad=LWRadiationData.zeros((ix, il), kx).copy(dfabs=dfabs),
             mod_radcon=ModRadConData.zeros((ix, il), kx).copy(st4a=st4a, flux=flux, tau2=tau2, stratc=stratc),

--- a/jcm/physics/speedy/orographic_correction_test.py
+++ b/jcm/physics/speedy/orographic_correction_test.py
@@ -68,6 +68,7 @@ def create_test_physics_state(layers=8, lon_points=96, lat_points=48):
     # Create wind fields
     u_wind = jnp.zeros(shape)
     v_wind = jnp.zeros(shape)
+    w_wind = jnp.zeros(shape)
     
     # Create geopotential (increases with height)
     geopotential = jnp.zeros(shape)
@@ -78,6 +79,7 @@ def create_test_physics_state(layers=8, lon_points=96, lat_points=48):
     return PhysicsState(
         u_wind=u_wind,
         v_wind=v_wind,
+        w_wind=w_wind,
         temperature=temperature,
         specific_humidity=humidity,
         geopotential=geopotential,

--- a/jcm/physics/speedy/physical_constants.py
+++ b/jcm/physics/speedy/physical_constants.py
@@ -12,8 +12,8 @@ grav = c.grav # Gravitational acceleration (m/s/s)
 # Physical constants for thermodynamics
 p0 = c.p0 # Reference pressure (Pa)
 cp = c.cp # Specific heat at constant pressure (J/K/kg)
-akap = 2.0/7.0 # 1 - 1/gamma where gamma is the heat capacity ratio of a perfect diatomic gas (7/5)
-rgas = akap * cp # Gas constant per unit mass for dry air (J/K/kg)
+akap = c.akap # 1 - 1/gamma where gamma is the heat capacity ratio of a perfect diatomic gas (7/5)
+rgas = c.rgas # Gas constant per unit mass for dry air (J/K/kg)
 alhc = 2501.0 # Latent heat of condensation, in J/g for consistency with specific humidity in g/Kg
 alhs = 2801.0 # Latent heat of sublimation
 sbc = 5.67e-8 # Stefan-Boltzmann constant

--- a/jcm/physics/speedy/shortwave_radiation_test.py
+++ b/jcm/physics/speedy/shortwave_radiation_test.py
@@ -278,7 +278,7 @@ class TestShortWaveRadiation(unittest.TestCase):
         date_data = DateData.set_date(model_time=jdt.to_datetime('2000-03-21'))
         physics_data = PhysicsData.zeros(xy,kx,date=date_data, speedy_coords=speedy_coords)
 
-        state = PhysicsState(jnp.zeros(zxy), jnp.zeros(zxy), jnp.zeros(zxy), jnp.zeros(zxy), jnp.zeros(zxy), jnp.zeros(xy))
+        state = PhysicsState.zeros(zxy)
        
         physics_data = get_zonal_average_fields(state, physics_data, forcing, terrain)
 
@@ -293,7 +293,7 @@ class TestShortWaveRadiation(unittest.TestCase):
         date_data = DateData.set_date(model_time=jdt.to_datetime('2000-03-21'))
         physics_data = PhysicsData.zeros(xy,kx,date=date_data, speedy_coords=speedy_coords)
 
-        state = PhysicsState(jnp.zeros(zxy), jnp.zeros(zxy), jnp.zeros(zxy), jnp.zeros(zxy), jnp.zeros(zxy), jnp.zeros(xy))
+        state = PhysicsState.zeros(zxy)
         
         physics_data = get_zonal_average_fields(state, physics_data, forcing, terrain)
 
@@ -308,7 +308,7 @@ class TestShortWaveRadiation(unittest.TestCase):
         date_data = DateData.set_date(model_time=jdt.to_datetime('2000-04-01 12:00:00'))
 
         physics_data = PhysicsData.zeros(xy,kx,date=date_data, speedy_coords=speedy_coords)
-        state = PhysicsState(jnp.zeros(zxy), jnp.zeros(zxy), jnp.zeros(zxy), jnp.zeros(zxy), jnp.zeros(zxy), jnp.zeros(xy))
+        state = PhysicsState.zeros(zxy)
         physics_data = get_zonal_average_fields(state, physics_data, forcing, terrain)
 
         # Expected form for ozone based on the provided formula

--- a/jcm/physics/speedy/surface_flux_test.py
+++ b/jcm/physics/speedy/surface_flux_test.py
@@ -46,7 +46,7 @@ class TestSurfaceFluxesUnit(unittest.TestCase):
         rlds = 400. * jnp.ones((ix, il)) #surface downward longwave
         soilw_am = 0.5* jnp.ones(((ix,il)))
         stl_am = 288* jnp.ones((ix,il))
-        state = PhysicsState.zeros(zxy,ua, va, ta, qa, phi, psa)
+        state = PhysicsState.zeros(zxy, u_wind=ua, v_wind=va, temperature=ta, specific_humidity=qa, geopotential=phi, normalized_surface_pressure=psa)
         sflux_data = SurfaceFluxData.zeros(xy,rlds=rlds)
         hum_data = HumidityData.zeros(xy,kx,rh=rh)
         conv_data = ConvectionData.zeros(xy,kx)
@@ -87,7 +87,7 @@ class TestSurfaceFluxesUnit(unittest.TestCase):
         rlds = 400 * jnp.ones(xy)
         soilw_am = 0.5* jnp.ones(((ix,il)))
         stl_am = 288* jnp.ones((ix,il))
-        state = PhysicsState.zeros(zxy, ua, va, ta, qa, phi, psa)
+        state = PhysicsState.zeros(zxy, u_wind=ua, v_wind=va, temperature=ta, specific_humidity=qa, geopotential=phi, normalized_surface_pressure=psa)
         terrain = TerrainData.from_coords(coords, orography=phi0/grav, fmask=fmask, lfluxland=True)
         terrain, speedy_c = convert_to_speedy_latitudes(terrain, speedy_coords)
         sflux_data = SurfaceFluxData.zeros(xy,rlds=rlds)
@@ -133,7 +133,7 @@ class TestSurfaceFluxesUnit(unittest.TestCase):
         soilw_am = 0.5* jnp.ones(((ix,il)))
         stl_am = 288* jnp.ones((ix,il))
         # vars = get_surface_fluxes(psa,ua,va,ta,qa,rh,phi,phi0,fmask,sea_surface_temperature,rsds,rlds,lfluxland)
-        state = PhysicsState.zeros(zxy,ua, va, ta, qa, phi, psa)
+        state = PhysicsState.zeros(zxy, u_wind=ua, v_wind=va, temperature=ta, specific_humidity=qa, geopotential=phi, normalized_surface_pressure=psa)
         sflux_data = SurfaceFluxData.zeros(xy,rlds=rlds)
         hum_data = HumidityData.zeros(xy,kx,rh=rh)
         conv_data = ConvectionData.zeros(xy,kx)
@@ -183,7 +183,7 @@ class TestSurfaceFluxesUnit(unittest.TestCase):
         soilw_am = 0.5* jnp.ones(((ix,il)))
         stl_am = 288* jnp.ones((ix,il))
         # vars = get_surface_fluxes(psa,ua,va,ta,qa,rh,phi,phi0,fmask,sea_surface_temperature,rsds,rlds,lfluxland)
-        state = PhysicsState.zeros(zxy,ua, va, ta, qa, phi, psa)
+        state = PhysicsState.zeros(zxy, u_wind=ua, v_wind=va, temperature=ta, specific_humidity=qa, geopotential=phi, normalized_surface_pressure=psa)
         sflux_data = SurfaceFluxData.zeros(xy,rlds=rlds)
         hum_data = HumidityData.zeros(xy,kx,rh=rh)
         conv_data = ConvectionData.zeros(xy,kx)
@@ -235,7 +235,7 @@ class TestSurfaceFluxesUnit(unittest.TestCase):
         soilw_am = 0.5* jnp.ones(((ix,il)))
         stl_am = 288* jnp.ones((ix,il))
         # vars = get_surface_fluxes(psa,ua,va,ta,qa,rh,phi,phi0,fmask,sea_surface_temperature,rsds,rlds,lfluxland)
-        state = PhysicsState.zeros(zxy,ua, va, ta, qa, phi, psa)
+        state = PhysicsState.zeros(zxy, u_wind=ua, v_wind=va, temperature=ta, specific_humidity=qa, geopotential=phi, normalized_surface_pressure=psa)
         sflux_data = SurfaceFluxData.zeros(xy,rlds=rlds)
         hum_data = HumidityData.zeros(xy,kx,rh=rh)
         conv_data = ConvectionData.zeros(xy,kx)
@@ -288,7 +288,7 @@ class TestSurfaceFluxesUnit(unittest.TestCase):
         rlds = 400. * jnp.ones((ix, il)) #surface downward longwave
 
         # vars = get_surface_fluxes(psa,ua,va,ta,qa,rh,phi,phi0,fmask,sea_surface_temperature,rsds,rlds,lfluxland)
-        state = PhysicsState.zeros(zxy,ua, va, ta, qa, phi, psa)
+        state = PhysicsState.zeros(zxy, u_wind=ua, v_wind=va, temperature=ta, specific_humidity=qa, geopotential=phi, normalized_surface_pressure=psa)
         sflux_data = SurfaceFluxData.zeros(xy,rlds=rlds)
         hum_data = HumidityData.zeros(xy,kx,rh=rh)
         conv_data = ConvectionData.zeros(xy,kx)
@@ -340,7 +340,7 @@ class TestSurfaceFluxesUnit(unittest.TestCase):
         rsds = 400. * jnp.ones((ix, il)) #surface downward shortwave
         rlds = 400. * jnp.ones((ix, il)) #surface downward longwave
 
-        state = PhysicsState.zeros(zxy,ua, va, ta, qa, phi, psa)
+        state = PhysicsState.zeros(zxy, u_wind=ua, v_wind=va, temperature=ta, specific_humidity=qa, geopotential=phi, normalized_surface_pressure=psa)
         sflux_data = SurfaceFluxData.zeros(xy,rlds=rlds)
         hum_data = HumidityData.zeros(xy,kx,rh=rh)
         conv_data = ConvectionData.zeros(xy,kx)
@@ -403,7 +403,7 @@ class TestSurfaceFluxesUnit(unittest.TestCase):
         soilw_am = 0.5* jnp.ones(((ix,il)))
         stl_am = 288* jnp.ones((ix,il))
         # vars = get_surface_fluxes(psa,ua,va,ta,qa,rh,phi,phi0,fmask,sea_surface_temperature,rsds,rlds,lfluxland)
-        state = PhysicsState.zeros(zxy,ua, va, ta, qa, phi, psa)
+        state = PhysicsState.zeros(zxy, u_wind=ua, v_wind=va, temperature=ta, specific_humidity=qa, geopotential=phi, normalized_surface_pressure=psa)
         sflux_data = SurfaceFluxData.zeros(xy,rlds=rlds)
         hum_data = HumidityData.zeros(xy,kx,rh=rh)
         conv_data = ConvectionData.zeros(xy,kx)
@@ -510,7 +510,7 @@ class TestAquaplanetSurfaceFluxes(unittest.TestCase):
         rsds = 400.0 * jnp.ones((ix, il))
         rlds = 350.0 * jnp.ones((ix, il))
 
-        state = PhysicsState.zeros(zxy, ua, va, ta, qa, phi, psa)
+        state = PhysicsState.zeros(zxy, u_wind=ua, v_wind=va, temperature=ta, specific_humidity=qa, geopotential=phi, normalized_surface_pressure=psa)
         sflux_data = SurfaceFluxData.zeros(xy, rlds=rlds)
         hum_data = HumidityData.zeros(xy, kx, rh=rh)
         conv_data = ConvectionData.zeros(xy, kx)
@@ -561,7 +561,7 @@ class TestAquaplanetSurfaceFluxes(unittest.TestCase):
         rsds = 400.0 * jnp.ones((ix, il))
         rlds = 350.0 * jnp.ones((ix, il))
 
-        state = PhysicsState.zeros(zxy, ua, va, ta, qa, phi, psa)
+        state = PhysicsState.zeros(zxy, u_wind=ua, v_wind=va, temperature=ta, specific_humidity=qa, geopotential=phi, normalized_surface_pressure=psa)
         sflux_data = SurfaceFluxData.zeros(xy, rlds=rlds)
         hum_data = HumidityData.zeros(xy, kx, rh=rh)
         conv_data = ConvectionData.zeros(xy, kx)
@@ -597,7 +597,7 @@ class TestAquaplanetSurfaceFluxes(unittest.TestCase):
         rsds = 400.0 * jnp.ones((ix, il))
         rlds = 350.0 * jnp.ones((ix, il))
 
-        state = PhysicsState.zeros(zxy, ua, va, ta, qa, phi, psa)
+        state = PhysicsState.zeros(zxy, u_wind=ua, v_wind=va, temperature=ta, specific_humidity=qa, geopotential=phi, normalized_surface_pressure=psa)
         sflux_data = SurfaceFluxData.zeros(xy, rlds=rlds)
         hum_data = HumidityData.zeros(xy, kx, rh=rh)
         conv_data = ConvectionData.zeros(xy, kx)

--- a/jcm/physics/speedy/surface_flux_test.py
+++ b/jcm/physics/speedy/surface_flux_test.py
@@ -436,8 +436,8 @@ class TestSurfaceFluxesUnit(unittest.TestCase):
 
         check_vjp(f, f_vjp, args = (state_floats, physics_data_floats, parameters_floats, forcing_floats, terrain_floats), 
                                 atol=None, rtol=1, eps=0.00001)
-        check_jvp(f, f_jvp, args = (state_floats,physics_data_floats,  parameters_floats, forcing_floats, terrain_floats), 
-                                atol=None, rtol=1, eps=0.000001)
+        check_jvp(f, f_jvp, args = (state_floats, physics_data_floats, parameters_floats, forcing_floats, terrain_floats),
+                                atol=None, rtol=1, eps=0.00001)
         
     def test_surface_fluxes_drag_test_gradient_check(self):
         phi0 = 500. * jnp.ones((ix, il)) #surface geopotential

--- a/jcm/physics_interface.py
+++ b/jcm/physics_interface.py
@@ -247,14 +247,15 @@ def dynamics_state_to_physics_state(state: State, dynamics: PrimitiveEquations) 
     # Compute vertical velocity (code adapted and extended from dinosaur.primitive_equations.compute_vertical_velocity)
     sigma_dot_full_boundaries = jnp.pad(
         nodal_state.sigma_dot_full,
-        [(1, 1) if i == nodal_state.sigma_dot_full.ndim - 3 else (0, 0) for i in range(nodal_state.sigma_dot_full.ndim)]
+        [(1, 1) if i == nodal_state.sigma_dot_full.ndim - 3 else (0, 0) 
+         for i in range(nodal_state.sigma_dot_full.ndim)]
     ) # pad vertical dimension with boundary conditions
     sigma_dot_full_centers, sigma_centers = (
-        (a[1:] + a[:-1])/2
-        for a in (sigma_dot_full_boundaries, dynamics.coords.vertical.boundaries)
+        (a[..., 1:, :, :] + a[..., :-1, :, :]) / 2
+        for a in (sigma_dot_full_boundaries, dynamics.coords.vertical.boundaries[:, jnp.newaxis, jnp.newaxis])
     ) # get values at layer centers
     w = - (rgas * t / grav) * (
-        sigma_dot_full_centers / sigma_centers[:, jnp.newaxis, jnp.newaxis] 
+        sigma_dot_full_centers / sigma_centers
         + dynamics.nodal_log_pressure_tendency(nodal_state)
     ) # convert from sigma_dot to vertical velocity using the hydrostatic relation and ideal gas law
 

--- a/jcm/physics_interface.py
+++ b/jcm/physics_interface.py
@@ -244,12 +244,19 @@ def dynamics_state_to_physics_state(state: State, dynamics: PrimitiveEquations) 
     t += dynamics.reference_temperature[:, jnp.newaxis, jnp.newaxis]
     q = dynamics.physics_specs.dimensionalize(q, units.gram / units.kilogram).m
 
-    # compute vertical velocity
-    Dsigma_Dt = compute_vertical_velocity(state, dynamics.coords)
-    Dlog_sp_Dt = dynamics.nodal_log_pressure_tendency(nodal_state)
-    sigma_boundaries = dynamics.coords.vertical.boundaries
-    sigma_centers = 0.5 * (sigma_boundaries[:-1] + sigma_boundaries[1:])
-    w = - (rgas * t / grav) * (Dsigma_Dt/sigma_centers[:, jnp.newaxis, jnp.newaxis] + Dlog_sp_Dt)
+    # Compute vertical velocity (code adapted and extended from dinosaur.primitive_equations.compute_vertical_velocity)
+    sigma_dot_full_boundaries = jnp.pad(
+        nodal_state.sigma_dot_full,
+        [(1, 1) if i == nodal_state.sigma_dot_full.ndim - 3 else (0, 0) for i in range(nodal_state.sigma_dot_full.ndim)]
+    )
+    sigma_dot_full_centers, sigma_centers = (
+        (a[1:] + a[:-1])/2
+        for a in (sigma_dot_full_boundaries, dynamics.coords.vertical.boundaries)
+    )
+    w = - (rgas * t / grav) * (
+        sigma_dot_full_centers / sigma_centers[:, jnp.newaxis, jnp.newaxis] 
+        + dynamics.nodal_log_pressure_tendency(nodal_state)
+    )
 
     return PhysicsState(u, v, w, t, q, phi, jnp.squeeze(sp, axis=-3))
 

--- a/jcm/physics_interface.py
+++ b/jcm/physics_interface.py
@@ -9,7 +9,7 @@ import tree_math
 from dinosaur import scales
 from dinosaur.scales import units
 from dinosaur.spherical_harmonic import vor_div_to_uv_nodal, uv_nodal_to_vor_div_modal
-from dinosaur.primitive_equations import compute_vertical_velocity, get_geopotential, compute_diagnostic_state, State, PrimitiveEquations
+from dinosaur.primitive_equations import get_geopotential, compute_diagnostic_state, State, PrimitiveEquations
 from dinosaur.coordinate_systems import CoordinateSystem
 from dinosaur.filtering import horizontal_diffusion_filter
 from jax import tree_util
@@ -248,15 +248,15 @@ def dynamics_state_to_physics_state(state: State, dynamics: PrimitiveEquations) 
     sigma_dot_full_boundaries = jnp.pad(
         nodal_state.sigma_dot_full,
         [(1, 1) if i == nodal_state.sigma_dot_full.ndim - 3 else (0, 0) for i in range(nodal_state.sigma_dot_full.ndim)]
-    )
+    ) # pad vertical dimension with boundary conditions
     sigma_dot_full_centers, sigma_centers = (
         (a[1:] + a[:-1])/2
         for a in (sigma_dot_full_boundaries, dynamics.coords.vertical.boundaries)
-    )
+    ) # get values at layer centers
     w = - (rgas * t / grav) * (
         sigma_dot_full_centers / sigma_centers[:, jnp.newaxis, jnp.newaxis] 
         + dynamics.nodal_log_pressure_tendency(nodal_state)
-    )
+    ) # convert from sigma_dot to vertical velocity using the hydrostatic relation and ideal gas law
 
     return PhysicsState(u, v, w, t, q, phi, jnp.squeeze(sp, axis=-3))
 

--- a/jcm/physics_interface.py
+++ b/jcm/physics_interface.py
@@ -92,8 +92,6 @@ Attributes:
         The mass of water vapor per unit mass of moist air.
     geopotential : jnp.ndarray
         The gravitational potential energy per unit mass at a given height.
-    vertical_velocity : jnp.ndarray
-        The vertical component of the wind.
     normalized_surface_pressure : jnp.ndarray
         Surface pressure normalized by a reference pressure p0.
 """

--- a/jcm/physics_interface.py
+++ b/jcm/physics_interface.py
@@ -9,13 +9,14 @@ import tree_math
 from dinosaur import scales
 from dinosaur.scales import units
 from dinosaur.spherical_harmonic import vor_div_to_uv_nodal, uv_nodal_to_vor_div_modal
-from dinosaur.primitive_equations import get_geopotential, compute_diagnostic_state, State, PrimitiveEquations
+from dinosaur.primitive_equations import compute_vertical_velocity, get_geopotential, compute_diagnostic_state, State, PrimitiveEquations
 from dinosaur.coordinate_systems import CoordinateSystem
 from dinosaur.filtering import horizontal_diffusion_filter
 from jax import tree_util
 from jcm.forcing import ForcingData
 from jcm.terrain import TerrainData
 from jcm.date import DateData
+from jcm.constants import rgas, grav
 from typing import Tuple, Any
 from jcm.diffusion import DiffusionFilter
 import logging
@@ -26,16 +27,18 @@ logger = logging.getLogger(__name__)
 class PhysicsState:
     u_wind: jnp.ndarray
     v_wind: jnp.ndarray
+    w_wind: jnp.ndarray
     temperature: jnp.ndarray
     specific_humidity: jnp.ndarray
     geopotential: jnp.ndarray
     normalized_surface_pressure: jnp.ndarray # Normalized by global mean sea level pressure
 
     @classmethod
-    def zeros(cls, shape, u_wind=None, v_wind=None, temperature=None, specific_humidity=None, geopotential=None, normalized_surface_pressure=None):
+    def zeros(cls, shape, u_wind=None, v_wind=None, w_wind=None, temperature=None, specific_humidity=None, geopotential=None, normalized_surface_pressure=None):
         return cls(
             u_wind if u_wind is not None else jnp.zeros(shape),
             v_wind if v_wind is not None else jnp.zeros(shape),
+            w_wind if w_wind is not None else jnp.zeros(shape),
             temperature if temperature is not None else jnp.zeros(shape),
             specific_humidity if specific_humidity is not None else jnp.zeros(shape),
             geopotential if geopotential is not None else jnp.zeros(shape),
@@ -43,20 +46,22 @@ class PhysicsState:
         )
 
     @classmethod
-    def ones(cls, shape, u_wind=None, v_wind=None, temperature=None, specific_humidity=None, geopotential=None, normalized_surface_pressure=None):
+    def ones(cls, shape, u_wind=None, v_wind=None, w_wind=None, temperature=None, specific_humidity=None, geopotential=None, normalized_surface_pressure=None):
         return cls(
             u_wind if u_wind is not None else jnp.ones(shape),
             v_wind if v_wind is not None else jnp.ones(shape),
+            w_wind if w_wind is not None else jnp.ones(shape),
             temperature if temperature is not None else jnp.ones(shape),
             specific_humidity if specific_humidity is not None else jnp.ones(shape),
             geopotential if geopotential is not None else jnp.ones(shape),
             normalized_surface_pressure if normalized_surface_pressure is not None else jnp.ones(shape[1:])
         )
 
-    def copy(self,u_wind=None,v_wind=None,temperature=None,specific_humidity=None,geopotential=None,normalized_surface_pressure=None):
+    def copy(self,u_wind=None,v_wind=None,w_wind=None,temperature=None,specific_humidity=None,geopotential=None,normalized_surface_pressure=None):
         return PhysicsState(
             u_wind if u_wind is not None else self.u_wind,
             v_wind if v_wind is not None else self.v_wind,
+            w_wind if w_wind is not None else self.w_wind,
             temperature if temperature is not None else self.temperature,
             specific_humidity if specific_humidity is not None else self.specific_humidity,
             geopotential if geopotential is not None else self.geopotential,
@@ -79,12 +84,16 @@ Attributes:
         Zonal (east-west) component of wind.
     v_wind : jnp.ndarray
         Meridional (north-south) component of wind.
+    w_wind : jnp.ndarray
+        Vertical (up-down) component of wind.
     temperature : jnp.ndarray
         Atmospheric temperature.
     specific_humidity : jnp.ndarray
         The mass of water vapor per unit mass of moist air.
     geopotential : jnp.ndarray
         The gravitational potential energy per unit mass at a given height.
+    vertical_velocity : jnp.ndarray
+        The vertical component of the wind.
     normalized_surface_pressure : jnp.ndarray
         Surface pressure normalized by a reference pressure p0.
 """
@@ -237,7 +246,14 @@ def dynamics_state_to_physics_state(state: State, dynamics: PrimitiveEquations) 
     t += dynamics.reference_temperature[:, jnp.newaxis, jnp.newaxis]
     q = dynamics.physics_specs.dimensionalize(q, units.gram / units.kilogram).m
 
-    return PhysicsState(u, v, t, q, phi, jnp.squeeze(sp, axis=-3))
+    # compute vertical velocity
+    Dsigma_Dt = compute_vertical_velocity(state, dynamics.coords)
+    Dlog_sp_Dt = dynamics.nodal_log_pressure_tendency(nodal_state)
+    sigma_boundaries = dynamics.coords.vertical.boundaries
+    sigma_centers = 0.5 * (sigma_boundaries[:-1] + sigma_boundaries[1:])
+    w = - (rgas * t / grav) * (Dsigma_Dt/sigma_centers[:, jnp.newaxis, jnp.newaxis] + Dlog_sp_Dt)
+
+    return PhysicsState(u, v, w, t, q, phi, jnp.squeeze(sp, axis=-3))
 
 def physics_state_to_dynamics_state(physics_state: PhysicsState, dynamics: PrimitiveEquations) -> State:
     """Convert state variables from the physics (nodal space) back to the dynamical core (spectral space).

--- a/jcm/physics_interface_test.py
+++ b/jcm/physics_interface_test.py
@@ -19,7 +19,7 @@ class TestPhysicsInterfaceUnit(unittest.TestCase):
         v = jnp.ones((kx, ix, il)) * -0.5
         q = jnp.ones((kx, ix, il)) * 0.5
         phi = jnp.ones((kx, ix, il)) * 5000
-        sp = jnp.ones((kx, ix, il))
+        sp = jnp.ones((ix, il))
 
         coords = get_speedy_coords()
         _, aux_features = primitive_equations_states.isothermal_rest_atmosphere(

--- a/jcm/physics_interface_test.py
+++ b/jcm/physics_interface_test.py
@@ -36,7 +36,7 @@ class TestPhysicsInterfaceUnit(unittest.TestCase):
             coords,
             PHYSICS_SPECS)
 
-        state = PhysicsState.zeros((kx, ix, il), u, v, temp, q, phi, sp)
+        state = PhysicsState.zeros((kx, ix, il), u_wind=u, v_wind=v, temperature=temp, specific_humidity=q, geopotential=phi, normalized_surface_pressure=sp)
 
         dynamics_state = physics_state_to_dynamics_state(state, primitive)
         physics_state_recovered = dynamics_state_to_physics_state(dynamics_state, primitive)


### PR DESCRIPTION
So far I haven't found a dinosaur library function that gets w-wind or omega directly; there's one that produces d(sigma)/dt but it would internally run compute_diagnostic_state, which is redundant with the fact that we already do that earlier in dynamics_state_to_physics_state.

* Added w-wind to PhysicsState
* Added calculation of w-wind in dynamics_state_to_physics_state
* Switched from positional to keyword args in PhysicsState initializations so they still work
* Added switch in post_process to handle the fact that dinosaur.primitive_equations.compute_diagnostic_state does not properly handle states with a time dimension
* Fixed bug in physics_interface_test