### PR TITLE
T63 grid + ECHAM file readers + balanced-isothermal init

### DIFF
--- a/jcm/config/forcing/echam_amip.yaml
+++ b/jcm/config/forcing/echam_amip.yaml
@@ -1,0 +1,8 @@
+# ECHAM-style AMIP boundary forcing: monthly SST + monthly sea-ice
+# concentration + a static ECHAM surface file (for ALB/WS/SN). Combined
+# by ``ForcingData.from_echam_files``. The three paths must be provided
+# at the command line.
+kind: echam_amip
+sst_file: ???
+sic_file: ???
+surface_file: ???

--- a/jcm/config/grid/icon_t63_l47_hybrid.yaml
+++ b/jcm/config/grid/icon_t63_l47_hybrid.yaml
@@ -1,0 +1,8 @@
+# T63 / 47 hybrid (a + b·P_s) levels — matches ECHAM standard production
+# grid (192 lon × 96 lat). Use this when running with the ECHAM
+# T63GR15_jan_surf.nc + T63_amip{sst,sic}_1979-2008_mean.nc boundary files
+# so no orography-statistic interpolation is needed.
+vertical: hybrid
+layers: 47
+spectral_truncation: 63
+spmd_mesh: null

--- a/jcm/config/init/balanced_isothermal.yaml
+++ b/jcm/config/init/balanced_isothermal.yaml
@@ -1,0 +1,4 @@
+# Isothermal-rest atmosphere with hydrostatic ps balanced against
+# orography. Equivalent to the legacy ``isothermal`` init for flat
+# terrain; over real topography it avoids placing air below ground.
+kind: balanced_isothermal

--- a/jcm/forcing.py
+++ b/jcm/forcing.py
@@ -164,6 +164,92 @@ class ForcingData:
                                 align_mode=align_mode)
 
     @classmethod
