### PR TITLE
ECHAM 2M microphysics: stabilise T63L47 30d, fix precip diagnostic

### DIFF
--- a/docs/source/echam_physics.rst
+++ b/docs/source/echam_physics.rst
@@ -84,7 +84,28 @@ The RRTMGP path provides physically correct heating rates suitable for multi-day
 
 The reference (g256 / g224) variant ships with the ``jax-rrtmgp`` package and can be selected by editing the file paths in :py:func:`jcm.physics.radiation.rrtmgp._ensure_rrtmgp` if higher spectral fidelity is needed; with the chunked-vmap strategy described below it still fits on a single 80 GiB A100.
 
-*Memory & cost*: RRTMGP has substantial intermediate-array memory needs. JAX-GCM evaluates it in chunks of 4608 columns (T63 = 4 chunks via ``lax.map``) so peak GPU memory stays around 17 GiB per chunk on T63L47, well under 80 GiB. Per-call cost is roughly 40× the grey scheme; with the default 2-hour ``radiation_interval`` cache, the amortised cost is ~4× grey total.
+*Memory & cost*: RRTMGP has substantial intermediate-array memory needs. JAX-GCM evaluates it in chunks via ``lax.map``; the chunk size is auto-detected from device HBM (see :func:`jcm.physics.radiation.rrtmgp.chunk_budget`) and on a single 80 GiB A100 picks 9216 columns / chunk for T63L47 (2 chunks), with peak per-chunk memory around 33 GiB. The earlier 4608-column / 4-chunk default was ~74 % slower per call.
+
+Per-call cost at T63L47 g128/g112 is dominated by gas-optics interpolation table lookups across ``ncols × nlev × ngpt`` cells, so it scales close to linear in horizontal resolution and in ``nlev``. Measured on an idle 80 GiB A100 (single steady-state RRTMGP call inside a single-step ``model.resume`` Python loop, after warm-up):
+
+.. list-table:: Steady-state per-step cost on T63L47 (real terrain + sponge, dt = 12 min)
+   :header-rows: 1
+   :widths: 30 25 25 20
+
+   * - Scheme
+     - RRTMGP step (RAD)
+     - cache step
+     - rad/cache ratio
+   * - 1M microphysics
+     - 16.3 s
+     - ≈ 98 ms
+     - ~165×
+   * - 2M microphysics
+     - 15.8 s
+     - ≈ 101 ms
+     - ~155×
+
+The microphysics choice has effectively no impact on RRTMGP per-call cost — the work is entirely radiation. With the default 2-hour ``radiation_interval`` cache (RRTMGP fires on 1 step in 10 at dt = 12 min) a 30-day T63L47 + sponge integration takes ~78 min wall vs ~6.5 min for grey radiation — i.e. **~12× the grey total**, not the ~4× a smaller-config measurement might suggest. That works out to ~1.5 sim-yr per wall-day on one A100 at climate-quality resolution.
 
 **Grey two-stream** (development / ML training)
 

--- a/jcm/physics/clouds/lohmann_2m.py
+++ b/jcm/physics/clouds/lohmann_2m.py
@@ -202,7 +202,14 @@ def microphysics_dt_constants(dt: jnp.ndarray) -> tuple[jnp.ndarray, jnp.ndarray
     ztmst = dt
     ztmst_rcp = 1.0 / jnp.maximum(ztmst, eps)
     zcons1 = cpd*vtmpc2
-    zcons2 = ztmst * rgrav
+    # Match the ECHAM Fortran (mo_cloud_micro_2m.f90 line 535):
+    # ``zcons2 = ztmst_rcp * rgrav = 1 / (dt * g)``. The earlier port had
+    # ``ztmst * rgrav`` which was dt^2 too large in every site that uses
+    # zcons2 to convert ``pdp * mmr`` into a flux (kg/m^2/s) — so the
+    # large-scale surface precip diagnostic came out ~dt^2 (~5x10^5 at
+    # dt=12 min) too large, and the latent heat in melt/sub paths was
+    # similarly mis-scaled.
+    zcons2 = ztmst_rcp * rgrav
     zcons3 = 1.0 / ( pi*crhosno*cn0s*cvtfall**(1.0/1.16) )**0.25
     
     return ztmst, ztmst_rcp, zcons1, zcons2, zcons3
@@ -3045,7 +3052,7 @@ def cloud_microphysics_2m(
     activated_cdnc: jnp.ndarray,    # (nlev,)  1/m³   aerosol-activated CDNC (from MACv2-SP)
     dt: jnp.ndarray,                # scalar   seconds
     params: CloudParams2M,          # tunable parameters
-) -> MicrophysicsTendencies_2M:
+) -> tuple[MicrophysicsTendencies_2M, jnp.ndarray, jnp.ndarray]:
     """Column-sweep orchestrator for the two-moment microphysics scheme.
 
     Processes (in ECHAM6 order):
@@ -3073,6 +3080,22 @@ def cloud_microphysics_2m(
     so we convert at the boundary.
     """
     eps_dt = jnp.finfo(qc.dtype).eps
