### PR TITLE
Remove spmd_mesh arg from Model; document on coords helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,15 @@ Run a simple aquaplanet simulation:
 
 ```python
 from jcm.model import Model
+from jcm.physics.speedy.speedy_coords import get_speedy_coords
+
+# Build coords (pass spmd_mesh=(x, y, z) here to enable multi-device sharding)
+coords = get_speedy_coords(layers=8, spectral_truncation=31)
 
 # Create a model with default configuration
 model = Model(
-    time_step=30.0,          # minutes
-    layers=8,                 # vertical levels
-    horizontal_resolution=31  # T31 spectral grid
+    coords=coords,
+    time_step=30.0,  # minutes
 )
 
 # Run a 120-day simulation

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -165,7 +165,7 @@ Multi-Device Parallelization
 
 JCM supports multi-device parallelization using JAX's SPMD (Single Program Multiple Data) sharding. This allows you to split computation across multiple GPUs or TPUs for faster execution, especially useful for higher resolution simulations.
 
-If you don't specify ``spmd_mesh``, JCM runs on a single device by default. This is the recommended approach for smaller resolutions (T31, T42) or when you only have a single GPU/TPU available.
+If you don't specify ``spmd_mesh`` when building your coords, JCM runs on a single device by default. This is the recommended approach for smaller resolutions (T31, T42) or when you only have a single GPU/TPU available.
 
 Basic Concepts
 ^^^^^^^^^^^^^^
@@ -179,7 +179,8 @@ Future implementations may allow for more flexible sharding strategies.
 Enabling Parallelization
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-To enable multi-device parallelization, simply pass an ``spmd_mesh`` when creating your Model:
+To enable multi-device parallelization, pass ``spmd_mesh`` to the coords helper
+(e.g. ``get_speedy_coords`` or ``get_coords``) and build the ``Model`` with those coords:
 
 .. code-block:: python
 
@@ -196,8 +197,8 @@ To enable multi-device parallelization, simply pass an ``spmd_mesh`` when creati
    #   - Split longitude dimension across 4 devices
    #   - Don't split latitude (1)
    #   - Don't split vertical (1)
-   # Otherwise, create and run model as usual
-   model = Model(coords=get_speedy_coords(), spmd_mesh=(4, 1, 1))
+   coords = get_speedy_coords(spmd_mesh=(4, 1, 1))
+   model = Model(coords=coords)
    predictions = model.run(save_interval=5.0, total_time=30.0)
 
 Mesh Configuration Guidelines

--- a/jcm/model.py
+++ b/jcm/model.py
@@ -203,13 +203,14 @@ class Model:
     """Top level class for a JAX-GCM configuration using the Speedy physics on an aquaplanet."""
 
     def __init__(self, coords: CoordinateSystem, time_step=30.0, terrain: TerrainData=None,
-                 physics: Physics=None, diffusion: DiffusionFilter=None, spmd_mesh: tuple[int, ...]=None,
+                 physics: Physics=None, diffusion: DiffusionFilter=None,
                  start_date: jdt.Datetime=jdt.to_datetime('2000-01-01'), log_level=logging.CRITICAL) -> None:
         """Initialize the model with the given time step, save interval, and total time.
 
         Args:
             coords:
-                CoordinateSystem object describing the model coordinates
+                CoordinateSystem object describing the model coordinates. To enable SPMD
+                parallelization, pass ``spmd_mesh`` to the coords helper (e.g. ``get_speedy_coords``).
             time_step:
                 Model time step in minutes
             terrain:
@@ -218,8 +219,6 @@ class Model:
                 Physics object describing the model physics
             diffusion:
                 DiffusionFilter object describing horizontal diffusion filter params
-            spmd_mesh:
-                Optional tuple describing the SPMD mesh for parallelization
             start_date:
                 jax_datetime.Datetime object containing start date of the simulation (default January 1, 2000)
             log_level:

--- a/jcm/physics/held_suarez/utils.py
+++ b/jcm/physics/held_suarez/utils.py
@@ -22,7 +22,9 @@ def get_held_suarez_coords(layers=8, spectral_truncation=31, nodal_shape=None, s
         spectral_truncation: Spectral truncation number (default 31)
         nodal_shape: Optional nodal shape (ix, il) to infer spectral_truncation
         sigma_boundaries: Optional array of sigma boundaries. If None, uses DEFAULT_SIGMA_BOUNDARIES.
-        spmd_mesh: Optional SPMD mesh for parallelization
+        spmd_mesh: Optional ``(x, y, z)`` tuple giving the SPMD device mesh over
+            (longitude, latitude, vertical). The product must equal ``len(jax.devices())``.
+            Pass this here (not to ``Model``) to enable multi-device sharding.
 
     Returns:
         CoordinateSystem object

--- a/jcm/physics/speedy/speedy_coords.py
+++ b/jcm/physics/speedy/speedy_coords.py
@@ -15,7 +15,9 @@ def get_speedy_coords(layers=8, spectral_truncation=31, nodal_shape=(96,48), spm
         layers: Number of vertical levels (7 or 8)
         spectral_truncation: Spectral truncation number (default 31)
         nodal_shape: Optional nodal shape (ix, il) to infer spectral_truncation
-        spmd_mesh: Optional SPMD mesh for parallelization
+        spmd_mesh: Optional ``(x, y, z)`` tuple giving the SPMD device mesh over
+            (longitude, latitude, vertical). The product must equal ``len(jax.devices())``.
+            Pass this here (not to ``Model``) to enable multi-device sharding.
 
     Returns:
         CoordinateSystem object with SPEEDY sigma levels

--- a/jcm/utils.py
+++ b/jcm/utils.py
@@ -43,7 +43,11 @@ def get_coords(sigma_boundaries, spectral_truncation=31, nodal_shape=None, spmd_
         sigma_boundaries: Array of sigma layer boundaries (required)
         spectral_truncation: Spectral truncation number (default 31)
         nodal_shape: Optional nodal shape (ix, il) to infer spectral_truncation
-        spmd_mesh: Optional SPMD mesh for parallelization
+        spmd_mesh: Optional tuple ``(x, y, z)`` describing the SPMD device mesh
+            for sharding (longitude, latitude, vertical). The product must equal
+            ``len(jax.devices())``. When set, a ``FastSphericalHarmonics`` implementation
+            is used; otherwise the model runs on a single device. This is the only
+            place to configure SPMD — ``Model`` consumes the sharding via ``coords``.
 
     Returns:
         CoordinateSystem object


### PR DESCRIPTION
## Summary
- `Model(spmd_mesh=...)` was broken/dead after coords construction moved out of `Model`. Removed the argument.
- SPMD is now configured exclusively on the coords helpers (`get_coords`, `get_speedy_coords`, `get_held_suarez_coords`); expanded their docstrings to spell out the `(x, y, z)` mesh shape and the `product == len(jax.devices())` rule.
- Updated `docs/source/getting_started.rst` SPMD example to pass `spmd_mesh` into `get_speedy_coords` and feed the resulting `coords` to `Model`.
- Fixed the stale README Quick Start (it still referenced the removed `layers=` / `horizontal_resolution=` kwargs on `Model`).

## Test plan
- [ ] `ruff check .`
- [ ] `pytest -m "not slow"`
- [ ] Build docs (`cd docs && make html`) and spot-check the SPMD section