### PR TITLE
Add RRTMGP-NN gas optics emulator validation

### DIFF
--- a/jcm/physics/echam/echam_physics.py
+++ b/jcm/physics/echam/echam_physics.py
@@ -35,6 +35,12 @@ from jcm.physics.aerosol.spa import spa_activated_cdnc
 
 logger = logging.getLogger(__name__)
 
+
+def _column_vector(value: jnp.ndarray, ncols: int) -> jnp.ndarray:
+    """Return a vmapped scalar diagnostic as one value per column."""
+    return jnp.reshape(value, (ncols,))
+
+
 @jit
 def _prepare_common_physics_state(
     state: PhysicsState,
@@ -297,30 +303,27 @@ def _apply_radiation_inner(state: PhysicsState,
         tracers={}
     )
     
-    # Reconstruct RadiationData from vmapped diagnostics
-    # Most fields need to be transposed from [ncols, ...] to [..., ncols].
-    # ``squeeze(-1)`` (not bare ``squeeze``) drops only the trailing
-    # length-1 dim so a single-column run keeps shape ``[1]`` instead of
-    # collapsing to a scalar (which mismatches the cached path's shape and
-    # breaks the radiation ``lax.cond`` at ``ncols=1``).
+    # Reconstruct RadiationData from vmapped diagnostics. Scalar
+    # diagnostics are reshaped to [ncols] so compute/cache branches
+    # preserve identical shapes for single-column and global runs.
     rad_out = RadiationData(
-        cos_zenith=diagnostics_vmapped.cos_zenith.squeeze(-1),  # [ncols, 1] -> [ncols]
-        surface_albedo_vis=diagnostics_vmapped.surface_albedo_vis,
-        surface_albedo_nir=diagnostics_vmapped.surface_albedo_nir,
-        surface_emissivity=diagnostics_vmapped.surface_emissivity,
+        cos_zenith=_column_vector(diagnostics_vmapped.cos_zenith, ncols),  # [ncols, 1] -> [ncols]
+        surface_albedo_vis=_column_vector(diagnostics_vmapped.surface_albedo_vis, ncols),
+        surface_albedo_nir=_column_vector(diagnostics_vmapped.surface_albedo_nir, ncols),
+        surface_emissivity=_column_vector(diagnostics_vmapped.surface_emissivity, ncols),
         sw_flux_up=diagnostics_vmapped.sw_flux_up.transpose(1, 0, 2).sum(axis=-1),  # [nlev+1, ncols] (summed over bands)
         sw_flux_down=diagnostics_vmapped.sw_flux_down.transpose(1, 0, 2).sum(axis=-1),
         sw_heating_rate=tendencies_vmapped.shortwave_heating.T,  # [ncols, nlev] -> [nlev, ncols]
         lw_flux_up=diagnostics_vmapped.lw_flux_up.transpose(1, 0, 2).sum(axis=-1),
         lw_flux_down=diagnostics_vmapped.lw_flux_down.transpose(1, 0, 2).sum(axis=-1),
         lw_heating_rate=tendencies_vmapped.longwave_heating.T,  # [ncols, nlev] -> [nlev, ncols]
-        surface_sw_down=diagnostics_vmapped.surface_sw_down,  # Already [ncols]
-        surface_lw_down=diagnostics_vmapped.surface_lw_down,
-        surface_sw_up=diagnostics_vmapped.surface_sw_up,
-        surface_lw_up=diagnostics_vmapped.surface_lw_up,
-        toa_sw_up=diagnostics_vmapped.toa_sw_up,
-        toa_lw_up=diagnostics_vmapped.toa_lw_up,
-        toa_sw_down=diagnostics_vmapped.toa_sw_down
+        surface_sw_down=_column_vector(diagnostics_vmapped.surface_sw_down, ncols),  # Already [ncols]
+        surface_lw_down=_column_vector(diagnostics_vmapped.surface_lw_down, ncols),
+        surface_sw_up=_column_vector(diagnostics_vmapped.surface_sw_up, ncols),
+        surface_lw_up=_column_vector(diagnostics_vmapped.surface_lw_up, ncols),
+        toa_sw_up=_column_vector(diagnostics_vmapped.toa_sw_up, ncols),
+        toa_lw_up=_column_vector(diagnostics_vmapped.toa_lw_up, ncols),
+        toa_sw_down=_column_vector(diagnostics_vmapped.toa_sw_down, ncols)
     )
     
     updated_physics_data = physics_data.copy(radiation=rad_out)
@@ -414,23 +417,23 @@ def _apply_radiation_rrtmgp_inner(
     )
 
     rad_out = RadiationData(
-        cos_zenith=diagnostics_vmapped.cos_zenith.squeeze(-1),
-        surface_albedo_vis=diagnostics_vmapped.surface_albedo_vis,
-        surface_albedo_nir=diagnostics_vmapped.surface_albedo_nir,
-        surface_emissivity=diagnostics_vmapped.surface_emissivity,
+        cos_zenith=_column_vector(diagnostics_vmapped.cos_zenith, ncols),
+        surface_albedo_vis=_column_vector(diagnostics_vmapped.surface_albedo_vis, ncols),
+        surface_albedo_nir=_column_vector(diagnostics_vmapped.surface_albedo_nir, ncols),
+        surface_emissivity=_column_vector(diagnostics_vmapped.surface_emissivity, ncols),
         sw_flux_up=diagnostics_vmapped.sw_flux_up.transpose(1, 0, 2).sum(axis=-1),
         sw_flux_down=diagnostics_vmapped.sw_flux_down.transpose(1, 0, 2).sum(axis=-1),
         sw_heating_rate=tendencies_vmapped.shortwave_heating.T,
         lw_flux_up=diagnostics_vmapped.lw_flux_up.transpose(1, 0, 2).sum(axis=-1),
         lw_flux_down=diagnostics_vmapped.lw_flux_down.transpose(1, 0, 2).sum(axis=-1),
         lw_heating_rate=tendencies_vmapped.longwave_heating.T,
-        surface_sw_down=diagnostics_vmapped.surface_sw_down,
-        surface_lw_down=diagnostics_vmapped.surface_lw_down,
-        surface_sw_up=diagnostics_vmapped.surface_sw_up,
-        surface_lw_up=diagnostics_vmapped.surface_lw_up,
-        toa_sw_up=diagnostics_vmapped.toa_sw_up,
-        toa_lw_up=diagnostics_vmapped.toa_lw_up,
-        toa_sw_down=diagnostics_vmapped.toa_sw_down,
+        surface_sw_down=_column_vector(diagnostics_vmapped.surface_sw_down, ncols),
+        surface_lw_down=_column_vector(diagnostics_vmapped.surface_lw_down, ncols),
+        surface_sw_up=_column_vector(diagnostics_vmapped.surface_sw_up, ncols),
+        surface_lw_up=_column_vector(diagnostics_vmapped.surface_lw_up, ncols),
+        toa_sw_up=_column_vector(diagnostics_vmapped.toa_sw_up, ncols),
+        toa_lw_up=_column_vector(diagnostics_vmapped.toa_lw_up, ncols),
+        toa_sw_down=_column_vector(diagnostics_vmapped.toa_sw_down, ncols),
     )
 
     updated_physics_data = physics_data.copy(radiation=rad_out)
@@ -537,23 +540,23 @@ def _apply_radiation_emulated_inner(
     # vmapped output shapes are [ncols, nlev+1] for fluxes and
     # [ncols, nlev] for heating rates.
     rad_out = RadiationData(
-        cos_zenith=diagnostics_vmapped.cos_zenith.squeeze(-1),
-        surface_albedo_vis=diagnostics_vmapped.surface_albedo_vis.squeeze(-1),
-        surface_albedo_nir=diagnostics_vmapped.surface_albedo_nir.squeeze(-1),
-        surface_emissivity=diagnostics_vmapped.surface_emissivity.squeeze(-1),
+        cos_zenith=_column_vector(diagnostics_vmapped.cos_zenith, ncols),
+        surface_albedo_vis=_column_vector(diagnostics_vmapped.surface_albedo_vis, ncols),
+        surface_albedo_nir=_column_vector(diagnostics_vmapped.surface_albedo_nir, ncols),
+        surface_emissivity=_column_vector(diagnostics_vmapped.surface_emissivity, ncols),
         sw_flux_up=diagnostics_vmapped.sw_flux_up.T,        # [ncols, nlev+1] -> [nlev+1, ncols]
         sw_flux_down=diagnostics_vmapped.sw_flux_down.T,
         sw_heating_rate=tendencies_vmapped.shortwave_heating.T,
         lw_flux_up=diagnostics_vmapped.lw_flux_up.T,
         lw_flux_down=diagnostics_vmapped.lw_flux_down.T,
         lw_heating_rate=tendencies_vmapped.longwave_heating.T,
-        surface_sw_down=diagnostics_vmapped.surface_sw_down.squeeze(),
-        surface_lw_down=diagnostics_vmapped.surface_lw_down.squeeze(),
-        surface_sw_up=diagnostics_vmapped.surface_sw_up.squeeze(),
-        surface_lw_up=diagnostics_vmapped.surface_lw_up.squeeze(),
-        toa_sw_up=diagnostics_vmapped.toa_sw_up.squeeze(),
-        toa_lw_up=diagnostics_vmapped.toa_lw_up.squeeze(),
-        toa_sw_down=diagnostics_vmapped.toa_sw_down.squeeze(),
+        surface_sw_down=_column_vector(diagnostics_vmapped.surface_sw_down, ncols),
+        surface_lw_down=_column_vector(diagnostics_vmapped.surface_lw_down, ncols),
+        surface_sw_up=_column_vector(diagnostics_vmapped.surface_sw_up, ncols),
+        surface_lw_up=_column_vector(diagnostics_vmapped.surface_lw_up, ncols),
+        toa_sw_up=_column_vector(diagnostics_vmapped.toa_sw_up, ncols),
+        toa_lw_up=_column_vector(diagnostics_vmapped.toa_lw_up, ncols),
+        toa_sw_down=_column_vector(diagnostics_vmapped.toa_sw_down, ncols),
     )
 
     updated_physics_data = physics_data.copy(radiation=rad_out)

--- a/jcm/physics/echam/echam_terms.py
+++ b/jcm/physics/echam/echam_terms.py
@@ -629,7 +629,7 @@ class ComposableEchamPhysics(ComposablePhysics):
 def echam_physics(
     parameters: Parameters | None = None,
     checkpoint_terms: bool = True,
-    radiation_scheme: str = "grey",
+    radiation_scheme: str | PhysicsTerm = "grey",
     cloud_scheme: str = "1m",
 ):
     """Create a ComposableEchamPhysics with standard ECHAM ordering.
@@ -637,7 +637,8 @@ def echam_physics(
     Args:
         parameters: Optional ECHAM Parameters. Uses defaults if None.
         checkpoint_terms: Whether to checkpoint terms.
-        radiation_scheme: "grey" (default), "rrtmgp", or "emulated".
+        radiation_scheme: "grey" (default), "rrtmgp", "emulated", or a
+            custom ``PhysicsTerm`` with category "radiation".
         cloud_scheme: "1m" (default, single-moment) or "2m" (two-moment
             warm-rain; see issue #341 for ongoing scheme completion).
 
@@ -647,7 +648,14 @@ def echam_physics(
     """
     p = parameters or Parameters.default()
 
-    if radiation_scheme == "rrtmgp":
+    if isinstance(radiation_scheme, PhysicsTerm):
+        if radiation_scheme.category != "radiation":
+            raise ValueError(
+                "Custom radiation_scheme terms must have category "
+                "'radiation'."
+            )
+        rad_term = radiation_scheme
+    elif radiation_scheme == "rrtmgp":
         rad_term = EchamRadiationRRTMGP()
     elif radiation_scheme == "grey":
         rad_term = EchamRadiation()
@@ -656,7 +664,8 @@ def echam_physics(
     else:
         raise ValueError(
             f"Unknown radiation_scheme={radiation_scheme!r}. "
-            "Choose 'grey', 'rrtmgp', or 'emulated'."
+            "Choose 'grey', 'rrtmgp', 'emulated', or pass a radiation "
+            "PhysicsTerm."
         )
 
     if cloud_scheme == "1m":

--- a/jcm/physics/echam/echam_terms_test.py
+++ b/jcm/physics/echam/echam_terms_test.py
@@ -16,6 +16,21 @@ from jcm.forcing import ForcingData
 from jcm.terrain import TerrainData
 from jcm.date import DateData
 from jcm.utils import get_coords
+from jcm.physics.physics_term import PhysicsTerm
+
+
+class DummyRadiationTerm(PhysicsTerm):
+    """Minimal radiation term used to test ECHAM factory dispatch."""
+
+    name = "dummy_radiation"
+    category = "radiation"
+
+
+class DummyConvectionTerm(PhysicsTerm):
+    """Minimal non-radiation term used to test factory validation."""
+
+    name = "dummy_convection"
+    category = "convection"
 
 
 def _make_echam_test_setup(nlev=8, nlat=64, nlon=32):
@@ -90,6 +105,39 @@ class TestEchamComposablePhysics(unittest.TestCase):
         self.assertLess(
             categories.index("cloud_fraction"),
             categories.index("clouds"),
+        )
+
+    def test_echam_physics_accepts_custom_radiation_term(self):
+        """A radiation PhysicsTerm can be passed directly."""
+        from jcm.physics.echam.echam_terms import echam_physics
+
+        custom_rad = DummyRadiationTerm()
+        physics = echam_physics(
+            checkpoint_terms=False,
+            radiation_scheme=custom_rad,
+        )
+
+        self.assertIs(physics.terms[4], custom_rad)
+        self.assertEqual(physics.terms[4].category, "radiation")
+
+    def test_echam_physics_rejects_non_radiation_custom_term(self):
+        """Custom radiation terms must declare the radiation category."""
+        from jcm.physics.echam.echam_terms import echam_physics
+
+        with self.assertRaisesRegex(ValueError, "category 'radiation'"):
+            echam_physics(
+                checkpoint_terms=False,
+                radiation_scheme=DummyConvectionTerm(),
+            )
+
+    def test_column_vector_handles_vmap_scalar_shapes(self):
+        """Radiation scalar diagnostics are normalized to [ncols]."""
+        from jcm.physics.echam.echam_physics import _column_vector
+
+        self.assertEqual(_column_vector(jnp.arange(3), 3).shape, (3,))
+        self.assertEqual(
+            _column_vector(jnp.arange(3).reshape(3, 1), 3).shape,
+            (3,),
         )
 
     def test_composable_with_model(self):


### PR DESCRIPTION
## Summary

Adds an RRTMGP-NN v2 gas-optics emulator path for ICON radiation experiments, following Ukkonen and Hogan (2023). This address Issue #426.

The emulator replaces RRTMGP gas-optics table interpolation with dense MLPs, while keeping the existing `jax-rrtmgp` two-stream radiative-transfer solver. 

The runtime path remains explicit via `radiation_scheme="emulated_optics"`. The existing `radiation_scheme="emulated"` GRU/broadband path is preserved separately.

## Runtime comparison
<img width="661" height="461" alt="image" src="https://github.com/user-attachments/assets/23216751-6fb7-43ba-a8d1-df696d20baf3" />

## RFMIP validation
More plots are in `validation/rrtmgp_emulator/rrtmgp_emulator_validation.ipynb`, and includes analysis on
- Training/validation data visualization
- Offline test w.r.t. default RRTMGP and gray scheme
- Online test w.r.t. default RRTMGP and gray scheme

<img width="1211" height="1011" alt="image" src="https://github.com/user-attachments/assets/65c50bc2-1bca-4178-86db-ce79495728dc" />

<img width="1211" height="410" alt="image" src="https://github.com/user-attachments/assets/746b2568-cfbb-4ead-92c1-0c5b446059bd" />

<img width="1211" height="410" alt="image" src="https://github.com/user-attachments/assets/e88d6547-d81b-4722-95dc-8c986cbf4d94" />


## How To Use

```python
from jcm.physics.echam.echam_terms import echam_physics
from jcm.physics.echam.parameters import Parameters
from jcm.physics.radiation.nn_emulator import load_reference_checkpoint

params = Parameters.default().with_radiation(
    radiation_interval=7200.0,
)

# Case 1: Default RRTMGP
physics = echam_physics(
    parameters=params,
    radiation_scheme="rrtmgp",
)

# Case 2: RRTMGP-NN gas-optics emulator with the bundled reference checkpoint
params_nn = params.with_radiation(
    emulated_optics_checkpoint=load_reference_checkpoint(),
)

physics = echam_physics(
    parameters=params_nn,
    radiation_scheme="emulated_optics",
)

# Case 3: Custom checkpoint
from jcm.physics.radiation.nn_emulator import load_emulator_artifact

payload = load_emulator_artifact("path/to/my_checkpoint.pkl")

params_custom = params.with_radiation(
    emulated_optics_checkpoint=payload["checkpoint"],
)

physics = echam_physics(
    parameters=params_custom,
    radiation_scheme="emulated_optics",
)
```

## Checkpoint

The committed path-free reference checkpoint lives at: `validation/rrtmgp_emulator/checkpoints/v2_reference_checkpoint.pkl`

It contains the trained RRTMGP-NN v2 MLP weights, scaling coefficients, training history, metrics, and path-free summary metadata. Generated datasets and Zenodo NetCDF files are intentionally not committed, but are provided as scripts under `validation/rrtmgp_emulator` directory.

## Changes

- Extends jcm.physics.radiation.nn_emulator with the RRTMGP-NN v2 gas-optics MLP setup while preserving the existing GRU emulator path.
- Adds an emulated radiation wrapper that swaps the gas-optics backend and reuses the RRTMGP RTE solver.
- Adds validation tooling under validation/rrtmgp_emulator for:
    - Zenodo v2 data download/extraction
    - processed dataset construction
    - checkpoint training
    - held-out gas-optics evaluation
    - offline RFMIP RTE comparisons
    - notebook-based validation/visualization
- Documents data generation, training, evaluation, notebook usage, and online ICON usage.


## Reference

Ukkonen, P. and Hogan, R. J.: Implementation of a machine-learned gas optics parameterization in the ECMWF Integrated Forecasting System: RRTMGP-NN 2.0, Geosci. Model Dev., 16, 3241-3261, https://doi.org/10.5194/gmd-16-3241-2023, 2023.

## Notes

- The emulator is gas optics only; radiative transfer still uses jax-rrtmgp.
- radiation_interval=0.0 computes radiation every model step. Set a positive interval, e.g. 7200.0, to reuse cached radiation tendencies between radiation calls.