### PR TITLE
ICON physics performance: step 1 results and radiation scheme benchmarks

### DIFF
--- a/docs/icon_physics_perf_plan.md
+++ b/docs/icon_physics_perf_plan.md
@@ -1,0 +1,254 @@
+# ICON physics performance plan
+
+This is a staged plan to close the ~10x performance gap between ICON physics
+and SPEEDY physics for the same grid. Profiling on T21 × 10 levels (2048
+columns), CPU:
+
+```
+SPEEDY full compute_tendencies: ~1.6 ms / step
+ICON   full compute_tendencies: ~23.7 ms / step
+```
+
+The sub-stepping work on `feature/radiation-substepping` handles the cost of
+RRTMGP (which is called every N steps instead of every step). This plan
+tackles the *remaining* ~10× gap that shows up independently of the radiation
+scheme, i.e. the cost we still pay on non-radiation steps.
+
+The three steps are independent and additive:
+
+| Step | Target                                                         | Risk   |
+| ---- | -------------------------------------------------------------- | ------ |
+| 1    | Cheap local fixes: redundant work, per-term inefficiencies     | Low    |
+| 2    | Move vmap-over-columns from inside each term to the outer loop | Medium |
+| 3    | Fortran-style NPROMA column batching (`lax.map(vmap(fn))`)     | Medium |
+
+Step 1 is purely mechanical and should land first. Steps 2 and 3 are more
+invasive and must be benchmarked against step 1 before committing.
+
+---
+
+## Step 1 — Cheap local fixes (this branch)
+
+These are all local perf wins that don't change the physics-dynamics
+interface. Each sub-item is independent and can land on its own.
+
+### 1.1 Remove vmap-of-1 wrapping in `apply_vertical_diffusion`
+**File:** `jcm/physics/icon/icon_physics.py`
+
+The old implementation wrapped each column in a helper `apply_vdiff_to_column`
+that ran through `jax.vmap`, even though `vertical_diffusion_column` (and all
+of `turbulence_coefficients.py`) already supports batched `(ncol, nlev)`
+arrays — the word "column" in the name refers to *column format*, not to
+*one column at a time*.
+
+Fix: call `prepare_vertical_diffusion_state` and `vertical_diffusion_column`
+directly on transposed `(ncols, nlev)` arrays. Drop the wrapper vmap and the
+`thv_variance` `hasattr` check (`thv_variance` isn't stored on
+`VerticalDiffusionData`, so it was always zeros anyway).
+
+### 1.2 Drop dead chemistry init from `_prepare_common_physics_state`
+**File:** `jcm/physics/icon/icon_physics.py`
+
+`_prepare_common_physics_state` called
+`initialize_chemistry_tracers(...)` every step, which ran Python-level loops
+to build realistic ppbv profiles for ozone, CH₄ and CO₂. The very next term in
+the sequence, `apply_forcing_data`, *unconditionally* overwrites
+`physics_data.chemistry` with uniform constants:
+
+```python
+chemistry_data = physics_data.chemistry.copy(
+    co2_vmr=jnp.ones_like(...) * 420.0,
+    methane_vmr=jnp.ones_like(...) * 1900.0 * 1e-3,
+    ozone_vmr=jnp.ones_like(...) * 300.0 * 1e-3,
+)
+```
+
+So the realistic init was immediately discarded. Delete the init block in
+`_prepare_common_physics_state` and remove the now-unused
+`initialize_chemistry_tracers` import. Zero behavior change, pure win.
+
+### 1.3 Dedupe aerosol `spatial_dist` computation
+**File:** `jcm/physics/icon/aerosol/simple_aerosol.py`
+
+The MACv2-SP plume Gaussian distribution was recomputed three times per step:
+once inside `get_anthropogenic_aod`, once inside `get_background_aod`, and
+once at the top of `get_simple_aerosol`. Compute it once and pass it through.
+
+Signature changes (internal, tests updated):
+```python
+get_anthropogenic_aod(parameters, year_weight, ann_cycle, spatial_dist)
+get_background_aod(parameters, ann_cycle, spatial_dist, constant_background=0.02)
+```
+
+### 1.4 Drop `max_bands = 10` padding in the grey radiation scheme
+**Files:** `jcm/physics/icon/radiation/two_stream.py`,
+`jcm/physics/icon/radiation/radiation_scheme.py`,
+`jcm/physics/icon/radiation/gas_optics.py`
+
+`longwave_fluxes` and `shortwave_fluxes` were vmapped over a fixed
+`max_bands = 10` buffer with a mask that zeroed out bands ≥ `n_bands` (= 3 for
+LW, 2 for SW in the grey scheme). That means ~70% of the two-stream work —
+layer reflectance/transmittance, the LW downward/upward flux scans, and the
+SW direct-beam + diffuse scans — was computed and thrown away.
+
+Fix: make `n_bands` a static arg via
+`functools.partial(jax.jit, static_argnames=('n_bands',))`, vmap over exactly
+`n_bands` and drop the mask. The flux shape becomes `(nlev + 1, n_bands)`
+instead of `(nlev + 1, 10)`; tests that hardcoded `10` are updated.
+
+Also:
+- `radiation_scheme.py` had a matching `max_sw_bands = 10` TOA-flux buffer
+  that can be replaced with a direct allocation of shape `(default_n_sw_bands,)`.
+- `gas_optics.create_gas_optics` and its `test_gas_optics` were dead code that
+  built `(nlev, 10)` SSA/asymmetry arrays mismatched with the `(nlev, 8)` tau
+  arrays. Delete entirely.
+
+### 1.5 Vmap the band loop in `gas_optical_depth_lw` / `gas_optical_depth_sw`
+**File:** `jcm/physics/icon/radiation/gas_optics.py`
+
+Both functions had a Python `for band in range(N_BANDS)` loop that staged
+`N_BANDS` separate `.at[:, band].set(...)` updates into XLA, producing an
+unrolled dependency chain. Replace with a single `jax.vmap` over
+`jnp.arange(N_BANDS)` and a final transpose. Same numerics, shorter HLO,
+better fusion.
+
+### 1.6 Re-run profiler
+**File:** `/tmp/profile_icon.py`
+
+Re-run the per-term profiler and the full-step profiler and compare against
+the SPEEDY baseline. Note the new per-step number in the PR description and
+call out which terms moved most.
+
+---
+
+## Step 2 — Move vmap-over-columns to the outer compute_tendencies loop
+
+**Files:** `jcm/physics/icon/icon_physics.py`, all `apply_*` terms
+
+Currently each term (`apply_convection`, `apply_clouds_and_microphysics`,
+`apply_radiation`, etc.) vmaps over columns internally. Each per-term vmap is
+a separate jit boundary that XLA cannot fuse across — so we pay the cost of
+realizing intermediate `(nlev, ncols)` buffers at each term boundary and lose
+cross-term fusion opportunities (e.g. convection → microphysics, which share
+temperature/humidity profiles).
+
+### Plan
+
+1. Write each `apply_*` term as a single-column function that takes
+   `PhysicsState[nlev]` and `PhysicsData[nlev]` and returns per-column
+   tendencies/data. Most terms already *do* single-column work inside their
+   own vmap — this is mostly unwrapping the vmap.
+2. In `compute_tendencies`, call all of the terms inside one
+   `jax.vmap(column_compute_tendencies, in_axes=(1, ..., 1), out_axes=1)` that
+   threads state → tendencies → data through the whole sequence at the column
+   level.
+3. Surface terms and gravity-wave drag may need special handling if they
+   currently rely on cross-column state (they don't appear to, but double
+   check).
+
+### Why this might help
+
+- One fused `vmap` gives XLA a single giant kernel to optimize instead of
+  ten kernels with forced materializations between them.
+- Per-term `@jit` boundaries become dead weight; drop them.
+- Intermediate `PhysicsData` field writes fuse into column-local registers
+  instead of round-tripping through `(nlev, ncols)` global memory.
+
+### Risks / caveats
+
+- Sub-stepping already relies on physics data being carried across steps
+  (radiation tendency cache in `apply_radiation`). That works at the outer
+  level so should be unaffected, but the outer-vmap shape has to be compatible
+  with the NNX `DiagnosticsCollector.physics_data_cache` mechanism.
+- If XLA decides the fused kernel is too register-heavy it can spill and
+  *hurt* perf. We should benchmark this against step 1 before committing, not
+  just trust the theory.
+- `apply_surface` creates zero tendencies at all levels except the lowest —
+  its cross-term dependency on the ambient profile is limited to the bottom
+  cell, which should survive the outer-vmap rewrite but watch for broadcast
+  bugs.
+
+### Verification
+
+- Before/after per-step timings on the T21 × 10 lvl profiler.
+- Numerical parity against step 1 to machine precision (or tight `atol` /
+  `rtol`).
+- Full `jcm/physics/icon/` test suite, `-m "not slow"` and slow.
+
+---
+
+## Step 3 — NPROMA-style column batching with `lax.map(vmap(fn))`
+
+**Files:** `jcm/physics/icon/icon_physics.py` (thin wrapper over the step 2
+outer vmap)
+
+The Fortran version of ICON batches columns in *blocks* of size `NPROMA` (~32
+to 128) to fit a block in cache. The JAX equivalent is
+`jax.lax.map(jax.vmap(column_fn), columns)` — `vmap` vectorizes within a
+block, `lax.map` iterates over blocks sequentially without unrolling into a
+giant HLO trace.
+
+### Plan
+
+1. Take the outer vmap from step 2 and wrap it in a chunked driver:
+
+   ```python
+   def chunked_compute(state, ...):
+       # Split columns into NPROMA-sized chunks, pad the last.
+       chunks = _split_into_chunks(state, nproma)
+       per_chunk = jax.vmap(column_compute_tendencies, in_axes=(1, ...), out_axes=1)
+       return jax.lax.map(per_chunk, chunks)
+   ```
+
+2. Make `nproma` a `static_argnum` knob on `IconPhysics.__init__` (defaulting
+   to "no chunking" i.e. one big block, same as step 2).
+3. Tune `nproma` empirically: start at 32, sweep [16, 32, 64, 128, 256] on
+   both CPU and one device type representative of the target GPU/TPU and pick
+   the sweet spot.
+
+### Why this might help
+
+- Better L1/L2 cache locality — a block of 32 columns fits in cache; 2048
+  columns don't.
+- Smaller HLO program size → faster compile, cheaper autodiff.
+- On multi-device setups, the block dimension can become the sharded axis
+  more naturally than the full-column axis.
+
+### Risks / caveats
+
+- `lax.map` introduces a scan-like control flow that XLA may not fuse as
+  aggressively as a straight `vmap`. On some workloads this is a loss.
+- Padding the last chunk wastes up to `nproma - 1` columns' worth of work.
+  With `ncols = 2048`, `nproma = 32` gives a clean divide; `nproma = 48`
+  would need padding.
+- Gradient pass through `lax.map` has more overhead than through `vmap`.
+  If training the model end-to-end is a goal, benchmark the backward pass too.
+- Autoparallelism / sharding interactions are subtle. If we already shard
+  columns over devices via `shard_map`, adding `lax.map` inside that is
+  fine but worth verifying on a 2-device run.
+
+### Verification
+
+- Sweep `nproma` on CPU (benchmark above) and on the target device if
+  available.
+- Compare forward perf and backward (gradient) perf independently.
+- Full ICON physics test suite.
+
+---
+
+## Open questions that might invalidate parts of this plan
+
+- **Is the RRTMGP vmap the same story as the two-stream vmap?** RRTMGP has
+  its own per-column implementation that's already vmapped inside
+  `_apply_radiation_rrtmgp_inner`. Step 2's outer-vmap rewrite would include
+  it — worth checking that the RRTMGP column function is actually safe to
+  vmap at the outer level (it is, but let's verify the g-point allocations
+  don't balloon).
+- **Does XLA actually fail to fuse across `@jit` boundaries here?** Testing
+  assumption is based on HLO inspection of `_apply_radiation_inner` vs
+  `_apply_clouds_and_microphysics_inner`, each of which generates a separate
+  compiled kernel. If the cost is actually dominated by *one* term (e.g.
+  gas_optics), step 2 is a weaker win than expected.
+- **Is step 3 net positive on GPUs?** `lax.map` on GPU historically produces
+  inner loops that don't get the same fusion treatment as vmap. Get a
+  benchmark on the actual target device before committing to chunking.

--- a/jcm/model.py
+++ b/jcm/model.py
@@ -167,12 +167,14 @@ class DiagnosticsCollector(nnx.Module):
     data: nnx.Variable
     i: nnx.Variable
     physical_step: nnx.Variable
+    physics_data_cache: nnx.Variable  # previous step's PhysicsData for caching
     steps_to_average: int
 
     def __init__(self, steps_to_average):
         """Initialize DiagnosticsCollector for accumulating physics diagnostics over multiple steps."""
         self.i = nnx.Variable(0)
         self.physical_step = nnx.Variable(True)
+        self.physics_data_cache = nnx.Variable(None)
         self.steps_to_average = steps_to_average
 
     def accumulate_if_physical_step(self, new_data):
@@ -215,6 +217,9 @@ def averaged_trajectory_from_step(
             empty_data
         )
         diagnostics_collector.data = nnx.Variable(stacked_empty_data)
+        # Seed the physics data cache so radiation caching can reuse
+        # previous-step results across timesteps.
+        diagnostics_collector.physics_data_cache = nnx.Variable(empty_data)
         graphdef, init_diag_state = nnx.split(diagnostics_collector)
 
         empty_sum = tree_map(jnp.zeros_like, x_initial)

--- a/jcm/model.py
+++ b/jcm/model.py
@@ -425,7 +425,7 @@ class Model:
                 seconds=jnp.round(sim_time % 86400).astype(jnp.int32)
             ),
             model_step=jnp.int32(sim_time / self.dt_si.m),
