### PR TITLE
Add neural network radiation emulator (issue #426)

### DIFF
--- a/jcm/physics/icon/icon_physics.py
+++ b/jcm/physics/icon/icon_physics.py
@@ -59,9 +59,10 @@ class IconPhysics(Physics):
             parameters: Optional physics parameters (uses defaults if None).
                 Set ``radiation_interval`` on the radiation parameters to
                 control sub-stepping (e.g. 7200 s for 2-hourly radiation).
-            radiation_scheme: Which radiation scheme to use. Either "grey"
-                (default simplified multi-band scheme) or "rrtmgp" (requires
-                jax-rrtmgp package).
+            radiation_scheme: Which radiation scheme to use. One of "grey"
+                (default simplified multi-band scheme), "rrtmgp" (requires
+                jax-rrtmgp package), or "emulated" (bidirectional GRU
+                neural network emulator — see ``nn_emulator`` module).
 
         """
         self.write_output = write_output
@@ -76,10 +77,12 @@ class IconPhysics(Physics):
             rad_term = apply_radiation_rrtmgp
         elif radiation_scheme == "grey":
             rad_term = apply_radiation
+        elif radiation_scheme == "emulated":
+            rad_term = apply_radiation_emulated
         else:
             raise ValueError(
                 f"Unknown radiation_scheme={radiation_scheme!r}. "
-                "Choose 'grey' or 'rrtmgp'."
+                "Choose 'grey', 'rrtmgp', or 'emulated'."
             )
 
         # Build list of physics terms
@@ -722,6 +725,20 @@ def apply_radiation_rrtmgp(
     )
 
 
+def apply_radiation_emulated(
+    state: PhysicsState,
+    physics_data: PhysicsData,
+    parameters: Parameters,
+    forcing: ForcingData,
+    terrain: TerrainData,
+) -> tuple[PhysicsTendency, PhysicsData]:
+    """Emulated (neural network) radiation with sub-stepping."""
+    return _radiation_with_caching(
+        _apply_radiation_emulated_inner,
+        state, physics_data, parameters, forcing, terrain,
+    )
+
+
 @jit
 def _apply_radiation_inner(state: PhysicsState,
     physics_data: PhysicsData,
@@ -931,6 +948,126 @@ def _apply_radiation_rrtmgp_inner(
         toa_sw_up=diagnostics_vmapped.toa_sw_up,
         toa_lw_up=diagnostics_vmapped.toa_lw_up,
         toa_sw_down=diagnostics_vmapped.toa_sw_down,
+    )
+
+    updated_physics_data = physics_data.copy(radiation=rad_out)
+    return physics_tendencies, updated_physics_data
+
+
+@jit
+def _apply_radiation_emulated_inner(
+    state: PhysicsState,
+    physics_data: PhysicsData,
+    parameters: Parameters,
+    forcing: ForcingData,
+    terrain: TerrainData,
+) -> tuple[PhysicsTendency, PhysicsData]:
+    """Apply emulated (neural-network) radiation heating rates.
+
+    Uses bidirectional GRU networks to predict SW and LW fluxes for each
+    atmospheric column, then derives heating rates from flux divergence.
+    """
+    from jcm.physics.icon.radiation.radiation_scheme_emulated import (
+        radiation_scheme_emulated,
+    )
+
+    nlev, ncols = state.temperature.shape
+
+    # Lat/lon from cached coordinates
+    lat, lon = jax.numpy.meshgrid(
+        physics_data.icon_coords.lat * 180.0 / jnp.pi,
+        physics_data.icon_coords.lon * 180.0 / jnp.pi,
+    )
+    latitudes, longitudes = lat.reshape(ncols), lon.reshape(ncols)
+
+    date = physics_data.date.dt
+
+    cloud_water = state.tracers.get('qc', jnp.zeros_like(state.temperature))
+    cloud_ice = state.tracers.get('qi', jnp.zeros_like(state.temperature))
+    cloud_fraction = physics_data.clouds.cloud_fraction
+
+    ozone_vmr = physics_data.chemistry.ozone_vmr * 1e-6
+    co2_vmr = jnp.mean(physics_data.chemistry.co2_vmr) * 1e-6
+
+    surface_temperature_col = physics_data.surface.surface_temperature.reshape(ncols)
+    surface_albedo_vis_col = physics_data.radiation.surface_albedo_vis.reshape(ncols)
+    surface_albedo_nir_col = physics_data.radiation.surface_albedo_nir.reshape(ncols)
+    surface_emissivity_col = physics_data.radiation.surface_emissivity.reshape(ncols)
+
+    aerosol_data_for_vmap = physics_data.aerosol.copy(
+        aod_profile=physics_data.aerosol.aod_profile.reshape(nlev, ncols).T,
+        ssa_profile=physics_data.aerosol.ssa_profile.reshape(nlev, ncols).T,
+        asy_profile=physics_data.aerosol.asy_profile.reshape(nlev, ncols).T,
+        cdnc_factor=physics_data.aerosol.cdnc_factor.reshape(ncols),
+        aod_total=physics_data.aerosol.aod_total.reshape(ncols),
+        aod_anthropogenic=physics_data.aerosol.aod_anthropogenic.reshape(ncols),
+        aod_background=physics_data.aerosol.aod_background.reshape(ncols),
+        angstrom=physics_data.aerosol.angstrom.reshape(ncols),
+    )
+
+    # Extract emulator weights and scaling from radiation parameters
+    emulator_weights = parameters.radiation.emulator_weights
+    sw_scaling = parameters.radiation.sw_scaling
+    lw_scaling = parameters.radiation.lw_scaling
+
+    radiation_results = jax.vmap(
+        radiation_scheme_emulated,
+        in_axes=(
+            1, 1, 1, 1, 1,     # temperature..layer_thickness
+            1, 1, 1, 1,        # air_density..cloud_fraction
+            0, 0, 0, 0,        # surface scalars
+            None, 0, 0,        # date, lat, lon
+            None, 0, 1, None,  # parameters, aerosol, ozone, co2
+            None, None, None,  # emulator_weights, sw_scaling, lw_scaling
+        ),
+        out_axes=(0, 0),
+        axis_size=ncols,
+    )(
+        state.temperature, state.specific_humidity,
+        physics_data.diagnostics.pressure_full,
+        physics_data.diagnostics.pressure_half,
+        physics_data.diagnostics.layer_thickness,
+        physics_data.diagnostics.air_density,
+        cloud_water, cloud_ice, cloud_fraction,
+        surface_temperature_col, surface_albedo_vis_col,
+        surface_albedo_nir_col, surface_emissivity_col,
+        date, latitudes, longitudes,
+        parameters.radiation, aerosol_data_for_vmap, ozone_vmr, co2_vmr,
+        emulator_weights, sw_scaling, lw_scaling,
+    )
+
+    tendencies_vmapped, diagnostics_vmapped = radiation_results
+    temperature_tendency = tendencies_vmapped.temperature_tendency.T
+
+    physics_tendencies = PhysicsTendency(
+        u_wind=jnp.zeros((nlev, ncols)),
+        v_wind=jnp.zeros((nlev, ncols)),
+        temperature=temperature_tendency,
+        specific_humidity=jnp.zeros((nlev, ncols)),
+        tracers={},
+    )
+
+    # Emulated fluxes are 1D per column (no spectral bands), so the
+    # vmapped output shapes are [ncols, nlev+1] for fluxes and
+    # [ncols, nlev] for heating rates.
+    rad_out = RadiationData(
+        cos_zenith=diagnostics_vmapped.cos_zenith.squeeze(),
+        surface_albedo_vis=diagnostics_vmapped.surface_albedo_vis.squeeze(),
+        surface_albedo_nir=diagnostics_vmapped.surface_albedo_nir.squeeze(),
+        surface_emissivity=diagnostics_vmapped.surface_emissivity.squeeze(),
+        sw_flux_up=diagnostics_vmapped.sw_flux_up.T,        # [ncols, nlev+1] -> [nlev+1, ncols]
+        sw_flux_down=diagnostics_vmapped.sw_flux_down.T,
+        sw_heating_rate=tendencies_vmapped.shortwave_heating.T,
+        lw_flux_up=diagnostics_vmapped.lw_flux_up.T,
+        lw_flux_down=diagnostics_vmapped.lw_flux_down.T,
+        lw_heating_rate=tendencies_vmapped.longwave_heating.T,
+        surface_sw_down=diagnostics_vmapped.surface_sw_down.squeeze(),
+        surface_lw_down=diagnostics_vmapped.surface_lw_down.squeeze(),
+        surface_sw_up=diagnostics_vmapped.surface_sw_up.squeeze(),
+        surface_lw_up=diagnostics_vmapped.surface_lw_up.squeeze(),
+        toa_sw_up=diagnostics_vmapped.toa_sw_up.squeeze(),
+        toa_lw_up=diagnostics_vmapped.toa_lw_up.squeeze(),
+        toa_sw_down=diagnostics_vmapped.toa_sw_down.squeeze(),
     )
 
     updated_physics_data = physics_data.copy(radiation=rad_out)

--- a/jcm/physics/icon/radiation/__init__.py
+++ b/jcm/physics/icon/radiation/__init__.py
@@ -1,1 +1,10 @@
 from .radiation_types import RadiationParameters as RadiationParameters
+from .nn_emulator import (
+    EmulatorWeights as EmulatorWeights,
+    InputScaling as InputScaling,
+    init_emulator_weights as init_emulator_weights,
+    load_weights_from_netcdf as load_weights_from_netcdf,
+)
+from .radiation_scheme_emulated import (
+    radiation_scheme_emulated as radiation_scheme_emulated,
+)

--- a/jcm/physics/icon/radiation/nn_emulator.py
+++ b/jcm/physics/icon/radiation/nn_emulator.py
@@ -1,0 +1,649 @@
+"""Neural network emulator for radiative transfer.
+
+Implements the bidirectional RNN architecture from Ukkonen (2024) for emulating
+the RTE+RRTMGP radiation scheme. Separate models handle shortwave (SW) and
+longwave (LW) radiation, each predicting normalized flux profiles that are
+converted to heating rates via flux divergence.
+
+Reference: https://github.com/peterukk/rte-rrtmgp-nn (nn_dev branch)
+
+Date: 2026-04-11
+"""
+
+from typing import Optional
+
+import jax
+import jax.numpy as jnp
+import tree_math
+
+
+# ---------------------------------------------------------------------------
+# Activation functions
+# ---------------------------------------------------------------------------
+
+def softsign(x: jnp.ndarray) -> jnp.ndarray:
+    """Softsign activation: x / (|x| + 1)."""
+    return x / (jnp.abs(x) + 1.0)
+
+
+def sigmoid(x: jnp.ndarray) -> jnp.ndarray:
+    """Sigmoid activation."""
+    return jax.nn.sigmoid(x)
+
+
+ACTIVATIONS = {
+    "softsign": softsign,
+    "sigmoid": sigmoid,
+    "relu": jax.nn.relu,
+    "linear": lambda x: x,
+    "tanh": jnp.tanh,
+}
+
+
+# ---------------------------------------------------------------------------
+# Weight data structures
+# ---------------------------------------------------------------------------
+
+@tree_math.struct
+class DenseWeights:
+    """Weights for a single Dense layer: y = activation(x @ kernel + bias)."""
+
+    kernel: jnp.ndarray  # (in_features, out_features)
+    bias: jnp.ndarray    # (out_features,)
+
+
+@tree_math.struct
+class GRUWeights:
+    """Weights for a GRU cell.
+
+    Gate layout follows Keras convention: [z (update), r (reset), h (candidate)].
+    ``kernel`` multiplies the input, ``recurrent_kernel`` multiplies the hidden state.
+    """
+
+    kernel: jnp.ndarray           # (input_dim, 3 * units)
+    recurrent_kernel: jnp.ndarray # (units, 3 * units)
+    bias: jnp.ndarray             # (2, 3 * units) — input bias + recurrent bias
+
+
+@tree_math.struct
+class SWEmulatorWeights:
+    """Weights for the shortwave bidirectional-GRU emulator.
+
+    Architecture (brnn.py):
+      aux_dense_fwd  : albedo → initial state for forward GRU
+      aux_dense_bwd  : albedo → initial state for backward GRU
+      gru_fwd        : forward GRU (Bidirectional wrapper forward)
+      gru_bwd        : backward GRU (Bidirectional wrapper backward)
+      gru2           : second GRU on concatenated hidden states
+      output_dense   : TimeDistributed Dense → 2 outputs (rsd_norm, rsu_norm)
+    """
+
+    aux_dense_fwd: DenseWeights
+    aux_dense_bwd: DenseWeights
+    gru_fwd: GRUWeights
+    gru_bwd: GRUWeights
+    gru2: GRUWeights
+    output_dense: DenseWeights
+
+
+@tree_math.struct
+class LWEmulatorWeights:
+    """Weights for the longwave GRU emulator.
+
+    Architecture (brnn2.py):
+      gru_fwd       : forward GRU
+      surface_dense : Dense on [last_state, emissivity]
+      gru_bwd       : backward GRU (go_backwards=True)
+      gru3          : third GRU on concatenated hidden states
+      output_dense  : TimeDistributed Dense → 2 outputs (rld_norm, rlu_norm)
+    """
+
+    gru_fwd: GRUWeights
+    surface_dense: DenseWeights
+    gru_bwd: GRUWeights
+    gru3: GRUWeights
+    output_dense: DenseWeights
+
+
+@tree_math.struct
+class EmulatorWeights:
+    """All weights for the emulated radiation scheme."""
+
+    sw: SWEmulatorWeights
+    lw: LWEmulatorWeights
+
+
+@tree_math.struct
+class InputScaling:
+    """Min-max scaling coefficients for NN inputs: x_scaled = x / x_max."""
+
+    x_max: jnp.ndarray  # (n_features,)
+
+
+# ---------------------------------------------------------------------------
+# GRU cell
+# ---------------------------------------------------------------------------
+
+def gru_cell(
+    x: jnp.ndarray,
+    h: jnp.ndarray,
+    weights: GRUWeights,
+) -> jnp.ndarray:
+    """Single GRU step.
+
+    Args:
+        x: Input vector (input_dim,).
+        h: Previous hidden state (units,).
+        weights: GRU weights.
+
+    Returns:
+        New hidden state (units,).
+
+    """
+    units = h.shape[-1]
+
+    # Gate projections
+    x_z = x @ weights.kernel[:, :units]
+    x_r = x @ weights.kernel[:, units:2*units]
+    x_h = x @ weights.kernel[:, 2*units:]
+
+    h_z = h @ weights.recurrent_kernel[:, :units]
+    h_r = h @ weights.recurrent_kernel[:, units:2*units]
+
+    # Keras uses two bias rows: input_bias and recurrent_bias
+    bx = weights.bias[0]
+    bh = weights.bias[1]
+
+    z = sigmoid(x_z + bx[:units] + h_z + bh[:units])
+    r = sigmoid(x_r + bx[units:2*units] + h_r + bh[units:2*units])
+
+    h_candidate = jnp.tanh(
+        x_h + bx[2*units:] + r * (h @ weights.recurrent_kernel[:, 2*units:] + bh[2*units:])
+    )
+
+    h_new = z * h + (1.0 - z) * h_candidate
+    return h_new
+
+
+# ---------------------------------------------------------------------------
+# GRU sequence processing
+# ---------------------------------------------------------------------------
+
+def gru_forward_sequence(
+    x_seq: jnp.ndarray,
+    h0: jnp.ndarray,
+    weights: GRUWeights,
+) -> jnp.ndarray:
+    """Run a GRU forward over a sequence.
+
+    Args:
+        x_seq: Input sequence (seq_len, input_dim).
+        h0: Initial hidden state (units,).
+        weights: GRU weights.
+
+    Returns:
+        Hidden states at all time steps (seq_len, units).
+
+    """
+    def step(h, x):
+        h_new = gru_cell(x, h, weights)
+        return h_new, h_new
+
+    _, hidden_seq = jax.lax.scan(step, h0, x_seq)
+    return hidden_seq
+
+
+def gru_backward_sequence(
+    x_seq: jnp.ndarray,
+    h0: jnp.ndarray,
+    weights: GRUWeights,
+) -> jnp.ndarray:
+    """Run a GRU backward over a sequence (go_backwards=True).
+
+    Args:
+        x_seq: Input sequence (seq_len, input_dim).
+        h0: Initial hidden state (units,).
+        weights: GRU weights.
+
+    Returns:
+        Hidden states at all time steps (seq_len, units), reversed back
+        to original ordering.
+
+    """
+    hidden_rev = gru_forward_sequence(x_seq[::-1], h0, weights)
+    return hidden_rev[::-1]
+
+
+# ---------------------------------------------------------------------------
+# Dense layer
+# ---------------------------------------------------------------------------
+
+def dense(x: jnp.ndarray, weights: DenseWeights, activation=None) -> jnp.ndarray:
+    """Apply a Dense layer: y = activation(x @ kernel + bias).
+
+    Works for both single vectors and batched (seq_len, features) inputs
+    (TimeDistributed pattern).
+    """
+    y = x @ weights.kernel + weights.bias
+    if activation is not None:
+        y = activation(y)
+    return y
+
+
+# ---------------------------------------------------------------------------
+# Input preprocessing
+# ---------------------------------------------------------------------------
+
+def preprocess_sw_inputs(
+    temperature: jnp.ndarray,
+    pressure: jnp.ndarray,
+    h2o: jnp.ndarray,
+    o3: jnp.ndarray,
+    cloud_water: jnp.ndarray,
+    cloud_ice: jnp.ndarray,
+    cos_zenith: jnp.ndarray,
+    scaling: InputScaling,
+) -> jnp.ndarray:
+    """Prepare SW NN inputs from atmospheric profiles.
+
+    Follows the reference preprocessing: log(pressure), power transforms
+    for gases, divide-by-max scaling.
+
+    Args:
+        temperature: Temperature profile (nlev,) [K].
+        pressure: Pressure at full levels (nlev,) [Pa].
+        h2o: Water vapour mass mixing ratio (nlev,) [kg/kg].
+        o3: Ozone mass mixing ratio (nlev,) [kg/kg].
+        cloud_water: Cloud liquid water path (nlev,) [kg/m^2].
+        cloud_ice: Cloud ice water path (nlev,) [kg/m^2].
+        cos_zenith: Cosine of solar zenith angle (scalar).
+        scaling: Input normalization coefficients.
+
+    Returns:
+        Scaled input array (nlev, n_features).
+
+    """
+    log_p = jnp.log(jnp.maximum(pressure, 1.0))
+    h2o_t = h2o ** 0.25
+    o3_t = o3 ** 0.25
+
+    mu0 = jnp.broadcast_to(cos_zenith, temperature.shape)
+
+    # Stack features: [T, log(p), h2o^1/4, o3^1/4, lwp, iwp, mu0]
+    x = jnp.stack([temperature, log_p, h2o_t, o3_t,
+                    cloud_water, cloud_ice, mu0], axis=-1)
+
+    # Divide-by-max scaling
+    return x / jnp.maximum(scaling.x_max, 1e-30)
+
+
+def preprocess_lw_inputs(
+    temperature: jnp.ndarray,
+    pressure: jnp.ndarray,
+    h2o: jnp.ndarray,
+    o3: jnp.ndarray,
+    cloud_water: jnp.ndarray,
+    cloud_ice: jnp.ndarray,
+    co2_vmr: float,
+    scaling: InputScaling,
+) -> jnp.ndarray:
+    """Prepare LW NN inputs from atmospheric profiles.
+
+    Args:
+        temperature: Temperature profile (nlev,) [K].
+        pressure: Pressure at full levels (nlev,) [Pa].
+        h2o: Water vapour mass mixing ratio (nlev,) [kg/kg].
+        o3: Ozone mass mixing ratio (nlev,) [kg/kg].
+        cloud_water: Cloud liquid water path (nlev,) [kg/m^2].
+        cloud_ice: Cloud ice water path (nlev,) [kg/m^2].
+        co2_vmr: CO2 volume mixing ratio (scalar).
+        scaling: Input normalization coefficients.
+
+    Returns:
+        Scaled input array (nlev, n_features).
+
+    """
+    log_p = jnp.log(jnp.maximum(pressure, 1.0))
+    h2o_t = h2o ** 0.25
+    o3_t = o3 ** 0.25
+    co2 = jnp.broadcast_to(jnp.asarray(co2_vmr), temperature.shape)
+
+    # Stack features: [T, log(p), h2o^1/4, o3^1/4, lwp, iwp, co2]
+    x = jnp.stack([temperature, log_p, h2o_t, o3_t,
+                    cloud_water, cloud_ice, co2], axis=-1)
+
+    return x / jnp.maximum(scaling.x_max, 1e-30)
+
+
+# ---------------------------------------------------------------------------
+# SW emulator (bidirectional GRU — brnn.py architecture)
+# ---------------------------------------------------------------------------
+
+def sw_emulator_column(
+    x_seq: jnp.ndarray,
+    surface_albedo: jnp.ndarray,
+    weights: SWEmulatorWeights,
+) -> jnp.ndarray:
+    """Run the SW bidirectional-GRU emulator for one column.
+
+    Args:
+        x_seq: Preprocessed input features (nlev, n_features).
+        surface_albedo: Surface albedo (1,).
+        weights: SW emulator weights.
+
+    Returns:
+        Normalized flux predictions (nlev, 2) — (rsd_norm, rsu_norm).
+        These represent the fraction of TOA flux reaching each level (down)
+        and reflected upward (up), before boundary-condition reconstruction.
+
+    """
+    nneur = weights.gru_fwd.recurrent_kernel.shape[0]
+
+    # Auxiliary inputs: albedo → initial hidden states for bidirectional GRU
+    h0_fwd = dense(surface_albedo, weights.aux_dense_fwd, activation=None)
+    h0_bwd = dense(surface_albedo, weights.aux_dense_bwd, activation=None)
+
+    # Bidirectional GRU (merge_mode='concat')
+    hidden_fwd = gru_forward_sequence(x_seq, h0_fwd, weights.gru_fwd)
+    hidden_bwd = gru_backward_sequence(x_seq, h0_bwd, weights.gru_bwd)
+    hidden_bi = jnp.concatenate([hidden_fwd, hidden_bwd], axis=-1)
+
+    # Second GRU
+    h0_gru2 = jnp.zeros(nneur)
+    hidden2 = gru_forward_sequence(hidden_bi, h0_gru2, weights.gru2)
+
+    # Output dense (sigmoid activation)
+    output = dense(hidden2, weights.output_dense, activation=sigmoid)
+    return output
+
+
+def reconstruct_sw_fluxes(
+    nn_output: jnp.ndarray,
+    toa_sw_down: jnp.ndarray,
+    surface_albedo: jnp.ndarray,
+) -> tuple[jnp.ndarray, jnp.ndarray]:
+    """Reconstruct physical SW fluxes from normalized NN output.
+
+    Args:
+        nn_output: NN predictions (nlev, 2) — normalized (down, up) per layer.
+        toa_sw_down: Incoming SW flux at TOA (scalar, W/m^2).
+        surface_albedo: Surface albedo (scalar).
+
+    Returns:
+        sw_flux_down: Downward SW flux at interfaces (nlev+1,) [W/m^2].
+        sw_flux_up: Upward SW flux at interfaces (nlev+1,) [W/m^2].
+
+    """
+    rsd_norm = nn_output[:, 0]  # normalized downwelling per layer
+    rsu_norm = nn_output[:, 1]  # normalized upwelling per layer
+
+    # Downwelling: TOA boundary = toa_sw_down, then NN predictions
+    rsd = jnp.concatenate([jnp.array([1.0]), rsd_norm]) * toa_sw_down
+
+    # Upwelling: NN predictions, then surface reflection = albedo * rsd_surface
+    rsu_surface = surface_albedo * rsd[-1]
+    rsu = jnp.concatenate([rsu_norm * toa_sw_down, jnp.array([rsu_surface])])
+
+    return rsd, rsu
+
+
+# ---------------------------------------------------------------------------
+# LW emulator (forward-backward GRU — brnn2.py architecture)
+# ---------------------------------------------------------------------------
+
+def lw_emulator_column(
+    x_seq: jnp.ndarray,
+    surface_emissivity: jnp.ndarray,
+    weights: LWEmulatorWeights,
+) -> jnp.ndarray:
+    """Run the LW forward-backward GRU emulator for one column.
+
+    Architecture: Forward GRU → surface Dense (last state + emissivity) →
+    append to sequence → backward GRU → optional 3rd GRU → Dense output.
+
+    Args:
+        x_seq: Preprocessed input features (nlev, n_features).
+        surface_emissivity: Surface emissivity (1,).
+        weights: LW emulator weights.
+
+    Returns:
+        Normalized flux predictions (nlev+1, 2) — (rld_norm, rlu_norm).
+
+    """
+    nneur = weights.gru_fwd.recurrent_kernel.shape[0]
+    h0 = jnp.zeros(nneur)
+
+    # Forward GRU
+    hidden_fwd = gru_forward_sequence(x_seq, h0, weights.gru_fwd)
+    last_state = hidden_fwd[-1]
+
+    # Surface processing: Dense on [last_state, emissivity]
+    surface_input = jnp.concatenate([last_state, surface_emissivity])
+    surface_hidden = dense(surface_input, weights.surface_dense, activation=None)
+
+    # Append surface hidden state to forward sequence
+    hidden_fwd_extended = jnp.concatenate(
+        [hidden_fwd, surface_hidden[jnp.newaxis, :]], axis=0
+    )
+
+    # Backward GRU on extended sequence
+    h0_bwd = jnp.zeros(nneur)
+    hidden_bwd = gru_backward_sequence(hidden_fwd_extended, h0_bwd, weights.gru_bwd)
+
+    # Concatenate forward and backward
+    hidden_concat = jnp.concatenate([hidden_fwd_extended, hidden_bwd], axis=-1)
+
+    # Third GRU
+    h0_gru3 = jnp.zeros(nneur)
+    hidden3 = gru_forward_sequence(hidden_concat, h0_gru3, weights.gru3)
+
+    # Output dense (sigmoid activation)
+    output = dense(hidden3, weights.output_dense, activation=sigmoid)
+    return output
+
+
+def reconstruct_lw_fluxes(
+    nn_output: jnp.ndarray,
+    surface_temperature: jnp.ndarray,
+    surface_emissivity: jnp.ndarray,
+) -> tuple[jnp.ndarray, jnp.ndarray]:
+    """Reconstruct physical LW fluxes from normalized NN output.
+
+    Args:
+        nn_output: NN predictions (nlev+1, 2) — normalized (down, up) at interfaces.
+        surface_temperature: Surface temperature (scalar, K).
+        surface_emissivity: Surface emissivity (scalar).
+
+    Returns:
+        lw_flux_down: Downward LW flux at interfaces (nlev+1,) [W/m^2].
+        lw_flux_up: Upward LW flux at interfaces (nlev+1,) [W/m^2].
+
+    """
+    sigma = 5.670374419e-8  # Stefan-Boltzmann constant
+
+    # Scale factor: surface blackbody emission
+    surface_emission = surface_emissivity * sigma * surface_temperature ** 4
+
+    rld = nn_output[:, 0] * surface_emission
+    rlu = nn_output[:, 1] * surface_emission
+
+    return rld, rlu
+
+
+# ---------------------------------------------------------------------------
+# Heating rates from fluxes
+# ---------------------------------------------------------------------------
+
+def flux_to_heating_rate(
+    flux_down: jnp.ndarray,
+    flux_up: jnp.ndarray,
+    pressure_interfaces: jnp.ndarray,
+) -> jnp.ndarray:
+    """Compute heating rate from flux profiles via flux divergence.
+
+    dT/dt = -(g / c_p) * dF_net / dp
+
+    Args:
+        flux_down: Downward flux at interfaces (nlev+1,) [W/m^2].
+        flux_up: Upward flux at interfaces (nlev+1,) [W/m^2].
+        pressure_interfaces: Pressure at interfaces (nlev+1,) [Pa].
+
+    Returns:
+        Heating rate at full levels (nlev,) [K/s].
+
+    """
+    g = 9.81
+    cp = 1004.0
+
+    net_flux = flux_down - flux_up  # positive downward
+    d_net_flux = jnp.diff(net_flux)  # (nlev,)
+    dp = jnp.diff(pressure_interfaces)  # (nlev,)
+
+    # dT/dt = (g/cp) * dF_net/dp  (positive heating when net flux increases downward)
+    return (g / cp) * d_net_flux / dp
+
+
+# ---------------------------------------------------------------------------
+# Weight loading from NetCDF
+# ---------------------------------------------------------------------------
+
+def load_weights_from_netcdf(filepath: str) -> tuple:
+    """Load NN weights from a NetCDF file in the rte-rrtmgp-nn format.
+
+    The NetCDF file contains weight matrices and bias vectors for each layer,
+    along with activation function names and scaling coefficients.
+
+    Args:
+        filepath: Path to the .nc file.
+
+    Returns:
+        Tuple of (list of DenseWeights, InputScaling, activation_names).
+
+    """
+    import xarray as xr
+
+    ds = xr.open_dataset(filepath)
+
+    layer_weights = []
+    i = 1
+    while f"w{i}" in ds:
+        kernel = jnp.array(ds[f"w{i}"].values)
+        bias = jnp.array(ds[f"b{i}"].values)
+        layer_weights.append(DenseWeights(kernel=kernel, bias=bias))
+        i += 1
+
+    x_max = jnp.array(ds["xmax"].values) if "xmax" in ds else jnp.ones(1)
+    scaling = InputScaling(x_max=x_max)
+
+    activation_names = []
+    if "activations" in ds:
+        activation_names = [
+            str(a) for a in ds["activations"].values
+        ]
+
+    ds.close()
+    return layer_weights, scaling, activation_names
+
+
+# ---------------------------------------------------------------------------
+# Random weight initialization (for testing / training from scratch)
+# ---------------------------------------------------------------------------
+
+def init_gru_weights(
+    input_dim: int,
+    units: int,
+    key: jax.Array,
+) -> GRUWeights:
+    """Initialize GRU weights with Glorot uniform."""
+    k1, k2, k3 = jax.random.split(key, 3)
+    scale_k = jnp.sqrt(2.0 / (input_dim + units))
+    scale_r = jnp.sqrt(2.0 / (units + units))
+    return GRUWeights(
+        kernel=jax.random.normal(k1, (input_dim, 3 * units)) * scale_k,
+        recurrent_kernel=jax.random.normal(k2, (units, 3 * units)) * scale_r,
+        bias=jnp.zeros((2, 3 * units)),
+    )
+
+
+def init_dense_weights(
+    input_dim: int,
+    output_dim: int,
+    key: jax.Array,
+) -> DenseWeights:
+    """Initialize Dense weights with Glorot uniform."""
+    scale = jnp.sqrt(2.0 / (input_dim + output_dim))
+    return DenseWeights(
+        kernel=jax.random.normal(key, (input_dim, output_dim)) * scale,
+        bias=jnp.zeros(output_dim),
+    )
+
+
+def init_sw_emulator_weights(
+    n_features: int = 7,
+    units: int = 16,
+    n_outputs: int = 2,
+    key: Optional[jax.Array] = None,
+) -> SWEmulatorWeights:
+    """Initialize random SW emulator weights.
+
+    Args:
+        n_features: Number of input features per layer.
+        units: GRU hidden size.
+        n_outputs: Number of outputs (default 2: rsd_norm, rsu_norm).
+        key: PRNG key (default: key(0)).
+
+    """
+    if key is None:
+        key = jax.random.key(0)
+    keys = jax.random.split(key, 6)
+    return SWEmulatorWeights(
+        aux_dense_fwd=init_dense_weights(1, units, keys[0]),
+        aux_dense_bwd=init_dense_weights(1, units, keys[1]),
+        gru_fwd=init_gru_weights(n_features, units, keys[2]),
+        gru_bwd=init_gru_weights(n_features, units, keys[3]),
+        gru2=init_gru_weights(2 * units, units, keys[4]),
+        output_dense=init_dense_weights(units, n_outputs, keys[5]),
+    )
+
+
+def init_lw_emulator_weights(
+    n_features: int = 7,
+    units: int = 16,
+    n_outputs: int = 2,
+    key: Optional[jax.Array] = None,
+) -> LWEmulatorWeights:
+    """Initialize random LW emulator weights.
+
+    Args:
+        n_features: Number of input features per layer.
+        units: GRU hidden size.
+        n_outputs: Number of outputs (default 2: rld_norm, rlu_norm).
+        key: PRNG key (default: key(1)).
+
+    """
+    if key is None:
+        key = jax.random.key(1)
+    keys = jax.random.split(key, 5)
+    return LWEmulatorWeights(
+        gru_fwd=init_gru_weights(n_features, units, keys[0]),
+        surface_dense=init_dense_weights(units + 1, units, keys[1]),
+        gru_bwd=init_gru_weights(units, units, keys[2]),
+        gru3=init_gru_weights(2 * units, units, keys[3]),
+        output_dense=init_dense_weights(units, n_outputs, keys[4]),
+    )
+
+
+def init_emulator_weights(
+    sw_features: int = 7,
+    lw_features: int = 7,
+    units: int = 16,
+    key: Optional[jax.Array] = None,
+) -> EmulatorWeights:
+    """Initialize random weights for both SW and LW emulators."""
+    if key is None:
+        key = jax.random.key(42)
+    k1, k2 = jax.random.split(key)
+    return EmulatorWeights(
+        sw=init_sw_emulator_weights(n_features=sw_features, units=units, key=k1),
+        lw=init_lw_emulator_weights(n_features=lw_features, units=units, key=k2),
+    )

--- a/jcm/physics/icon/radiation/nn_emulator_test.py
+++ b/jcm/physics/icon/radiation/nn_emulator_test.py
@@ -1,0 +1,445 @@
+"""Tests for the neural network radiation emulator.
+
+Covers: GRU cell, sequence processing, SW/LW emulators, flux
+reconstruction, heating rates, weight initialization, and gradient
+flow through the NN weights.
+
+Date: 2026-04-11
+"""
+
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from jcm.physics.icon.radiation.nn_emulator import (
+    gru_cell,
+    gru_forward_sequence,
+    gru_backward_sequence,
+    dense,
+    softsign,
+    sigmoid,
+    preprocess_sw_inputs,
+    preprocess_lw_inputs,
+    sw_emulator_column,
+    lw_emulator_column,
+    reconstruct_sw_fluxes,
+    reconstruct_lw_fluxes,
+    flux_to_heating_rate,
+    init_gru_weights,
+    init_dense_weights,
+    init_sw_emulator_weights,
+    init_lw_emulator_weights,
+    init_emulator_weights,
+    DenseWeights,
+    SWEmulatorWeights,
+    LWEmulatorWeights,
+    EmulatorWeights,
+    InputScaling,
+)
+
+
+class TestActivations(unittest.TestCase):
+    """Basic activation function sanity checks."""
+
+    def test_softsign_values(self):
+        x = jnp.array([-2.0, 0.0, 2.0])
+        y = softsign(x)
+        np.testing.assert_allclose(y, np.array([-2/3, 0.0, 2/3]), atol=1e-6)
+
+    def test_sigmoid_range(self):
+        x = jnp.linspace(-5, 5, 20)
+        y = sigmoid(x)
+        self.assertTrue(jnp.all(y >= 0.0))
+        self.assertTrue(jnp.all(y <= 1.0))
+
+
+class TestDense(unittest.TestCase):
+    """Tests for the dense layer."""
+
+    def test_output_shape(self):
+        key = jax.random.key(0)
+        w = init_dense_weights(4, 8, key)
+        x = jnp.ones(4)
+        y = dense(x, w)
+        self.assertEqual(y.shape, (8,))
+
+    def test_batched_output_shape(self):
+        """TimeDistributed pattern: (seq_len, features)."""
+        key = jax.random.key(0)
+        w = init_dense_weights(4, 8, key)
+        x = jnp.ones((10, 4))
+        y = dense(x, w)
+        self.assertEqual(y.shape, (10, 8))
+
+    def test_activation_applied(self):
+        w = DenseWeights(kernel=jnp.eye(2), bias=jnp.zeros(2))
+        x = jnp.array([-1.0, 1.0])
+        y = dense(x, w, activation=jax.nn.relu)
+        np.testing.assert_allclose(y, np.array([0.0, 1.0]))
+
+
+class TestGRUCell(unittest.TestCase):
+    """Tests for a single GRU step."""
+
+    def setUp(self):
+        self.input_dim = 7
+        self.units = 16
+        self.key = jax.random.key(42)
+        self.weights = init_gru_weights(self.input_dim, self.units, self.key)
+
+    def test_output_shape(self):
+        x = jnp.ones(self.input_dim)
+        h = jnp.zeros(self.units)
+        h_new = gru_cell(x, h, self.weights)
+        self.assertEqual(h_new.shape, (self.units,))
+
+    def test_zero_input_nonzero_output(self):
+        """Even with zero input, the candidate gate should produce output."""
+        x = jnp.zeros(self.input_dim)
+        h = jnp.ones(self.units) * 0.5
+        h_new = gru_cell(x, h, self.weights)
+        self.assertFalse(jnp.allclose(h_new, jnp.zeros(self.units)))
+
+    def test_deterministic(self):
+        x = jax.random.normal(self.key, (self.input_dim,))
+        h = jnp.zeros(self.units)
+        h1 = gru_cell(x, h, self.weights)
+        h2 = gru_cell(x, h, self.weights)
+        np.testing.assert_array_equal(h1, h2)
+
+
+class TestGRUSequence(unittest.TestCase):
+    """Tests for forward and backward GRU sequence processing."""
+
+    def setUp(self):
+        self.input_dim = 7
+        self.units = 16
+        self.seq_len = 40
+        self.key = jax.random.key(1)
+        self.weights = init_gru_weights(self.input_dim, self.units, self.key)
+
+    def test_forward_output_shape(self):
+        x_seq = jnp.ones((self.seq_len, self.input_dim))
+        h0 = jnp.zeros(self.units)
+        hidden = gru_forward_sequence(x_seq, h0, self.weights)
+        self.assertEqual(hidden.shape, (self.seq_len, self.units))
+
+    def test_backward_output_shape(self):
+        x_seq = jnp.ones((self.seq_len, self.input_dim))
+        h0 = jnp.zeros(self.units)
+        hidden = gru_backward_sequence(x_seq, h0, self.weights)
+        self.assertEqual(hidden.shape, (self.seq_len, self.units))
+
+    def test_backward_reversal(self):
+        """Backward GRU reverses before processing, then reverses output."""
+        k1, k2 = jax.random.split(self.key)
+        x_seq = jax.random.normal(k1, (self.seq_len, self.input_dim))
+        h0 = jnp.zeros(self.units)
+        # backward sequence should match forward on reversed input, then reversed
+        fwd_on_rev = gru_forward_sequence(x_seq[::-1], h0, self.weights)
+        bwd = gru_backward_sequence(x_seq, h0, self.weights)
+        np.testing.assert_allclose(bwd, fwd_on_rev[::-1], atol=1e-6)
+
+
+class TestSWEmulator(unittest.TestCase):
+    """Tests for the shortwave emulator column function."""
+
+    def setUp(self):
+        self.nlev = 40
+        self.n_features = 7
+        self.units = 16
+        self.key = jax.random.key(10)
+        self.weights = init_sw_emulator_weights(
+            n_features=self.n_features, units=self.units, key=self.key
+        )
+
+    def test_output_shape(self):
+        x_seq = jnp.ones((self.nlev, self.n_features))
+        albedo = jnp.array([0.3])
+        out = sw_emulator_column(x_seq, albedo, self.weights)
+        self.assertEqual(out.shape, (self.nlev, 2))
+
+    def test_output_in_0_1(self):
+        """Sigmoid output should be in [0, 1]."""
+        x_seq = jax.random.normal(self.key, (self.nlev, self.n_features))
+        albedo = jnp.array([0.3])
+        out = sw_emulator_column(x_seq, albedo, self.weights)
+        self.assertTrue(jnp.all(out >= 0.0))
+        self.assertTrue(jnp.all(out <= 1.0))
+
+
+class TestLWEmulator(unittest.TestCase):
+    """Tests for the longwave emulator column function."""
+
+    def setUp(self):
+        self.nlev = 40
+        self.n_features = 7
+        self.units = 16
+        self.key = jax.random.key(20)
+        self.weights = init_lw_emulator_weights(
+            n_features=self.n_features, units=self.units, key=self.key
+        )
+
+    def test_output_shape(self):
+        """LW emulator outputs at nlev+1 interfaces."""
+        x_seq = jnp.ones((self.nlev, self.n_features))
+        emissivity = jnp.array([0.97])
+        out = lw_emulator_column(x_seq, emissivity, self.weights)
+        self.assertEqual(out.shape, (self.nlev + 1, 2))
+
+    def test_output_in_0_1(self):
+        x_seq = jax.random.normal(self.key, (self.nlev, self.n_features))
+        emissivity = jnp.array([0.97])
+        out = lw_emulator_column(x_seq, emissivity, self.weights)
+        self.assertTrue(jnp.all(out >= 0.0))
+        self.assertTrue(jnp.all(out <= 1.0))
+
+
+class TestFluxReconstruction(unittest.TestCase):
+    """Tests for SW and LW flux reconstruction."""
+
+    def test_sw_flux_shapes(self):
+        nlev = 40
+        nn_output = jnp.ones((nlev, 2)) * 0.5
+        toa_sw_down = jnp.array(1361.0)
+        albedo = jnp.array(0.3)
+        rsd, rsu = reconstruct_sw_fluxes(nn_output, toa_sw_down, albedo)
+        self.assertEqual(rsd.shape, (nlev + 1,))
+        self.assertEqual(rsu.shape, (nlev + 1,))
+
+    def test_sw_toa_boundary(self):
+        """TOA downwelling should equal toa_sw_down."""
+        nlev = 40
+        nn_output = jnp.ones((nlev, 2)) * 0.5
+        toa_sw_down = jnp.array(1361.0)
+        albedo = jnp.array(0.3)
+        rsd, _ = reconstruct_sw_fluxes(nn_output, toa_sw_down, albedo)
+        np.testing.assert_allclose(rsd[0], 1361.0, atol=1e-5)
+
+    def test_sw_surface_reflection(self):
+        """Surface upwelling should equal albedo * surface downwelling."""
+        nlev = 10
+        nn_output = jnp.ones((nlev, 2)) * 0.8
+        toa_sw_down = jnp.array(1000.0)
+        albedo = jnp.array(0.25)
+        rsd, rsu = reconstruct_sw_fluxes(nn_output, toa_sw_down, albedo)
+        np.testing.assert_allclose(rsu[-1], albedo * rsd[-1], atol=1e-5)
+
+    def test_lw_flux_shapes(self):
+        nlev = 40
+        nn_output = jnp.ones((nlev + 1, 2)) * 0.5
+        surface_temp = jnp.array(288.0)
+        emissivity = jnp.array(0.97)
+        rld, rlu = reconstruct_lw_fluxes(nn_output, surface_temp, emissivity)
+        self.assertEqual(rld.shape, (nlev + 1,))
+        self.assertEqual(rlu.shape, (nlev + 1,))
+
+    def test_lw_fluxes_positive(self):
+        """LW fluxes should be non-negative for positive NN output."""
+        nlev = 40
+        nn_output = jnp.ones((nlev + 1, 2)) * 0.5
+        surface_temp = jnp.array(288.0)
+        emissivity = jnp.array(0.97)
+        rld, rlu = reconstruct_lw_fluxes(nn_output, surface_temp, emissivity)
+        self.assertTrue(jnp.all(rld >= 0.0))
+        self.assertTrue(jnp.all(rlu >= 0.0))
+
+
+class TestHeatingRate(unittest.TestCase):
+    """Tests for flux → heating rate conversion."""
+
+    def test_output_shape(self):
+        nlev = 40
+        flux_down = jnp.linspace(1000, 800, nlev + 1)
+        flux_up = jnp.linspace(200, 300, nlev + 1)
+        p_int = jnp.linspace(100.0, 101325.0, nlev + 1)
+        hr = flux_to_heating_rate(flux_down, flux_up, p_int)
+        self.assertEqual(hr.shape, (nlev,))
+
+    def test_zero_flux_divergence(self):
+        """Constant net flux → zero heating rate."""
+        nlev = 10
+        flux_down = jnp.ones(nlev + 1) * 500.0
+        flux_up = jnp.ones(nlev + 1) * 200.0
+        p_int = jnp.linspace(100.0, 101325.0, nlev + 1)
+        hr = flux_to_heating_rate(flux_down, flux_up, p_int)
+        np.testing.assert_allclose(hr, 0.0, atol=1e-10)
+
+
+class TestPreprocessing(unittest.TestCase):
+    """Tests for input preprocessing."""
+
+    def test_sw_preprocessing_shape(self):
+        nlev = 40
+        scaling = InputScaling(x_max=jnp.ones(7) * 1000.0)
+        x = preprocess_sw_inputs(
+            temperature=jnp.full(nlev, 250.0),
+            pressure=jnp.linspace(100, 101325, nlev),
+            h2o=jnp.full(nlev, 0.01),
+            o3=jnp.full(nlev, 5e-6),
+            cloud_water=jnp.zeros(nlev),
+            cloud_ice=jnp.zeros(nlev),
+            cos_zenith=jnp.array(0.5),
+            scaling=scaling,
+        )
+        self.assertEqual(x.shape, (nlev, 7))
+
+    def test_lw_preprocessing_shape(self):
+        nlev = 40
+        scaling = InputScaling(x_max=jnp.ones(7) * 1000.0)
+        x = preprocess_lw_inputs(
+            temperature=jnp.full(nlev, 250.0),
+            pressure=jnp.linspace(100, 101325, nlev),
+            h2o=jnp.full(nlev, 0.01),
+            o3=jnp.full(nlev, 5e-6),
+            cloud_water=jnp.zeros(nlev),
+            cloud_ice=jnp.zeros(nlev),
+            co2_vmr=400e-6,
+            scaling=scaling,
+        )
+        self.assertEqual(x.shape, (nlev, 7))
+
+
+class TestWeightInitialization(unittest.TestCase):
+    """Tests for random weight initialization."""
+
+    def test_gru_shapes(self):
+        w = init_gru_weights(7, 16, jax.random.key(0))
+        self.assertEqual(w.kernel.shape, (7, 48))
+        self.assertEqual(w.recurrent_kernel.shape, (16, 48))
+        self.assertEqual(w.bias.shape, (2, 48))
+
+    def test_dense_shapes(self):
+        w = init_dense_weights(4, 8, jax.random.key(0))
+        self.assertEqual(w.kernel.shape, (4, 8))
+        self.assertEqual(w.bias.shape, (8,))
+
+    def test_sw_emulator_init(self):
+        w = init_sw_emulator_weights(n_features=7, units=16)
+        self.assertEqual(w.gru_fwd.kernel.shape, (7, 48))
+        self.assertEqual(w.gru2.kernel.shape, (32, 48))
+        self.assertEqual(w.output_dense.kernel.shape, (16, 2))
+
+    def test_lw_emulator_init(self):
+        w = init_lw_emulator_weights(n_features=7, units=16)
+        self.assertEqual(w.gru_fwd.kernel.shape, (7, 48))
+        self.assertEqual(w.surface_dense.kernel.shape, (17, 16))  # units + 1
+        self.assertEqual(w.gru3.kernel.shape, (32, 48))
+
+    def test_full_emulator_init(self):
+        w = init_emulator_weights()
+        self.assertIsInstance(w, EmulatorWeights)
+        self.assertIsInstance(w.sw, SWEmulatorWeights)
+        self.assertIsInstance(w.lw, LWEmulatorWeights)
+
+
+class TestGradientFlow(unittest.TestCase):
+    """Test that gradients flow through the NN weights."""
+
+    def test_sw_gradient_wrt_weights(self):
+        """jax.grad of a scalar loss w.r.t. SW emulator weights should be non-zero."""
+        nlev = 10
+        n_features = 7
+        units = 8
+        weights = init_sw_emulator_weights(
+            n_features=n_features, units=units, key=jax.random.key(99)
+        )
+        x_seq = jnp.ones((nlev, n_features)) * 0.5
+        albedo = jnp.array([0.3])
+
+        def loss_fn(w):
+            out = sw_emulator_column(x_seq, albedo, w)
+            return jnp.sum(out)
+
+        grads = jax.grad(loss_fn)(weights)
+        # Check that at least one gradient is non-zero
+        grad_flat = jax.tree_util.tree_leaves(grads)
+        total_abs = sum(jnp.sum(jnp.abs(g)) for g in grad_flat)
+        self.assertGreater(float(total_abs), 0.0)
+
+    def test_lw_gradient_wrt_weights(self):
+        """jax.grad of a scalar loss w.r.t. LW emulator weights should be non-zero."""
+        nlev = 10
+        n_features = 7
+        units = 8
+        weights = init_lw_emulator_weights(
+            n_features=n_features, units=units, key=jax.random.key(100)
+        )
+        x_seq = jnp.ones((nlev, n_features)) * 0.5
+        emissivity = jnp.array([0.97])
+
+        def loss_fn(w):
+            out = lw_emulator_column(x_seq, emissivity, w)
+            return jnp.sum(out)
+
+        grads = jax.grad(loss_fn)(weights)
+        grad_flat = jax.tree_util.tree_leaves(grads)
+        total_abs = sum(jnp.sum(jnp.abs(g)) for g in grad_flat)
+        self.assertGreater(float(total_abs), 0.0)
+
+    def test_full_pipeline_gradient(self):
+        """Gradient through SW emulator + flux reconstruction + heating rate."""
+        nlev = 10
+        n_features = 7
+        units = 8
+        sw_weights = init_sw_emulator_weights(
+            n_features=n_features, units=units, key=jax.random.key(101)
+        )
+        p_int = jnp.linspace(100.0, 101325.0, nlev + 1)
+
+        def loss_fn(w):
+            x_seq = jnp.ones((nlev, n_features)) * 0.5
+            albedo = jnp.array([0.3])
+            nn_out = sw_emulator_column(x_seq, albedo, w)
+            toa_sw = jnp.array(1361.0)
+            rsd, rsu = reconstruct_sw_fluxes(nn_out, toa_sw, jnp.array(0.3))
+            hr = flux_to_heating_rate(rsd, rsu, p_int)
+            return jnp.mean(hr ** 2)
+
+        grads = jax.grad(loss_fn)(sw_weights)
+        grad_flat = jax.tree_util.tree_leaves(grads)
+        total_abs = sum(jnp.sum(jnp.abs(g)) for g in grad_flat)
+        self.assertGreater(float(total_abs), 0.0)
+
+
+class TestJITCompatibility(unittest.TestCase):
+    """Ensure all main functions can be JIT-compiled."""
+
+    def test_sw_emulator_jit(self):
+        weights = init_sw_emulator_weights(n_features=7, units=8)
+        x_seq = jnp.ones((20, 7))
+        albedo = jnp.array([0.3])
+
+        @jax.jit
+        def run(x, a, w):
+            return sw_emulator_column(x, a, w)
+
+        out = run(x_seq, albedo, weights)
+        self.assertEqual(out.shape, (20, 2))
+
+    def test_lw_emulator_jit(self):
+        weights = init_lw_emulator_weights(n_features=7, units=8)
+        x_seq = jnp.ones((20, 7))
+        emissivity = jnp.array([0.97])
+
+        @jax.jit
+        def run(x, e, w):
+            return lw_emulator_column(x, e, w)
+
+        out = run(x_seq, emissivity, weights)
+        self.assertEqual(out.shape, (21, 2))
+
+    def test_heating_rate_jit(self):
+        nlev = 20
+        p_int = jnp.linspace(100, 101325, nlev + 1)
+        fd = jnp.linspace(1000, 800, nlev + 1)
+        fu = jnp.linspace(200, 300, nlev + 1)
+
+        hr = jax.jit(flux_to_heating_rate)(fd, fu, p_int)
+        self.assertEqual(hr.shape, (nlev,))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jcm/physics/icon/radiation/radiation_scheme_emulated.py
+++ b/jcm/physics/icon/radiation/radiation_scheme_emulated.py
@@ -1,0 +1,164 @@
+"""Emulated radiation scheme using bidirectional GRU neural networks.
+
+Drop-in replacement for ``radiation_scheme_rrtmgp`` that uses trained neural
+networks to predict shortwave and longwave fluxes. The NN weights are passed
+as JAX arrays through the ``emulator_weights`` argument, making them
+fully differentiable for gradient-based optimization.
+
+Reference architecture: Ukkonen (2024), https://github.com/peterukk/rte-rrtmgp-nn
+
+Date: 2026-04-11
+"""
+
+from typing import Tuple, Optional
+
+import jax.numpy as jnp
+
+from jcm.physics.icon.radiation.radiation_types import (
+    RadiationParameters,
+    RadiationTendencies,
+)
+from jcm.physics.icon.icon_physics_data import RadiationData
+from jcm.physics.icon.radiation.nn_emulator import (
+    EmulatorWeights,
+    InputScaling,
+    preprocess_sw_inputs,
+    preprocess_lw_inputs,
+    sw_emulator_column,
+    lw_emulator_column,
+    reconstruct_sw_fluxes,
+    reconstruct_lw_fluxes,
+    flux_to_heating_rate,
+)
+from jcm.physics.icon.constants.physical_constants import PhysicalConstants
+
+
+def radiation_scheme_emulated(
+    temperature: jnp.ndarray,
+    specific_humidity: jnp.ndarray,
+    pressure_levels: jnp.ndarray,
+    pressure_interfaces: jnp.ndarray,
+    layer_thickness: jnp.ndarray,
+    air_density: jnp.ndarray,
+    cloud_water: jnp.ndarray,
+    cloud_ice: jnp.ndarray,
+    cloud_fraction: jnp.ndarray,
+    surface_temperature: jnp.ndarray,
+    surface_albedo_vis: jnp.ndarray,
+    surface_albedo_nir: jnp.ndarray,
+    surface_emissivity: jnp.ndarray,
+    date,
+    latitude: float,
+    longitude: float,
+    parameters: RadiationParameters,
+    aerosol_data,
+    ozone_vmr: Optional[jnp.ndarray] = None,
+    co2_vmr: float = 400e-6,
+    emulator_weights: Optional[EmulatorWeights] = None,
+    sw_scaling: Optional[InputScaling] = None,
+    lw_scaling: Optional[InputScaling] = None,
+) -> Tuple[RadiationTendencies, RadiationData]:
+    """Emulated radiation scheme — drop-in replacement for ``radiation_scheme_rrtmgp``.
+
+    Uses bidirectional GRU neural networks to predict shortwave and longwave
+    fluxes, then derives heating rates from flux divergence. The call
+    signature matches the other radiation schemes so it can be used
+    interchangeably.
+
+    Additional Args:
+        emulator_weights: Trained NN weights (``EmulatorWeights``). Must be
+            provided; passed through the parameters mechanism in IconPhysics.
+        sw_scaling: Input normalization for SW network.
+        lw_scaling: Input normalization for LW network.
+    """
+    from jax_solar import OrbitalTime, radiation_flux, get_solar_sin_altitude
+
+    nlev = temperature.shape[0]
+    phys = PhysicalConstants()
+
+    # --- Solar geometry ---
+    actual_date = getattr(date, "dt", date)
+    orbital_time = OrbitalTime.from_datetime(actual_date)
+    toa_flux = radiation_flux(
+        orbital_time, longitude, latitude, parameters.solar_constant
+    )
+    sin_altitude = get_solar_sin_altitude(orbital_time, longitude, latitude)
+    cos_zenith = jnp.maximum(sin_altitude, parameters.min_cos_zenith)
+
+    # --- Prepare inputs common to SW and LW ---
+    # Water vapour mixing ratio
+    eps = phys.eps  # Mv/Md ≈ 0.622
+    h2o_vmr = specific_humidity / (eps * (1.0 - specific_humidity) + specific_humidity)
+
+    # Ozone
+    if ozone_vmr is None:
+        ozone_vmr = jnp.full(nlev, 5e-6)
+
+    # Cloud water/ice paths (kg/m^2)
+    cwp = cloud_water * air_density * layer_thickness * cloud_fraction
+    cip = cloud_ice * air_density * layer_thickness * cloud_fraction
+
+    # Default scaling if not provided
+    if sw_scaling is None:
+        sw_scaling = InputScaling(x_max=jnp.ones(7))
+    if lw_scaling is None:
+        lw_scaling = InputScaling(x_max=jnp.ones(7))
+
+    # --- Shortwave ---
+    sw_input = preprocess_sw_inputs(
+        temperature, pressure_levels, h2o_vmr, ozone_vmr,
+        cwp, cip, cos_zenith, sw_scaling,
+    )
+    surface_albedo = 0.5 * (surface_albedo_vis + surface_albedo_nir)
+    sw_nn_output = sw_emulator_column(
+        sw_input, jnp.atleast_1d(surface_albedo), emulator_weights.sw,
+    )
+    toa_sw_down = jnp.maximum(toa_flux, 0.0)
+    sw_flux_down, sw_flux_up = reconstruct_sw_fluxes(
+        sw_nn_output, toa_sw_down, surface_albedo,
+    )
+
+    # --- Longwave ---
+    lw_input = preprocess_lw_inputs(
+        temperature, pressure_levels, h2o_vmr, ozone_vmr,
+        cwp, cip, co2_vmr, lw_scaling,
+    )
+    lw_nn_output = lw_emulator_column(
+        lw_input, jnp.atleast_1d(surface_emissivity), emulator_weights.lw,
+    )
+    lw_flux_down, lw_flux_up = reconstruct_lw_fluxes(
+        lw_nn_output, surface_temperature, surface_emissivity,
+    )
+
+    # --- Heating rates ---
+    sw_heating = flux_to_heating_rate(sw_flux_down, sw_flux_up, pressure_interfaces)
+    lw_heating = flux_to_heating_rate(lw_flux_down, lw_flux_up, pressure_interfaces)
+    total_heating = sw_heating + lw_heating
+
+    tendencies = RadiationTendencies(
+        temperature_tendency=total_heating,
+        longwave_heating=lw_heating,
+        shortwave_heating=sw_heating,
+    )
+
+    diagnostics = RadiationData(
+        cos_zenith=cos_zenith,
+        surface_albedo_vis=jnp.atleast_1d(surface_albedo_vis),
+        surface_albedo_nir=jnp.atleast_1d(surface_albedo_nir),
+        surface_emissivity=jnp.atleast_1d(surface_emissivity),
+        sw_flux_up=sw_flux_up,
+        sw_flux_down=sw_flux_down,
+        sw_heating_rate=sw_heating,
+        lw_flux_up=lw_flux_up,
+        lw_flux_down=lw_flux_down,
+        lw_heating_rate=lw_heating,
+        surface_sw_down=sw_flux_down[-1],
+        surface_lw_down=lw_flux_down[-1],
+        surface_sw_up=sw_flux_up[-1],
+        surface_lw_up=lw_flux_up[-1],
+        toa_sw_up=sw_flux_up[0],
+        toa_lw_up=lw_flux_up[0],
+        toa_sw_down=toa_sw_down,
+    )
+
+    return tendencies, diagnostics

--- a/jcm/physics/icon/radiation/radiation_types.py
+++ b/jcm/physics/icon/radiation/radiation_types.py
@@ -7,41 +7,46 @@ Date: 2025-01-10
 """
 
 import jax.numpy as jnp
-from typing import NamedTuple
+from typing import NamedTuple, Optional
 import tree_math
 
 
 @tree_math.struct
 class RadiationParameters:
     """Configuration parameters for radiation scheme"""
-    
+
     # Time stepping
     dt_rad: float            # Radiation time step (s)
     radiation_interval: float  # Seconds between radiation calls (0 = every step)
 
     # Solar parameters
     solar_constant: float    # Solar constant (W/m²)
-    
+
     # Spectral bands
     n_sw_bands: int          # Number of shortwave bands
     n_lw_bands: int          # Number of longwave bands
-    
+
     # Band limits (wavenumber in cm⁻¹)
     lw_band_limits: tuple    # LW bands
     sw_band_limits: tuple    # SW bands
-    
+
     # Gas concentrations (volume mixing ratios)
     co2_vmr: float           # CO2 volume mixing ratio
     ch4_vmr: float           # CH4 volume mixing ratio
     n2o_vmr: float           # N2O volume mixing ratio
-    
+
     # Numerical parameters
     min_cos_zenith: float    # Minimum cosine solar zenith angle (~88 deg)
     flux_epsilon: float      # Small value for flux calculations
-    
+
     # Cloud optics parameters
     cld_tau_min: float       # Minimum cloud optical depth
     cld_frac_min: float      # Minimum cloud fraction
+
+    # Neural-network emulator (only used when radiation_scheme="emulated")
+    emulator_weights: Optional[object] = None  # EmulatorWeights pytree
+    sw_scaling: Optional[object] = None        # InputScaling for SW network
+    lw_scaling: Optional[object] = None        # InputScaling for LW network
 
     @classmethod
     def default(cls, dt_rad=3600.0, radiation_interval=0.0,
@@ -50,7 +55,9 @@ class RadiationParameters:
                  sw_band_limits=((4000, 14500), (14500, 50000)),
                  co2_vmr=400e-6, ch4_vmr=1.8e-6, n2o_vmr=0.32e-6,
                  min_cos_zenith=0.035, flux_epsilon=1e-6,
-                 cld_tau_min=1e-6, cld_frac_min=1e-3) -> 'RadiationParameters':
+                 cld_tau_min=1e-6, cld_frac_min=1e-3,
+                 emulator_weights=None, sw_scaling=None,
+                 lw_scaling=None) -> 'RadiationParameters':
         """Return default radiation parameters"""
         return cls(
             dt_rad=jnp.array(dt_rad),
@@ -66,7 +73,10 @@ class RadiationParameters:
             min_cos_zenith=jnp.array(min_cos_zenith),
             flux_epsilon=jnp.array(flux_epsilon),
             cld_tau_min=jnp.array(cld_tau_min),
-            cld_frac_min=jnp.array(cld_frac_min)
+            cld_frac_min=jnp.array(cld_frac_min),
+            emulator_weights=emulator_weights,
+            sw_scaling=sw_scaling,
+            lw_scaling=lw_scaling,
         )
 
 


### PR DESCRIPTION
Implement a bidirectional GRU-based emulator for the RRTMGP radiation scheme, following the architecture from Ukkonen (2024). The emulator provides a fully differentiable, drop-in replacement for the expensive RRTMGP radiation calculation.

New files:
- nn_emulator.py: Core NN module with GRU cells, bidirectional sequence processing, SW/LW emulator architectures, flux reconstruction, heating rate computation, weight loading from NetCDF, and random initialization
- radiation_scheme_emulated.py: Drop-in replacement for radiation_scheme_rrtmgp with identical interface plus emulator weight arguments
- nn_emulator_test.py: Tests for GRU cell, sequence processing, SW/LW emulators, flux reconstruction, heating rates, gradient flow, and JIT

Modified files:
- icon_physics.py: Add "emulated" radiation scheme option and _apply_radiation_emulated_inner() with vmap over columns
- radiation_types.py: Add optional emulator_weights, sw_scaling, lw_scaling fields to RadiationParameters
- radiation/__init__.py: Export new emulator modules

https://claude.ai/code/session_01XSStQRApvbQwemBVniYFZs

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
