### PR TITLE
Fix output_averages crash on hybrid coords (#463)

### DIFF
--- a/jcm/model.py
+++ b/jcm/model.py
@@ -239,17 +239,25 @@ def averaged_trajectory_from_step(
             _, updated_diag_state = nnx.split(temp_collector_inner)
             return (x_next, x_sum, updated_diag_state), empty_output
 
+        # `post_process_fn` is applied per-save inside the scan body so it
+        # sees a single instantaneous state, matching dinosaur's
+        # `trajectory_from_step`. Calling it once on the stacked trajectory
+        # would add a leading time axis to the surface pressure that
+        # `compute_diagnostic_state_hybrid` cannot broadcast against the
+        # `(nlev,)` hybrid `a/b_thickness` arrays — that bug only happens
+        # to slip through on sigma coords (where `a_thickness` is zero).
         @nnx.scan(in_axes=(nnx.Carry,), out_axes=out_axes, length=outer_steps)
         def outer_step(carry):
             (x_final, x_sum, diag_state), _ = inner_step(carry)
             temp_collector_outer = nnx.merge(graphdef, diag_state)
             temp_collector_outer.i.value += 1
             _, updated_diag_state = nnx.split(temp_collector_outer)
-            return (x_final, empty_sum, updated_diag_state), (x_sum / inner_steps,)
-        
+            averaged_state = x_sum / inner_steps
+            return (x_final, empty_sum, updated_diag_state), (post_process_fn(averaged_state),)
+
         carry = (x_initial, empty_sum, init_diag_state)
         (x_final, _, final_diag_state), (preds,) = outer_step(carry)
-        return x_final, post_process_fn(preds).replace(
+        return x_final, preds.replace(
             physics=nnx.merge(graphdef, final_diag_state).data.value,
         )
 

--- a/jcm/model_test.py
+++ b/jcm/model_test.py
@@ -157,6 +157,52 @@ class TestModelUnit(unittest.TestCase):
         )
 
     @pytest.mark.slow
+    def test_echam_hybrid_model_output_averages(self):
+        """Regression test for #463.
+
+        ``output_averages=True`` on hybrid vertical coordinates used to crash
+        in ``compute_diagnostic_state_hybrid`` because the post-processor was
+        applied once to the stacked trajectory (with a leading time axis on
+        the surface pressure) instead of per-save. The fix moves
+        post-processing inside the scan body. Sigma coords masked the bug
+        because their ``a_thickness`` is zero so the bad broadcast happened
+        to succeed.
+        """
+        import logging
+        from jcm.model import Model
+        from jcm.utils import get_coords
+        from jcm.physics.echam.echam_levels import get_echam_levels
+        from jcm.physics.echam.echam_terms import echam_physics
+
+        # Smallest hybrid setup that exercises the same code path as the
+        # T63L47 + real-terrain configuration that surfaced the bug.
+        coords = get_coords(get_echam_levels(47), spectral_truncation=31)
+        model = Model(
+            coords=coords,
+            physics=echam_physics(radiation_scheme="grey", checkpoint_terms=False),
+            time_step=3.0,
+            log_level=logging.CRITICAL,
+        )
+
+        save_interval = 1.0 / 24.0  # 1 hour
+        total_time = 2.0 / 24.0     # 2 hours -> 2 saves
+        preds = model.run(
+            save_interval=save_interval,
+            total_time=total_time,
+            output_averages=True,
+        )
+
+        # Predictions should carry a leading time axis matching the number
+        # of saves and the spatial dims should match the model grid — i.e.
+        # the post-processor ran per-save on a single state, not once on
+        # the stacked trajectory.
+        n_saves = int(total_time / save_interval)
+        self.assertEqual(preds.dynamics.temperature.shape[0], n_saves)
+        self.assertEqual(
+            preds.dynamics.temperature.shape[1:], coords.nodal_shape,
+        )
+
+    @pytest.mark.slow
     def test_speedy_model_gradients_isnan(self):
         from jcm.model import Model
         from jcm.utils import ones_like


### PR DESCRIPTION
## Summary

Fixes #463: `model.run(output_averages=True, ...)` crashes on hybrid vertical coordinates with `TypeError: mul got incompatible shapes for broadcasting: (47, 1, 1, 1), (N, 1, lon, lat)`.

`averaged_trajectory_from_step` applied `post_process_fn` once to the stacked trajectory, so the post-processor saw a leading time axis on the surface pressure. `compute_diagnostic_state_hybrid` then tried to broadcast `(nlev,)` `a/b_thickness` against `(time, 1, lat, lon)` and failed. Sigma coords happened to mask this — their `a_thickness` is zero, so the multiplication degenerated and the broadcast snuck through.

The fix moves `post_process_fn` inside the scan body in `averaged_trajectory_from_step` (matching the per-save semantics of dinosaur's `trajectory_from_step`). The scan now stacks already-post-processed `Predictions` along the time axis, and the trailing `replace(physics=...)` continues to swap in the diagnostics collectors accumulated stack.

This is fix idea (1) from the issue.

## Test plan

- [x] New regression test `test_echam_hybrid_model_output_averages` (T31 + 47-level hybrid + ECHAM, two-save run with `output_averages=True`). Pre-fix it reproduces the issues exact traceback (`mul got incompatible shapes for broadcasting: (47, 1, 1, 1), (2, 1, 96, 48)`); post-fix it passes and asserts the leading time axis matches the number of saves and per-save spatial dims match the model grid.
- [x] Existing `test_speedy_model_averages` (sigma + SPEEDY) still passes — no regression on the path that previously worked.
- [x] `pytest jcm/model_test.py` — 11 passed, 1 skipped.
- [x] `pytest jcm/physics_interface_hybrid_test.py` — 2 passed.
- [x] `ruff check .` — clean.

Generated with Claude Code (https://claude.com/claude-code)