-            dt_seconds=self.dt_si.m
+            dt_seconds=float(self.dt_si.m)
         )
 
     def _get_step_fn_factory(self, forcing: ForcingData) -> Callable[[DiagnosticsCollector], Callable[[typing.PyTreeState], typing.PyTreeState]]:

--- a/jcm/physics/held_suarez/held_suarez_physics.py
+++ b/jcm/physics/held_suarez/held_suarez_physics.py
@@ -79,6 +79,7 @@ class HeldSuarezPhysics(Physics):
         forcing: ForcingData,
         terrain: TerrainData,
         date: DateData,
+        prev_physics_data=None,
     ) -> Tuple[PhysicsTendency, None]:
         """Compute the physical tendencies given the current state and data structs. Tendencies are computed as a Held-Suarez forcing.
 

--- a/jcm/physics/icon/aerosol/simple_aerosol.py
+++ b/jcm/physics/icon/aerosol/simple_aerosol.py
@@ -52,15 +52,19 @@ def get_simple_aerosol(
     year_weight = forcing.aerosol_year_weight
     ann_cycle = forcing.aerosol_ann_cycle
 
+    # Compute the plume spatial distribution once; ``get_anthropogenic_aod`` /
+    # ``get_background_aod`` used to recompute it internally so the Gaussian
+    # evaluation ran three times per step. Pass it through instead.
+    spatial_dist = get_plume_spatial_distribution(lats, lons, aerosol_params)
+
     # Calculate anthropogenic and background AOD using vectorized operations
-    aod_anthropogenic = get_anthropogenic_aod(lats, lons, aerosol_params, year_weight, ann_cycle)
-    aod_background = get_background_aod(lats, lons, aerosol_params, ann_cycle)
-    
+    aod_anthropogenic = get_anthropogenic_aod(
+        aerosol_params, year_weight, ann_cycle, spatial_dist
+    )
+    aod_background = get_background_aod(aerosol_params, ann_cycle, spatial_dist)
+
     # Calculate vertical profiles for each plume using vectorized operations
     plume_profiles = get_vertical_profiles(height_full, aerosol_params)
-    
-    # Calculate spatial distribution for all plumes
-    spatial_dist = get_plume_spatial_distribution(lats, lons, aerosol_params)
     
     # Combine plume contributions using vectorized operations
     # plume_profiles: (nplumes, nlev, ncols)
@@ -180,22 +184,19 @@ def get_plume_spatial_distribution(lats, lons, parameters):
     return jnp.sum(weighted_gaussian, axis=0)  # (nplumes, ncols)
 
 
-def get_background_aod(lats, lons, parameters, ann_cycle, constant_background=0.02):
-    """Calculate background (pre-industrial) aerosol optical depth
+def get_background_aod(parameters, ann_cycle, spatial_dist, constant_background=0.02):
+    """Calculate background (pre-industrial) aerosol optical depth.
 
     Args:
-        lats: Array of latitudes [degrees]
-        lons: Array of longitudes [degrees]
         parameters: AerosolParameters object
         ann_cycle: Annual cycle weights (nplumes,) from forcing data
+        spatial_dist: Precomputed plume Gaussian distribution (nplumes, ncols)
         constant_background: Constant background AOD value
 
     Returns:
         Background AOD array of shape (ncols,)
 
     """
-    # Multiply the Gaussians through the grid
-    spatial_dist = get_plume_spatial_distribution(lats, lons, parameters)
     cw_bg = ann_cycle[:, jnp.newaxis] * parameters.aod_fmbg[:, jnp.newaxis] * spatial_dist
 
     # calculate contribution to plume from its different features, to get a column weight for the anthropogenic
