### PR TITLE
feat(deploy): NRP Nautilus k8s manifests for JCM Hydra runs

### DIFF
--- a/.github/workflows/build_docker_image.yaml
+++ b/.github/workflows/build_docker_image.yaml
@@ -1,0 +1,92 @@
+# Build the JCM container image and push to GHCR on each published release.
+#
+# Why `release: published` instead of `push: tags: [v*]`? Matches the
+# convention used by python-publish.yml so a single GitHub Release fires
+# both PyPI and image publication, keeping the tag-to-artifact mapping
+# consistent. The `Verify tag is on main` step rejects releases cut from
+# a non-main branch — without it, `release: published` would happily run
+# on any tagged commit.
+name: Build Docker image
+
+on:
+  release:
+    types: [published]
+  # Allow maintainers to trigger a build out-of-band (e.g. to retry a
+  # failed release run). The image is tagged with `manual-<sha>` so it
+  # can't shadow a real release artifact.
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to build (commit SHA, branch, or tag)'
+        required: false
+        default: main
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+          # Need full history so `merge-base --is-ancestor` can resolve
+          # main and the tagged commit.
+          fetch-depth: 0
+
+      - name: Verify tag is on main
+        if: github.event_name == 'release'
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::Release commit $GITHUB_SHA is not reachable from origin/main — refusing to build a release image from an off-main branch."
+            exit 1
+          fi
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags
+        id: tags
+        run: |
+          IMAGE="ghcr.io/${{ github.repository_owner }}/jcm"
+          SHORT_SHA="${GITHUB_SHA::7}"
+          if [ "${{ github.event_name }}" = "release" ]; then
+            # e.g. v1.2.3 -> push :latest, :v1.2.3, :<short-sha>
+            TAGS="$IMAGE:latest,$IMAGE:${{ github.event.release.tag_name }},$IMAGE:$SHORT_SHA"
+          else
+            # workflow_dispatch — don't poison :latest from an ad-hoc run
+            TAGS="$IMAGE:manual-$SHORT_SHA"
+          fi
+          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+          echo "Pushing tags: $TAGS"
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          # GHA cache cuts subsequent builds from ~40min (local QEMU) to
+          # a few minutes when only requirements.txt / source changed.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # OCI metadata: lets `docker inspect` / GHCR show the source.
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ github.event.release.tag_name || github.sha }}

--- a/.github/workflows/build_docker_image.yaml
+++ b/.github/workflows/build_docker_image.yaml
@@ -37,12 +37,24 @@ jobs:
           # main and the tagged commit.
           fetch-depth: 0
 
+      - name: Resolve checked-out commit
+        id: commit
+        # `$GITHUB_SHA` reflects the workflow's dispatched ref, not the
+        # `inputs.ref` we just checked out — so for a workflow_dispatch
+        # with a non-default `ref` they differ. Read the SHA out of the
+        # working tree so tag computation and OCI labels match the code
+        # we actually build.
+        run: |
+          SHA=$(git rev-parse HEAD)
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${SHA:0:7}" >> "$GITHUB_OUTPUT"
+
       - name: Verify tag is on main
         if: github.event_name == 'release'
         run: |
           git fetch origin main
-          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
-            echo "::error::Release commit $GITHUB_SHA is not reachable from origin/main — refusing to build a release image from an off-main branch."
+          if ! git merge-base --is-ancestor "${{ steps.commit.outputs.sha }}" origin/main; then
+            echo "::error::Release commit ${{ steps.commit.outputs.sha }} is not reachable from origin/main — refusing to build a release image from an off-main branch."
             exit 1
           fi
 
@@ -63,7 +75,7 @@ jobs:
         id: tags
         run: |
           IMAGE="ghcr.io/${{ github.repository_owner }}/jcm"
-          SHORT_SHA="${GITHUB_SHA::7}"
+          SHORT_SHA="${{ steps.commit.outputs.short_sha }}"
           if [ "${{ github.event_name }}" = "release" ]; then
             # e.g. v1.2.3 -> push :latest, :v1.2.3, :<short-sha>
             TAGS="$IMAGE:latest,$IMAGE:${{ github.event.release.tag_name }},$IMAGE:$SHORT_SHA"
