### PR TITLE
Fix NaN gradients in model differentiation

### DIFF
--- a/jcm/model.py
+++ b/jcm/model.py
@@ -359,6 +359,9 @@ class Model:
         return primitive_equations.State(**state.asdict(), sim_time=sim_time)
 
     def _date_from_sim_time(self, sim_time) -> DateData:
+        # Stop gradient: date/calendar computations use non-differentiable ops
+        # (floor, round, int casts) and should not be part of the AD graph.
+        sim_time = jax.lax.stop_gradient(sim_time)
         return DateData.set_date(
             model_time=self.start_date + jdt.Timedelta(
                 days=jnp.floor(sim_time / 86400).astype(jnp.int32),

--- a/jcm/model_test.py
+++ b/jcm/model_test.py
@@ -165,7 +165,7 @@ class TestModelUnit(unittest.TestCase):
         self.assertFalse(jnp.any(jnp.isnan(df_dstate[0].temperature_variation)))
         self.assertFalse(jnp.any(jnp.isnan(df_dstate[0].log_surface_pressure)))
         self.assertFalse(jnp.any(jnp.isnan(df_dstate[0].tracers['specific_humidity'])))
-        # self.assertFalse(jnp.any(jnp.isnan(df_dstate[0].sim_time))) FIXME: this is ending up nan
+        self.assertFalse(jnp.any(jnp.isnan(df_dstate[0].sim_time)))
 
     @pytest.mark.slow
     def test_speedy_model_gradients_multiple_timesteps_isnan(self):
@@ -190,7 +190,7 @@ class TestModelUnit(unittest.TestCase):
         self.assertFalse(jnp.any(jnp.isnan(df_dstate[0].temperature_variation)))
         self.assertFalse(jnp.any(jnp.isnan(df_dstate[0].log_surface_pressure)))
         self.assertFalse(jnp.any(jnp.isnan(df_dstate[0].tracers['specific_humidity'])))
-        # self.assertFalse(jnp.any(jnp.isnan(df_dstate[0].sim_time))) FIXME: this is ending up nan
+        self.assertFalse(jnp.any(jnp.isnan(df_dstate[0].sim_time)))
 
     @pytest.mark.slow
     def test_speedy_model_param_gradients_isnan_vjp(self):
@@ -252,7 +252,7 @@ class TestModelUnit(unittest.TestCase):
         tangent = ones_like_tangent(params)
         _, jvp_sum = jax.jvp(model_run_wrapper, (params,), (tangent,))
         state = jvp_sum.dynamics
-        # physics_data = jvp_sum.physics
+        physics_data = jvp_sum.physics
 
         # Check dynamics state
         self.assertFalse(jnp.any(jnp.isnan(state.u_wind)))
@@ -261,9 +261,8 @@ class TestModelUnit(unittest.TestCase):
         self.assertFalse(jnp.any(jnp.isnan(state.specific_humidity)))
         self.assertFalse(jnp.any(jnp.isnan(state.geopotential)))
         self.assertFalse(jnp.any(jnp.isnan(state.normalized_surface_pressure)))
-        # self.assertFalse(jnp.any(jnp.isnan(df_dstate[0].sim_time))) FIXME: this is ending up nan
         # Check Physics Data object
-        # self.assertFalse(physics_data.isnan().any_true())  FIXME: shortwave_rad has integer value somewehre
+        self.assertFalse(physics_data.isnan().any_true())
 
     @pytest.mark.skip(reason="finite differencing produces nans")
     def test_speedy_model_state_gradient_check(self):

--- a/jcm/physics/speedy/physics_data.py
+++ b/jcm/physics/speedy/physics_data.py
@@ -1,8 +1,18 @@
+import jax
 import jax.numpy as jnp
 import tree_math
 from jcm.date import DateData
 from jcm.physics.speedy.speedy_coords import SpeedyCoords
 from jax import tree_util
+
+
+def _safe_isnan(x):
+    """Check for NaN, handling integer and float0 dtypes that lack NaN representation."""
+    if hasattr(x, 'dtype') and (x.dtype == jax.dtypes.float0
+                                or jnp.issubdtype(x.dtype, jnp.integer)
+                                or jnp.issubdtype(x.dtype, jnp.bool_)):
+        return False
+    return jnp.isnan(x)
 
 ablco2_ref = 6.0
 
@@ -135,9 +145,7 @@ class SWRadiationData:
         )
     
     def isnan(self):
-        self.icltop = jnp.zeros_like(self.icltop, dtype=float)
-        self.compute_shortwave = jnp.zeros_like(self.compute_shortwave, dtype=float)
-        return tree_util.tree_map(jnp.isnan, self)
+        return tree_util.tree_map(_safe_isnan, self)
     
 @tree_math.struct
 class ModRadConData:
@@ -297,12 +305,8 @@ class ConvectionData:
             precnv=precnv if precnv is not None else self.precnv
         )
     