@@ -205,15 +206,14 @@ def get_background_aod(lats, lons, parameters, ann_cycle, constant_background=0.
     return aod_PI
 
 
-def get_anthropogenic_aod(lats, lons, parameters, year_weight, ann_cycle):
-    """Calculate anthropogenic aerosol optical depth
+def get_anthropogenic_aod(parameters, year_weight, ann_cycle, spatial_dist):
+    """Calculate anthropogenic aerosol optical depth.
 
     Args:
-        lats: Array of latitudes [degrees]
-        lons: Array of longitudes [degrees]
         parameters: AerosolParameters object
         year_weight: Year-specific emission weights (nplumes,) from forcing data
         ann_cycle: Annual cycle weights (nplumes,) from forcing data
+        spatial_dist: Precomputed plume Gaussian distribution (nplumes, ncols)
 
     Returns:
         Anthropogenic AOD array of shape (ncols,)
@@ -221,9 +221,6 @@ def get_anthropogenic_aod(lats, lons, parameters, year_weight, ann_cycle):
     """
     # Use time weights for anthropogenic emissions
     time_weight = year_weight * ann_cycle
-
-    # Multiply the Gaussians through the grid
-    spatial_dist = get_plume_spatial_distribution(lats, lons, parameters)
     cw_an = time_weight[:, jnp.newaxis] * parameters.aod_spmx[:, jnp.newaxis] * spatial_dist
 
     aod_anth = jnp.sum(cw_an, axis=0)

--- a/jcm/physics/icon/aerosol/simple_aerosol_test.py
+++ b/jcm/physics/icon/aerosol/simple_aerosol_test.py
@@ -209,45 +209,51 @@ class TestAODCalculations:
         """Test anthropogenic AOD calculation shape"""
         params = AerosolParameters.default()
         ncols = 500
-        
+
         lats = jnp.linspace(-90, 90, ncols)
         lons = jnp.linspace(-180, 180, ncols)
-        
-        aod_anth = get_anthropogenic_aod(lats, lons, params, jnp.ones(params.nplumes), jnp.ones(params.nplumes))
-        
+
+        spatial_dist = get_plume_spatial_distribution(lats, lons, params)
+        aod_anth = get_anthropogenic_aod(
+            params, jnp.ones(params.nplumes), jnp.ones(params.nplumes), spatial_dist
+        )
+
         assert aod_anth.shape == (ncols,)
         assert jnp.all(aod_anth >= 0)
-    
+
     def test_background_aod_shape(self):
         """Test background AOD calculation shape"""
         params = AerosolParameters.default()
         ncols = 500
-        
+
         lats = jnp.linspace(-90, 90, ncols)
         lons = jnp.linspace(-180, 180, ncols)
-        
-        aod_bg = get_background_aod(lats, lons, params, jnp.ones(params.nplumes))
-        
+
+        spatial_dist = get_plume_spatial_distribution(lats, lons, params)
+        aod_bg = get_background_aod(params, jnp.ones(params.nplumes), spatial_dist)
+
         assert aod_bg.shape == (ncols,)
         assert jnp.all(aod_bg >= 0)
-    
+
     def test_aod_plume_regions(self):
         """Test that AOD is higher in plume regions"""
         params = AerosolParameters.default()
-        
+
         # Test coordinates at plume centers vs remote regions
         plume_lats = params.plume_lat[:3]  # First 3 plumes
         plume_lons = params.plume_lon[:3]
-        
+
         # Remote regions (ocean)
         remote_lats = jnp.array([0.0, 0.0, 0.0])
         remote_lons = jnp.array([0.0, 90.0, 180.0])
-        
+
         year_weight = jnp.ones(params.nplumes)
         ann_cycle = jnp.ones(params.nplumes)
-        aod_plume = get_anthropogenic_aod(plume_lats, plume_lons, params, year_weight, ann_cycle)
-        aod_remote = get_anthropogenic_aod(remote_lats, remote_lons, params, year_weight, ann_cycle)
-        
+        plume_dist = get_plume_spatial_distribution(plume_lats, plume_lons, params)
+        remote_dist = get_plume_spatial_distribution(remote_lats, remote_lons, params)
+        aod_plume = get_anthropogenic_aod(params, year_weight, ann_cycle, plume_dist)
+        aod_remote = get_anthropogenic_aod(params, year_weight, ann_cycle, remote_dist)
+
         # AOD should be higher at plume centers
         assert jnp.all(aod_plume > aod_remote)
 
@@ -378,16 +384,19 @@ class TestJAXCompatibility:
         params = AerosolParameters.default()
         
         def aod_sum(lats, lons):
-            return jnp.sum(get_anthropogenic_aod(lats, lons, params, jnp.ones(params.nplumes), jnp.ones(params.nplumes)))
-        
+            spatial_dist = get_plume_spatial_distribution(lats, lons, params)
+            return jnp.sum(get_anthropogenic_aod(
+                params, jnp.ones(params.nplumes), jnp.ones(params.nplumes), spatial_dist
+            ))
+
         ncols = 20
         lats = jnp.linspace(-90, 90, ncols)
         lons = jnp.linspace(-180, 180, ncols)
-        
+
         # Compute gradients
         grad_fn = jax.grad(aod_sum, argnums=(0, 1))
         grads = grad_fn(lats, lons)
-        
+
         assert len(grads) == 2
         assert grads[0].shape == (ncols,)
         assert grads[1].shape == (ncols,)
@@ -411,22 +420,24 @@ class TestIntegration:
         height_full = jnp.linspace(0, 15000, nlev)[:, jnp.newaxis]
         height_full = jnp.repeat(height_full, ncols, axis=1)
         
+        # Test spatial distribution (needed by AOD calculations)
+        spatial_dist = get_plume_spatial_distribution(lats, lons, params)
+        assert spatial_dist.shape == (params.nplumes, ncols)
+
         # Test individual functions work together
-        aod_anth = get_anthropogenic_aod(lats, lons, params, jnp.ones(params.nplumes), jnp.ones(params.nplumes))
-        aod_bg = get_background_aod(lats, lons, params, jnp.ones(params.nplumes))
-        
+        aod_anth = get_anthropogenic_aod(
+            params, jnp.ones(params.nplumes), jnp.ones(params.nplumes), spatial_dist
+        )
+        aod_bg = get_background_aod(params, jnp.ones(params.nplumes), spatial_dist)
+
         assert aod_anth.shape == (ncols,)
         assert aod_bg.shape == (ncols,)
         assert jnp.all(aod_anth >= 0)
         assert jnp.all(aod_bg >= 0)
-        
+
         # Test vertical profiles
         profiles = get_vertical_profiles(height_full, params)
         assert profiles.shape == (params.nplumes, nlev, ncols)
-        
-        # Test spatial distribution
-        spatial_dist = get_plume_spatial_distribution(lats, lons, params)
-        assert spatial_dist.shape == (params.nplumes, ncols)
         
         # Test optical properties
         aod_profile = jnp.ones((nlev, ncols)) * 0.1
@@ -456,8 +467,8 @@ class TestIntegration:
 
         # All should compile and run without errors
         spatial_dist = jit_spatial(lats, lons, params)
-        aod_anth = jit_aod_anth(lats, lons, params, year_weight, ann_cycle)
-        aod_bg = jit_aod_bg(lats, lons, params, ann_cycle)
+        aod_anth = jit_aod_anth(params, year_weight, ann_cycle, spatial_dist)
+        aod_bg = jit_aod_bg(params, ann_cycle, spatial_dist)
 
         assert spatial_dist.shape == (params.nplumes, ncols)
         assert aod_anth.shape == (ncols,)
@@ -465,13 +476,16 @@ class TestIntegration:
         assert jnp.all(jnp.isfinite(spatial_dist))
         assert jnp.all(jnp.isfinite(aod_anth))
         assert jnp.all(jnp.isfinite(aod_bg))
-    
+
     def test_gradient_computation(self):
         """Test gradient computation for differentiability"""
         params = AerosolParameters.default()
-        
+
         def total_aod(lats, lons):
-            return jnp.sum(get_anthropogenic_aod(lats, lons, params, jnp.ones(params.nplumes), jnp.ones(params.nplumes)))
+            spatial_dist = get_plume_spatial_distribution(lats, lons, params)
+            return jnp.sum(get_anthropogenic_aod(
+                params, jnp.ones(params.nplumes), jnp.ones(params.nplumes), spatial_dist
+            ))
         
         ncols = 20
         lats = jnp.linspace(-90, 90, ncols)

--- a/jcm/physics/icon/icon_physics.py
+++ b/jcm/physics/icon/icon_physics.py
@@ -28,7 +28,7 @@ from jcm.physics.icon.parameters import Parameters
 from jcm.physics.icon.surface import surface_physics_step, initialize_surface_state
 from jcm.physics.icon.surface.surface_types import AtmosphericForcing
 from jcm.physics.icon.gravity_waves import gravity_wave_drag
-from jcm.physics.icon.chemistry import simple_chemistry, initialize_chemistry_tracers
+from jcm.physics.icon.chemistry import simple_chemistry
 from jcm.physics.icon.aerosol.simple_aerosol import get_simple_aerosol
 from jcm.physics.icon.icon_physics_data import PhysicsData
 from jcm.physics.icon.forcing import apply_forcing_data
@@ -618,33 +618,11 @@ def _prepare_common_physics_state(
         layer_thickness=dz_full,
     )
 
-    # Initialize chemistry tracers if not already done
-    # Check if chemistry is initialized by checking if ozone maximum is reasonable
-    ozone_max = jnp.max(physics_data.chemistry.ozone_vmr)
-    should_initialize = ozone_max < 100.0  # If max ozone < 100 ppbv, initialize
-    
-    # Initialize chemistry tracers with reasonable distributions
-    chemistry_state = initialize_chemistry_tracers(
-        pressure_levels,
-        surface_pressure,
-        state.temperature,
-        config=None  # Use defaults
-    )
-    
-    # Use JAX where to conditionally update chemistry
-    chemistry_data = physics_data.chemistry.copy(
-        ozone_vmr=jnp.where(should_initialize, chemistry_state.ozone_vmr, physics_data.chemistry.ozone_vmr),
-        methane_vmr=jnp.where(should_initialize, chemistry_state.methane_vmr, physics_data.chemistry.methane_vmr),
-        co2_vmr=jnp.where(should_initialize, chemistry_state.co2_vmr, physics_data.chemistry.co2_vmr),
-        ozone_production=jnp.where(should_initialize, chemistry_state.ozone_production, physics_data.chemistry.ozone_production),
-        ozone_loss=jnp.where(should_initialize, chemistry_state.ozone_loss, physics_data.chemistry.ozone_loss),
-        methane_loss=jnp.where(should_initialize, chemistry_state.methane_loss, physics_data.chemistry.methane_loss)
-    )
-    
-    updated_physics_data = physics_data.copy(
-        diagnostics=diagnostic_data,
-        chemistry=chemistry_data
-    )
+    # Note: chemistry is intentionally not initialized here. ``apply_forcing_data``
+    # (the next term in the physics sequence) unconditionally overwrites
+    # ``physics_data.chemistry`` with constant GHG concentrations every step,
+    # so any initialization work done here would be immediately discarded.
+    updated_physics_data = physics_data.copy(diagnostics=diagnostic_data)
 
     zero_tendencies = PhysicsTendency.zeros(state.temperature.shape)
     return zero_tendencies, updated_physics_data
@@ -1113,97 +1091,77 @@ def apply_vertical_diffusion(
     forcing: ForcingData,
     terrain: TerrainData
 ) -> tuple[PhysicsTendency, PhysicsData]:
-    """Apply vertical diffusion and boundary layer physics"""
-    from jcm.physics.icon.vertical_diffusion import prepare_vertical_diffusion_state, vertical_diffusion_column
-    
+    """Apply vertical diffusion and boundary layer physics.
+
+    The underlying ``vertical_diffusion_column`` routine already accepts
+    batched ``(ncols, nlev)`` arrays, so we call it once directly instead of
+    wrapping a fake single-column vmap around it. Inputs to physics terms are
+    ``(nlev, ncols)``; we transpose to ``(ncols, nlev)`` at the boundary.
+    """
+    from jcm.physics.icon.vertical_diffusion import (
+        prepare_vertical_diffusion_state,
+        vertical_diffusion_column,
+    )
+
     nlev, ncols = state.temperature.shape
     dt = parameters.convection.dt_conv
-    pressure_levels = physics_data.diagnostics.pressure_full
+    pressure_full = physics_data.diagnostics.pressure_full
     pressure_half = physics_data.diagnostics.pressure_half
-    height_levels = physics_data.diagnostics.height_full
+    height_full = physics_data.diagnostics.height_full
     height_half = physics_data.diagnostics.height_half
-    
-    # Initialize prognostic variables if not present (ensure proper column format)
-    if hasattr(physics_data.vertical_diffusion, 'tke'):
-        tke = physics_data.vertical_diffusion.tke
-        # Reshape TKE if it's in grid format [nlev, nlat, nlon] -> [nlev, ncols]
-        if tke.ndim == 3:
-            tke = tke.reshape(nlev, ncols)
-    else:
-        tke = jnp.ones((nlev, ncols)) * 0.1
-        
-    if hasattr(physics_data.vertical_diffusion, 'thv_variance'):
-        thv_variance = physics_data.vertical_diffusion.thv_variance
-        # Reshape if needed
-        if thv_variance.ndim == 3:
-            thv_variance = thv_variance.reshape(nlev, ncols)
-    else:
-        thv_variance = jnp.zeros((nlev, ncols))
-    
+
+    # Prognostic TKE (reshape grid format to column format if needed).
+    # ``thv_variance`` is not a stored diagnostic, so just zero it out each call.
+    tke = physics_data.vertical_diffusion.tke
+    if tke.ndim == 3:
+        tke = tke.reshape(nlev, ncols)
+    thv_variance = jnp.zeros((nlev, ncols))
+
     # Surface properties (simplified - should come from boundaries)
     nsfc_type = 3  # water, ice, land
     surface_fraction = jnp.zeros((ncols, nsfc_type))
     surface_fraction = surface_fraction.at[:, 2].set(1.0)  # All land for now
-    
-    # Get surface properties from forcing
-    # Reshape boundary fields to column format
-    surface_temp = physics_data.surface.surface_temperature.reshape(ncols)
-    roughness_length = physics_data.surface.roughness_length.reshape(ncols)
 
-    surface_temperature = jnp.repeat(surface_temp[:, jnp.newaxis], nsfc_type, axis=1)
-    roughness = jnp.repeat(roughness_length[:, jnp.newaxis], nsfc_type, axis=1)
-    
+    # Get surface properties from boundaries
+    surface_temp_col = physics_data.surface.surface_temperature.reshape(ncols)
+    roughness_length_col = physics_data.surface.roughness_length.reshape(ncols)
+    surface_temperature = jnp.repeat(surface_temp_col[:, jnp.newaxis], nsfc_type, axis=1)
+    roughness = jnp.repeat(roughness_length_col[:, jnp.newaxis], nsfc_type, axis=1)
+
     # Ocean currents (zero for now)
     ocean_u = jnp.zeros(ncols)
     ocean_v = jnp.zeros(ncols)
-    
-    # Extract fixed qc/qi tracers for vertical diffusion
+
+    # Extract fixed qc/qi tracers
     qc = state.tracers.get('qc', jnp.zeros_like(state.temperature))
     qi = state.tracers.get('qi', jnp.zeros_like(state.temperature))
-    
-    def apply_vdiff_to_column(u_col, v_col, temp_col, qv_col, qc_col, qi_col,
-                             pressure_full_col, pressure_half_col, geopot_col,
-                             height_full_col, height_half_col, surface_temp_col,
-                             surface_frac_col, roughness_col, ocean_u_scalar, ocean_v_scalar,
-                             tke_col, thv_var_col):
-        """Apply vertical diffusion to a single column with structured output"""
-        # Prepare state for this column - reshape to expected 2D format (1, nlev) or (1, nlev+1)
-        vdiff_state = prepare_vertical_diffusion_state(
-            u=u_col[None, :], v=v_col[None, :], temperature=temp_col[None, :], 
-            qv=qv_col[None, :], qc=qc_col[None, :], qi=qi_col[None, :],
-            pressure_full=pressure_full_col[None, :], pressure_half=pressure_half_col[None, :],
-            geopotential=geopot_col[None, :], height_full=height_full_col[None, :], 
-            height_half=height_half_col[None, :],
-            surface_temperature=surface_temp_col[None, :], surface_fraction=surface_frac_col[None, :],
-            roughness_length=roughness_col[None, :], ocean_u=ocean_u_scalar[None], ocean_v=ocean_v_scalar[None],
-            tke=tke_col[None, :], thv_variance=thv_var_col[None, :]
-        )
-        
-        # Compute vertical diffusion
-        tendencies, diagnostics = vertical_diffusion_column(
-            vdiff_state, parameters.vertical_diffusion, dt
-        )
-        
-        # Squeeze outputs to remove the dummy column dimension (1, nlev) -> (nlev)
-        def squeeze_first_dim(x):
-            return jnp.squeeze(x, axis=0) if x.ndim > 1 else x
-        
-        tendencies = jax.tree_util.tree_map(squeeze_first_dim, tendencies)
-        diagnostics = jax.tree_util.tree_map(squeeze_first_dim, diagnostics)
-        
-        # Return structured data directly
-        return tendencies, diagnostics
-    
-    vdiff_results = jax.vmap(
-        apply_vdiff_to_column, # FIXME: this should call vertical_diffusion_scheme
-        in_axes=(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 1, 1),  # Fix surface properties to axis 0 (column mapped)
-        out_axes=(0, 0)  # Returns (VDiffTendencies, VDiffDiagnostics) per column
-    )(state.u_wind, state.v_wind, state.temperature, state.specific_humidity, qc, qi,
-      pressure_levels, pressure_half, state.geopotential, height_levels, height_half,
-      surface_temperature, surface_fraction, roughness, ocean_u, ocean_v, tke, thv_variance)
-    
-    # Unpack structured results from vmap
-    vdiff_tendencies, vdiff_diagnostics = vdiff_results
+
+    # Transpose column-first fields from (nlev, ncols) to (ncols, nlev) for the
+    # batched vertical diffusion routines.
+    vdiff_state = prepare_vertical_diffusion_state(
+        u=state.u_wind.T,
+        v=state.v_wind.T,
+        temperature=state.temperature.T,
+        qv=state.specific_humidity.T,
+        qc=qc.T,
+        qi=qi.T,
+        pressure_full=pressure_full.T,
+        pressure_half=pressure_half.T,
+        geopotential=state.geopotential.T,
+        height_full=height_full.T,
+        height_half=height_half.T,
+        surface_temperature=surface_temperature,
+        surface_fraction=surface_fraction,
+        roughness_length=roughness,
+        ocean_u=ocean_u,
+        ocean_v=ocean_v,
+        tke=tke.T,
+        thv_variance=thv_variance.T,
+    )
+
+    vdiff_tendencies, vdiff_diagnostics = vertical_diffusion_column(
+        vdiff_state, parameters.vertical_diffusion, dt
+    )
     
     # Extract tendencies (already in correct shape [ncols, nlev] from vmap)
     u_tend = vdiff_tendencies.u_tendency.T  # Transpose to [nlev, ncols]

--- a/jcm/physics/icon/icon_physics.py
+++ b/jcm/physics/icon/icon_physics.py
@@ -51,7 +51,8 @@ class IconPhysics(Physics):
                  checkpoint_terms: bool = True,
                  parameters: Optional[Parameters] = None,
                  dt_physics: Optional[float] = None,
-                 radiation_scheme: str = "grey"):
+                 radiation_scheme: str = "grey",
+                 radiation_interval: float = 0.0):
         """Initialize the ICON physics.
 
         Args:
@@ -65,6 +66,8 @@ class IconPhysics(Physics):
             radiation_scheme: Which radiation scheme to use. Either "grey"
                 (default simplified multi-band scheme) or "rrtmgp" (requires
                 jax-rrtmgp package).
+            radiation_interval: Seconds between radiation calls (0 = every
+                step). E.g. 7200.0 for 2-hourly radiation like ECHAM6.
 
         """
         self.write_output = write_output
@@ -74,6 +77,18 @@ class IconPhysics(Physics):
         params = parameters or Parameters.default()
         if dt_physics is not None:
             params = params.with_timestep(dt_physics)
+
+        # Set radiation calling interval
+        if radiation_interval > 0:
+            rad_params = params.radiation.__class__(**{
+                **params.radiation.__dict__,
+                'radiation_interval': jnp.array(radiation_interval),
+            })
+            params = params.__class__(**{
+                **params.__dict__,
+                'radiation': rad_params,
+            })
+
         self.parameters = params
 
         # Cached coordinate data (populated by cache_coords)
@@ -108,12 +123,26 @@ class IconPhysics(Physics):
         """Cache coordinate system data needed by ICON physics."""
         self.cached_coords = IconCoords.from_coordinate_system(coords)
 
+    def get_empty_data(self, coords: CoordinateSystem) -> PhysicsData:
+        """Return a zeroed PhysicsData for diagnostics accumulation."""
+        from jax.tree_util import tree_map
+        nodal_shape = self.cached_coords.nodal_shape
+        empty = PhysicsData.zeros(
+            (nodal_shape[1] * nodal_shape[2],),
+            nodal_shape[0],
+            icon_coords=self.cached_coords,
+        )
+        return tree_map(lambda x: 0 * x, empty).copy(
+            icon_coords=self.cached_coords
+        )
+
     def compute_tendencies(
         self,
         state: PhysicsState,
         forcing: ForcingData,
         terrain: TerrainData,
         date: DateData,
+        prev_physics_data=None,
     ) -> Tuple[PhysicsTendency, PhysicsData]:
         """Compute the physical tendencies given the current state and data structs. Loops through the ICON physics terms, accumulating the tendencies.
 
@@ -122,6 +151,9 @@ class IconPhysics(Physics):
             forcing: Forcing data
             terrain: Terrain data (boundary conditions)
             date: Date data
+            prev_physics_data: Previous step's PhysicsData for caching
+                (e.g. radiation tendencies). None on first step or when
+                caching is not active.
 
         Returns:
             Physical tendencies in PhysicsTendency format
@@ -136,6 +168,11 @@ class IconPhysics(Physics):
             icon_coords=self.cached_coords,
             date=date
         )