+
+    # ECHAM's per-level loop clamps icnc to ``[icemin, icemax]`` and
+    # forces cdnc to ``[cqtmin, cdnc_min_upper]``-or-above (lines 1252-3
+    # of mo_cloud_micro_2m.f90 and the activation block in
+    # update_in_cloud_water). Mirror that on the orchestrator's INPUT so
+    # the dynamical-core's spectral round-trip ringing — which can leave
+    # small negative artefacts that ``update_in_cloud_water`` amplifies
+    # via the ``delta_cdnc = activated_cdnc - droplet_number`` step —
+    # cannot drive a multi-day runaway. Upper bound chosen as
+    # ``cdnc_max_phys`` (1e11 / m^3, well above any realistic activation
+    # output) and ``icemax`` (1e7 / m^3) so realistic clouds are
+    # unaffected.
+    _cdnc_max_phys_per_m3 = 1.0e11
+    inv_rho_safe = 1.0 / jnp.maximum(air_density, eps_dt)
+    qnc = jnp.clip(qnc, 0.0, _cdnc_max_phys_per_m3 * inv_rho_safe)
+    qni = jnp.clip(qni, 0.0, params.icemax * inv_rho_safe)
 
     # Number-per-kg-of-air → per-m^3 at the scheme's API boundary.
     cdnc = qnc * air_density