-    # Isnan function to check if any elements of ConvectionData are NaN. This function is used after getting the gradient of something with respect to
-    # a ConvectionData input object, to check if the gradient is valid. We skip the check on iptop because it is an integer and the gradient is not meaningful
-    # or intended to be used.
     def isnan(self):
-        self.iptop = jnp.zeros_like(self.iptop, dtype=float)
-        return tree_util.tree_map(jnp.isnan, self)
+        return tree_util.tree_map(_safe_isnan, self)
 
 @tree_math.struct
 class HumidityData:

--- a/jcm/physics_interface.py
+++ b/jcm/physics_interface.py
@@ -9,7 +9,8 @@ import tree_math
 from dinosaur import scales
 from dinosaur.scales import units
 from dinosaur.spherical_harmonic import vor_div_to_uv_nodal, uv_nodal_to_vor_div_modal
-from dinosaur.primitive_equations import get_geopotential, compute_diagnostic_state, State, PrimitiveEquations
+from dinosaur.primitive_equations import get_geopotential_diff_sigma, compute_diagnostic_state_sigma as compute_diagnostic_state, State, PrimitiveEquations
+from dinosaur.spherical_harmonic import add_constant
 from dinosaur.coordinate_systems import CoordinateSystem
 from dinosaur.filtering import horizontal_diffusion_filter
 from jax import tree_util
@@ -221,13 +222,12 @@ def dynamics_state_to_physics_state(state: State, dynamics: PrimitiveEquations) 
     t = nodal_state.temperature_variation
     q = nodal_state.tracers['specific_humidity']
 
-    phi_spectral = get_geopotential(
-        state.temperature_variation,
-        dynamics.reference_temperature,
-        dynamics.orography,
-        dynamics.coords.vertical,
-        dynamics.physics_specs.nondimensionalize(scales.GRAVITY_ACCELERATION),
-        dynamics.physics_specs.nondimensionalize(scales.IDEAL_GAS_CONSTANT),
+    g = dynamics.physics_specs.nondimensionalize(scales.GRAVITY_ACCELERATION)
+    R = dynamics.physics_specs.nondimensionalize(scales.IDEAL_GAS_CONSTANT)
+    surface_geopotential = dynamics.orography * g
+    temperature = add_constant(state.temperature_variation, dynamics.reference_temperature)
+    phi_spectral = surface_geopotential + get_geopotential_diff_sigma(
+        temperature, dynamics.coords.vertical, R,
     )
 
     phi = dynamics.coords.horizontal.to_nodal(phi_spectral)


### PR DESCRIPTION
## Summary
- **stop_gradient on sim_time**: Date/calendar computations in `_date_from_sim_time` use non-differentiable ops (floor, int casts) that produce NaN gradients. Applying `jax.lax.stop_gradient` detaches them from the AD graph.
- **Switch to `get_geopotential_diff_sigma`**: The previous `get_geopotential` function produced NaN gradients during backprop. `get_geopotential_diff_sigma` (with `compute_diagnostic_state_sigma`) is numerically better behaved for AD.
- **Robust `isnan()` checks**: Added `_safe_isnan` helper that gracefully handles integer, `float0`, and bool dtypes in physics data structs, replacing the old workaround of casting integer fields to float before checking.

Re-enables previously commented-out gradient assertions in tests.

Closes #354

## Test plan
- [x] Fast tests pass locally (`pytest -m 'not slow'`)
- [x] Lint passes (`ruff check`)
- [ ] Slow gradient tests pass in CI (these are the tests that were previously failing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)