@@ -86,7 +98,9 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           # OCI metadata: lets `docker inspect` / GHCR show the source.
+          # `steps.commit.outputs.sha` (not `github.sha`) so the revision
+          # label matches the code we built — see the comment above.
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.version=${{ github.event.release.tag_name || github.sha }}
+            org.opencontainers.image.revision=${{ steps.commit.outputs.sha }}
+            org.opencontainers.image.version=${{ github.event.release.tag_name || steps.commit.outputs.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,11 @@
 # libs) and lets `jax[cuda12]` pull its own bundled NVIDIA wheels —
 # cuBLAS, cuDNN, NCCL, etc. live under `nvidia-*-cu12` in pip and JAX
 # loads them from there at import time. Going from `cudnn-runtime` to
-# `base` cuts the final image from ~6 GiB to ~2 GiB without giving up
-# anything JAX uses.
+# `base` cuts the compressed registry size from ~6.0 GiB to ~3.8 GiB
+# (about 36%, measured 2026-05-12). Savings are smaller than you might
+# expect because JAX detects system-installed CUDA libs and skips its
+# bundled wheels when they're available — so the old base wasn't pure
+# overhead, it was substituting for the wheels.
 #
 # JAX falls back to CPU if no GPU is visible at runtime, so the same
 # image works on hosts without `--gpus all`, just without acceleration.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,20 @@
-# GPU build of the JCM image. Uses an NVIDIA CUDA runtime base and JAX's
-# bundled CUDA 12 wheels. JAX falls back to CPU if no GPU is visible at
-# runtime, so the same image works on hosts without `--gpus all`, just
-# without acceleration.
+# GPU build of the JCM image. Uses the slim `cuda:base` image (just the
+# driver-compat shim and CUDA repo metadata, no preinstalled CUDA/cuDNN
+# libs) and lets `jax[cuda12]` pull its own bundled NVIDIA wheels —
+# cuBLAS, cuDNN, NCCL, etc. live under `nvidia-*-cu12` in pip and JAX
+# loads them from there at import time. Going from `cudnn-runtime` to
+# `base` cuts the final image from ~6 GiB to ~2 GiB without giving up
+# anything JAX uses.
+#
+# JAX falls back to CPU if no GPU is visible at runtime, so the same
+# image works on hosts without `--gpus all`, just without acceleration.
 #
 # Build:
 #     docker build -t jcm .
 #
 # Run on a GPU host:
 #     docker run --rm --gpus all jcm physics=icon run.total_time=2
-FROM nvidia/cuda:12.6.3-cudnn-runtime-ubuntu22.04
+FROM nvidia/cuda:12.6.3-base-ubuntu22.04
 
 # Ubuntu 22.04 ships Python 3.10; pull 3.11 from deadsnakes to satisfy
 # JCM's >=3.11 requirement. DEBIAN_FRONTEND=noninteractive prevents tzdata

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -1,0 +1,166 @@
+# Running JCM on Kubernetes (NRP Nautilus example)
+
+This directory holds example manifests for running JCM as a non-interactive
+batch job on the [NRP Nautilus](https://nrp.ai/documentation/) Kubernetes
+cluster. The same manifests work on any cluster with NVIDIA GPU operators
+installed; only the storage class and registry path need adjustment.
+
+The container `ENTRYPOINT` is `python -m jcm.main`, so anything you pass
+as args is treated as Hydra overrides — see [`jcm/config/`](../../jcm/config/)
+for the available config groups.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| [`job.yaml`](./job.yaml) | One-shot batch Job for a JCM simulation run (GPU). |
+| [`interactive-pod.yaml`](./interactive-pod.yaml) | Long-lived pod for `kubectl exec` debugging (no GPU by default). |
+| [`pvc.yaml`](./pvc.yaml) | Optional 50 GiB PVC for persisting outputs across Job runs. |
+
+Each manifest uses `${VAR}` placeholders that `envsubst` expands at apply
+time, so secrets and per-run parameters never get committed.
+
+## Prerequisites
+
+1. **`kubectl` + `kubelogin`.** NRP uses OIDC, which requires the
+   `kubelogin` plugin (separate from `kubectl`):
+   ```bash
+   brew install int128/kubelogin/kubelogin   # macOS
+   # or: go install github.com/int128/kubelogin/cmd/kubelogin@latest
+   ```
+   Verify with `kubectl auth whoami` against the `nautilus` context.
+
+2. **Namespace.** NRP issues a per-group namespace. Pin it for the current
+   context so you don't have to pass `-n` every time:
+   ```bash
+   kubectl config set-context --current --namespace=<your-namespace>
+   ```
+   For the Climate Analytics Lab, the namespace is `climate-analytics`.
+
+3. **A pushed image.** NRP nodes need to pull JCM from a registry they can
+   reach. Released versions are published to GHCR automatically by
+   [`build_docker_image.yaml`](../../.github/workflows/build_docker_image.yaml)
+   on every GitHub Release, tagged `:latest`, `:vX.Y.Z`, and `:<short-sha>`:
+
+   ```
+   ghcr.io/climate-analytics-lab/jcm:latest
+   ```
+
+   To cut a release: tag a commit on `main` and create a Release in the
+   GitHub UI (or `gh release create vX.Y.Z`). The workflow guards
+   against publishing from off-main branches.
+
+   For ad-hoc dev images use `workflow_dispatch` (Actions tab → Build
+   Docker image → Run workflow). Those publish as `:manual-<short-sha>`
+   so they can't shadow a real release.
+
+   **Local fallback** when you need a build before a release:
+   ```bash
+   # Apple Silicon needs --platform; native amd64 hosts can omit it.
+   docker buildx build --platform=linux/amd64 \
+     -t ghcr.io/climate-analytics-lab/jcm:dev-$(git rev-parse --short HEAD) \
+     --push .
+   ```
+   Expect ~40 min under QEMU emulation on M-series Macs (vs ~5 min via
+   GHA cache hits).
+
+   Alternative registry: **NRP's GitLab**,
+   `gitlab-registry.nrp-nautilus.io/<group>/jcm` — lives inside the
+   cluster so pulls are fast, but needs you to set up that GitLab repo
+   first.
+
+   `envsubst` is in `gettext` on macOS: `brew install gettext`.
+
+## Submitting a Job
+
+```bash
+export JCM_IMAGE=ghcr.io/climate-analytics-lab/jcm:latest
+export JCM_JOB_NAME=jcm-icon-t31-$(date +%s)
+export JCM_HYDRA_ARGS='physics=icon run.total_time=24'
+
+envsubst < deploy/k8s/job.yaml | kubectl apply -f -
+```
+
+Watch it run:
+
+```bash
+kubectl get jobs,pods -l app=jcm
+kubectl logs -f -l job-name=$JCM_JOB_NAME --tail=200
+```
+
+Copy outputs out when it's done (if you didn't mount a PVC):
+
+```bash
+POD=$(kubectl get pod -l job-name=$JCM_JOB_NAME -o jsonpath='{.items[0].metadata.name}')
+kubectl cp "$POD:/app/outputs" ./outputs-from-$JCM_JOB_NAME
+```
+
+Delete a finished Job manually if you don't want to wait for the TTL:
+
+```bash
+kubectl delete job $JCM_JOB_NAME
+```
+
+## Interactive debugging
+
+```bash
+export JCM_IMAGE=ghcr.io/climate-analytics-lab/jcm:latest
+envsubst < deploy/k8s/interactive-pod.yaml | kubectl apply -f -
+kubectl exec -it jcm-shell -- bash
+# ...poke around, run `python -m jcm.main physics=speedy run.total_time=1`, etc.
+kubectl delete pod jcm-shell    # please don't forget — see NRP etiquette
+```
+
+## Picking a GPU
+
+The default `nvidia.com/gpu: 1` request lets the scheduler pick any
+available GPU. For specific models, edit `job.yaml`:
+
+- **A100 / H100 / H200** — switch the resource key to
+  `nvidia.com/a100`, `nvidia.com/h100`, `nvidia.com/h200`. These nodes
+  are reservation-gated; check the NRP cluster resources page first.
+- **A40 / RTX A6000 / RTX 6000 Blackwell** — use `nvidia.com/a40`,
+  `nvidia.com/rtxa6000`, `nvidia.com/rtx6000bw`.
+- **MIG slice** — `nvidia.com/mig-small` for a 1g.10gb A100 slice
+  (cheaper, fine for T31 smoke tests).
+- **A specific consumer GPU model** — use `nodeAffinity` on
+  `nvidia.com/gpu.product` (commented example in `job.yaml`).
+
+For **Grace Hopper / ARM64** add the `nautilus.io/arm64` toleration and
+build an `arm64` image (the Dockerfile is portable; pass
+`--platform=linux/arm64` to `docker buildx build`).
+
+## Persisting outputs
+
+By default Hydra writes runs to `/app/outputs/YYYY-MM-DD/HH-MM-SS/`
+inside the container. Without a PVC, those vanish when the Job's pod is
+deleted. Apply `pvc.yaml` once per namespace, then uncomment the
+`outputs` volume blocks in `job.yaml` to mount the PVC at `/app/outputs`.
+
+If you need to share outputs across Jobs running concurrently, change
+`accessModes` in `pvc.yaml` from `ReadWriteOnce` to `ReadWriteMany`
+(NRP's `rook-cephfs` storage class supports both).
+
+## Resource sizing
+
+The defaults in `job.yaml` (1 GPU, 4–8 CPU, 16–32 GiB memory, 4 GiB
+`/dev/shm`) are sized for T31–T63 single-device runs. For larger
+truncations or longer integrations:
+
+- **Multi-GPU SPMD** — bump `nvidia.com/gpu` (up to 2 in a Pod, 8 in a
+  Job per NRP policy) and match the JCM sharding config in
+  `jcm/config/`.
+- **Big shared-memory ops** — raise `dshm.sizeLimit`. Without an
+  explicit limit NRP caps `/dev/shm` at 64 MB, which JAX collectives
+  outgrow quickly.
+
+## Etiquette
+
+NRP is a shared resource. Two things to keep in mind:
+
+1. **Delete finished pods.** The TTL on the Job does this automatically
+   after 24 h, but a successful run can be deleted immediately with
+   `kubectl delete job <name>`.
+2. **Don't sit on idle GPUs.** Use Jobs (which terminate) rather than
+   long-running Pods for actual work; the `interactive-pod.yaml`
+   template deliberately omits the GPU request for this reason.

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -81,6 +81,14 @@ export JCM_HYDRA_ARGS='physics=icon run.total_time=24'
 envsubst < deploy/k8s/job.yaml | kubectl apply -f -
 ```
 
+**For reproducible runs, prefer an immutable tag** (`:vX.Y.Z` or
+`:<short-sha>`) over `:latest`. With `:latest`, Kubernetes pulls on
+every Job (correct, since `:latest` is mutable) but you can't tell
+afterwards which build of the code actually ran. With an immutable
+tag, K8s reuses the cached image (saving the ~4 GiB pull) and the
+provenance is unambiguous. `:latest` is best reserved for quick
+iteration during development.
+
 Watch it run:
 
 ```bash

--- a/deploy/k8s/interactive-pod.yaml
+++ b/deploy/k8s/interactive-pod.yaml
@@ -22,7 +22,9 @@ spec:
   containers:
   - name: jcm
     image: ${JCM_IMAGE}
-    imagePullPolicy: IfNotPresent
+    # `imagePullPolicy` is intentionally unset — see the matching
+    # comment in job.yaml. K8s defaults to `Always` for `:latest`
+    # and `IfNotPresent` for immutable tags, which is exactly right.
     command: ["sleep", "infinity"]
     resources:
       limits:

--- a/deploy/k8s/interactive-pod.yaml
+++ b/deploy/k8s/interactive-pod.yaml
@@ -1,0 +1,50 @@
+# Interactive JCM pod for debugging / shelling in.
+#
+# Usage:
+#   export JCM_IMAGE=ghcr.io/climate-analytics-lab/jcm:latest
+#   envsubst < deploy/k8s/interactive-pod.yaml | kubectl apply -f -
+#   kubectl exec -it jcm-shell -- bash
+#   # ...work, then:
+#   kubectl delete pod jcm-shell
+#
+# This pod intentionally does NOT request a GPU by default — NRP asks
+# users not to sit on GPUs interactively. Uncomment the GPU resource
+# lines below if you actually need device access for the session.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: jcm-shell
+  labels:
+    app: jcm
+    purpose: interactive
+spec:
+  restartPolicy: Never
+  containers:
+  - name: jcm
+    image: ${JCM_IMAGE}
+    imagePullPolicy: IfNotPresent
+    command: ["sleep", "infinity"]
+    resources:
+      limits:
+        cpu: "4"
+        memory: 16Gi
+        ephemeral-storage: 20Gi
+        # nvidia.com/gpu: 1
+      requests:
+        cpu: "2"
+        memory: 8Gi
+        ephemeral-storage: 10Gi
+        # nvidia.com/gpu: 1
+    volumeMounts:
+    - name: dshm
+      mountPath: /dev/shm
+    # - name: outputs
+    #   mountPath: /app/outputs
+  volumes:
+  - name: dshm
+    emptyDir:
+      medium: Memory
+      sizeLimit: 2Gi
+  # - name: outputs
+  #   persistentVolumeClaim:
+  #     claimName: jcm-outputs

--- a/deploy/k8s/job.yaml
+++ b/deploy/k8s/job.yaml
@@ -55,7 +55,13 @@ spec:
       containers:
       - name: jcm
         image: ${JCM_IMAGE}
-        imagePullPolicy: IfNotPresent
+        # `imagePullPolicy` is intentionally unset: Kubernetes then
+        # defaults to `Always` for the `:latest` tag and `IfNotPresent`
+        # for everything else. That's what we want — `:latest` is
+        # mutable so we must re-pull (otherwise a node with a cached
+        # `:latest` would silently run stale code), but `:vX.Y.Z` and
+        # `:<sha>` tags are immutable, so reusing the cache is safe and
+        # saves a ~4 GiB pull on every Job.
         # Hydra overrides are inlined into a `bash -c` string at apply
         # time so users can pass a single shell-quoted string from the
         # CLI without YAML-escaping each token. `exec` replaces bash

--- a/deploy/k8s/job.yaml
+++ b/deploy/k8s/job.yaml
@@ -1,0 +1,110 @@
+# Example JCM batch Job for the NRP Nautilus cluster.
+#
+# Usage:
+#   export JCM_IMAGE=ghcr.io/climate-analytics-lab/jcm:latest
+#   export JCM_JOB_NAME=jcm-icon-t31           # must be a valid DNS label
+#   export JCM_HYDRA_ARGS='physics=icon run.total_time=24'
+#   envsubst < deploy/k8s/job.yaml | kubectl apply -f -
+#
+# `envsubst` is part of `gettext` on macOS (`brew install gettext`).
+#
+# The container ENTRYPOINT is `python -m jcm.main`, so JCM_HYDRA_ARGS is
+# forwarded verbatim as Hydra overrides — see jcm/config/ for the available
+# config groups. Anything Hydra accepts on the CLI works here.
+#
+# Why a Job (not a Deployment): JCM runs are finite, and NRP asks users to
+# release GPUs as soon as work finishes. `backoffLimit: 0` prevents the
+# scheduler from re-running a failed sim (which would silently waste a GPU
+# slot on a bug). `ttlSecondsAfterFinished` auto-deletes the Job object a
+# day later so the namespace doesn't fill up with completed Jobs.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JCM_JOB_NAME}
+  labels:
+    app: jcm
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        app: jcm
+        job-name: ${JCM_JOB_NAME}
+    spec:
+      restartPolicy: Never
+      # NRP nodes are tainted/labelled by GPU model. The generic
+      # `nvidia.com/gpu` request below lets the scheduler pick any
+      # available GPU. To pin to a specific model, switch the resource
+      # key (e.g. `nvidia.com/a100: 1`) and uncomment the affinity block.
+      #
+      # affinity:
+      #   nodeAffinity:
+      #     requiredDuringSchedulingIgnoredDuringExecution:
+      #       nodeSelectorTerms:
+      #       - matchExpressions:
+      #         - key: nvidia.com/gpu.product
+      #           operator: In
+      #           values: ["NVIDIA-A100-SXM4-80GB"]
+      #
+      # For ARM64 (GH200) nodes, also add:
+      # tolerations:
+      # - key: "nautilus.io/arm64"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+      containers:
+      - name: jcm
+        image: ${JCM_IMAGE}
+        imagePullPolicy: IfNotPresent
+        # Hydra overrides are inlined into a `bash -c` string at apply
+        # time so users can pass a single shell-quoted string from the
+        # CLI without YAML-escaping each token. `exec` replaces bash
+        # with python so signals (SIGTERM on Job deletion) reach JCM
+        # directly. The fully-rendered command is visible in
+        # `kubectl describe job/<name>`, which helps debugging.
+        command: ["/bin/bash", "-c"]
+        args:
+        - 'exec python -m jcm.main ${JCM_HYDRA_ARGS}'
+        env:
+        # JAX picks CUDA by default when a GPU is present. We list `cpu`
+        # explicitly because jcm uses `jax.debug.callback`, which needs
+        # to materialize inputs on the local CPU device — `JAX_PLATFORMS=cuda`
+        # alone hides CPU and the callback crashes at runtime.
+        - name: JAX_PLATFORMS
+          value: "cuda,cpu"
+        resources:
+          # NRP allows up to 2 GPUs per Pod and 8 per Job. Bump GPU
+          # count for multi-device runs once the SPMD sharding configs
+          # in jcm support more than one device.
+          #
+          # NRP policy: cpu/memory limit must be ≤ 1.2× request. The
+          # simplest way to satisfy that (and to land in the Guaranteed
+          # QoS class) is to set requests == limits.
+          limits:
+            nvidia.com/gpu: 1
+            cpu: "4"
+            memory: 16Gi
+            ephemeral-storage: 20Gi
+          requests:
+            nvidia.com/gpu: 1
+            cpu: "4"
+            memory: 16Gi
+            ephemeral-storage: 20Gi
+        volumeMounts:
+        # JAX collectives and dataloader workers expect a real /dev/shm.
+        # NRP defaults this to 64MB, which is too small for non-trivial
+        # batch sizes.
+        - name: dshm
+          mountPath: /dev/shm
+        # Uncomment to persist outputs across Job runs. Requires a PVC
+        # named `jcm-outputs` in the namespace (see pvc.yaml).
+        # - name: outputs
+        #   mountPath: /app/outputs
+      volumes:
+      - name: dshm
+        emptyDir:
+          medium: Memory
+          sizeLimit: 4Gi
+      # - name: outputs
+      #   persistentVolumeClaim:
+      #     claimName: jcm-outputs

--- a/deploy/k8s/pvc.yaml
+++ b/deploy/k8s/pvc.yaml
@@ -1,0 +1,25 @@
+# Persistent storage for JCM outputs.
+#
+# Apply once per namespace:
+#   kubectl apply -f deploy/k8s/pvc.yaml
+#
+# Then uncomment the `outputs` volume blocks in job.yaml / interactive-pod.yaml
+# to mount it at /app/outputs (where Hydra writes results by default).
+#
+# Storage class: NRP exposes several. `rook-cephfs` is a good default
+# (multi-AZ, ReadWriteMany-capable). Use ReadWriteOnce here since one
+# Job typically writes from a single pod; switch to ReadWriteMany if
+# you need to fan out reads from multiple pods at once.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jcm-outputs
+  labels:
+    app: jcm
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi
+  storageClassName: rook-cephfs


### PR DESCRIPTION
## Summary

- Adds `deploy/k8s/` with example Job, interactive Pod, and PVC
  manifests for running JCM on NRP Nautilus (or any cluster with the
  NVIDIA GPU operator). Manifests use `envsubst` placeholders so
  image, job name, and Hydra overrides can be set per-run without
  editing YAML.
- Resource requests/limits in `job.yaml` are equal (Guaranteed QoS
  class) to satisfy NRP's `limit <= 1.2 * request` admission policy.
  `JAX_PLATFORMS=cuda,cpu` (rather than `cuda` alone) is required
  because `jcm/model.py:751` uses `jax.debug.callback`, which
  materializes inputs on the local CPU device.
- Bundles the same GHCR publish workflow + slim-CUDA-base Dockerfile
  change that are going through #473 against `main` -- duplicating
  here so dev gains them too without waiting for the next dev/main
  sync. Both branches end up at the same Dockerfile and workflow
  content, so a future merge in either direction is conflict-free.

Closes #376 (the issue this work was tracked under, in the sense
that we now have an actual deployment story for Kubernetes rather
than just a CLI-args-friendly Dockerfile).

## Test plan

- [x] `kubectl apply` of `job.yaml` (rendered via `envsubst`) against
      NRP Nautilus succeeds in `climate-analytics` namespace.
- [x] Smoke run (`run=smoke physics=speedy`) completes end-to-end:
      image pull -> GPU-resident JCM run -> `smoke_run.nc` written ->
      pod exits 0.
- [x] Job cleanup via `ttlSecondsAfterFinished: 86400` works as
      designed (Job lingers 24h for log inspection, then auto-deletes).
- [ ] Re-run smoke test against the slim `:base`-derived image once
      #473 lands and the workflow publishes one.
- [ ] `interactive-pod.yaml` works for `kubectl exec` debugging
      (not GPU-gated by default; please don't sit on GPUs).
- [ ] `pvc.yaml` provisions cleanly on `rook-cephfs` and outputs
      persist across Job runs when mounted.

Generated with [Claude Code](https://claude.com/claude-code)
