### PR TITLE
feat: publish JCM image to GHCR on release (modernized Dockerfile + workflow)

### DIFF
--- a/.github/workflows/build_docker_image.yaml
+++ b/.github/workflows/build_docker_image.yaml
@@ -1,0 +1,92 @@
+# Build the JCM container image and push to GHCR on each published release.
+#
+# Why `release: published` instead of `push: tags: [v*]`? Matches the
+# convention used by python-publish.yml so a single GitHub Release fires
+# both PyPI and image publication, keeping the tag-to-artifact mapping
+# consistent. The `Verify tag is on main` step rejects releases cut from
+# a non-main branch — without it, `release: published` would happily run
+# on any tagged commit.
+name: Build Docker image
+
+on:
+  release:
+    types: [published]
+  # Allow maintainers to trigger a build out-of-band (e.g. to retry a
+  # failed release run). The image is tagged with `manual-<sha>` so it
+  # can't shadow a real release artifact.
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to build (commit SHA, branch, or tag)'
+        required: false
+        default: main
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+          # Need full history so `merge-base --is-ancestor` can resolve
+          # main and the tagged commit.
+          fetch-depth: 0
+
+      - name: Verify tag is on main
+        if: github.event_name == 'release'
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::Release commit $GITHUB_SHA is not reachable from origin/main — refusing to build a release image from an off-main branch."
+            exit 1
+          fi
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags
+        id: tags
+        run: |
+          IMAGE="ghcr.io/${{ github.repository_owner }}/jcm"
+          SHORT_SHA="${GITHUB_SHA::7}"
+          if [ "${{ github.event_name }}" = "release" ]; then
+            # e.g. v1.2.3 -> push :latest, :v1.2.3, :<short-sha>
+            TAGS="$IMAGE:latest,$IMAGE:${{ github.event.release.tag_name }},$IMAGE:$SHORT_SHA"
+          else
+            # workflow_dispatch — don't poison :latest from an ad-hoc run
+            TAGS="$IMAGE:manual-$SHORT_SHA"
+          fi
+          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+          echo "Pushing tags: $TAGS"
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          # GHA cache cuts subsequent builds from ~40min (local QEMU) to
+          # a few minutes when only requirements.txt / source changed.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # OCI metadata: lets `docker inspect` / GHCR show the source.
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ github.event.release.tag_name || github.sha }}

--- a/.github/workflows/build_docker_image.yaml
+++ b/.github/workflows/build_docker_image.yaml
@@ -37,12 +37,24 @@ jobs:
           # main and the tagged commit.
           fetch-depth: 0
 
+      - name: Resolve checked-out commit
+        id: commit
+        # `$GITHUB_SHA` reflects the workflow's dispatched ref, not the
+        # `inputs.ref` we just checked out — so for a workflow_dispatch
+        # with a non-default `ref` they differ. Read the SHA out of the
+        # working tree so tag computation and OCI labels match the code
+        # we actually build.
+        run: |
+          SHA=$(git rev-parse HEAD)
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${SHA:0:7}" >> "$GITHUB_OUTPUT"
+
       - name: Verify tag is on main
         if: github.event_name == 'release'
         run: |
           git fetch origin main
-          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
-            echo "::error::Release commit $GITHUB_SHA is not reachable from origin/main — refusing to build a release image from an off-main branch."
+          if ! git merge-base --is-ancestor "${{ steps.commit.outputs.sha }}" origin/main; then
+            echo "::error::Release commit ${{ steps.commit.outputs.sha }} is not reachable from origin/main — refusing to build a release image from an off-main branch."
             exit 1
           fi
 
@@ -63,7 +75,7 @@ jobs:
         id: tags
         run: |
           IMAGE="ghcr.io/${{ github.repository_owner }}/jcm"
-          SHORT_SHA="${GITHUB_SHA::7}"
+          SHORT_SHA="${{ steps.commit.outputs.short_sha }}"
           if [ "${{ github.event_name }}" = "release" ]; then
             # e.g. v1.2.3 -> push :latest, :v1.2.3, :<short-sha>
             TAGS="$IMAGE:latest,$IMAGE:${{ github.event.release.tag_name }},$IMAGE:$SHORT_SHA"
