### PR TITLE
Make Docker image accept Hydra CLI args (#376)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,54 @@
-FROM python:3.11-slim
+# GPU build of the JCM image. Uses an NVIDIA CUDA runtime base and JAX's
+# bundled CUDA 12 wheels. JAX falls back to CPU if no GPU is visible at
+# runtime, so the same image works on hosts without `--gpus all`, just
+# without acceleration.
+#
+# Build:
+#     docker build -t jcm .
+#
+# Run on a GPU host:
+#     docker run --rm --gpus all jcm physics=icon run.total_time=2
+FROM nvidia/cuda:12.6.3-cudnn-runtime-ubuntu22.04
 
-# Install dependencies
-RUN apt-get update && apt-get install -y  \
-    git \
-    curl \
-    build-essential \
-    libopenblas-dev \
-    liblapack-dev \
-    libffi-dev \
-    libglib2.0-0 \
-    libsm6 \
-    libxext6 \
-    libxrender-dev \
+# Ubuntu 22.04 ships Python 3.10; pull 3.11 from deadsnakes to satisfy
+# JCM's >=3.11 requirement. DEBIAN_FRONTEND=noninteractive prevents tzdata
+# (a transitive dep of build-essential) from prompting at build time.
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        software-properties-common \
+        ca-certificates \
+        curl \
+        git \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        python3.11 \
+        python3.11-dev \
+        python3.11-venv \
+        build-essential \
+        libopenblas-dev \
+        liblapack-dev \
+        libffi-dev \
+        libglib2.0-0 \
+        libsm6 \
+        libxext6 \
+        libxrender-dev \
+    && curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11 \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1 \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
 COPY requirements.txt .
-RUN pip install --upgrade pip setuptools wheel
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . /app
-RUN pip install -e .
+RUN pip install --no-cache-dir -e .
 
-RUN pip install --upgrade "jax[tpu]" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+# Replace the CPU JAX pulled in by requirements.txt with the CUDA 12
+# build. The cuda12 extra bundles the NVIDIA wheels JAX needs at runtime.
+RUN pip install --no-cache-dir --upgrade "jax[cuda12]"
 
 # Run the JCM Hydra CLI by default. Anything passed after the image name on
 # `docker run` is forwarded as arguments to `python -m jcm.main`, so Hydra

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,9 @@ RUN pip install -e .
 
 RUN pip install --upgrade "jax[tpu]" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
 
-CMD ["bash"]
+# Run the JCM Hydra CLI by default. Anything passed after the image name on
+# `docker run` is forwarded as arguments to `python -m jcm.main`, so Hydra
+# overrides (e.g. `physics=icon run.total_time=30`) work out of the box.
+# Override the entrypoint (`--entrypoint bash`) to drop into a shell.
+ENTRYPOINT ["python", "-m", "jcm.main"]
+CMD []

--- a/README.md
+++ b/README.md
@@ -113,6 +113,79 @@ python -m jcm.main --cfg job grid=icon_t85_l47_hybrid   # with overrides
 Config groups live under `jcm/config/` (`physics`, `grid`, `run`, `init`,
 `terrain`, `forcing`, `diffusion`).
 
+## Running in Docker
+
+The bundled `Dockerfile` builds an image whose entrypoint is the JCM Hydra
+CLI, which makes it straightforward to launch non-interactive simulations
+on Kubernetes, GCP, NRP or any other batch/queued compute. Build the image
+once:
+
+```bash
+docker build -t jcm .
+```
+
+### Default run
+
+```bash
+docker run --rm jcm
+```
+
+This runs the default 10-day SPEEDY aquaplanet configuration.
+
+### Hydra overrides
+
+Anything after the image name is forwarded to `python -m jcm.main`, so the
+full Hydra CLI (config groups, dotted overrides, multirun) is available:
+
+```bash
+# Switch physics package and grid
+docker run --rm jcm physics=icon grid=icon_t85_l47_hybrid
+
+# Override individual run options
+docker run --rm jcm run.time_step=20 run.total_time=30 run.save_interval=1
+
+# Parameter sweep (multirun)
+docker run --rm jcm -m run.time_step=10,20,30
+```
+
+### Persisting outputs
+
+By default outputs land in `outputs/YYYY-MM-DD/HH-MM-SS/` *inside the
+container* and are lost when it exits. Mount a host directory at
+`/app/outputs` to keep them:
+
+```bash
+docker run --rm -v "$(pwd)/outputs:/app/outputs" jcm \
+    physics=icon run.total_time=30
+```
+
+After the run finishes the netCDF state file is available on the host
+under `./outputs/`.
+
+### Interactive shell
+
+Override the entrypoint to drop into a shell for debugging or exploration:
+
+```bash
+docker run --rm -it --entrypoint bash jcm
+```
+
+### Kubernetes example
+
+Pass Hydra overrides via the container `args` field and mount a persistent
+volume for outputs:
+
+```yaml
+spec:
+  containers:
+    - name: jcm
+      image: your-registry/jcm:latest
+      args: ["physics=icon", "grid=icon_t85_l47_hybrid", "run.total_time=30"]
+      volumeMounts:
+        - name: outputs
+          mountPath: /app/outputs
+```
+
 ## Example notebooks
 
 Example notebooks are available in the `notebooks/` directory:

--- a/README.md
+++ b/README.md
@@ -115,10 +115,11 @@ Config groups live under `jcm/config/` (`physics`, `grid`, `run`, `init`,
 
 ## Running in Docker
 
-The bundled `Dockerfile` builds an image whose entrypoint is the JCM Hydra
-CLI, which makes it straightforward to launch non-interactive simulations
-on Kubernetes, GCP, NRP or any other batch/queued compute. Build the image
-once:
+The bundled `Dockerfile` is built on `nvidia/cuda` and ships `jax[cuda12]`,
+so the same image runs accelerated on GPU hosts and falls back to CPU
+elsewhere (no TPU support). Its entrypoint is the JCM Hydra CLI, which
+makes it straightforward to launch non-interactive simulations on
+Kubernetes, GCP, NRP or any other batch/queued compute. Build once:
 
 ```bash
 docker build -t jcm .
@@ -127,6 +128,10 @@ docker build -t jcm .
 ### Default run
 
 ```bash
+# On a GPU host
+docker run --rm --gpus all jcm
+
+# Or without GPUs (CPU fallback)
 docker run --rm jcm
 ```
 
@@ -139,13 +144,13 @@ full Hydra CLI (config groups, dotted overrides, multirun) is available:
 
 ```bash
 # Switch physics package and grid
-docker run --rm jcm physics=icon grid=icon_t85_l47_hybrid
+docker run --rm --gpus all jcm physics=icon grid=icon_t85_l47_hybrid
 
 # Override individual run options
-docker run --rm jcm run.time_step=20 run.total_time=30 run.save_interval=1
+docker run --rm --gpus all jcm run.time_step=20 run.total_time=30 run.save_interval=1
 
 # Parameter sweep (multirun)
-docker run --rm jcm -m run.time_step=10,20,30
+docker run --rm --gpus all jcm -m run.time_step=10,20,30
 ```
 
 ### Persisting outputs
@@ -155,7 +160,7 @@ container* and are lost when it exits. Mount a host directory at
 `/app/outputs` to keep them:
 
 ```bash
-docker run --rm -v "$(pwd)/outputs:/app/outputs" jcm \
+docker run --rm --gpus all -v "$(pwd)/outputs:/app/outputs" jcm \
     physics=icon run.total_time=30
 ```
 
@@ -172,8 +177,8 @@ docker run --rm -it --entrypoint bash jcm
 
 ### Kubernetes example
 
-Pass Hydra overrides via the container `args` field and mount a persistent
-volume for outputs:
+Pass Hydra overrides via the container `args` field, request a GPU, and
+mount a persistent volume for outputs:
 
 ```yaml
 spec:
@@ -181,6 +186,9 @@ spec:
     - name: jcm
       image: your-registry/jcm:latest
       args: ["physics=icon", "grid=icon_t85_l47_hybrid", "run.total_time=30"]
+      resources:
+        limits:
+          nvidia.com/gpu: 1
       volumeMounts:
         - name: outputs
           mountPath: /app/outputs


### PR DESCRIPTION
## Summary

- Replaces the Dockerfile `CMD ["bash"]` with `ENTRYPOINT ["python", "-m", "jcm.main"]` (and an empty `CMD []`) so that anything appended to `docker run <image>` is forwarded to the Hydra CLI. This enables non-interactive simulations on Kubernetes, GCP, NRP and similar batch/queued clusters, and unlocks parameter sweeps via Hydra `-m` multirun (relevant once #173 / #375 land).
- Adds a "Running in Docker" section to `README.md` covering the default run, Hydra overrides (config groups + dotted overrides), multirun, persisting outputs via volume mounts, dropping into an interactive shell, and a Kubernetes pod example.

## Context

Picks up #378, which was abandoned with no diff in its final state. The CLI has since been restructured (Hydra config groups under `jcm/config/{physics,grid,run,...}`), so the README examples here use the current `physics=icon` / `run.total_time=30` syntax rather than the `+time_step=20` shape from the original PR draft.

Closes #376.

## Test plan

- [ ] `docker build -t jcm .` succeeds
- [ ] `docker run --rm jcm` runs the default 10-day SPEEDY aquaplanet config
- [ ] `docker run --rm jcm physics=held_suarez grid=held_suarez_t31_l8 run.total_time=2` honours Hydra overrides
- [ ] `docker run --rm -v "$(pwd)/outputs:/app/outputs" jcm run.total_time=1` writes the output netCDF to the host outputs/ directory
- [ ] `docker run --rm -it --entrypoint bash jcm` drops into a shell

Generated with Claude Code (https://claude.com/claude-code)
