### PR TITLE
Fix ruff errors in era5 example notebook

### DIFF
--- a/notebooks/04_jcm_era5_example.ipynb
+++ b/notebooks/04_jcm_era5_example.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {},
    "source": [
     "# JCM v1.0 — Running the Base Model with ERA5 Initial Conditions\n",
@@ -18,6 +19,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "acae54e37e7d407bbb7b55eff062a284",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -32,6 +34,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
    "metadata": {},
    "source": [
     "## 1. Load ERA5\n",
@@ -43,6 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8dd0d8092fe74a7c96281538738b07e2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,6 +68,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "72eea5119410473aa328ad9291626812",
    "metadata": {},
    "source": [
     "## 2. Interpolate ERA5 → JCM grid\n",
@@ -78,6 +83,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8edb47106e1a46a883d545849b8ab81b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,9 +107,10 @@
     "        Passed to ``era5_ds.sel(time=...)``.\n",
     "\n",
     "    Returns\n",
-    "    \n",
+    "    -------\n",
     "    xr.Dataset\n",
     "        Merged dataset on the JCM grid.\n",
+    "\n",
     "    \"\"\"\n",
     "    ds = era5_ds.sel(time=time_slice)\n",
     "\n",
@@ -122,6 +129,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "10185d26023b46108eb7d9f57d49d2b3",
    "metadata": {},
    "source": [
     "## 3. Convert interpolated ERA5 to a `PhysicsState`\n",
@@ -134,6 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8763a12b2bbd4a93a75aff182afb95dc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -159,6 +168,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7623eae2785240b9bd12b16a66d81610",
    "metadata": {},
    "source": [
     "## 4. ERA5-initialised simulation\n",
@@ -170,6 +180,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7cdc8c89c7104fffa095e18ddfef8986",
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
## Summary
- Fixes the 3 ruff errors on `main` (D407/D412/D413) in `notebooks/04_jcm_era5_example.ipynb` — the "Returns" docstring section was missing its dashed underline and had a stray blank line after the header. All auto-fixed by `ruff --fix`.

## Test plan
- [x] `ruff check .` passes