+    def from_echam_files(
+        cls,
+        sst_path: str,
+        sic_path: str,
+        surface_path: str,
+        coords: CoordinateSystem = None,
+        align_mode: str = "auto",
+    ):
+        """Initialize forcing data from ECHAM-style boundary files.
+
+        Combines an AMIP monthly SST file, an AMIP monthly sea-ice file,
+        and a static ECHAM surface file (the same one used for terrain
+        / SSO descriptors) into the canonical JCM forcing layout, then
+        delegates to :meth:`from_dataset`.
+
+        Field mapping:
+
+        - ``sst`` (K, monthly): straight from the AMIP SST file.
+        - ``icec`` (fraction 0..1, monthly): from the AMIP sea-ice file's
+          ``sic`` field, which is in percent — divided by 100 and clipped
+          to [0, 1] (interpolation noise can produce <0 or >100 values).
+        - ``stl`` (K, monthly): set equal to SST as a first-order
+          stand-in. The ECHAM AMIP files include extrapolated SST values
+          over land, which gives a physically sensible land-T initial
+          guess; a real prescribed land-T climatology can replace this
+          when available.
+        - ``alb`` (annual mean): the surface file's ``ALB`` field.
+        - ``soilw_am`` (m, monthly): the surface file's ``WS`` field
+          (water content), constant in time.
+        - ``snowc`` (m, monthly): the surface file's ``SN`` (snow depth),
+          constant in time.
+
+        All ECHAM-style fields are normalised by
+        :func:`jcm.terrain._normalize_echam_dataset` (uppercase →
+        lowercase, ``(lat, lon)`` → ``(lon, lat)``, north-to-south →
+        south-to-north).
+        """
+        import xarray as xr
+
+        from jcm.terrain import _normalize_echam_dataset
+
+        sst_ds = _normalize_echam_dataset(xr.open_dataset(sst_path))
+        sic_ds = _normalize_echam_dataset(xr.open_dataset(sic_path))
+        surf_ds = _normalize_echam_dataset(xr.open_dataset(surface_path))
+
+        # The three ECHAM files write the same gaussian latitudes but
+        # differ in the last few bits (file → xarray round-tripping). xarray
+        # aligns coordinates exactly when combining datasets, which would
+        # mask the disagreeing rows as NaN. Use one set of coordinates
+        # (from the SST file) as canonical for all three.
+        sic_ds = sic_ds.assign_coords(lat=sst_ds["lat"], lon=sst_ds["lon"])
+        surf_ds = surf_ds.assign_coords(lat=sst_ds["lat"], lon=sst_ds["lon"])
+
+        # Sea-ice: percent → fraction, clip noise.
+        sic = sic_ds["sic"].clip(0.0, 100.0) * 0.01
+
+        # Build the time-axis-tied land surface fields by broadcasting the
+        # static surface fields against the SST time axis (12 months).
+        time = sst_ds["time"]
+        ones_t = xr.ones_like(time, dtype="float32")
+        ws = surf_ds["WS"] if "WS" in surf_ds else surf_ds["lsm"] * 0.0
+        sn = surf_ds["SN"] if "SN" in surf_ds else surf_ds["lsm"] * 0.0
+        alb = surf_ds["ALB"] if "ALB" in surf_ds else surf_ds["lsm"] * 0.0
+
+        soilw_t = (ws * ones_t).transpose("lon", "lat", "time")
+        snowc_t = (sn * ones_t).transpose("lon", "lat", "time")
+        # Land surface T proxy = SST (extrapolated over land in the AMIP file).
+        stl_t = sst_ds["sst"].transpose("lon", "lat", "time")
+
+        ds = xr.Dataset({
+            "sst":      sst_ds["sst"].transpose("lon", "lat", "time"),
+            "icec":     sic.transpose("lon", "lat", "time"),
+            "stl":      stl_t,
+            "soilw_am": soilw_t,
+            "snowc":    snowc_t,
+            "alb":      alb.transpose("lon", "lat"),
+        })
+        # ECHAM AMIP files timestamp the monthly mean at the month centre
+        # (e.g. 1979-01-16T12:00); the JCM interpolator wants month-start
+        # frequency. Snap the time axis to month-start so pandas detects it.
+        import pandas as pd
+        snapped_time = pd.to_datetime(ds["time"].values).to_period("M").to_timestamp()
+        ds = ds.assign_coords(time=snapped_time)
+        return cls.from_dataset(ds, coords=coords, align_mode=align_mode)
+
+    @classmethod
     def from_dataset(cls, ds, coords: CoordinateSystem = None,
                      align_mode: str = "auto"):
         """Initialize forcing data from an in-memory xarray Dataset.
@@ -205,6 +291,12 @@ class ForcingData:
             # FIXME: Consider validating lat/lon values here - would have to construct a coords object to get expected values though
         elif target_resolution not in VALID_TRUNCATIONS:
             raise ValueError(f"Invalid target resolution: {target_resolution}. Must be one of: {VALID_TRUNCATIONS}.")
+        elif ds["stl"].shape[:2] == coords.horizontal.nodal_shape:
+            # Source already at target resolution — skip the lat/lon interp
+            # pipeline (which can introduce NaN through pole padding when
+            # lat values match exactly). Only the time-axis interpolation
+            # is needed for monthly → daily.
+            ds = interpolate_to_daily(ds)
         else:
             ds = upsample_forcings_ds(interpolate_to_daily(ds), grid=coords.horizontal)
 

--- a/jcm/physics/composable_physics.py
+++ b/jcm/physics/composable_physics.py
@@ -283,6 +283,29 @@ class ComposablePhysics(nnx.Module, Physics):
                 for sk, sv in sub.items():
                     items[f"{out_key}{sep}{sk}"] = sv
 
+        # Reshape column-vectorized diagnostics (a flattened ncols axis,
+        # produced when ``vectorize_columns=True``) back to ``(lon, lat)``
+        # before xarray sees them. The ``nodal_shape`` argument from
+        # ``Predictions.to_xarray`` may include leading non-spatial axes
+        # (level, time, ...); the spatial portion is the trailing pair.
+        if nodal_shape is not None and len(nodal_shape) >= 2:
+            spatial_shape = tuple(nodal_shape[-2:])
+            ncols = spatial_shape[0] * spatial_shape[1]
+            for k in list(items.keys()):
+                v = items[k]
+                if not isinstance(v, jax.Array):
+                    continue
+                if ncols not in v.shape:
+                    continue
+                # Find the (single) ncols axis and unflatten it.
+                ncols_axes = [i for i, n in enumerate(v.shape) if n == ncols]
+                if len(ncols_axes) != 1:
+                    continue
+                axis = ncols_axes[0]
+                new_shape = (v.shape[:axis] + spatial_shape
+                             + v.shape[axis + 1:])
+                items[k] = v.reshape(new_shape)
+
         # Expand multi-channel fields (trailing dim beyond nodal_shape)
         if nodal_shape is not None:
             original_keys = list(items.keys())
@@ -296,6 +319,8 @@ class ComposablePhysics(nnx.Module, Physics):
                     and s[1:-1] == nodal_shape
                     or len(s) == 4
                     and s[1:-1] == nodal_shape[1:]
+                    or len(s) == 3
+                    and s[:-1] == nodal_shape
                 ):
                     items.update(
                         {f"{k}{sep}{i}": v[..., i] for i in range(s[-1])}

--- a/jcm/runners.py
+++ b/jcm/runners.py
@@ -187,6 +187,12 @@ def build_terrain(cfg: DictConfig, coords) -> TerrainData:
             terrain_file=terrain_cfg.file,
             interpolate=terrain_cfg.get("interpolate", True),
         )
+    if kind == "from_file_enveloped":
+        return TerrainData.from_file(
+            terrain_cfg.file, coords=coords,
+            orog_envelope_wavenumber=terrain_cfg.get(
+                "orog_envelope_wavenumber", None),
+        )
     raise ValueError(f"Unknown terrain.kind={kind!r}")
 
 
@@ -233,6 +239,42 @@ _T0_C = 273.15   # K, melting point reference
 
 # Tropopause cap above which we set RH = 0 in the JW humidity profile.
 _RH_CAP_PRESSURE_PA = 20000.0   # 200 hPa
+
+
+def inject_balanced_isothermal_profile(model: Model) -> None:
+    """Inject an isothermal-rest atmosphere with orography-balanced ``ps``.
+
+    Same ps-rebalance logic as :func:`inject_jw_profile` (so air doesn't
+    end up below ground over tall topography), but keeps the temperature
+    field at a uniform 288 K and humidity at zero. Useful as a robust
+    starting state for moist-physics runs over real terrain when the
+    full JW lapse-rate profile is unstable at the chosen resolution.
+
+    Mutates ``model._final_modal_state`` in place. Follow with
+    ``model.resume(...)`` rather than ``model.run(...)``.
+    """
+    from dinosaur.scales import units
+    from jcm.constants import grav, p0s1_bg, rd
+
+    model._final_modal_state = model._prepare_initial_modal_state(
+        physics_state=None, random_seed=0,
+    )
+    state = model._final_modal_state
+    p0_pa = p0s1_bg
+
+    orog = jnp.asarray(model.terrain.orog)
+    if jnp.any(orog > 1.0):
+        # Hydrostatic balance with the actual isothermal T (288 K), not
+        # ``_HYDROSTATIC_T_REF`` (260 K which is appropriate for the
+        # JW lapse-rate profile). Using the matching T avoids an
+        # initial-step pressure-temperature inconsistency.
+        ps_pa_nodal = p0_pa * jnp.exp(-grav * orog / (rd * _JW_T_SFC))
+        scale = float(model.physics_specs.nondimensionalize(1.0 * units.pascal))
+        log_ps_nodal = jnp.log(ps_pa_nodal * scale)
+        state.log_surface_pressure = model.coords.horizontal.to_modal(
+            log_ps_nodal[None, ...]
+        )
+    model._final_modal_state = state
 
 
 def inject_jw_profile(model: Model, rh: float = 0.6) -> None:
@@ -351,6 +393,14 @@ def build_forcing(cfg: DictConfig, coords):
     if forcing_cfg.kind == "from_file":
         from jcm.forcing import ForcingData
         return ForcingData.from_file(forcing_cfg.file, coords=coords)
+    if forcing_cfg.kind == "echam_amip":
+        from jcm.forcing import ForcingData
+        return ForcingData.from_echam_files(
+            sst_path=forcing_cfg.sst_file,
+            sic_path=forcing_cfg.sic_file,
+            surface_path=forcing_cfg.surface_file,
+            coords=coords,
+        )
     raise ValueError(f"Unknown forcing.kind={forcing_cfg.kind!r}")
 
 
@@ -408,6 +458,14 @@ def _run_full(cfg: DictConfig, model: Model | None = None) -> ModelPredictions:
         )
     if cfg.init.kind == "jw":
         inject_jw_profile(model)
+        return model.resume(
+            forcing=forcing,
+            save_interval=cfg.run.save_interval,
+            total_time=cfg.run.total_time,
+            output_averages=cfg.run.output_averages,
+        )
+    if cfg.init.kind == "balanced_isothermal":
+        inject_balanced_isothermal_profile(model)
         return model.resume(
             forcing=forcing,
             save_interval=cfg.run.save_interval,
@@ -556,6 +614,14 @@ def run_chunked(
         t0 = time.perf_counter()
         if i == 0 and cfg.init.kind == "jw":
             inject_jw_profile(model)
+            preds = model.resume(
+                forcing=forcing,
+                save_interval=save_interval,
+                total_time=cur_chunk,
+                output_averages=cfg.run.output_averages,
+            )
+        elif i == 0 and cfg.init.kind == "balanced_isothermal":
+            inject_balanced_isothermal_profile(model)
             preds = model.resume(
                 forcing=forcing,
                 save_interval=save_interval,

--- a/jcm/terrain.py
+++ b/jcm/terrain.py
@@ -233,8 +233,10 @@ def get_terrain(orography: jnp.ndarray = None, fmask: jnp.ndarray = None, nodal_
             if target_resolution not in VALID_TRUNCATIONS:
                 raise ValueError(f"Invalid target resolution: {target_resolution}. Must be one of: {VALID_TRUNCATIONS}.")
             ds = upsample_terrain_ds(ds, grid=grid)
-        elif orography.shape not in VALID_NODAL_SHAPES:
-            raise ValueError(f"Invalid terrain data shape: {orography.shape}. Must be one of: {VALID_NODAL_SHAPES}.")
+        else:
+            file_shape = (ds.sizes["lon"], ds.sizes["lat"])
+            if file_shape not in VALID_NODAL_SHAPES:
+                raise ValueError(f"Invalid terrain data shape: {file_shape}. Must be one of: {VALID_NODAL_SHAPES}.")
 
         # set orography and fmask after upsampling happens
         orography, fmask = jnp.asarray(ds['orog']), jnp.asarray(ds['lsm'])
@@ -442,7 +444,8 @@ class TerrainData:
                    lfluxland=jnp.bool_(lfluxland), **sso)
 
     @classmethod
-    def from_file(cls, terrain_file, coords: CoordinateSystem, lfluxland=True):
+    def from_file(cls, terrain_file, coords: CoordinateSystem, lfluxland=True,
+                  orog_envelope_wavenumber: int = None):
         """Initialize TerrainData from a terrain file containing orog and lsm.
 
         SSO descriptor handling, in order of precedence:
@@ -495,7 +498,20 @@ class TerrainData:
                 f"horizontal shape {target_shape}"
             )
         phi0 = grav * orography
-        phis0 = spectral_truncation(target_grid, phi0)
+        if orog_envelope_wavenumber is not None:
+            # Envelope orography: low-pass filter the orographic geopotential
+            # to a lower spectral wavenumber than the model truncation, to
+            # suppress Gibbs oscillations near sharp coast/mountain edges
+            # that would otherwise produce negative effective elevations.
+            modal = target_grid.to_modal(phi0)
+            nx, mx = modal.shape
+            n_idx, m_idx = jnp.meshgrid(jnp.arange(nx), jnp.arange(mx),
+                                        indexing='ij')
+            total_wn = m_idx + n_idx
+            modal = jnp.where(total_wn > orog_envelope_wavenumber, 0.0, modal)
+            phis0 = target_grid.to_nodal(modal)
+        else:
+            phis0 = spectral_truncation(target_grid, phi0)
 
         # Pick the best available SSO source.
         if src_has_sso:

--- a/jcm/terrain.py
+++ b/jcm/terrain.py
@@ -227,6 +227,7 @@ def get_terrain(orography: jnp.ndarray = None, fmask: jnp.ndarray = None, nodal_
         import xarray as xr
         from jcm.data.bc.interpolate import upsample_terrain_ds
         ds = xr.open_dataset(terrain_file)
+        ds = _normalize_echam_dataset(ds)
         validate_ds(ds, expected_structure={"lsm": ("lon", "lat"), "orog": ("lon", "lat")})
         if target_resolution is not None:
             if target_resolution not in VALID_TRUNCATIONS:
@@ -252,6 +253,62 @@ def get_terrain(orography: jnp.ndarray = None, fmask: jnp.ndarray = None, nodal_
     return orography, fmask
 
 
+# Mapping from ECHAM uppercase variable names to JCM lowercase. ECHAM uses
+# OROMEA / OROSTD / … plus SLM (sea-land mask). This is the only place we
+# need to know about the ECHAM convention; downstream code sees only
+# normalized lowercase names.
+_ECHAM_TO_JCM_NAMES = {
+    "SLM": "lsm",        # sea-land mask (binary 0/1)
+    "SLF": "lsm",        # land fraction (preferred when both present)
+    "OROMEA": "orog",    # mean orography in metres above sea level
+    "OROSTD": "orostd",
+    "OROSIG": "orosig",
+    "OROGAM": "orogam",
+    "OROTHE": "orothe",
+    "OROPIC": "oropic",
+    "OROVAL": "oroval",
+}
+
+
+def _normalize_echam_dataset(ds):
+    """Translate an ECHAM-style boundary-data dataset into JCM conventions.
+
+    ECHAM gridded files differ from the existing JCM T30 convention in three
+    ways that this function fixes:
+
+    1. Variable names are uppercase (``OROSTD`` etc.) — rename to
+       lowercase. ``SLF`` (fractional land mask, 0..1) is preferred over
+       ``SLM`` (binary 0/1) when both are present.
+    2. Dimensions are ordered ``(lat, lon)`` rather than ``(lon, lat)`` —
+       transpose.
+    3. Latitudes run north-to-south (descending) — flip so they run
+       south-to-north (ascending), which is what dinosaur grids use.
+
+    Returns the normalized xarray Dataset (or the original, if it already
+    follows JCM conventions). The function is a no-op for files that
+    don't contain any of the ECHAM uppercase fields.
+    """
+    rename = {
+        echam: jcm for echam, jcm in _ECHAM_TO_JCM_NAMES.items()
+        if echam in ds
+    }
+    # When both SLF (fractional) and SLM (binary) exist, prefer SLF.
+    if "SLF" in ds and "SLM" in ds:
+        rename.pop("SLM", None)
+        ds = ds.drop_vars("SLM")
+    if rename:
+        ds = ds.rename(rename)
+
+    # Reorder dims to (lon, lat) and flip lat to ascending. Apply this
+    # regardless of whether any ECHAM-uppercase fields were present so
+    # that companion files (SST, sea-ice etc.) read with the same convention.
+    if "lat" in ds.dims and "lon" in ds.dims:
+        ds = ds.transpose("lon", "lat", ...)
+        if float(ds["lat"][0]) > float(ds["lat"][-1]):
+            ds = ds.isel(lat=slice(None, None, -1))
+    return ds
+
+
 def _load_sso_from_file(terrain_file):
     """Load SSO descriptor fields from a terrain file if present.
 
@@ -261,6 +318,7 @@ def _load_sso_from_file(terrain_file):
     """
     import xarray as xr
     ds = xr.open_dataset(terrain_file)
+    ds = _normalize_echam_dataset(ds)
     sso_names = ("orostd", "orosig", "orogam", "orothe", "oropic", "oroval")
     if not all(name in ds for name in sso_names):
         return None
@@ -418,13 +476,14 @@ class TerrainData:
 
         # Read raw orography first to inspect its source resolution.
         with xr.open_dataset(terrain_file) as raw_ds:
-            src_lat_n = raw_ds.sizes.get("lat", 0)
-            src_lon_n = raw_ds.sizes.get("lon", 0)
-            src_lat = jnp.asarray(raw_ds["lat"].values)
-            src_lon = jnp.asarray(raw_ds["lon"].values)
-            src_orog = jnp.asarray(raw_ds["orog"].values)
+            ds_norm = _normalize_echam_dataset(raw_ds)
+            src_lat_n = ds_norm.sizes.get("lat", 0)
+            src_lon_n = ds_norm.sizes.get("lon", 0)
+            src_lat = jnp.asarray(ds_norm["lat"].values)
+            src_lon = jnp.asarray(ds_norm["lon"].values)
+            src_orog = jnp.asarray(ds_norm["orog"].values)
             src_has_sso = all(
-                name in raw_ds for name in
+                name in ds_norm for name in
                 ("orostd", "orosig", "orogam", "orothe", "oropic", "oroval")
             )
 

--- a/jcm/utils.py
+++ b/jcm/utils.py
@@ -22,6 +22,7 @@ TRUNCATION_FOR_NODAL_SHAPE = {
     (64, 32): 21,
     (96, 48): 31,
     (128, 64): 42,
+    (192, 96): 63,    # T63 — ECHAM standard production grid
     (256, 128): 85,
     (320, 160): 106,
     (360, 180): 119,
@@ -74,7 +75,19 @@ def get_coords(
         spectral_truncation = TRUNCATION_FOR_NODAL_SHAPE[nodal_shape]
     elif spectral_truncation not in VALID_TRUNCATIONS:
         raise ValueError(f"Invalid horizontal resolution: {spectral_truncation}. Must be one of: {VALID_TRUNCATIONS}.")
-    horizontal_grid = getattr(dinosaur.spherical_harmonic.Grid, f'T{spectral_truncation}')
+    # Most truncations have a dedicated dinosaur factory (Grid.T31, T42, …);
+    # T63 doesn't, so build it directly via Grid.construct with
+    # gaussian_nodes=(max_wavenumber+1)/2-rounded so the nodal grid matches
+    # the ECHAM T63 file (192 lon × 96 lat). For all other supported
+    # truncations the dedicated Grid.T* factory uses the same convention,
+    # so we use it where available.
+    if spectral_truncation == 63:
+        def horizontal_grid(**kwargs):
+            return dinosaur.spherical_harmonic.Grid.construct(
+                max_wavenumber=63, gaussian_nodes=48, **kwargs)
+    else:
+        horizontal_grid = getattr(
+            dinosaur.spherical_harmonic.Grid, f'T{spectral_truncation}')
 
     physics_specs = PrimitiveEquationsSpecs.from_si(scale=SI_SCALE)
 
@@ -255,6 +268,30 @@ def _infer_dims_shape_and_coords(
     ) + NODAL_AXES_NAMES
     basic_shape_to_dims[nodal_shape] = NODAL_AXES_NAMES
     basic_shape_to_dims[modal_shape] = MODAL_AXES_NAMES
+    # Column-vectorized layout: physics terms running under
+    # ``ComposablePhysics(vectorize_columns=True)`` write per-column
+    # scalars and profiles in flattened ``(ncols,)`` / ``(nlev, ncols)``
+    # shape rather than ``(lon, lat)`` / ``(nlev, lon, lat)``. Map the
+    # flat shapes back to the same xarray dims so downstream reshape is
+    # a no-op axis relabel.
+    nlon, nlat = nodal_shape
+    nlev = coords.vertical.layers
+    basic_shape_to_dims[(nlon * nlat,)] = NODAL_AXES_NAMES
+    basic_shape_to_dims[(nlev, nlon * nlat)] = (
+        XR_LEVEL_NAME,
+    ) + NODAL_AXES_NAMES
+    # Half-level fields (e.g. fluxes, half-pressure) — emit them on a
+    # ``level_i`` (interface) axis so they don't clash with the full-level
+    # ``level`` coord, which has length nlev.
+    XR_LEVEL_INTERFACE_NAME = 'level_i'
+    if XR_LEVEL_INTERFACE_NAME not in all_xr_coords:
+        all_xr_coords[XR_LEVEL_INTERFACE_NAME] = np.arange(nlev + 1)
+    basic_shape_to_dims[(nlev + 1,) + nodal_shape] = (
+        XR_LEVEL_INTERFACE_NAME,
+    ) + NODAL_AXES_NAMES
+    basic_shape_to_dims[(nlev + 1, nlon * nlat)] = (
+        XR_LEVEL_INTERFACE_NAME,
+    ) + NODAL_AXES_NAMES
     basic_shape_to_dims[(coords.vertical.layers,)] = (XR_LEVEL_NAME,)
     basic_shape_to_dims[sin_lat.shape] = (XR_LAT_NAME,)
     # Add unconventional shape for nodal covariate surface data, which have dim=2
@@ -338,6 +375,17 @@ def data_to_xarray(
 
   if additional_coords is None:
     additional_coords = {}
+
+  def _maybe_reshape_to_dims(value, dims, all_coords):
+    """If ``value`` has a flattened ncols axis but ``dims`` calls for
+    separate (lon, lat) axes, reshape it. Otherwise pass through.
+    """
+    if 'lon' not in dims or 'lat' not in dims:
+      return value
+    expected = tuple(len(all_coords[d]) for d in dims)
+    if value.shape == expected:
+      return value
+    return value.reshape(expected)
   # if XR_SURFACE_NAME is not specified manually, set by default.
   if (coords.vertical.layers != 1) and (
       XR_SURFACE_NAME not in additional_coords
@@ -357,6 +405,7 @@ def data_to_xarray(
       )
     else:
       dims = shape_to_dims[value.shape]
+      value = _maybe_reshape_to_dims(value, dims, all_coords)
       data_vars[key] = (dims, value)
       dims_in_state.update(set(dims))
 
@@ -366,6 +415,7 @@ def data_to_xarray(
       raise ValueError(f'Value of shape {value.shape} is not recognized.')
     else:
       dims = shape_to_dims[value.shape]
+      value = _maybe_reshape_to_dims(value, dims, all_coords)
       data_vars[key] = (dims, value)
       dims_in_state.update(set(dims))
 
@@ -375,6 +425,7 @@ def data_to_xarray(
       raise ValueError(f'Value of shape {value.shape} is not recognized.')
     else:
       dims = shape_to_dims[value.shape]
+      value = _maybe_reshape_to_dims(value, dims, all_coords)
       data_vars[key] = (dims, value)
       dims_in_state.update(set(dims))
 


### PR DESCRIPTION
## Summary

Adds T63 (192 lon × 96 lat) grid support so JCM can run at the ECHAM standard production resolution natively, plus the readers and configs needed to plug in the matching ECHAM boundary files (`T63GR15_jan_surf.nc` for surface/SSO descriptors, `T63_amipsst_*.nc` and `T63_amipsic_*.nc` for monthly SST and sea-ice).

Closes nothing yet — depends on follow-up work for real-terrain stability (see "Open" below).

## What's in

**T63 grid wiring** (`jcm/utils.py`, `jcm/config/grid/icon_t63_l47_hybrid.yaml`)
- Register `(192, 96): 63` in `TRUNCATION_FOR_NODAL_SHAPE`.
- Special-case the `Grid.T63` lookup with `Grid.construct(max_wavenumber=63, gaussian_nodes=48)` since dinosaur doesn't ship a T63 helper.

**ECHAM file readers** (`jcm/terrain.py`, `jcm/forcing.py`)
- `_normalize_echam_dataset`: maps ECHAM-style boundary files into JCM convention — uppercase variable names → lowercase (`OROSTD`/`SLM`/`OROMEA`/etc.), `(lat, lon)` → `(lon, lat)` axis order, latitude flipped to ascending.
- `TerrainData.from_file` now picks up the real ECHAM SSO descriptors when `T63GR15_jan_surf.nc` is loaded (so `derive_sso_descriptors`/`get_simplified_sso_descriptors` are not needed).
- `ForcingData.from_echam_files(sst_path, sic_path, surface_path, coords)` combines AMIP SST + AMIP sea-ice (percent → fraction) + a static ECHAM surface file (ALB/WS/SN) into the canonical JCM forcing layout. Lat/lon coords are forced to match across the three files (avoids a "last-bit" alignment mismatch that masks aligned cells as NaN).
- `from_dataset` skips the lat/lon interp pipeline when source resolution already matches the target (the pole-padding step can introduce NaN through exact-match interpolation; bypass avoids it).

**Output adapter** (`jcm/utils.py`, `jcm/physics/composable_physics.py`)
- Register half-level (`nlev+1`) shapes and column-vectorized layouts in the shape→dims map so the new T63 ICON physics output round-trips through xarray cleanly.
- `ComposablePhysics.data_struct_to_dict` reshapes any flattened `ncols` axis on a column-vectorized diagnostic back to `(lon, lat)` before xarray sees it; multi-channel expansion now handles 3D `(lon, lat, nchan)` too.

**Init + forcing configs**
- `jcm/config/init/balanced_isothermal.yaml`: isothermal-rest atmosphere with hydrostatic `ps` rebalanced against orography. Uses the same 288 K T as the air column (matching what the dycore will see) rather than the 260 K reference baked into the JW path, avoiding a step-1 pressure-temperature inconsistency.
- `jcm/config/forcing/echam_amip.yaml`: hydra config wiring for `from_echam_files`.
- `terrain.kind=from_file_enveloped` (with `orog_envelope_wavenumber: int`): optional low-pass envelope filter on the orographic geopotential, useful for resolution-truncation Gibbs control.

## Integration-test status

| Config | Result |
|---|---|
| T63 / 47 hybrid + aquaplanet + default forcing + isothermal init, 1 year, dt=12 min | ✅ **stable** — 4 × 90-day chunks all healthy (T 222–282 K, q max ~6.7 g/kg, precip OK, all finite end-to-end) |
| T63 + aquaplanet + AMIP forcing + isothermal init, 5 days | ✅ stable smoke (T 270–290 K) |
| T63 + real terrain (`T63GR15_jan_surf.nc`) + AMIP forcing, any init, any envelope cutoff | ❌ NaN at the first dynamics step |

## Open

The real-terrain runs NaN immediately. After bisecting, it isn't:

- **The new GWD/SSO** — disabling both with `physics.params.{sso,hines}.*=0` doesn't help.
- **Init choice** — fails with isothermal, balanced_isothermal, and JW.
- **Orography Gibbs overshoots alone** — applying envelope filter down to T21 (which caps overshoot at ~280 m below sea level) doesn't help.

Notably, this is the first attempt to run JCM with real terrain at *any* resolution — all the long-stable runs in the project history (including the 1-year T85 moist debug) are aquaplanet. So this is a generic dycore/physics + topography interaction issue, not T63-specific. Diagnosing it is the next step (not blocking the T63 grid + reader infrastructure landing).

## Test plan

- [ ] `JAX_PLATFORMS=cpu pytest -n 12 jcm/terrain_test.py jcm/forcing_test.py` — no regressions.
- [ ] T63 aquaplanet 1-year run: `python -m jcm.main physics=icon grid=icon_t63_l47_hybrid init=isothermal terrain=aquaplanet forcing=default run=longrun run.time_step=12` — ~3 hours wall, all 4 chunks should be healthy.
- [ ] AMIP T63 5-day smoke: `python -m jcm.main physics=icon grid=icon_t63_l47_hybrid init=isothermal terrain=aquaplanet forcing=echam_amip forcing.sst_file=$DATA/T63_amipsst_1979-2008_mean.nc forcing.sic_file=$DATA/T63_amipsic_1979-2008_mean.nc forcing.surface_file=$DATA/T63GR15_jan_surf.nc run=longrun run.total_time=5 run.chunk_days=5 run.time_step=12`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)