@@ -86,7 +98,9 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           # OCI metadata: lets `docker inspect` / GHCR show the source.
+          # `steps.commit.outputs.sha` (not `github.sha`) so the revision
+          # label matches the code we built — see the comment above.
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.version=${{ github.event.release.tag_name || github.sha }}
+            org.opencontainers.image.revision=${{ steps.commit.outputs.sha }}
+            org.opencontainers.image.version=${{ github.event.release.tag_name || steps.commit.outputs.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,64 @@
-FROM python:3.11-slim
+# GPU build of the JCM image. Uses the slim `cuda:base` image (just the
+# driver-compat shim and CUDA repo metadata, no preinstalled CUDA/cuDNN
+# libs) and lets `jax[cuda12]` pull its own bundled NVIDIA wheels —
+# cuBLAS, cuDNN, NCCL, etc. live under `nvidia-*-cu12` in pip and JAX
+# loads them from there at import time. Going from `cudnn-runtime` to
+# `base` cuts the final image from ~6 GiB to ~2 GiB without giving up
+# anything JAX uses.
+#
+# JAX falls back to CPU if no GPU is visible at runtime, so the same
+# image works on hosts without `--gpus all`, just without acceleration.
+#
+# Build:
+#     docker build -t jcm .
+#
+# Run on a GPU host:
+#     docker run --rm --gpus all jcm physics=icon run.total_time=2
+FROM nvidia/cuda:12.6.3-base-ubuntu22.04
 
-# Install dependencies
-RUN apt-get update && apt-get install -y  \
-    git \
-    curl \
-    build-essential \
-    libopenblas-dev \
-    liblapack-dev \
-    libffi-dev \
-    libglib2.0-0 \
-    libsm6 \
-    libxext6 \
-    libxrender-dev \
+# Ubuntu 22.04 ships Python 3.10; pull 3.11 from deadsnakes to satisfy
+# JCM's >=3.11 requirement. DEBIAN_FRONTEND=noninteractive prevents tzdata
+# (a transitive dep of build-essential) from prompting at build time.
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        software-properties-common \
+        ca-certificates \
+        curl \
+        git \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        python3.11 \
+        python3.11-dev \
+        python3.11-venv \
+        build-essential \
+        libopenblas-dev \
+        liblapack-dev \
+        libffi-dev \
+        libglib2.0-0 \
+        libsm6 \
+        libxext6 \
+        libxrender-dev \
+    && curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11 \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1 \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
 COPY requirements.txt .
-RUN pip install --upgrade pip setuptools wheel
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . /app
-RUN pip install -e .
+RUN pip install --no-cache-dir -e .
 
-RUN pip install --upgrade "jax[tpu]" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+# Replace the CPU JAX pulled in by requirements.txt with the CUDA 12
+# build. The cuda12 extra bundles the NVIDIA wheels JAX needs at runtime.
+RUN pip install --no-cache-dir --upgrade "jax[cuda12]"
 
-CMD ["bash"]
+# Run the JCM Hydra CLI by default. Anything passed after the image name on
+# `docker run` is forwarded as arguments to `python -m jcm.main`, so Hydra
+# overrides (e.g. `physics=icon run.total_time=30`) work out of the box.
+# Override the entrypoint (`--entrypoint bash`) to drop into a shell.
+ENTRYPOINT ["python", "-m", "jcm.main"]
+CMD []


### PR DESCRIPTION
## Summary

- Ports the modernized `Dockerfile` (GPU base + non-interactive Hydra
  CLI ENTRYPOINT, originally tracked in #376 / #464 on `dev`) to `main`,
  with a swap from `cudnn-runtime` to the slim `cuda:base` so the final
  image lands at ~2 GiB instead of ~6 GiB.
- Adds `.github/workflows/build_docker_image.yaml` to publish the JCM
  image to `ghcr.io/climate-analytics-lab/jcm` on every published
  Release (tags: `:latest`, `:vX.Y.Z`, `:<short-sha>`). A guard step
  rejects the build if the released commit is not reachable from
  `origin/main`, so off-main release branches can't ship images.
- Exposes `workflow_dispatch` for ad-hoc dev builds; those publish as
  `:manual-<short-sha>` so they can't shadow a real release. The
  workflow file must live on the default branch for `workflow_dispatch`
  to be triggerable, which is why this PR targets `main` directly
  rather than going through `dev` first.

Companion PR against `dev` adds the matching Kubernetes Job/Pod/PVC
templates under `deploy/k8s/` (manifests + README) -- see the linked
branch `feat/k8s-deployment`.

## Test plan

- [ ] Workflow YAML parses (validated locally with PyYAML).
- [ ] Trigger `workflow_dispatch` against this branch after merge and
      confirm an image is pushed as
      `ghcr.io/climate-analytics-lab/jcm:manual-<short-sha>`.
- [ ] `docker pull` the pushed image on the NRP cluster and verify
      `python -m jcm.main run=smoke physics=speedy` completes (already
      verified end-to-end against a manually built `:7f00896` image
      from this Dockerfile -- the slim-base swap is the only change
      since that validation).
- [ ] On the next published Release, confirm the workflow fires
      automatically and the main-guard step passes when the tag is on
      main.

Generated with [Claude Code](https://claude.com/claude-code)