@@ -3454,8 +3477,13 @@ def cloud_microphysics_2m(
     (qi_after_scan, icnc_after_scan, cdnc_after_scan,
      snow_sublim, rain_evap) = scan_outs
 
-    # Extract final snow_melt from carry.
-    (_, _, _, _, _, _, snow_melt_final) = _final_carry
+    # Extract carry state at the bottom of the column. The first two
+    # elements are the surface rain and snow flux (kg/m^2/s) — these are
+    # the large-scale precipitation diagnostics that callers need.
+    (
+        surface_rain_flux, surface_snow_flux,
+        _, _, _, _, snow_melt_final,
+    ) = _final_carry
 
     # ------------------------------------------------------------------
     # update_tendencies_and_important_vars: full ECHAM6 accounting step
@@ -3475,8 +3503,16 @@ def cloud_microphysics_2m(
         cdnc=cdnc_after_scan,
         ice_mmr_prev=in_cloud_ice_cold,
         liq_mmr_prev=in_cloud_liquid_cold,
-        tracer_tm1_cdnc=cdnc,        # original input = previous-timestep value
-        tracer_tm1_icnc=icnc,
+        # ECHAM convention: pxtm1_cdnc / pxtm1_icnc are the previous-step
+        # tracer values in per-kg-of-air. ``cdnc`` and ``icnc`` here are
+        # the working per-m^3 values (qnc * rho, qni * rho), so we pass
+        # the per-kg ``qnc``/``qni`` instead. With the original (per-m^3)
+        # values the formula mixes per-kg with per-m^3 in the same
+        # subtraction and the resulting per-step amplification (~1/rho^2
+        # at upper levels) compounds qnc/qni 10+ orders of magnitude
+        # over a few days, producing the day-6 NaN.
+        tracer_tm1_cdnc=qnc,
+        tracer_tm1_icnc=qni,
         condensation_rate=condensation_rate,
         deposition_rate=deposition_rate,
         rain_evap_mmr=rain_evap,
@@ -3521,11 +3557,14 @@ def cloud_microphysics_2m(
     dqrdt = (qr_gain_warm - rain_evap) * inv_dt
     dqsdt = (qc_to_snow + qi_to_snow + qi_sedi_melt_loss - snow_sublim) * inv_dt
 
-    # Number tendencies from update_tendencies (per-m³ → per-kg-of-air)
-    dqncdt = dqncdt_m3 * inv_rho
-    dqnidt = dqnidt_m3 * inv_rho
+    # update_tendencies' tracer_tendency_{cdnc,icnc} is already in per-kg-
+    # of-air per second once we pass qnc/qni (per-kg) as the tm1 tracers
+    # — see the fix above. The legacy ``* inv_rho`` here was a second
+    # units error compounded with the per-kg-vs-per-m^3 swap above.
+    dqncdt = dqncdt_m3
+    dqnidt = dqnidt_m3
 
-    return MicrophysicsTendencies_2M(
+    tendencies = MicrophysicsTendencies_2M(
         dtedt=dtedt,
         dqdt=dqdt,
         dqcdt=dqcdt,
@@ -3535,6 +3574,7 @@ def cloud_microphysics_2m(
         dqrdt=dqrdt,
         dqsdt=dqsdt,
     )
+    return tendencies, surface_rain_flux, surface_snow_flux
 
 
 # Back-compat alias while the Phase 5a callers are migrated.

--- a/jcm/physics/echam/echam_physics.py
+++ b/jcm/physics/echam/echam_physics.py
@@ -930,14 +930,21 @@ def apply_microphysics_2m(
     forcing: ForcingData,
     terrain: TerrainData,
 ) -> tuple[PhysicsTendency, PhysicsData]:
-    """Run ECHAM 2-moment cloud microphysics (Phase 5a: minimal warm-rain only).
+    """Run ECHAM 2-moment cloud microphysics.
 
-    Consumes the post-condensation ``qc``/``qi``/``cloud_fraction`` emitted by
-    :func:`apply_cloud_fraction` and returns tendencies for the full 2M tracer
-    set ``{qc, qi, qnc, qni, qr, qs}``. Warm-rain (KK2000) + cold-phase
-    precipitation formation (ice aggregation + riming) are wired in;
-    sedimentation, melting, deposition/WBF, and latent-heat release are
-    later Phase-5b steps — see issue #341.
+    Consumes the post-condensation ``qc``/``qi``/``cloud_fraction`` emitted
+    by :func:`apply_cloud_fraction` and returns tendencies for the full 2M
+    tracer set ``{qc, qi, qnc, qni, qr, qs}``. The orchestrator
+    :func:`jcm.physics.clouds.lohmann_2m.cloud_microphysics_2m` chains the
+    full ECHAM6 process list: warm precip (KK2000) + mixed-phase
+    deposition/condensation + freezing-below-238K + DeMott(2010) INP
+    mixed-phase freezing (placeholder for ECHAM's ``het_mxphase_freezing``
+    which would need HAM aerosol modes — see #436) + WBF + cold precip +
+    a top-down ``lax.scan`` over levels for sedimentation / melting /
+    sublimation+evap / precip-flux accumulation, then ECHAM's
+    ``update_tendencies_and_important_vars`` for the final tendency
+    bookkeeping. Heterogeneous freezing is intentionally simplified to
+    DeMott(2010) since JCM does not yet ingest a real IN field.
     """
     from jcm.physics.clouds.lohmann_2m import cloud_microphysics_2m
 
@@ -974,10 +981,10 @@ def apply_microphysics_2m(
         exponent=parameters.aerosol.spa_exponent,
     )
 
-    tend_all = jax.vmap(
+    tend_all, surface_rain_flux, surface_snow_flux = jax.vmap(
         cloud_microphysics_2m,
         in_axes=(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, None, None),
-        out_axes=0,
+        out_axes=(0, 0, 0),
     )(state.temperature, state.specific_humidity, pressure_levels,
       qc_interim, qi_interim, qnc, qni, qr, qs,
       cloud_fraction, air_density, layer_thickness, tke,
@@ -1001,7 +1008,16 @@ def apply_microphysics_2m(
     # this term (or downstream update_tendencies_and_important_vars) can
     # read previous-step number concentrations. PhysicsData.clouds is
     # carried forward across timesteps in ComposableEchamPhysics.__call__.
-    clouds_next = physics_data.clouds.copy(qnc_prev=qnc, qni_prev=qni)
+    # Also expose the large-scale surface precip from the column scan as
+    # diagnostic ``precip_rain``/``precip_snow`` (kg/m^2/s) — these are the
+    # gravitational-fall flux at the bottom of the orchestrator's
+    # top-down ``lax.scan``, summing autoconv + accretion + melt - evap
+    # contributions across all levels.
+    clouds_next = physics_data.clouds.copy(
+        qnc_prev=qnc, qni_prev=qni,
+        precip_rain=surface_rain_flux,
+        precip_snow=surface_snow_flux,
+    )
     return tendencies, physics_data.copy(clouds=clouds_next)
 
 

--- a/jcm/physics/echam/echam_physics.py
+++ b/jcm/physics/echam/echam_physics.py
@@ -883,18 +883,10 @@ def apply_microphysics_1m(
     cdnc_m3 = jnp.ones_like(state.temperature) * base_cdnc * cdnc_factor[jnp.newaxis, :]
     droplet_number_per_kg = cdnc_m3 / air_density
 
-    # Reverted from cloud_microphysics_column_sweep — that scheme's
-    # Rotstayn rain evaporation creates a positive-feedback loop
-    # (rain evaporates → moistens dry layer → Sundqvist condenses →
-    # latent heat release → drives convection → more rain) that the
-    # surface bisect identified as the dominant amplifier of the
-    # day-7 NaN on T63L47 + real terrain. The per-level
-    # `cloud_microphysics` discards rain each step (no propagating
-    # flux, no inter-level evap coupling), which breaks the feedback
-    # at the cost of microphysics fidelity. Tracked as follow-up
-    # work — needs either ICON's RH-hysteresis bound on the evap
-    # source or a tighter Newton solve so the evap stays bounded
-    # under coupling with Sundqvist.
+    # Rain / snow are in-step column fluxes in ICON's 1M scheme (see
+    # ``mo_cloud.f90`` lines 267-268: ``zrfl/zsfl`` reset to 0 at TOA at
+    # the start of every call). The ``cloud_microphysics`` helper
+    # initialises ``rain_water`` and ``snow`` to zeros internally.
     micro_tend_all, micro_state_all = jax.vmap(
         cloud_microphysics,
         in_axes=(1, 1, 1, 1, 1, 1, 1, 1, 1, None, None),

--- a/jcm/physics/echam/echam_physics.py
+++ b/jcm/physics/echam/echam_physics.py
@@ -883,10 +883,18 @@ def apply_microphysics_1m(
     cdnc_m3 = jnp.ones_like(state.temperature) * base_cdnc * cdnc_factor[jnp.newaxis, :]
     droplet_number_per_kg = cdnc_m3 / air_density
 
-    # Rain / snow are in-step column fluxes in ICON's 1M scheme (see
-    # ``mo_cloud.f90`` lines 267-268: ``zrfl/zsfl`` reset to 0 at TOA at
-    # the start of every call). The ``cloud_microphysics`` helper
-    # initialises ``rain_water`` and ``snow`` to zeros internally.
+    # Reverted from cloud_microphysics_column_sweep — that scheme's
+    # Rotstayn rain evaporation creates a positive-feedback loop
+    # (rain evaporates → moistens dry layer → Sundqvist condenses →
+    # latent heat release → drives convection → more rain) that the
+    # surface bisect identified as the dominant amplifier of the
+    # day-7 NaN on T63L47 + real terrain. The per-level
+    # `cloud_microphysics` discards rain each step (no propagating
+    # flux, no inter-level evap coupling), which breaks the feedback
+    # at the cost of microphysics fidelity. Tracked as follow-up
+    # work — needs either ICON's RH-hysteresis bound on the evap
+    # source or a tighter Newton solve so the evap stays bounded
+    # under coupling with Sundqvist.
     micro_tend_all, micro_state_all = jax.vmap(
         cloud_microphysics,
         in_axes=(1, 1, 1, 1, 1, 1, 1, 1, 1, None, None),
@@ -1293,13 +1301,18 @@ def apply_surface(
     # use ``stl_am`` instead of ``sst``).
     ocean_temp = forcing.sea_surface_temperature.reshape(ncols)
     ctfreez = 271.38  # K, ECHAM ``iniphy.f90:71`` saline-water freezing
-    # ``stl_am`` is the JSBACH land surface temperature climatology
-    # (``surf_temp`` from ``ic_land_soil_T63GR15_*.nc``), already at the
-    # model's orography — no lapse correction needed. (An earlier workaround
-    # subtracted 6.5 K/km · orog because the bundled BCs used ``stl ≈ sst``
-    # extrapolated over land — see ``utils/convert_echam_bc.py`` for the
-    # path that picks the right field.)
-    land_temp = forcing.stl_am.reshape(ncols)
+    # Apply a 6.5 K/km dry lapse-rate correction to the prescribed land
+    # surface temperature so it represents the temperature at the model's
+    # actual orography rather than at sea level. The BC files distributed
+    # in ``jcm/data/bc/t63`` set ``stl_am ≈ sst`` everywhere, which gives
+    # a ~+30 K bias over the Tibetan / Andean / Himalayan plateaux at
+    # 4–5 km elevation. The unlapsed temperature drives runaway sensible-
+    # heat flux upward at the lowest model level (ΔT ≈ 30 K · ρ · cp · CH · U)
+    # and is the dominant cause of the T63L47 ``test_real_terrain_with_sponge_stable_30_days``
+    # NaN around day 7. The lapse coefficient matches the standard
+    # atmospheric lapse used by ECHAM's ``initemp.f90`` for downscaling
+    # boundary surface temperatures to model orography.
+    land_temp = forcing.stl_am.reshape(ncols) - 6.5e-3 * terrain.orog.reshape(ncols)
     ice_surface_temp = jnp.where(sea_ice_fraction > 0.0,
                                  jnp.minimum(ocean_temp, ctfreez),
                                  ocean_temp)

--- a/jcm/physics/echam/echam_physics.py
+++ b/jcm/physics/echam/echam_physics.py
@@ -1301,18 +1301,13 @@ def apply_surface(
     # use ``stl_am`` instead of ``sst``).
     ocean_temp = forcing.sea_surface_temperature.reshape(ncols)
     ctfreez = 271.38  # K, ECHAM ``iniphy.f90:71`` saline-water freezing
-    # Apply a 6.5 K/km dry lapse-rate correction to the prescribed land
-    # surface temperature so it represents the temperature at the model's
-    # actual orography rather than at sea level. The BC files distributed
-    # in ``jcm/data/bc/t63`` set ``stl_am ≈ sst`` everywhere, which gives
-    # a ~+30 K bias over the Tibetan / Andean / Himalayan plateaux at
-    # 4–5 km elevation. The unlapsed temperature drives runaway sensible-
-    # heat flux upward at the lowest model level (ΔT ≈ 30 K · ρ · cp · CH · U)
-    # and is the dominant cause of the T63L47 ``test_real_terrain_with_sponge_stable_30_days``
-    # NaN around day 7. The lapse coefficient matches the standard
-    # atmospheric lapse used by ECHAM's ``initemp.f90`` for downscaling
-    # boundary surface temperatures to model orography.
-    land_temp = forcing.stl_am.reshape(ncols) - 6.5e-3 * terrain.orog.reshape(ncols)
+    # ``stl_am`` is the JSBACH land surface temperature climatology
+    # (``surf_temp`` from ``ic_land_soil_T63GR15_*.nc``), already at the
+    # model's orography — no lapse correction needed. (An earlier workaround
+    # subtracted 6.5 K/km · orog because the bundled BCs used ``stl ≈ sst``
+    # extrapolated over land — see ``utils/convert_echam_bc.py`` for the
+    # path that picks the right field.)
+    land_temp = forcing.stl_am.reshape(ncols)
     ice_surface_temp = jnp.where(sea_ice_fraction > 0.0,
                                  jnp.minimum(ocean_temp, ctfreez),
                                  ocean_temp)

--- a/jcm/physics/echam/echam_physics.py
+++ b/jcm/physics/echam/echam_physics.py
@@ -337,50 +337,6 @@ def _apply_radiation_inner(state: PhysicsState,
     return physics_tendencies, updated_physics_data
 
 
-# RRTMGP chunked-vmap configuration. ``_RRTMGP_CHUNK_OVERRIDE`` is a
-# Python-side knob (NOT a JAX traced value) so the chunk count can be
-# resolved at trace time and baked into the JIT'd graph. ``None`` means
-# auto-detect from the JAX device's ``bytes_limit`` at first call.
-_RRTMGP_CHUNK_OVERRIDE = None  # int | None
-
-
-def set_rrtmgp_chunk_size(chunk_size) -> None:
-    """Override the RRTMGP chunked-vmap chunk size (cells per chunk).
-
-    Set to a positive integer to fix the chunk count; set to ``None``
-    to revert to auto-detection from device HBM. Must be called BEFORE
-    the first ``model.resume()`` so the JIT'd radiation function picks
-    up the new value (changing it after a JIT compile triggers a
-    recompile on the next radiation call).
-    """
-    global _RRTMGP_CHUNK_OVERRIDE
-    _RRTMGP_CHUNK_OVERRIDE = chunk_size
-
-
-def _rrtmgp_chunk_budget(nlev: int) -> int:
-    """Return the RRTMGP chunk-size budget (cells/chunk) for this device.
-
-    Uses ``_RRTMGP_CHUNK_OVERRIDE`` if set, else queries the JAX device
-    HBM via ``memory_stats()['bytes_limit']`` and computes the largest
-    chunk that fits at ~55 % of the budget — the empirically-measured
-    sweet spot on a single 80 GiB A100 (T63L47, ngpt=128, nlev=47:
-    chunk=9216 cells / 33 GiB peak ≈ 0.52 of the 63.7 GiB XLA bytes_limit;
-    margin covers XLA working memory). Per-cell cost scales linearly
-    with ``nlev`` for other vertical resolutions. Falls back to 9216
-    if the device doesn't report HBM (e.g. CPU run, non-CUDA backend).
-    """
-    if _RRTMGP_CHUNK_OVERRIDE is not None and _RRTMGP_CHUNK_OVERRIDE > 0:
-        return int(_RRTMGP_CHUNK_OVERRIDE)
-    bytes_per_cell = 3.6e6 * (nlev / 47.0)
-    try:
-        bytes_limit = jax.devices()[0].memory_stats().get('bytes_limit', 0)
-    except Exception:
-        bytes_limit = 0
-    if bytes_limit > 0:
-        return max(1, int(0.55 * bytes_limit / bytes_per_cell))
-    return 9216
-
-
 @jit
 def _apply_radiation_rrtmgp_inner(
     state: PhysicsState,

--- a/jcm/physics/echam/echam_physics.py
+++ b/jcm/physics/echam/echam_physics.py
@@ -337,6 +337,50 @@ def _apply_radiation_inner(state: PhysicsState,
     return physics_tendencies, updated_physics_data
 
 
+# RRTMGP chunked-vmap configuration. ``_RRTMGP_CHUNK_OVERRIDE`` is a
+# Python-side knob (NOT a JAX traced value) so the chunk count can be
+# resolved at trace time and baked into the JIT'd graph. ``None`` means
+# auto-detect from the JAX device's ``bytes_limit`` at first call.
+_RRTMGP_CHUNK_OVERRIDE = None  # int | None
+
+
+def set_rrtmgp_chunk_size(chunk_size) -> None:
+    """Override the RRTMGP chunked-vmap chunk size (cells per chunk).
+
+    Set to a positive integer to fix the chunk count; set to ``None``
+    to revert to auto-detection from device HBM. Must be called BEFORE
+    the first ``model.resume()`` so the JIT'd radiation function picks
+    up the new value (changing it after a JIT compile triggers a
+    recompile on the next radiation call).
+    """
+    global _RRTMGP_CHUNK_OVERRIDE
+    _RRTMGP_CHUNK_OVERRIDE = chunk_size
+
+
+def _rrtmgp_chunk_budget(nlev: int) -> int:
+    """Return the RRTMGP chunk-size budget (cells/chunk) for this device.
+
+    Uses ``_RRTMGP_CHUNK_OVERRIDE`` if set, else queries the JAX device
+    HBM via ``memory_stats()['bytes_limit']`` and computes the largest
+    chunk that fits at ~55 % of the budget — the empirically-measured
+    sweet spot on a single 80 GiB A100 (T63L47, ngpt=128, nlev=47:
+    chunk=9216 cells / 33 GiB peak ≈ 0.52 of the 63.7 GiB XLA bytes_limit;
+    margin covers XLA working memory). Per-cell cost scales linearly
+    with ``nlev`` for other vertical resolutions. Falls back to 9216
+    if the device doesn't report HBM (e.g. CPU run, non-CUDA backend).
+    """
+    if _RRTMGP_CHUNK_OVERRIDE is not None and _RRTMGP_CHUNK_OVERRIDE > 0:
+        return int(_RRTMGP_CHUNK_OVERRIDE)
+    bytes_per_cell = 3.6e6 * (nlev / 47.0)
+    try:
+        bytes_limit = jax.devices()[0].memory_stats().get('bytes_limit', 0)
+    except Exception:
+        bytes_limit = 0
+    if bytes_limit > 0:
+        return max(1, int(0.55 * bytes_limit / bytes_per_cell))
+    return 9216
+
+
 @jit
 def _apply_radiation_rrtmgp_inner(
     state: PhysicsState,

--- a/jcm/physics/echam/echam_t63_land_repro_test.py
+++ b/jcm/physics/echam/echam_t63_land_repro_test.py
@@ -203,5 +203,103 @@ class TestEchamLandT63L47Hybrid(unittest.TestCase):
         self.assertTrue(_state_is_finite(final))
 
 
+@pytest.mark.slow
+class TestEchamLand2MT63L47Hybrid(unittest.TestCase):
+    """T63L47 progression for the **two-moment** microphysics scheme.
+
+    Mirrors :class:`TestEchamLandT63L47Hybrid` but with
+    ``echam_physics(cloud_scheme="2m", ...)``. The 2M scheme manages six
+    cloud tracers (``qc, qi, qnc, qni, qr, qs``) with ECHAM's full
+    Lohmann–Lenderink–Levkov microphysics chain; this class exercises
+    each step in the previously-validated complexity ladder so we can
+    pinpoint regressions or omissions in the orchestrator.
+    """
+
+    def setUp(self):
+        _gpu_required()
+        self.terrain_real = TerrainData.from_file(
+            _T63_BC_DIR / "terrain.nc", coords=_t63l47_coords(),
+        )
+        self.terrain_aqua = TerrainData.aquaplanet(_t63l47_coords())
+        self.forcing = ForcingData.from_file(
+            _T63_BC_DIR / "forcing.nc", coords=_t63l47_coords(),
+        )
+
+    def test_2m_aquaplanet_t63l47_baseline(self):
+        """2M aquaplanet smoke: 1 day, grey radiation, no terrain."""
+        final = _run_steps(
+            echam_physics(cloud_scheme="2m", radiation_scheme="grey"),
+            self.terrain_aqua, self.forcing, n_steps=120,
+        )
+        self.assertTrue(_state_is_finite(final))
+
+    def test_2m_real_terrain_stable_for_24h(self):
+        """2M + real terrain + grey radiation, 1 day."""
+        final = _run_steps(
+            echam_physics(cloud_scheme="2m", radiation_scheme="grey"),
+            self.terrain_real, self.forcing, n_steps=120,
+        )
+        self.assertTrue(_state_is_finite(final))
+
+    def test_2m_real_terrain_with_sponge_stable_5_days(self):
+        """2M + grey + real terrain + UpperSponge, 5 days."""
+        from jcm.physics.dissipation import UpperSponge
+        physics = echam_physics(cloud_scheme="2m", radiation_scheme="grey") + UpperSponge(
+            n_sponge_levels=5, sponge_timescale_s=3 * 3600.0, enspodi=2.0,
+        )
+        final = _run_steps(
+            physics, self.terrain_real, self.forcing, n_steps=600,
+        )
+        self.assertTrue(_state_is_finite(final))
+
+    def test_2m_real_terrain_with_sponge_stable_30_days(self):
+        """2M + grey radiation + real terrain + UpperSponge, 30 days.
+
+        Long-run stability check for the 2M scheme. Originally failed at
+        day 6 due to a CDNC/ICNC tendency-units bug compounded by
+        spectral-truncation negatives that ``update_in_cloud_water``'s
+        activation-replacement step amplified into a multi-day runaway.
+        Fixed by (1) passing the per-kg ``qnc``/``qni`` (not the per-m^3
+        local ``cdnc``/``icnc``) as ``tracer_tm1_*`` to
+        ``update_tendencies_and_important_vars`` and removing the second
+        ``* inv_rho`` on the orchestrator's output, and (2) clipping
+        ``qnc``/``qni`` to physical bounds at the orchestrator entry
+        (matching ECHAM's per-level ``[icemin, icemax]`` clamps) so the
+        spectral round-trip's negative ringing can't seed runaway growth.
+        """
+        from jcm.physics.dissipation import UpperSponge
+        physics = echam_physics(cloud_scheme="2m", radiation_scheme="grey") + UpperSponge(
+            n_sponge_levels=5, sponge_timescale_s=3 * 3600.0, enspodi=2.0,
+        )
+        final = _run_steps(
+            physics, self.terrain_real, self.forcing, n_steps=30 * 120,
+        )
+        self.assertTrue(_state_is_finite(final))
+
+    def test_2m_rrtmgp_real_terrain_stable_for_24h(self):
+        """2M + RRTMGP + real terrain, 1 day. RRTMGP must accept the
+        full 2M cloud water (qc + qi) the same way it does for 1M."""
+        physics = echam_physics(cloud_scheme="2m", radiation_scheme="rrtmgp")
+        final = _run_steps(
+            physics, self.terrain_real, self.forcing, n_steps=120,
+        )
+        self.assertTrue(_state_is_finite(final))
+
+    def test_2m_rrtmgp_real_terrain_with_sponge_stable_30_days(self):
+        """Full production wiring for the 2M scheme: ECHAM 2M physics +
+        RRTMGP + UpperSponge + real terrain + real JSBACH land T. The
+        analogue of ``test_real_terrain_with_sponge_stable_30_days``."""
+        from jcm.physics.dissipation import UpperSponge
+        physics = echam_physics(
+            cloud_scheme="2m", radiation_scheme="rrtmgp",
+        ) + UpperSponge(
+            n_sponge_levels=5, sponge_timescale_s=3 * 3600.0, enspodi=2.0,
+        )
+        final = _run_steps(
+            physics, self.terrain_real, self.forcing, n_steps=30 * 120,
+        )
+        self.assertTrue(_state_is_finite(final))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/jcm/physics/echam/echam_t63_land_repro_test.py
+++ b/jcm/physics/echam/echam_t63_land_repro_test.py
@@ -152,23 +152,17 @@ class TestEchamLandT63L47Hybrid(unittest.TestCase):
         )
         self.assertTrue(_state_is_finite(final))
 
-    @pytest.mark.xfail(
-        reason="The Sundqvist port + qc/qi-prognostic fixes regressed the"
-        " 30-day stability from 30 days to ~7 days on T63L47. The Fortran-"
-        " match condensation reveals that our 1M microphysics column sweep"
-        " (no proper downward rain/snow flux with evap/sublim) under-removes"
-        " moisture once qc/qi are prognostic. Tracked separately; the 5-day"
-        " test below is the production-ready regression line until the"
-        " microphysics column-sweep port lands.",
-        strict=False,
-    )
     def test_real_terrain_with_sponge_stable_30_days(self):
         """Production wiring, full month.
 
-        Currently xfail — see decorator. Restoring this to a hard pass
-        needs a faithful port of ICON ``mo_cloud.f90``'s downward rain/
-        snow integration (lines 267-507) so the column moisture cycle
-        actually closes once condensation is properly bounded.
+        Restored to a hard pass after the real ECHAM land surface
+        temperature climatology landed in ``jcm/data/bc/t63``
+        (``surf_temp`` from JSBACH IC ``ic_land_soil_T63GR15_*``,
+        wired by ``utils/convert_echam_bc.py --land-init``). Earlier
+        iterations of this branch were xfail because the bundled BCs
+        used ``stl ≈ sst`` extrapolated over land — over the Antarctic
+        plateau that gave a ~+50 K bias in winter, driving the day-7
+        runaway sensible-heat NaN.
         """
         from jcm.physics.dissipation import UpperSponge
         physics = echam_physics(radiation_scheme="grey") + UpperSponge(

--- a/jcm/physics/echam/echam_t63_land_repro_test.py
+++ b/jcm/physics/echam/echam_t63_land_repro_test.py
@@ -277,8 +277,11 @@ class TestEchamLand2MT63L47Hybrid(unittest.TestCase):
         self.assertTrue(_state_is_finite(final))
 
     def test_2m_rrtmgp_real_terrain_stable_for_24h(self):
-        """2M + RRTMGP + real terrain, 1 day. RRTMGP must accept the
-        full 2M cloud water (qc + qi) the same way it does for 1M."""
+        """2M + RRTMGP + real terrain, 1 day.
+
+        RRTMGP must accept the full 2M cloud water (qc + qi) the same
+        way it does for 1M.
+        """
         physics = echam_physics(cloud_scheme="2m", radiation_scheme="rrtmgp")
         final = _run_steps(
             physics, self.terrain_real, self.forcing, n_steps=120,
@@ -286,9 +289,12 @@ class TestEchamLand2MT63L47Hybrid(unittest.TestCase):
         self.assertTrue(_state_is_finite(final))
 
     def test_2m_rrtmgp_real_terrain_with_sponge_stable_30_days(self):
-        """Full production wiring for the 2M scheme: ECHAM 2M physics +
-        RRTMGP + UpperSponge + real terrain + real JSBACH land T. The
-        analogue of ``test_real_terrain_with_sponge_stable_30_days``."""
+        """Full production wiring for the 2M scheme.
+
+        ECHAM 2M physics + RRTMGP + UpperSponge + real terrain + real
+        JSBACH land T — the analogue of
+        ``test_real_terrain_with_sponge_stable_30_days``.
+        """
         from jcm.physics.dissipation import UpperSponge
         physics = echam_physics(
             cloud_scheme="2m", radiation_scheme="rrtmgp",

--- a/jcm/physics/echam/echam_t63_land_repro_test.py
+++ b/jcm/physics/echam/echam_t63_land_repro_test.py
@@ -152,17 +152,23 @@ class TestEchamLandT63L47Hybrid(unittest.TestCase):
         )
         self.assertTrue(_state_is_finite(final))
 
+    @pytest.mark.xfail(
+        reason="The Sundqvist port + qc/qi-prognostic fixes regressed the"
+        " 30-day stability from 30 days to ~7 days on T63L47. The Fortran-"
+        " match condensation reveals that our 1M microphysics column sweep"
+        " (no proper downward rain/snow flux with evap/sublim) under-removes"
+        " moisture once qc/qi are prognostic. Tracked separately; the 5-day"
+        " test below is the production-ready regression line until the"
+        " microphysics column-sweep port lands.",
+        strict=False,
+    )
     def test_real_terrain_with_sponge_stable_30_days(self):
         """Production wiring, full month.
 
-        Restored to a hard pass after the real ECHAM land surface
-        temperature climatology landed in ``jcm/data/bc/t63``
-        (``surf_temp`` from JSBACH IC ``ic_land_soil_T63GR15_*``,
-        wired by ``utils/convert_echam_bc.py --land-init``). Earlier
-        iterations of this branch were xfail because the bundled BCs
-        used ``stl ≈ sst`` extrapolated over land — over the Antarctic
-        plateau that gave a ~+50 K bias in winter, driving the day-7
-        runaway sensible-heat NaN.
+        Currently xfail — see decorator. Restoring this to a hard pass
+        needs a faithful port of ICON ``mo_cloud.f90``'s downward rain/
+        snow integration (lines 267-507) so the column moisture cycle
+        actually closes once condensation is properly bounded.
         """
         from jcm.physics.dissipation import UpperSponge
         physics = echam_physics(radiation_scheme="grey") + UpperSponge(


### PR DESCRIPTION
## Summary

* Stabilise the 2M (Lohmann two-moment) microphysics scheme for 30-day T63L47 + sponge runs (was NaN at day 6 with both grey and RRTMGP); both 30d tests now hard-pass and run in 6:30 (grey) / 1:18 (RRTMGP) on a single A100.
* Fix the surface precipitation diagnostic — was off by ``dt²`` (~5×10⁵ at dt = 12 min), now produces physically reasonable Earth-like values.
* Expose ``physics_data.clouds.precip_rain`` / ``precip_snow`` from the 2M apply (mirrors the 1M wiring).
* Update the docs' RRTMGP cost claim with measured T63L47 numbers.

## Three coupled bugs in `cloud_microphysics_2m` / `apply_microphysics_2m`

The 1M scheme avoids all three because it doesn't carry CDNC/ICNC as advected tracers and inlines surface flux accumulation differently.

1. **qnc/qni units mismatch** in `update_tendencies_and_important_vars`: the orchestrator was passing the local per-m³ ``cdnc``/``icnc`` (= ``qnc * rho``) as ``tracer_tm1_*`` where the formula expects per-kg, then re-multiplied the output by ``inv_rho``. Effective per-step amplification of ``1/rho²`` (≈25× at 100 hPa, more at TOA) compounded ``qnc`` to ~1e30/kg by day 5. **Fix**: pass per-kg ``qnc``/``qni`` directly and drop the redundant ``* inv_rho``.

2. **Spectral-truncation seed**: dynamics-core advection of the prognostic ``qnc``/``qni`` leaves negative ringing on these positive-definite tracers. With negative ``droplet_number`` on entry, the ``delta_cdnc = activated_cdnc - droplet_number`` step in ``update_in_cloud_water`` blew up. **Fix**: clamp at orchestrator entry to ``[0, icemax/rho]`` (matching ECHAM's per-level clamps in `mo_cloud_micro_2m.f90:1252-3`).

3. **`zcons2` inverted in `microphysics_dt_constants`**: ECHAM Fortran has ``zcons2 = ztmst_rcp * rgrav = 1/(dt·g)`` (`mo_cloud_micro_2m.f90:535`), the JCM port had ``ztmst * rgrav = dt/g``, off by ``dt²``. The visible symptom was the surface precip diagnostic emerging at ~10000 mm/day mean (vs Earth's ~3 mm/day). Stability was unaffected because the precip diagnostic doesn't feed back into dynamics, but the latent cooling from melt was ``dt²`` under-counted.

## Validation

| Test | Before | After |
|---|---|---|
| 1d aquaplanet grey | ✓ | ✓ |
| 1d real terrain grey | ✓ | ✓ |
| 5d real terrain + sponge grey | ✓ | ✓ |
| 1d real terrain RRTMGP | ✓ | ✓ |
| **30d real terrain + sponge grey** | NaN day 6 | ✓ (6:30) |
| **30d real terrain + sponge RRTMGP** | NaN day 6 | ✓ (1:18:16) |

Day-5 spin-up surface precip:
* 1M: mean 0.013 mm/d, max 1.12 mm/d
* 2M: mean 0.038 mm/d, max 4.57 mm/d

Both well below climatological ~3 mm/d (5d isn't long enough to spin up); 2M within ~3× of 1M, consistent with the schemes' different autoconv + cold-phase treatments.

## Doc update (separate commit)

Per-step profiler at T63L47 finds steady-state RRTMGP costs are essentially identical for both schemes (~16 s per RAD call, ~100 ms per cache step) — the 2M overhead is one-time compile only. So the previous ``~4× grey total amortised`` claim was off by ~3×; updated to the measured ~12× at T63L47.

## Test plan

- [x] All 47 `lohmann_2m` unit tests still pass
- [x] CPU ECHAM test sweep (46 passed / 1 skipped)
- [x] T63L47 30d grey + sponge real-terrain (hard-pass)
- [x] T63L47 30d RRTMGP + sponge real-terrain (hard-pass)
- [x] Day-5 precip diagnostic in physical Earth-like range
- [ ] Reviewer: confirm the 4 extra prognostic tracers (qnc, qni, qr, qs) don't conflict with anything downstream

## Stacked on #458

Base is `debug/echam-land-fixes-v2`. After #458 lands on `dev`, this PR will auto-rebase against `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)