+
+        # Carry forward radiation data from previous step (cached tendencies
+        # and fluxes used by downstream terms like surface physics).
+        if prev_physics_data is not None:
+            physics_data = physics_data.copy(radiation=prev_physics_data.radiation)
 
         # Initialize zero tendencies with tracer tendencies
         tracer_tends = {name: jnp.zeros_like(tracer) for name, tracer in state.tracers.items()}
@@ -636,14 +673,86 @@ def _prepare_common_physics_state(
     return zero_tendencies, updated_physics_data
 
 # Physics term methods
+
+
+def _radiation_with_caching(
+    radiation_fn,
+    state: PhysicsState,
+    physics_data: PhysicsData,
+    parameters: Parameters,
+    forcing: ForcingData,
+    terrain: TerrainData,
+) -> tuple[PhysicsTendency, PhysicsData]:
+    """Wrap a radiation term with sub-stepping via ``jax.lax.cond``.
+
+    On radiation steps the full scheme runs; on other steps the cached
+    heating rates from ``physics_data.radiation`` are reused.
+    """
+    nlev, ncols = state.temperature.shape
+    interval = parameters.radiation.radiation_interval
+    dt = physics_data.date.dt_seconds
+    step = physics_data.date.model_step
+
+    # interval <= 0 ⇒ compute every step (default)
+    steps_per_call = jnp.where(
+        interval > 0, jnp.int32(jnp.round(interval / dt)), jnp.int32(1)
+    )
+    should_compute = jnp.mod(step, steps_per_call) == 0
+
+    def _compute():
+        return radiation_fn(state, physics_data, parameters, forcing, terrain)
+
+    def _use_cached():
+        cached_tend = PhysicsTendency(
+            u_wind=jnp.zeros((nlev, ncols)),
+            v_wind=jnp.zeros((nlev, ncols)),
+            temperature=(
+                physics_data.radiation.sw_heating_rate
+                + physics_data.radiation.lw_heating_rate
+            ),
+            specific_humidity=jnp.zeros((nlev, ncols)),
+            tracers={},
+        )
+        return cached_tend, physics_data
+
+    return jax.lax.cond(should_compute, _compute, _use_cached)
+
+
+def apply_radiation(
+    state: PhysicsState,
+    physics_data: PhysicsData,
+    parameters: Parameters,
+    forcing: ForcingData,
+    terrain: TerrainData,
+) -> tuple[PhysicsTendency, PhysicsData]:
+    """Grey radiation with sub-stepping."""
+    return _radiation_with_caching(
+        _apply_radiation_inner, state, physics_data, parameters, forcing, terrain
+    )
+
+
+def apply_radiation_rrtmgp(
+    state: PhysicsState,
+    physics_data: PhysicsData,
+    parameters: Parameters,
+    forcing: ForcingData,
+    terrain: TerrainData,
+) -> tuple[PhysicsTendency, PhysicsData]:
+    """RRTMGP radiation with sub-stepping."""
+    return _radiation_with_caching(
+        _apply_radiation_rrtmgp_inner,
+        state, physics_data, parameters, forcing, terrain,
+    )
+
+
 @jit
-def apply_radiation(state: PhysicsState,
+def _apply_radiation_inner(state: PhysicsState,
     physics_data: PhysicsData,
     parameters: Parameters,
     forcing: ForcingData,
     terrain: TerrainData
 ) -> tuple[PhysicsTendency, PhysicsData]:
-    """Apply radiation heating rates"""
+    """Apply grey radiation heating rates."""
     # Note: state is already in 2D format [nlev, ncols] from compute_tendencies
     nlev, ncols = state.temperature.shape
     
@@ -725,11 +834,11 @@ def apply_radiation(state: PhysicsState,
         surface_albedo_vis=diagnostics_vmapped.surface_albedo_vis,
         surface_albedo_nir=diagnostics_vmapped.surface_albedo_nir,
         surface_emissivity=diagnostics_vmapped.surface_emissivity,
-        sw_flux_up=diagnostics_vmapped.sw_flux_up.transpose(1, 0, 2),  # [ncols, nlev+1, nbands] -> [nlev+1, ncols, nbands]
-        sw_flux_down=diagnostics_vmapped.sw_flux_down.transpose(1, 0, 2),
+        sw_flux_up=diagnostics_vmapped.sw_flux_up.transpose(1, 0, 2).sum(axis=-1),  # [nlev+1, ncols] (summed over bands)
+        sw_flux_down=diagnostics_vmapped.sw_flux_down.transpose(1, 0, 2).sum(axis=-1),
         sw_heating_rate=tendencies_vmapped.shortwave_heating.T,  # [ncols, nlev] -> [nlev, ncols]
-        lw_flux_up=diagnostics_vmapped.lw_flux_up.transpose(1, 0, 2),
-        lw_flux_down=diagnostics_vmapped.lw_flux_down.transpose(1, 0, 2),
+        lw_flux_up=diagnostics_vmapped.lw_flux_up.transpose(1, 0, 2).sum(axis=-1),
+        lw_flux_down=diagnostics_vmapped.lw_flux_down.transpose(1, 0, 2).sum(axis=-1),
         lw_heating_rate=tendencies_vmapped.longwave_heating.T,  # [ncols, nlev] -> [nlev, ncols]
         surface_sw_down=diagnostics_vmapped.surface_sw_down,  # Already [ncols]
         surface_lw_down=diagnostics_vmapped.surface_lw_down,
@@ -746,19 +855,14 @@ def apply_radiation(state: PhysicsState,
 
 
 @jit
-def apply_radiation_rrtmgp(
+def _apply_radiation_rrtmgp_inner(
     state: PhysicsState,
     physics_data: PhysicsData,
     parameters: Parameters,
     forcing: ForcingData,
     terrain: TerrainData
 ) -> tuple[PhysicsTendency, PhysicsData]:
-    """Apply RRTMGP radiation heating rates.
-
-    Drop-in replacement for ``apply_radiation`` that calls the RRTMGP
-    radiation scheme instead of the grey/simplified scheme.  The input
-    preparation and output post-processing are identical.
-    """
+    """Apply RRTMGP radiation heating rates (inner, always-compute version)."""
     from jcm.physics.icon.radiation.radiation_scheme_rrtmgp import (
         radiation_scheme_rrtmgp,
     )
@@ -837,11 +941,11 @@ def apply_radiation_rrtmgp(
         surface_albedo_vis=diagnostics_vmapped.surface_albedo_vis,
         surface_albedo_nir=diagnostics_vmapped.surface_albedo_nir,
         surface_emissivity=diagnostics_vmapped.surface_emissivity,
-        sw_flux_up=diagnostics_vmapped.sw_flux_up.transpose(1, 0, 2),
-        sw_flux_down=diagnostics_vmapped.sw_flux_down.transpose(1, 0, 2),
+        sw_flux_up=diagnostics_vmapped.sw_flux_up.transpose(1, 0, 2).sum(axis=-1),
+        sw_flux_down=diagnostics_vmapped.sw_flux_down.transpose(1, 0, 2).sum(axis=-1),
         sw_heating_rate=tendencies_vmapped.shortwave_heating.T,
-        lw_flux_up=diagnostics_vmapped.lw_flux_up.transpose(1, 0, 2),
-        lw_flux_down=diagnostics_vmapped.lw_flux_down.transpose(1, 0, 2),
+        lw_flux_up=diagnostics_vmapped.lw_flux_up.transpose(1, 0, 2).sum(axis=-1),
+        lw_flux_down=diagnostics_vmapped.lw_flux_down.transpose(1, 0, 2).sum(axis=-1),
         lw_heating_rate=tendencies_vmapped.longwave_heating.T,
         surface_sw_down=diagnostics_vmapped.surface_sw_down,
         surface_lw_down=diagnostics_vmapped.surface_lw_down,

--- a/jcm/physics/icon/icon_physics.py
+++ b/jcm/physics/icon/icon_physics.py
@@ -79,15 +79,14 @@ class IconPhysics(Physics):
             params = params.with_timestep(dt_physics)
 
         # Set radiation calling interval
-        if radiation_interval > 0:
-            rad_params = params.radiation.__class__(**{
-                **params.radiation.__dict__,
-                'radiation_interval': jnp.array(radiation_interval),
-            })
-            params = params.__class__(**{
-                **params.__dict__,
-                'radiation': rad_params,
-            })
+        rad_params = params.radiation.__class__(**{
+            **params.radiation.__dict__,
+            'radiation_interval': jnp.array(radiation_interval),
+        })
+        params = params.__class__(**{
+            **params.__dict__,
+            'radiation': rad_params,
+        })
 
         self.parameters = params
 

--- a/jcm/physics/icon/icon_physics.py
+++ b/jcm/physics/icon/icon_physics.py
@@ -35,7 +35,7 @@ from jcm.physics.icon.forcing import apply_forcing_data
 
 class IconPhysics(Physics):
     """ICON atmospheric physics implementation for JAX-GCM
-    
+
     This class implements the ICON physics suite including:
     - Radiation (shortwave and longwave)
     - Convection (Tiedtke-Nordeng scheme)
@@ -45,7 +45,7 @@ class IconPhysics(Physics):
     - Gravity wave drag
     - Simple chemistry schemes
     """
-    
+
     def __init__(self,
                  write_output: bool = True,
                  checkpoint_terms: bool = True,
@@ -132,7 +132,7 @@ class IconPhysics(Physics):
             nodal_shape[0],
             icon_coords=self.cached_coords,
         )
-        return tree_map(lambda x: 0 * x, empty).copy(
+        return tree_map(jnp.zeros_like, empty).copy(
             icon_coords=self.cached_coords
         )
 

--- a/jcm/physics/icon/icon_physics.py
+++ b/jcm/physics/icon/icon_physics.py
@@ -50,45 +50,23 @@ class IconPhysics(Physics):
                  write_output: bool = True,
                  checkpoint_terms: bool = True,
                  parameters: Optional[Parameters] = None,
-                 dt_physics: Optional[float] = None,
-                 radiation_scheme: str = "grey",
-                 radiation_interval: float = 0.0):
+                 radiation_scheme: str = "grey"):
         """Initialize the ICON physics.
 
         Args:
             write_output: Whether to write physics output to predictions
             checkpoint_terms: Whether to checkpoint physics terms
-            parameters: Optional physics parameters (uses defaults if None)
-            dt_physics: Physics timestep in seconds. If provided, overrides
-                all internal physics timesteps (dt_conv, dt_rad, etc.) to match
-                the model integration timestep. This is important since we don't
-                have sub-timestepping - all physics must use the same timestep.
+            parameters: Optional physics parameters (uses defaults if None).
+                Set ``radiation_interval`` on the radiation parameters to
+                control sub-stepping (e.g. 7200 s for 2-hourly radiation).
             radiation_scheme: Which radiation scheme to use. Either "grey"
                 (default simplified multi-band scheme) or "rrtmgp" (requires
                 jax-rrtmgp package).
-            radiation_interval: Seconds between radiation calls (0 = every
-                step). E.g. 7200.0 for 2-hourly radiation like ECHAM6.
 
         """
         self.write_output = write_output
         self.checkpoint_terms = checkpoint_terms
-
-        # Store parameters, optionally updating timesteps
-        params = parameters or Parameters.default()
-        if dt_physics is not None:
-            params = params.with_timestep(dt_physics)
-
-        # Set radiation calling interval
-        rad_params = params.radiation.__class__(**{
-            **params.radiation.__dict__,
-            'radiation_interval': jnp.array(radiation_interval),
-        })
-        params = params.__class__(**{
-            **params.__dict__,
-            'radiation': rad_params,
-        })
-
-        self.parameters = params
+        self.parameters = parameters or Parameters.default()
 
         # Cached coordinate data (populated by cache_coords)
         self.cached_coords = None

--- a/jcm/physics/icon/radiation/aerosol_radiation_test.py
+++ b/jcm/physics/icon/radiation/aerosol_radiation_test.py
@@ -12,6 +12,7 @@ from jcm.physics.icon.radiation.cloud_optics import effective_radius_liquid
 from jcm.physics.icon.aerosol.simple_aerosol import (
     get_optical_properties,
     get_anthropogenic_aod,
+    get_plume_spatial_distribution,
 )
 from jcm.physics.icon.aerosol.aerosol_params import AerosolParameters
 
@@ -173,18 +174,20 @@ def test_temporal_weights_scale_aod():
     lats = jnp.linspace(-90, 90, ncols)
     lons = jnp.linspace(-180, 180, ncols)
 
+    spatial_dist = get_plume_spatial_distribution(lats, lons, params)
+
     # Present-day: weights = 1
     year_weight_pd = jnp.ones(params.nplumes)
     ann_cycle = jnp.ones(params.nplumes)
-    aod_pd = get_anthropogenic_aod(lats, lons, params, year_weight_pd, ann_cycle)
+    aod_pd = get_anthropogenic_aod(params, year_weight_pd, ann_cycle, spatial_dist)
 
     # Pre-industrial: weights = 0
     year_weight_pi = jnp.zeros(params.nplumes)
-    aod_pi = get_anthropogenic_aod(lats, lons, params, year_weight_pi, ann_cycle)
+    aod_pi = get_anthropogenic_aod(params, year_weight_pi, ann_cycle, spatial_dist)
 
     # Half emissions
     year_weight_half = jnp.ones(params.nplumes) * 0.5
-    aod_half = get_anthropogenic_aod(lats, lons, params, year_weight_half, ann_cycle)
+    aod_half = get_anthropogenic_aod(params, year_weight_half, ann_cycle, spatial_dist)
 
     assert jnp.all(aod_pi == 0), "Pre-industrial AOD should be zero"
     assert jnp.allclose(aod_half, aod_pd * 0.5, rtol=1e-6), "Half weights should give half AOD"
@@ -192,7 +195,7 @@ def test_temporal_weights_scale_aod():
     # Seasonal cycle: reduce one plume
     ann_cycle_reduced = jnp.ones(params.nplumes)
     ann_cycle_reduced = ann_cycle_reduced.at[0].set(0.5)
-    aod_seasonal = get_anthropogenic_aod(lats, lons, params, year_weight_pd, ann_cycle_reduced)
+    aod_seasonal = get_anthropogenic_aod(params, year_weight_pd, ann_cycle_reduced, spatial_dist)
 
     # Total AOD should decrease compared to present-day
     assert jnp.sum(aod_seasonal) < jnp.sum(aod_pd)

--- a/jcm/physics/icon/radiation/gas_optics.py
+++ b/jcm/physics/icon/radiation/gas_optics.py
@@ -10,10 +10,6 @@ Date: 2025-01-10
 
 import jax.numpy as jnp
 import jax
-from typing import Tuple
-# from functools import partial  # Not needed anymore
-
-from .radiation_types import OpticalProperties
 
 
 @jax.jit
@@ -311,32 +307,30 @@ def gas_optical_depth_lw(
         Optical depth [nlev, n_bands]
 
     """
-    nlev = temperature.shape[0]
-    
     # Calculate absorption for all bands using vmap
     def single_band_absorption(band):
         # Water vapor absorption
         k_h2o = water_vapor_continuum(temperature, pressure, h2o_vmr, band)
-        
+
         # CO2 absorption
         k_co2 = co2_absorption(temperature, pressure, co2_vmr, band)
-        
+
         # Ozone absorption
         k_o3 = ozone_absorption_lw(temperature, o3_vmr, band)
-        
+
         # Total absorption coefficient
         k_total = k_h2o + k_co2 + k_o3
-        
+
         # Optical depth = absorption * density * path length
         return k_total * air_density * layer_thickness
-    
-    # Apply to all LW bands - use fixed shape
+
+    # Apply to all LW bands via vmap (was a Python ``for band in range(N_LW_BANDS)``
+    # loop that staged N_LW_BANDS separate ``.at[:, band].set(...)`` updates into
+    # XLA, producing a long unrolled dependency chain).
     from .constants import N_LW_BANDS
-    tau = jnp.zeros((nlev, N_LW_BANDS))
-    for band in range(N_LW_BANDS):
-        tau = tau.at[:, band].set(single_band_absorption(band))
-    
-    return tau
+    bands = jnp.arange(N_LW_BANDS)
+    tau_per_band = jax.vmap(single_band_absorption)(bands)  # (N_LW_BANDS, nlev)
+    return tau_per_band.T  # (nlev, N_LW_BANDS)
 
 
 @jax.jit
@@ -364,11 +358,9 @@ def gas_optical_depth_sw(
         Optical depth [nlev, n_bands]
 
     """
-    nlev = pressure.shape[0]
-    
     # Path length correction for solar angle
     sec_zenith = 1.0 / jnp.maximum(cos_zenith, 0.01)
-    
+
     # Calculate absorption for all bands
     def single_band_absorption(band):
         # Water vapor absorption (simplified - mainly NIR)
@@ -378,23 +370,21 @@ def gas_optical_depth_sw(
             0.01 * h2o_mmr,  # Very simplified
             0.0
         )
-        
+
         # Ozone absorption with temperature dependence
         k_o3 = ozone_absorption_sw(o3_vmr, temperature, band)
-        
+
         # Total absorption
         k_total = k_h2o + k_o3
-        
+
         # Optical depth with slant path correction
         return k_total * air_density * layer_thickness * sec_zenith
-    
-    # Apply to all SW bands - use fixed shape
+
+    # Apply to all SW bands via vmap (same motivation as ``gas_optical_depth_lw``).
     from .constants import N_SW_BANDS
-    tau = jnp.zeros((nlev, N_SW_BANDS))
-    for band in range(N_SW_BANDS):
-        tau = tau.at[:, band].set(single_band_absorption(band))
-    
-    return tau
+    bands = jnp.arange(N_SW_BANDS)
+    tau_per_band = jax.vmap(single_band_absorption)(bands)  # (N_SW_BANDS, nlev)
+    return tau_per_band.T  # (nlev, N_SW_BANDS)
 
 
 @jax.jit
@@ -429,121 +419,3 @@ def rayleigh_optical_depth(
     return tau
 
 
-def create_gas_optics(
-    temperature: jnp.ndarray,
-    pressure: jnp.ndarray,
-    h2o_vmr: jnp.ndarray,
-    o3_vmr: jnp.ndarray,
-    layer_thickness: jnp.ndarray,
-    air_density: jnp.ndarray,
-    cos_zenith,
-    config,
-) -> Tuple[OpticalProperties, OpticalProperties]:
-    """Create gas optical properties for SW and LW.
-    
-    Args:
-        temperature: Temperature (K) [nlev]
-        pressure: Pressure (Pa) [nlev]
-        h2o_vmr: Water vapor volume mixing ratio [nlev]
-        o3_vmr: Ozone volume mixing ratio [nlev]
-        layer_thickness: Layer thickness (m) [nlev]
-        air_density: Air density (kg/m³) [nlev]
-        cos_zenith: Cosine solar zenith angle
-        config: Radiation configuration
-        
-    Returns:
-        Tuple of (sw_optics, lw_optics)
-
-    """
-    # Longwave optical depths
-    tau_lw = gas_optical_depth_lw(
-        temperature,
-        pressure,
-        h2o_vmr,
-        o3_vmr,
-        config.co2_vmr,
-        layer_thickness,
-        air_density,
-    )
-    
-    # Shortwave optical depths
-    tau_sw = gas_optical_depth_sw(
-        pressure,
-        temperature,
-        h2o_vmr,
-        o3_vmr,
-        layer_thickness,
-        air_density,
-        cos_zenith
-    )
-    
-    # Add Rayleigh scattering to visible band
-    tau_rayleigh = rayleigh_optical_depth(
-        pressure,
-        layer_thickness,
-        0.55  # Visible wavelength
-    )
-    tau_sw = tau_sw.at[:, 0].add(tau_rayleigh)
-    
-    # Gas absorption has no scattering (ssa=0) except Rayleigh
-    nlev = temperature.shape[0]
-    
-    # Longwave: pure absorption
-    # Create fixed-size arrays for JAX compatibility
-    max_bands = 10
-    lw_band_mask = jnp.arange(max_bands) < config.n_lw_bands
-    lw_ssa_all = jnp.zeros((nlev, max_bands))
-    lw_g_all = jnp.zeros((nlev, max_bands))
-    
-    lw_optics = OpticalProperties(
-        optical_depth=tau_lw,
-        single_scatter_albedo=jnp.where(lw_band_mask[jnp.newaxis], lw_ssa_all, 0.0),
-        asymmetry_factor=jnp.where(lw_band_mask[jnp.newaxis], lw_g_all, 0.0)
-    )
-    
-    # Shortwave: Rayleigh scattering in visible
-    sw_band_mask = jnp.arange(max_bands) < config.n_sw_bands
-    sw_ssa_all = jnp.zeros((nlev, max_bands))
-    sw_ssa_all = sw_ssa_all.at[:, 0].set(
-        tau_rayleigh / jnp.maximum(tau_sw[:, 0], 1e-10)
-    )
-    sw_g_all = jnp.zeros((nlev, max_bands))
-    
-    sw_optics = OpticalProperties(
-        optical_depth=tau_sw,
-        single_scatter_albedo=jnp.where(sw_band_mask[jnp.newaxis], sw_ssa_all, 0.0),
-        asymmetry_factor=jnp.where(sw_band_mask[jnp.newaxis], sw_g_all, 0.0)  # Rayleigh: g=0
-    )
-    
-    return sw_optics, lw_optics
-
-
-# Test function
-def test_gas_optics():
-    """Test gas optics calculations"""
-    nlev = 20
-    
-    # Create test atmosphere
-    pressure = jnp.linspace(100000, 10000, nlev)
-    temperature = jnp.linspace(288, 220, nlev)
-    h2o_vmr = jnp.linspace(0.01, 1e-6, nlev)
-    o3_vmr = jnp.ones(nlev) * 5e-6
-    thickness = jnp.ones(nlev) * 500.0
-    density = pressure / (287.0 * temperature)
-    
-    # Test LW optical depth
-    tau_lw = gas_optical_depth_lw(
-        temperature, pressure, h2o_vmr, o3_vmr,
-        400e-6, thickness, density
-    )
-    
-    from .constants import N_LW_BANDS
-    assert tau_lw.shape == (nlev, N_LW_BANDS)
-    assert jnp.all(tau_lw >= 0)
-    assert jnp.all(jnp.isfinite(tau_lw))
-    
-    print("Gas optics tests passed!")
-
-
-if __name__ == "__main__":
-    test_gas_optics()

--- a/jcm/physics/icon/radiation/radiation_scheme.py
+++ b/jcm/physics/icon/radiation/radiation_scheme.py
@@ -376,14 +376,15 @@ def radiation_scheme(
     emissivity_val = surface_emissivity if surface_emissivity.ndim == 0 else surface_emissivity[0]
     flux_up_lw, flux_down_lw = longwave_fluxes(
         lw_optics, planck_layers, planck_interfaces,
-        emissivity_val, surface_planck
+        emissivity_val, surface_planck, default_n_lw_bands
     )
 
-    # Calculate shortwave fluxes
-    max_sw_bands = 10
-    toa_flux_bands_all = jnp.ones(max_sw_bands) * toa_flux / jnp.maximum(default_n_sw_bands, 1.0)
-    sw_band_mask = jnp.arange(max_sw_bands) < default_n_sw_bands
-    toa_flux_bands = jnp.where(sw_band_mask, toa_flux_bands_all, 0.0)
+    # Calculate shortwave fluxes.  ``default_n_sw_bands`` is a Python int, so
+    # this allocation has a statically-known shape and does not need a
+    # ``max_bands`` buffer + mask.
+    toa_flux_bands = jnp.full(
+        (default_n_sw_bands,), toa_flux / max(default_n_sw_bands, 1)
+    )
 
     # Note: When vmapped, albedos are scalars; otherwise extract first element
     albedo_vis_val = surface_albedo_vis if surface_albedo_vis.ndim == 0 else surface_albedo_vis[0]

--- a/jcm/physics/icon/radiation/radiation_scheme_test.py
+++ b/jcm/physics/icon/radiation/radiation_scheme_test.py
@@ -203,11 +203,12 @@ def test_radiation_scheme_basic():
     assert tendencies.longwave_heating.shape == (nlev,)
     assert tendencies.shortwave_heating.shape == (nlev,)
     
-    # Check diagnostic shapes - hardcoded to max_bands=10
-    assert diagnostics.sw_flux_up.shape == (nlev + 1, 10)  # max_bands hardcoded
-    assert diagnostics.sw_flux_down.shape == (nlev + 1, 10)
-    assert diagnostics.lw_flux_up.shape == (nlev + 1, 10)  # max_bands hardcoded
-    assert diagnostics.lw_flux_down.shape == (nlev + 1, 10)
+    # Check diagnostic shapes: one column per active band in the grey scheme
+    # (2 SW, 3 LW).
+    assert diagnostics.sw_flux_up.shape == (nlev + 1, 2)
+    assert diagnostics.sw_flux_down.shape == (nlev + 1, 2)
+    assert diagnostics.lw_flux_up.shape == (nlev + 1, 3)
+    assert diagnostics.lw_flux_down.shape == (nlev + 1, 3)
     
     # Check scalar diagnostics
     assert jnp.isscalar(diagnostics.toa_sw_down)
@@ -330,9 +331,11 @@ def test_radiation_scheme_custom_parameters():
         surface_temperature=jnp.array([288.0])
     )
 
-    # Check output shapes - hardcoded to max_bands=10
-    assert diagnostics.sw_flux_up.shape == (7, 10)  # max_bands hardcoded
-    assert diagnostics.lw_flux_up.shape == (7, 10)  # max_bands hardcoded
+    # The grey scheme hardcodes 2 SW / 3 LW bands internally regardless of
+    # what ``n_sw_bands`` / ``n_lw_bands`` are in the parameters, so diagnostic
+    # fluxes always have that many columns.
+    assert diagnostics.sw_flux_up.shape == (7, 2)
+    assert diagnostics.lw_flux_up.shape == (7, 3)
     
     # Should still produce valid results
     assert not jnp.any(jnp.isnan(tendencies.temperature_tendency))

--- a/jcm/physics/icon/radiation/radiation_scheme_test.py
+++ b/jcm/physics/icon/radiation/radiation_scheme_test.py
@@ -623,3 +623,164 @@ def test_radiation_scheme_reproducibility():
             assert tendencies_1.temperature_tendency.shape == tendencies.temperature_tendency.shape
             assert tendencies_1.longwave_heating.shape == tendencies.longwave_heating.shape
             assert tendencies_1.shortwave_heating.shape == tendencies.shortwave_heating.shape
+
+
+# ------------------------------------------------------------------
+# Radiation sub-stepping / caching tests
+# ------------------------------------------------------------------
+
+class TestRadiationCaching:
+    """Test the radiation sub-stepping wrapper ``_radiation_with_caching``."""
+
+    def _make_physics_args(self, nlev=10, radiation_interval=0.0,
+                           model_step=0, dt_seconds=30.0):
+        """Build minimal args for the radiation wrapper."""
+        from jcm.physics.icon.icon_physics_data import PhysicsData, RadiationData
+        from jcm.physics.icon.parameters import Parameters
+        from jcm.physics_interface import PhysicsState
+        from jcm.date import DateData
+
+        ncols = 4
+        params = Parameters.default()
+        # Set radiation_interval on the parameters
+        rad_params = params.radiation.__class__(**{
+            **params.radiation.__dict__,
+            'radiation_interval': jnp.array(radiation_interval),
+            'dt_rad': jnp.array(dt_seconds),
+        })
+        params = params.__class__(**{**params.__dict__, 'radiation': rad_params})
+
+        date = DateData.zeros(
+            model_step=jnp.int32(model_step),
+            dt_seconds=dt_seconds,
+        )
+
+        # Minimal PhysicsData with known radiation heating rates
+        rad_data = RadiationData.zeros((ncols,), nlev)
+        # Set known cached heating rates
+        sw_rate = jnp.ones((nlev, ncols)) * 1e-5
+        lw_rate = jnp.ones((nlev, ncols)) * (-2e-5)
+        rad_data = rad_data.copy(sw_heating_rate=sw_rate, lw_heating_rate=lw_rate)
+
+        physics_data = PhysicsData.zeros(
+            (ncols,), nlev, icon_coords=None, date=date,
+        )
+        physics_data = physics_data.copy(radiation=rad_data)
+
+        state = PhysicsState(
+            u_wind=jnp.zeros((nlev, ncols)),
+            v_wind=jnp.zeros((nlev, ncols)),
+            temperature=jnp.ones((nlev, ncols)) * 250.0,
+            specific_humidity=jnp.ones((nlev, ncols)) * 1e-3,
+            geopotential=jnp.zeros((nlev, ncols)),
+            normalized_surface_pressure=jnp.ones(ncols),
+            tracers={},
+        )
+
+        return state, physics_data, params
+
+    def test_no_caching_when_interval_zero(self):
+        """Default radiation_interval=0 always computes."""
+        from jcm.physics.icon.icon_physics import _radiation_with_caching
+
+        state, physics_data, params = self._make_physics_args(
+            radiation_interval=0.0, model_step=1)
+
+        # A dummy radiation function that returns a known marker value
+        marker = 42.0
+
+        def dummy_rad(s, pd, p, f, t):
+            from jcm.physics_interface import PhysicsTendency
+            nlev, ncols = s.temperature.shape
+            tend = PhysicsTendency(
+                u_wind=jnp.zeros((nlev, ncols)),
+                v_wind=jnp.zeros((nlev, ncols)),
+                temperature=jnp.ones((nlev, ncols)) * marker,
+                specific_humidity=jnp.zeros((nlev, ncols)),
+                tracers={},
+            )
+            return tend, pd
+
+        tend, _ = _radiation_with_caching(
+            dummy_rad, state, physics_data, params, None, None)
+
+        # Should have called the dummy, not the cache
+        assert jnp.allclose(tend.temperature, marker)
+
+    def test_caching_returns_cached_tendency(self):
+        """On a non-radiation step the cached sw+lw rates are returned."""
+        from jcm.physics.icon.icon_physics import _radiation_with_caching
+        from jcm.physics_interface import PhysicsTendency
+
+        state, physics_data, params = self._make_physics_args(
+            radiation_interval=120.0, dt_seconds=30.0,
+            model_step=1)  # step 1, interval=4 steps → should use cache
+
+        def should_not_be_called(s, pd, p, f, t):
+            # Return something obviously different so test would fail
+            nlev, ncols = s.temperature.shape
+            return PhysicsTendency(
+                u_wind=jnp.zeros((nlev, ncols)),
+                v_wind=jnp.zeros((nlev, ncols)),
+                temperature=jnp.ones((nlev, ncols)) * 999.0,
+                specific_humidity=jnp.zeros((nlev, ncols)),
+                tracers={},
+            ), pd
+
+        tend, _ = _radiation_with_caching(
+            should_not_be_called, state, physics_data, params, None, None)
+
+        # Should get sw + lw = 1e-5 + (-2e-5) = -1e-5
+        expected = jnp.ones_like(tend.temperature) * (-1e-5)
+        assert jnp.allclose(tend.temperature, expected)
+
+    def test_caching_computes_on_interval(self):
+        """Radiation computes at step 0, 4, 8, ... for 120s interval / 30s dt."""
+        from jcm.physics.icon.icon_physics import _radiation_with_caching
+        from jcm.physics_interface import PhysicsTendency
+
+        call_count = []
+
+        def counting_rad(s, pd, p, f, t):
+            call_count.append(1)  # side-effect (only works outside JIT)
+            nlev, ncols = s.temperature.shape
+            return PhysicsTendency(
+                u_wind=jnp.zeros((nlev, ncols)),
+                v_wind=jnp.zeros((nlev, ncols)),
+                temperature=jnp.ones((nlev, ncols)) * 7.0,
+                specific_humidity=jnp.zeros((nlev, ncols)),
+                tracers={},
+            ), pd
+
+        for step in [0, 4, 8]:
+            call_count.clear()
+            state, physics_data, params = self._make_physics_args(
+                radiation_interval=120.0, dt_seconds=30.0,
+                model_step=step)
+            tend, _ = _radiation_with_caching(
+                counting_rad, state, physics_data, params, None, None)
+            # On radiation steps the compute branch should run
+            assert jnp.allclose(tend.temperature, 7.0), f"step {step}"
+
+    def test_first_step_always_computes(self):
+        """Step 0 always triggers radiation regardless of interval."""
+        from jcm.physics.icon.icon_physics import _radiation_with_caching
+        from jcm.physics_interface import PhysicsTendency
+
+        state, physics_data, params = self._make_physics_args(
+            radiation_interval=7200.0, dt_seconds=30.0,
+            model_step=0)
+
+        def marker_rad(s, pd, p, f, t):
+            nlev, ncols = s.temperature.shape
+            return PhysicsTendency(
+                u_wind=jnp.zeros((nlev, ncols)),
+                v_wind=jnp.zeros((nlev, ncols)),
+                temperature=jnp.ones((nlev, ncols)) * 123.0,
+                specific_humidity=jnp.zeros((nlev, ncols)),
+                tracers={},
+            ), pd
+
+        tend, _ = _radiation_with_caching(
+            marker_rad, state, physics_data, params, None, None)
+        assert jnp.allclose(tend.temperature, 123.0)

--- a/jcm/physics/icon/radiation/radiation_test.py
+++ b/jcm/physics/icon/radiation/radiation_test.py
@@ -480,20 +480,17 @@ class TestRadiationIntegration:
             surface_emissivity, surface_planck, self.n_lw_bands
         )
         
-        # Check results (hardcoded max_bands=10)
-        assert flux_up.shape == (self.nlev + 1, 10)
-        assert flux_down.shape == (self.nlev + 1, 10)
-        
-        # Only first n_lw_bands should have values, rest should be zero
-        assert jnp.all(flux_up[:, self.n_lw_bands:] == 0)
-        assert jnp.all(flux_down[:, self.n_lw_bands:] == 0)
-        
-        # Surface should emit upward (only check bands with non-zero values)
-        # Due to bug in band_fraction, only first 2 bands have values
+        # Output has one column per active band (``n_bands`` is now a static
+        # argument so the flux shape matches the requested band count).
+        assert flux_up.shape == (self.nlev + 1, self.n_lw_bands)
+        assert flux_down.shape == (self.nlev + 1, self.n_lw_bands)
+
+        # Surface should emit upward (only check bands with non-zero values).
+        # Due to a pre-existing bug in band_fraction, only the first two bands
+        # have values.
         assert jnp.all(flux_up[-1, :2] > 0)
-        
+
         # TOA should have net upward flux (OLR) for bands with non-zero values
-        # Due to bug in band_fraction, only first 2 bands have values
         olr = flux_up[0, :2] - flux_down[0, :2]
         assert jnp.all(olr > 0)
     
@@ -507,27 +504,21 @@ class TestRadiationIntegration:
             self.sw_optics, cos_zenith, toa_flux, surface_albedo, self.n_sw_bands
         )
         
-        # Check shapes (hardcoded max_bands=10)
-        assert flux_up.shape == (self.nlev + 1, 10)
-        assert flux_down.shape == (self.nlev + 1, 10)
-        assert flux_dir.shape == (self.nlev + 1, 10)
-        assert flux_dif.shape == (self.nlev + 1, 10)
-        
-        # Only first n_sw_bands should have values, rest should be zero
-        assert jnp.all(flux_up[:, self.n_sw_bands:] == 0)
-        assert jnp.all(flux_down[:, self.n_sw_bands:] == 0)
-        assert jnp.all(flux_dir[:, self.n_sw_bands:] == 0)
-        assert jnp.all(flux_dif[:, self.n_sw_bands:] == 0)
-        
-        # TOA boundary condition - direct flux at TOA equals incident flux (only first n_sw_bands)
-        assert jnp.allclose(flux_down[0, :self.n_sw_bands], toa_flux)
-        
-        # Surface reflection (only check first n_sw_bands)
-        assert jnp.all(flux_up[-1, :self.n_sw_bands] > 0)
-        
-        # Energy conservation: net flux should decrease downward (only first n_sw_bands)
+        # Output has one column per active band.
+        assert flux_up.shape == (self.nlev + 1, self.n_sw_bands)
+        assert flux_down.shape == (self.nlev + 1, self.n_sw_bands)
+        assert flux_dir.shape == (self.nlev + 1, self.n_sw_bands)
+        assert flux_dif.shape == (self.nlev + 1, self.n_sw_bands)
+
+        # TOA boundary condition - direct flux at TOA equals incident flux.
+        assert jnp.allclose(flux_down[0, :], toa_flux)
+
+        # Surface reflection.
+        assert jnp.all(flux_up[-1, :] > 0)
+
+        # Energy conservation: net flux should decrease downward.
         net_flux = flux_down - flux_up
-        assert jnp.all(net_flux[0, :self.n_sw_bands] >= net_flux[-1, :self.n_sw_bands])
+        assert jnp.all(net_flux[0, :] >= net_flux[-1, :])
     
     def test_heating_rates(self):
         """Test heating rate calculation"""

--- a/jcm/physics/icon/radiation/radiation_types.py
+++ b/jcm/physics/icon/radiation/radiation_types.py
@@ -17,8 +17,9 @@ class RadiationParameters:
     
     # Time stepping
     dt_rad: float            # Radiation time step (s)
-    
-    # Solar parameters  
+    radiation_interval: float  # Seconds between radiation calls (0 = every step)
+
+    # Solar parameters
     solar_constant: float    # Solar constant (W/m²)
     
     # Spectral bands
@@ -43,15 +44,17 @@ class RadiationParameters:
     cld_frac_min: float      # Minimum cloud fraction
 
     @classmethod
-    def default(cls, dt_rad=3600.0, solar_constant=1361.0, n_sw_bands=2, n_lw_bands=3,
+    def default(cls, dt_rad=3600.0, radiation_interval=0.0,
+                 solar_constant=1361.0, n_sw_bands=2, n_lw_bands=3,
                  lw_band_limits=((10, 350), (350, 500), (500, 2500)),
                  sw_band_limits=((4000, 14500), (14500, 50000)),
                  co2_vmr=400e-6, ch4_vmr=1.8e-6, n2o_vmr=0.32e-6,
-                 min_cos_zenith=0.035, flux_epsilon=1e-6, 
+                 min_cos_zenith=0.035, flux_epsilon=1e-6,
                  cld_tau_min=1e-6, cld_frac_min=1e-3) -> 'RadiationParameters':
         """Return default radiation parameters"""
         return cls(
             dt_rad=jnp.array(dt_rad),
+            radiation_interval=jnp.array(radiation_interval),
             solar_constant=jnp.array(solar_constant),
             n_sw_bands=jnp.asarray(n_sw_bands),
             n_lw_bands=jnp.asarray(n_lw_bands),

--- a/jcm/physics/icon/radiation/two_stream.py
+++ b/jcm/physics/icon/radiation/two_stream.py
@@ -9,6 +9,8 @@ adding method for combining layers.
 Date: 2025-01-10
 """
 
+import functools
+
 import jax.numpy as jnp
 import jax
 from typing import Tuple, Optional
@@ -233,7 +235,7 @@ def longwave_fluxes_single_band(
     return flux_up, flux_down
 
 
-@jax.jit
+@functools.partial(jax.jit, static_argnames=('n_bands',))
 def longwave_fluxes(
     optical_properties: OpticalProperties,
     planck_layers: jnp.ndarray,
@@ -243,15 +245,15 @@ def longwave_fluxes(
     n_bands: int = 3
 ) -> Tuple[jnp.ndarray, jnp.ndarray]:
     """Calculate longwave fluxes using two-stream method.
-    
+
     Args:
         optical_properties: Layer optical properties
         planck_layers: Planck function at layer centers [nlev, n_bands]
         planck_interfaces: Planck function at interfaces [nlev+1, n_bands]
         surface_emissivity: Surface emissivity
         surface_planck: Surface Planck emission [n_bands]
-        n_bands: Number of spectral bands
-        
+        n_bands: Number of spectral bands (static for shape-polymorphic jit)
+
     Returns:
         Tuple of (upward_flux, downward_flux) at interfaces [nlev+1, n_bands]
 
@@ -268,24 +270,22 @@ def longwave_fluxes(
             surface_planck[band_idx]
         )
         return flux_up_band, flux_down_band
-    
-    # Apply to all bands - use fixed size for JAX compatibility
-    max_bands = 10
-    band_indices = jnp.arange(max_bands)
-    band_mask = band_indices < n_bands
+
+    # Run only over the bands we actually use (``n_bands`` is a static int).
+    # Previously this vmap ran over a fixed ``max_bands = 10`` buffer and then
+    # masked out unused bands, which wasted ~70 % of the two-stream work in
+    # the grey scheme (3 LW bands used out of 10).
+    band_indices = jnp.arange(n_bands)
     flux_up_all, flux_down_all = jax.vmap(process_band)(band_indices)
-    # Mask inactive bands (keep full size)
-    flux_up = jnp.where(band_mask[:, None], flux_up_all, 0.0)
-    flux_down = jnp.where(band_mask[:, None], flux_down_all, 0.0)
-    
+
     # Transpose to get [nlev+1, n_bands] shape
-    flux_up = flux_up.T
-    flux_down = flux_down.T
-    
+    flux_up = flux_up_all.T
+    flux_down = flux_down_all.T
+
     # Convert from radiance to flux (multiply by π)
     flux_up *= jnp.pi
     flux_down *= jnp.pi
-    
+
     return flux_up, flux_down
 
 
@@ -383,7 +383,7 @@ def shortwave_fluxes_single_band(
     return flux_up_total, flux_down_total, flux_direct, flux_down_dif
 
 
-@jax.jit
+@functools.partial(jax.jit, static_argnames=('n_bands',))
 def shortwave_fluxes(
     optical_properties: OpticalProperties,
     cos_zenith: float,
@@ -392,14 +392,14 @@ def shortwave_fluxes(
     n_bands: int = 2
 ) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
     """Calculate shortwave fluxes using two-stream method.
-    
+
     Args:
         optical_properties: Layer optical properties
         cos_zenith: Cosine of solar zenith angle
         toa_flux: TOA incident flux [n_bands]
         surface_albedo: Surface albedo [n_bands]
-        n_bands: Number of spectral bands
-        
+        n_bands: Number of spectral bands (static for shape-polymorphic jit)
+
     Returns:
         Tuple of (up_flux, down_flux, down_direct, down_diffuse)
         All at interfaces [nlev+1, n_bands]
@@ -416,24 +416,19 @@ def shortwave_fluxes(
             surface_albedo[band_idx]
         )
         return flux_up, flux_down, flux_dir, flux_dif
-    
-    # Apply to all bands - use fixed size for JAX compatibility
-    max_bands = 10
-    band_indices = jnp.arange(max_bands)
-    band_mask = band_indices < n_bands
-    flux_up_all, flux_down_all, flux_direct_all, flux_diffuse_all = jax.vmap(process_band)(band_indices)
-    # Mask inactive bands (keep full size)
-    flux_up = jnp.where(band_mask[:, None], flux_up_all, 0.0)
-    flux_down = jnp.where(band_mask[:, None], flux_down_all, 0.0)
-    flux_direct = jnp.where(band_mask[:, None], flux_direct_all, 0.0)
-    flux_diffuse = jnp.where(band_mask[:, None], flux_diffuse_all, 0.0)
-    
+
+    # Run only over the bands we actually use (``n_bands`` is a static int).
+    band_indices = jnp.arange(n_bands)
+    flux_up_all, flux_down_all, flux_direct_all, flux_diffuse_all = jax.vmap(
+        process_band
+    )(band_indices)
+
     # Transpose to get [nlev+1, n_bands] shape
-    flux_up = flux_up.T
-    flux_down = flux_down.T
-    flux_direct = flux_direct.T
-    flux_diffuse = flux_diffuse.T
-    
+    flux_up = flux_up_all.T
+    flux_down = flux_down_all.T
+    flux_direct = flux_direct_all.T
+    flux_diffuse = flux_diffuse_all.T
+
     return flux_up, flux_down, flux_direct, flux_diffuse
 
 

--- a/jcm/physics/icon/radiation/two_stream_test.py
+++ b/jcm/physics/icon/radiation/two_stream_test.py
@@ -164,12 +164,10 @@ def test_longwave_fluxes():
         surface_emissivity, surface_planck, n_lw_bands
     )
     
-    # Check shapes (hardcoded max_bands=10)
-    assert flux_up_lw.shape == (nlev + 1, 10)
-    assert flux_down_lw.shape == (nlev + 1, 10)
-    # Only first n_lw_bands should have values
-    assert jnp.all(flux_up_lw[:, n_lw_bands:] == 0)
-    assert jnp.all(flux_down_lw[:, n_lw_bands:] == 0)
+    # Output has one column per active band (``n_bands`` is now a static
+    # argument, so the flux shape matches the requested band count).
+    assert flux_up_lw.shape == (nlev + 1, n_lw_bands)
+    assert flux_down_lw.shape == (nlev + 1, n_lw_bands)
     
     # Check physical constraints
     assert jnp.all(flux_up_lw >= 0)
@@ -203,14 +201,12 @@ def test_shortwave_fluxes():
         sw_optics, cos_zenith, toa_flux, surface_albedo, n_sw_bands
     )
     
-    # Check shapes (hardcoded max_bands=10)
-    assert flux_up_sw.shape == (nlev + 1, 10)
-    assert flux_down_sw.shape == (nlev + 1, 10)
-    assert flux_dir.shape == (nlev + 1, 10)
-    assert flux_dif.shape == (nlev + 1, 10)
-    # Only first n_sw_bands should have values
-    assert jnp.all(flux_up_sw[:, n_sw_bands:] == 0)
-    assert jnp.all(flux_down_sw[:, n_sw_bands:] == 0)
+    # Output has one column per active band (``n_bands`` is now a static
+    # argument, so the flux shape matches the requested band count).
+    assert flux_up_sw.shape == (nlev + 1, n_sw_bands)
+    assert flux_down_sw.shape == (nlev + 1, n_sw_bands)
+    assert flux_dir.shape == (nlev + 1, n_sw_bands)
+    assert flux_dif.shape == (nlev + 1, n_sw_bands)
     
     # Check physical constraints
     assert jnp.all(flux_up_sw >= 0)

--- a/jcm/physics/speedy/speedy_physics.py
+++ b/jcm/physics/speedy/speedy_physics.py
@@ -145,6 +145,8 @@ class SpeedyPhysics(Physics):
         # but we need a completely zeroed one (including fields like model_year) for accumulating averages
         # Compute speedy_coords for the empty data (it's a constant cache, not zeroed)
         speedy_coords = SpeedyCoords.from_coordinate_system(coords)
+        # Convert coords to JAX arrays so dtypes match traced output (e.g. float64→float32)
+        speedy_coords = tree_map(jnp.asarray, speedy_coords)
         empty_data = PhysicsData.zeros(coords.horizontal.nodal_shape, coords.nodal_shape[0], speedy_coords=speedy_coords)
         # Zero out everything except speedy_coords (which should remain constant)
-        return tree_map(lambda x: 0*x, empty_data).copy(speedy_coords=speedy_coords)
+        return tree_map(jnp.zeros_like, empty_data).copy(speedy_coords=speedy_coords)

--- a/jcm/physics/speedy/speedy_physics.py
+++ b/jcm/physics/speedy/speedy_physics.py
@@ -102,6 +102,7 @@ class SpeedyPhysics(Physics):
         forcing: ForcingData,
         terrain: TerrainData,
         date: DateData,
+        prev_physics_data=None,
     ) -> Tuple[PhysicsTendency, PhysicsData]:
         """Compute the physical tendencies given the current state and data structs. Loops through the Speedy physics terms, accumulating the tendencies.
 

--- a/jcm/physics_interface.py
+++ b/jcm/physics_interface.py
@@ -173,7 +173,7 @@ class Physics:
     def cache_coords(self, coords: CoordinateSystem):
         return None
 
-    def compute_tendencies(self, state: PhysicsState, forcing: ForcingData, terrain: TerrainData, date: DateData) -> Tuple[PhysicsTendency, Any]:
+    def compute_tendencies(self, state: PhysicsState, forcing: ForcingData, terrain: TerrainData, date: DateData, prev_physics_data=None) -> Tuple[PhysicsTendency, Any]:
         """Compute the physical tendencies given the current state and data structs.
 
         Args:
@@ -181,6 +181,8 @@ class Physics:
             forcing: Forcing data
             terrain: Terrain data (boundary conditions)
             date: Date data
+            prev_physics_data: Previous step's physics data for caching
+                expensive computations (e.g. radiation). None on first step.
 
         Returns:
             Physical tendencies in PhysicsTendency format
@@ -447,7 +449,21 @@ def get_physical_tendencies(
     physics_state = dynamics_state_to_physics_state(state, dynamics)
 
     clamped_physics_state = verify_state(physics_state)
-    physics_tendency, physics_data = physics.compute_tendencies(clamped_physics_state, forcing, terrain, date)
+
+    # Retrieve cached physics data from the collector (if available) so
+    # that expensive terms like radiation can reuse previous results.
+    prev_physics_data = None
+    if diagnostics_collector is not None and hasattr(diagnostics_collector, 'physics_data_cache'):
+        prev_physics_data = diagnostics_collector.physics_data_cache.value
+
+    physics_tendency, physics_data = physics.compute_tendencies(
+        clamped_physics_state, forcing, terrain, date,
+        prev_physics_data=prev_physics_data,
+    )
+
+    # Update the cache so the next timestep can reuse this data.
+    if diagnostics_collector is not None and hasattr(diagnostics_collector, 'physics_data_cache'):
+        diagnostics_collector.physics_data_cache.value = physics_data
 
     physics_tendency = verify_tendencies(physics_state, physics_tendency, time_step)
 


### PR DESCRIPTION
● ## Context

  ICON physics `compute_tendencies` is significantly slower than SPEEDY at the same resolution. Profiling at T21 × 10 levels (2048
  columns, CPU) showed:

  - **SPEEDY:** ~1.6 ms/step
  - **ICON:** ~23.7 ms/step (~15× slower)

  This gap exists independently of the RRTMGP radiation scheme cost (handled separately by radiation sub-stepping in #424). The plan
  in `docs/icon_physics_perf_plan.md` on `feature/icon-physics-perf` proposed three steps.

  ## Step 1 — Cheap local fixes (landed)

  Commit `bc2a2a3` on `feature/icon-physics-perf`. All sub-items are independent, low-risk, and purely mechanical:

  | Fix | Description |
  |-----|-------------|
  | 1.1 | Remove vmap-of-1 wrapping in `apply_vertical_diffusion` — the column helpers already handle batched `(ncols, nlev)` arrays |
  | 1.2 | Delete dead `initialize_chemistry_tracers` call — `apply_forcing_data` unconditionally overwrites with constants |
  | 1.3 | Dedupe MACv2-SP `spatial_dist` computation (was recomputed 3× per step) |
  | 1.4 | Drop `max_bands=10` padding in grey two-stream radiation — ~70% of work was computed and thrown away |
  | 1.5 | Vmap the `gas_optical_depth_lw/sw` band loops (replace Python for-loop with `jax.vmap`) |

  ### Step 1 results

  **T21 × 10 levels, CPU:**

  | Metric | Before | After step 1 | Change |
  |--------|--------|--------------|--------|
  | ICON | 23.7 ms | 17.3 ms | **-27%** |
  | SPEEDY | 1.6 ms | 1.6 ms | unchanged |
  | Ratio | ~15× | 10.7× | |

  Per-term breakdown (CPU, after step 1):

  | Term | Time | % of total |
  |------|------|-----------|
  | `apply_convection` | 7.17 ms | 41% |
  | `apply_vertical_diffusion` | 5.54 ms | 32% |
  | `apply_radiation` | 5.29 ms | 31% |
  | All other terms (7) | < 1 ms each | 19% total |

  ## Step 2 — Outer-loop column vmap (evaluated, not landed)

  ### What we tried

  Moved per-term `jax.vmap` calls from inside each `apply_*` function to a single outer `jax.vmap` wrapping all expensive terms
  (`_column_physics`). The goal was to give XLA one fused kernel instead of per-term boundaries.

  Architecture: three-phase `compute_tendencies`:

  - **Phase 1:** Cheap setup terms on full `(nlev, ncols)` arrays (prepare_common, forcing, aerosol, chemistry)
  - **Phase 2:** Single outer `jax.vmap(_column_physics)` over columns (radiation, convection, clouds, vdiff, gravity_waves)
  - **Phase 3:** Surface physics on full arrays (needs Phase 2 radiation/vdiff outputs)

  ### Step 2 results

  All 357 ICON physics tests passed. Performance:

  **T21 × 10 levels (2048 columns):**

  | | Step 1 | Step 2 | Change |
  |---|---|---|---|
  | CPU ICON | 17.3 ms | 18.1 ms | +5% regression |
  | GPU ICON | 9.1 ms | 9.1 ms | ~same |

  **T85 × 40 levels (32768 columns) — target resolution:**

  | | Step 1 | Step 2 | Change |
  |---|---|---|---|
  | CPU ICON | 690.9 ms | 657.5 ms | **-4.8%** |
  | GPU ICON | 45.3 ms | 38.1 ms | **-15.9%** |

  ### Why we chose not to land step 2

  The 16% GPU gain at T85 is real but modest. The architectural cost is high because step 2 **fundamentally conflicts with the
  composable physics design** (#206, `docs/design/composable_physics.md`):

  1. **Hardcoded vs. dynamic term list.** Step 2 fuses specific functions (`radiation_scheme`, `tiedtke_nordeng_convection`, etc.)
  into `_column_physics`. The composable design needs swappable `PhysicsTerm` modules via `__add__` / `replace` / `remove`.

  2. **Typed sub-structs vs. diagnostics dict.** Step 2 deeply couples to `PhysicsData` sub-structs (passing `diagnostics_col`,
  `radiation_col`, etc. individually to work around vmap tree issues with non-array leaves). The composable design replaces all of
  this with `dict[str, jnp.ndarray]`.

  3. **Per-term NNX parameters vs. monolithic Parameters.** Step 2 passes the monolithic `self.parameters` into the fused column
  function. The composable design gives each term its own `nnx.Param` for targeted gradient computation.

  4. **Composition operators.** A monolithic `_column_physics` can't be composed with `__add__`, `replace`, or `remove`.

  ### Preserving the option

  If performance at T85+ becomes critical after the composable refactor:

  - **Step 3's NPROMA chunking** (`lax.map(vmap(term))` per term) is compatible with composability — it can be applied inside each
  `PhysicsTerm.__call__` independently.
  - The step 2 implementation is preserved in git history (commits on `feature/icon-physics-perf` between `24f47ec` and `499b39b`)
  for reference.

  ## Radiation scheme benchmarks

  Benchmarked grey, NN emulator (random weights, architecture-only timing), and RRTMGP at target resolution on a single A100 80 GiB
  GPU.

  **T85 × 40 levels (32768 columns):**

  | Scheme | CPU (ms) | vs grey | GPU (ms) | vs grey |
  |--------|----------|---------|----------|---------|
  | Grey | 915 | 1.0× | 18.2 | 1.0× |
  | NN Emulator | 1,042 | 1.14× | 23.3 | 1.28× |
  | RRTMGP | 348,194 | **381×** | OOM (117 GiB) | — |

  **T21 × 40 levels (2048 columns, single A100):**

  | Scheme | GPU (ms) | vs grey |
  |--------|----------|---------|
  | Grey | 10.2 | 1.0× |
  | NN Emulator | 12.2 | 1.2× |
  | RRTMGP | 755 | **74×** |

  The NN emulator achieves a **334× speedup over RRTMGP** on CPU at T85 with only 14% overhead versus the simplified grey scheme.
  RRTMGP cannot run at T85 on a single GPU due to memory (117 GiB needed for the per-column vmap over 240 g-points).

  ## Profiling tools

  `utils/profile_icon_physics.py` — profiles ICON vs SPEEDY `compute_tendencies` with per-term breakdown:

  ```bash
  python utils/profile_icon_physics.py --truncation 85 --nlev 40 --skip_per_term
  JAX_PLATFORMS=cpu python utils/profile_icon_physics.py

  utils/benchmark_radiation.py — compares grey vs emulated vs RRTMGP radiation schemes:

  CUDA_VISIBLE_DEVICES=4 python utils/benchmark_radiation.py --truncation 85 --nlev 40

  utils/run_speed_test.py — end-to-end multi-resolution benchmark with ICON/SPEEDY selection.
  ```