### PR TITLE
Support HybridCoordinates in get_coords

### DIFF
--- a/jcm/physics/held_suarez/utils.py
+++ b/jcm/physics/held_suarez/utils.py
@@ -34,7 +34,7 @@ def get_held_suarez_coords(layers=8, spectral_truncation=31, nodal_shape=None, s
         sigma_boundaries = DEFAULT_SIGMA_BOUNDARIES
 
     return _get_coords(
-        sigma_boundaries=sigma_boundaries,
+        vertical_coords=sigma_boundaries,
         spectral_truncation=spectral_truncation,
         nodal_shape=nodal_shape,
         spmd_mesh=spmd_mesh

--- a/jcm/physics/speedy/speedy_coords.py
+++ b/jcm/physics/speedy/speedy_coords.py
@@ -25,7 +25,7 @@ def get_speedy_coords(layers=8, spectral_truncation=31, nodal_shape=None, spmd_m
         raise ValueError(f"SPEEDY physics supports {list(SIGMA_LAYER_BOUNDARIES.keys())} layers, got {layers}")
 
     return get_coords(
-        sigma_boundaries=SIGMA_LAYER_BOUNDARIES[layers],
+        vertical_coords=SIGMA_LAYER_BOUNDARIES[layers],
         spectral_truncation=spectral_truncation,
         nodal_shape=nodal_shape,
         spmd_mesh=spmd_mesh

--- a/jcm/utils.py
+++ b/jcm/utils.py
@@ -7,10 +7,12 @@ from importlib import resources
 import dinosaur
 import functools
 from dinosaur.coordinate_systems import CoordinateSystem, HorizontalGridTypes
+from dinosaur.hybrid_coordinates import HybridCoordinates
 from dinosaur.primitive_equations import PrimitiveEquationsSpecs
 from dinosaur.scales import SI_SCALE
+from dinosaur.sigma_coordinates import SigmaCoordinates
 from dinosaur import typing
-from typing import Any, Mapping, MutableMapping
+from typing import Any, Mapping, MutableMapping, Union
 from dinosaur.xarray_utils import _maybe_update_shape_and_dim_with_realization_time_sample
 import xarray
 
@@ -32,22 +34,33 @@ TRUNCATION_FOR_NODAL_SHAPE = {
 VALID_NODAL_SHAPES = tuple(TRUNCATION_FOR_NODAL_SHAPE.keys())
 VALID_TRUNCATIONS = tuple(TRUNCATION_FOR_NODAL_SHAPE.values())
 
-def get_coords(sigma_boundaries, spectral_truncation=31, nodal_shape=None, spmd_mesh=None) -> CoordinateSystem:
-    """Return a CoordinateSystem object for the given sigma boundaries and horizontal resolution.
+def get_coords(
+    vertical_coords: Union[typing.Array, SigmaCoordinates, HybridCoordinates],
+    spectral_truncation=31,
+    nodal_shape=None,
+    spmd_mesh=None,
+) -> CoordinateSystem:
+    """Return a CoordinateSystem object for the given vertical and horizontal resolution.
 
-    This is a physics-agnostic function. Use physics-specific helpers for default sigma boundaries:
+    This is a physics-agnostic function. Use physics-specific helpers for default
+    vertical coordinates:
     - jcm.physics.speedy.utils.get_speedy_coords()
     - jcm.physics.held_suarez.utils.get_held_suarez_coords()
+    - jcm.physics.icon.icon_levels.get_icon_levels()
 
     Args:
-        sigma_boundaries: Array of sigma layer boundaries (required)
+        vertical_coords: Vertical coordinate specification. Can be one of:
+            - An array of sigma layer boundaries (wrapped in SigmaCoordinates).
+            - A SigmaCoordinates instance (passed through).
+            - A HybridCoordinates instance (passed through), e.g. from
+              jcm.physics.icon.icon_levels.get_icon_levels().
         spectral_truncation: Spectral truncation number (default 31)
         nodal_shape: Optional nodal shape (ix, il) to infer spectral_truncation
         spmd_mesh: Optional SPMD mesh for parallelization
 
     Returns:
         CoordinateSystem object
-        
+
     """
     from dinosaur.spherical_harmonic import FastSphericalHarmonics, RealSphericalHarmonics
 
@@ -67,10 +80,15 @@ def get_coords(sigma_boundaries, spectral_truncation=31, nodal_shape=None, spmd_
     else:
         spherical_harmonics_impl = RealSphericalHarmonics
 
+    if isinstance(vertical_coords, (SigmaCoordinates, HybridCoordinates)):
+        vertical = vertical_coords
+    else:
+        vertical = SigmaCoordinates(vertical_coords)
+
     return CoordinateSystem(
         horizontal=horizontal_grid(radius=physics_specs.radius,
                                    spherical_harmonics_impl=spherical_harmonics_impl),
-        vertical=dinosaur.sigma_coordinates.SigmaCoordinates(sigma_boundaries),
+        vertical=vertical,
         spmd_mesh=spmd_mesh
     )
 

--- a/jcm/utils_test.py
+++ b/jcm/utils_test.py
@@ -9,6 +9,8 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import xarray as xr
+from dinosaur.hybrid_coordinates import HybridCoordinates
+from dinosaur.sigma_coordinates import SigmaCoordinates
 from jcm.utils import (
     get_coords,
     spectral_truncation,
@@ -75,6 +77,40 @@ class TestGetCoords(unittest.TestCase):
         coords = get_coords(sigma_boundaries, spectral_truncation=31, nodal_shape=(64, 32))
 
         # Should use T21 from nodal_shape
+        self.assertEqual(coords.horizontal.nodal_shape, (64, 32))
+
+    def test_get_coords_with_sigma_coordinates_instance(self):
+        """get_coords should accept a SigmaCoordinates instance directly."""
+        sigma_boundaries = SIGMA_LAYER_BOUNDARIES[8]
+        sigma_coords = SigmaCoordinates(sigma_boundaries)
+        coords = get_coords(sigma_coords, spectral_truncation=21)
+
+        self.assertIsInstance(coords.vertical, SigmaCoordinates)
+        self.assertEqual(coords.vertical.layers, 8)
+
+    def test_get_coords_with_hybrid_coordinates(self):
+        """get_coords should accept a HybridCoordinates instance."""
+        # Simple hybrid coords: 4 layers, a + b*ps
+        a_boundaries = np.array([0.0, 100.0, 200.0, 300.0, 0.0])
+        b_boundaries = np.array([0.0, 0.1, 0.3, 0.7, 1.0])
+        hybrid = HybridCoordinates(a_boundaries, b_boundaries)
+
+        coords = get_coords(hybrid, spectral_truncation=21)
+
+        self.assertIsInstance(coords.vertical, HybridCoordinates)
+        self.assertEqual(coords.vertical.layers, 4)
+        self.assertIs(coords.vertical, hybrid)
+        self.assertEqual(coords.horizontal.nodal_shape, (64, 32))
+
+    def test_get_coords_hybrid_with_nodal_shape(self):
+        """get_coords should accept HybridCoordinates with nodal_shape arg."""
+        a_boundaries = np.array([0.0, 100.0, 200.0, 300.0, 0.0])
+        b_boundaries = np.array([0.0, 0.1, 0.3, 0.7, 1.0])
+        hybrid = HybridCoordinates(a_boundaries, b_boundaries)
+
+        coords = get_coords(hybrid, nodal_shape=(64, 32))
+
+        self.assertIsInstance(coords.vertical, HybridCoordinates)
         self.assertEqual(coords.horizontal.nodal_shape, (64, 32))
 
 


### PR DESCRIPTION
## Describe your changes

Add the option to pass in hybrid (or Sigma) coordinates to get_coords which currently only accepts an array of sigma levels. 

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
