### PR TITLE
docs(readme): refresh for ECHAM rename + T63L47 RRTMGP target config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ JCM is a physical climate model that combines the [Dinosaur](https://github.com/
 
 - **Fully Differentiable**: Automatic differentiation through the entire model using JAX
 - **GPU/TPU Accelerated**: JIT compilation and hardware acceleration via JAX
-- **Modular Physics**: SPEEDY and ICON physics packages with radiation, convection, clouds, and surface processes
-- **Composable**: Mix and match parameterizations across physics packages (e.g., SPEEDY convection + ICON radiation)
-- **Flexible Grids**: Spectral dynamical core supporting multiple resolutions (T21 to T425)
+- **Modular Physics**: SPEEDY and ECHAM physics packages with radiation, convection, clouds, and surface processes
+- **Composable**: Mix and match parameterizations across physics packages (e.g., SPEEDY convection + ECHAM radiation)
+- **Flexible Grids**: Spectral dynamical core supporting multiple resolutions (T21 to T425), including hybrid (a + b·P_s) vertical coordinates
+- **Climate-Quality Target Config**: T63L47 hybrid grid with ECHAM physics and RRTMGP radiation (`physics=echam-rrtmgp grid=echam_t63_l47_hybrid`) for production-grade runs
 - **ML-Ready**: Designed for hybrid physics-ML workflows and parameter optimization
 
 ## Installation
@@ -84,18 +85,22 @@ any Python:
 # Default 10-day SPEEDY aquaplanet
 python -m jcm.main
 
-# ICON physics on T85x47 hybrid coords with grey radiation
-python -m jcm.main physics=icon grid=icon_t85_l47_hybrid
+# Targeted production setup: ECHAM physics on T63L47 hybrid coords with RRTMGP radiation
+python -m jcm.main physics=echam-rrtmgp grid=echam_t63_l47_hybrid
+
+# ECHAM physics with the default grey two-stream radiation (cheaper, good for tuning)
+python -m jcm.main physics=echam grid=echam_t63_l47_hybrid
 
 # Held-Suarez 30-day integration
 python -m jcm.main physics=held_suarez grid=held_suarez_t31_l8 \
     run.total_time=30 run.save_interval=1
 
-# Override individual physics parameters
-python -m jcm.main physics=icon physics.params.convection.entrpen=4e-4
+# Override individual physics parameters (the leading `+` is required because
+# `params` defaults to the scheme's `.default()` and is not in the yaml).
+python -m jcm.main physics=echam +physics.terms.tiedtke_convection.params.entrpen=4e-4
 
-# Long ICON run with chunked health checks
-python -m jcm.main physics=icon grid=icon_t85_l47_hybrid run=longrun
+# Long ECHAM + RRTMGP run with chunked health checks
+python -m jcm.main physics=echam-rrtmgp grid=echam_t63_l47_hybrid run=longrun
 
 # Single-column physics evolution from a saved JCM run
 python -m jcm.main run.mode=scm run.state_file=path/to/state.nc \
@@ -107,7 +112,7 @@ Inspect the available config groups and the fully-composed config:
 ```bash
 python -m jcm.main --help                  # config-group choices + Hydra usage
 python -m jcm.main --cfg job               # print the composed config
-python -m jcm.main --cfg job grid=icon_t85_l47_hybrid   # with overrides
+python -m jcm.main --cfg job grid=echam_t63_l47_hybrid   # with overrides
 ```
 
 Config groups live under `jcm/config/` (`physics`, `grid`, `run`, `init`,
@@ -143,8 +148,8 @@ Anything after the image name is forwarded to `python -m jcm.main`, so the
 full Hydra CLI (config groups, dotted overrides, multirun) is available:
 
 ```bash
-# Switch physics package and grid
-docker run --rm --gpus all jcm physics=icon grid=icon_t85_l47_hybrid
+# Switch physics package and grid (recommended ECHAM + RRTMGP setup)
+docker run --rm --gpus all jcm physics=echam-rrtmgp grid=echam_t63_l47_hybrid
 
 # Override individual run options
 docker run --rm --gpus all jcm run.time_step=20 run.total_time=30 run.save_interval=1
@@ -161,7 +166,7 @@ container* and are lost when it exits. Mount a host directory at
 
 ```bash
 docker run --rm --gpus all -v "$(pwd)/outputs:/app/outputs" jcm \
-    physics=icon run.total_time=30
+    physics=echam-rrtmgp grid=echam_t63_l47_hybrid run.total_time=30
 ```
 
 After the run finishes the netCDF state file is available on the host
@@ -177,15 +182,17 @@ docker run --rm -it --entrypoint bash jcm
 
 ### Kubernetes example
 
-Pass Hydra overrides via the container `args` field, request a GPU, and
-mount a persistent volume for outputs:
+Ready-to-use manifests for the NRP Nautilus cluster (Job, interactive
+pod, PVC) live under [`deploy/k8s/`](deploy/k8s/). For other clusters,
+pass Hydra overrides via the container `args` field, request a GPU,
+and mount a persistent volume for outputs:
 
 ```yaml
 spec:
   containers:
     - name: jcm
       image: your-registry/jcm:latest
-      args: ["physics=icon", "grid=icon_t85_l47_hybrid", "run.total_time=30"]
+      args: ["physics=echam-rrtmgp", "grid=echam_t63_l47_hybrid", "run.total_time=30"]
       resources:
         limits:
           nvidia.com/gpu: 1
@@ -200,8 +207,11 @@ Example notebooks are available in the `notebooks/` directory:
 
 - **`01_jcm_demo.ipynb`**: Basic model simulation with SPEEDY physics
 - **`02_optimization_example.ipynb`**: Parameter optimization examples
+- **`03_generate_speedy_default_stats.ipynb`**: Regenerate the bundled SPEEDY reference statistics
+- **`04_jcm_era5_example.ipynb`**: Initialising and verifying runs against ERA5
 - **`04_jcm_slides.ipynb`**: Presentation-ready overview
-- **`05_jcm_icon_demo.ipynb`**: Running with ICON physics and composable physics
+- **`05_jcm_echam_demo.ipynb`**: Running with ECHAM physics and composable physics
+- **`06_macv2_aerosols.py`**: Driving ECHAM with MACv2-SP aerosol parameters
 
 ## Physics Packages
 
@@ -218,33 +228,52 @@ The SPEEDY (Simplified Parameterizations, primitivE-Equation DYnamics) physics p
 - Vertical diffusion
 - Orographic drag
 
-### ICON Physics
+### ECHAM Physics
 
-The ICON physics package provides comprehensive atmospheric parameterizations based on the ECHAM/ICON Earth System Model:
+The ECHAM physics package is a JAX port of the MPI-M ECHAM6 / ICON-A
+atmospheric physics. It is the recommended package for climate-quality
+runs and is the target for the `T63L47` hybrid-coordinate setup
+(`grid=echam_t63_l47_hybrid`):
 
 - Tiedtke-Nordeng mass-flux convection
-- Single-moment cloud microphysics (Lohmann & Roeckner)
-- Two-stream radiation with gas, cloud, and aerosol optics (+ RRTMGP and NN emulator options)
-- TKE-based vertical diffusion
-- Multi-surface tile scheme (ocean, sea ice, land)
-- Gravity wave drag
-- MACv2-SP aerosol scheme with aerosol-cloud coupling
+- Sundqvist diagnostic cloud fraction
+- 1-moment (default) or 2-moment cloud microphysics (Lohmann & Roeckner)
+- Radiation, selectable per run via `radiation_scheme`:
+  - Grey two-stream (default, fast)
+  - RRTMGP correlated-k (production accuracy, `physics=echam-rrtmgp`)
+  - Neural-network RRTMGP emulator (RRTMGP accuracy at grey-like cost)
+- TTE-TKE vertical diffusion (Pithan & Brinkop)
+- Multi-tile surface scheme (ocean, sea ice, land)
+- Hines (1997) non-orographic + Lott-Miller (1997) sub-grid orographic gravity-wave drag
+- MACv2-SP aerosol scheme (Stevens et al., 2017) with aerosol-cloud coupling
 - Simple chemistry (ozone, CO2, CH4)
+
+See [`docs/source/echam_physics.rst`](docs/source/echam_physics.rst) for
+the per-scheme references and performance numbers on T63L47.
+
+> **Note:** ECHAM physics was previously called "ICON" in JCM. The
+> `jcm.physics.icon` namespace and `physics=icon` config group have been
+> renamed to `jcm.physics.echam` and `physics=echam` (PR #457).
 
 ### Composable Physics
 
-Individual parameterizations can be mixed across packages using the composable physics API:
+Individual parameterizations are wired together via the composable physics API. Both `speedy_physics()` and `echam_physics()` return a `ComposablePhysics` whose terms can be swapped (`replace`), removed (`remove`) or extended (`+`):
 
 ```python
-from jcm.physics.speedy.speedy_terms import speedy_physics
-from jcm.physics.icon.icon_terms import IconRadiationRRTMGP
+from jcm.physics.echam.echam_terms import echam_physics
 
-# Start with SPEEDY defaults, replace radiation with ICON RRTMGP
-physics = speedy_physics().replace("radiation_sw", IconRadiationRRTMGP())
+# Recommended T63L47 production setup — full RRTMGP correlated-k radiation
+physics = echam_physics(radiation_scheme="rrtmgp")
 
-# Or build from individual terms
-from jcm.physics.icon.icon_terms import icon_physics
-physics = icon_physics(radiation_scheme="emulated")  # Use NN radiation emulator
+# Cheaper alternative: NN radiation emulator at RRTMGP-like accuracy
+physics = echam_physics(radiation_scheme="emulated")
+
+# Drop a term by category, e.g. for sensitivity studies
+physics = echam_physics().remove("hines")
+
+# Or swap an individual term in by category
+from jcm.physics.radiation.rrtmgp import RRTMGPRadiation
+physics = echam_physics().replace("radiation", RRTMGPRadiation())
 ```
 
 Each `PhysicsTerm` stores its own tunable parameters as `flax.nnx.Param`, enabling per-scheme gradient-based optimization.

--- a/jcm/config/physics/echam.yaml
+++ b/jcm/config/physics/echam.yaml
@@ -3,11 +3,12 @@
 # Each entry under ``terms`` is a Hydra-style term spec — a target
 # class plus optional kwargs. Per-scheme parameters live in their own
 # ``params`` block; each unspecified field falls back to that scheme's
-# ``Parameters.default()``. Override individual fields at the CLI
-# without editing this file::
+# ``Parameters.default()``. Because ``params`` is intentionally absent
+# from this yaml (so the scheme default is used), overriding an
+# individual field at the CLI requires the Hydra ``+`` append prefix::
 #
 #     python -m jcm.main physics=echam \
-#         physics.terms.tiedtke_convection.params.entrpen=4e-4
+#         +physics.terms.tiedtke_convection.params.entrpen=4e-4
 #
 # Swap a term entirely from a curated preset (see ``echam-rrtmgp.yaml``)
 # or inline at the CLI by overriding ``_target_`` and the param block.

--- a/jcm/config/physics/speedy.yaml
+++ b/jcm/config/physics/speedy.yaml
@@ -7,10 +7,12 @@
 # dataclass (e.g. ``mod_radcon_params``); each shows up as its own
 # sub-block under the term entry.
 #
-# Override individual fields at the CLI without editing this file::
+# Per-scheme ``Parameters`` blocks are intentionally absent from this
+# yaml (each falls back to the scheme's ``.default()``), so overriding
+# an individual field at the CLI requires the Hydra ``+`` append prefix::
 #
 #     python -m jcm.main physics=speedy \
-#         physics.terms.speedy_convection.convection_params.entrpen=4e-4
+#         +physics.terms.speedy_convection.convection_params.entrpen=4e-4
 
 checkpoint_terms: true
 

--- a/notebooks/05_jcm_echam_demo.ipynb
+++ b/notebooks/05_jcm_echam_demo.ipynb
@@ -19,7 +19,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "import numpy as np\nfrom jcm.model import Model\nfrom jcm.physics.icon.icon_terms import icon_physics\nfrom jcm.physics.icon.parameters import Parameters\nfrom jcm.terrain import TerrainData\nfrom jcm.utils import get_coords\n\n# Create coordinates and terrain for aquaplanet\nsigma_boundaries = np.linspace(0, 1, 41)  # 40 layers\ncoords = get_coords(sigma_boundaries, spectral_truncation=31)\nterrain = TerrainData.aquaplanet(coords)\n\nphysics = icon_physics()\n\nmodel = Model(\n    coords=coords,\n    terrain=terrain,\n    physics=physics,\n)\n\nsave_interval, total_time = 1, 15\npredictions = model.run(\n    save_interval=save_interval,\n    total_time=total_time,\n)"
+   "source": "import numpy as np\nfrom jcm.model import Model\nfrom jcm.physics.echam.echam_terms import echam_physics\nfrom jcm.terrain import TerrainData\nfrom jcm.utils import get_coords\n\n# Create coordinates and terrain for aquaplanet\nsigma_boundaries = np.linspace(0, 1, 41)  # 40 layers\ncoords = get_coords(sigma_boundaries, spectral_truncation=31)\nterrain = TerrainData.aquaplanet(coords)\n\nphysics = echam_physics()\n\nmodel = Model(\n    coords=coords,\n    terrain=terrain,\n    physics=physics,\n)\n\nsave_interval, total_time = 1, 15\npredictions = model.run(\n    save_interval=save_interval,\n    total_time=total_time,\n)"
   },
   {
    "cell_type": "code",
@@ -179,7 +179,7 @@
        "\n",
        ".xr-section-summary-in + label:before {\n",
        "  display: inline-block;\n",
-       "  content: \"\u25ba\";\n",
+       "  content: \"►\";\n",
        "  font-size: 11px;\n",
        "  width: 15px;\n",
        "  text-align: center;\n",
@@ -190,7 +190,7 @@
        "}\n",
        "\n",
        ".xr-section-summary-in:checked + label:before {\n",
-       "  content: \"\u25bc\";\n",
+       "  content: \"▼\";\n",
        "}\n",
        "\n",
        ".xr-section-summary-in:checked + label > span {\n",
@@ -1469,7 +1469,7 @@
        "        [442.72806, 357.31137, 269.9044 , ...,   0.     ,   0.     ,\n",
        "           0.     ],\n",
        "        [442.13354, 355.94904, 267.77536, ...,   0.     ,   0.     ,\n",
-       "           0.     ]]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>geopotential</span></div><div class='xr-var-dims'>(time, level, lon, lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-c6e5c852-3dca-472c-9b75-aeecf9a7e9c4' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c6e5c852-3dca-472c-9b75-aeecf9a7e9c4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-108c463b-ba2a-4a1f-8862-5c7263915dc8' class='xr-var-data-in' type='checkbox'><label for='data-108c463b-ba2a-4a1f-8862-5c7263915dc8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m\u00b2/s\u00b2</dd><dt><span>description :</span></dt><dd>geopotential</dd></dl></div><div class='xr-var-data'><pre>Array([[[[  1039.1934 ,   1039.1934 ,   1039.1934 , ...,   1039.1934 ,\n",
+       "           0.     ]]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>geopotential</span></div><div class='xr-var-dims'>(time, level, lon, lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-c6e5c852-3dca-472c-9b75-aeecf9a7e9c4' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c6e5c852-3dca-472c-9b75-aeecf9a7e9c4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-108c463b-ba2a-4a1f-8862-5c7263915dc8' class='xr-var-data-in' type='checkbox'><label for='data-108c463b-ba2a-4a1f-8862-5c7263915dc8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m²/s²</dd><dt><span>description :</span></dt><dd>geopotential</dd></dl></div><div class='xr-var-data'><pre>Array([[[[  1039.1934 ,   1039.1934 ,   1039.1934 , ...,   1039.1934 ,\n",
        "            1039.1934 ,   1039.1934 ],\n",
        "         [  1039.1934 ,   1039.1934 ,   1039.1934 , ...,   1039.1934 ,\n",
        "            1039.1934 ,   1039.1934 ],\n",
@@ -3378,46 +3378,19 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Composable Physics\n",
-    "\n",
-    "JCM supports composable physics \u2014 you can mix and match parameterizations from different packages,\n",
-    "replace individual schemes, or remove terms entirely. The composable API provides the same\n",
-    "functionality as the prior monolithic IconPhysics orchestrator but with fine-grained control over individual terms."
-   ]
+   "source": "## Composable Physics\n\nJCM supports composable physics — you can mix and match parameterizations from different packages,\nreplace individual schemes, or remove terms entirely. The composable API provides the same\nfunctionality as the prior monolithic ECHAM orchestrator but with fine-grained control over individual terms."
   },
   {
    "cell_type": "code",
    "metadata": {},
    "execution_count": null,
    "outputs": [],
-   "source": [
-    "from jcm.physics.icon.icon_terms import icon_physics\n",
-    "\n",
-    "# Create composable ICON physics with standard ordering\n",
-    "composable = icon_physics()\n",
-    "print(\"Terms:\", [t.name for t in composable.terms])\n",
-    "\n",
-    "# Use the NN radiation emulator instead of grey radiation\n",
-    "composable_emulated = icon_physics(radiation_scheme=\"emulated\")\n",
-    "\n",
-    "# Remove gravity waves for faster testing\n",
-    "composable_no_gw = icon_physics().remove(\"gravity_waves\")\n",
-    "print(\"Without gravity waves:\", [t.name for t in composable_no_gw.terms])\n",
-    "\n",
-    "# Use composable physics in a model (same interface as legacy)\n",
-    "# model = Model(coords=coords, terrain=terrain, physics=composable)"
-   ]
+   "source": "from jcm.physics.echam.echam_terms import echam_physics\n\n# Create composable ECHAM physics with standard ordering\ncomposable = echam_physics()\nprint(\"Terms:\", [t.name for t in composable.terms])\n\n# Use the NN radiation emulator instead of grey radiation\ncomposable_emulated = echam_physics(radiation_scheme=\"emulated\")\n\n# Or use full RRTMGP correlated-k radiation for climate-quality runs\ncomposable_rrtmgp = echam_physics(radiation_scheme=\"rrtmgp\")\n\n# Remove the Hines non-orographic gravity-wave term (matched by category)\ncomposable_no_gw = echam_physics().remove(\"hines\")\nprint(\"Without Hines gravity waves:\", [t.name for t in composable_no_gw.terms])\n\n# Use composable physics in a model (same interface as legacy)\n# model = Model(coords=coords, terrain=terrain, physics=composable)"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Mixing SPEEDY and ICON terms\n",
-    "\n",
-    "The composable API also works with SPEEDY physics. Both packages' terms are `PhysicsTerm`\n",
-    "subclasses that share the same interface, enabling cross-package composition."
-   ]
+   "source": "### Mixing SPEEDY and ECHAM terms\n\nThe composable API also works with SPEEDY physics. Both packages' terms are `PhysicsTerm`\nsubclasses that share the same interface, enabling cross-package composition."
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary
- Refresh `README.md` for the ICON → ECHAM rename (#457). Features, CLI, Docker, Kubernetes, and the Physics Packages section now reflect the current term lineup (Tiedtke-Nordeng, Sundqvist, 1m/2m microphysics, grey / RRTMGP / NN-emulator radiation, TTE-TKE vdiff, Hines + Lott-Miller GWD, MACv2-SP, multi-tile surface).
- Promote `physics=echam-rrtmgp grid=echam_t63_l47_hybrid` as the recommended climate-quality target throughout the README and Docker/k8s examples; link to `deploy/k8s/` from the Kubernetes section.
- Rewrite the Composable Physics example around `echam_physics(radiation_scheme=...)`, `.remove("hines")`, and `.replace("radiation", RRTMGPRadiation())`. All three are verified to actually work.
- Rename `notebooks/05_jcm_icon_demo.ipynb` → `notebooks/05_jcm_echam_demo.ipynb`. Swap `jcm.physics.icon.icon_terms` → `jcm.physics.echam.echam_terms`, drop the unused `jcm.physics.icon.parameters` import (the namespace no longer ships an `__init__.py`), and fix the gravity-wave removal to use the actual category name (`"hines"`, not the long-gone `"gravity_waves"`).
- Fix the per-term override examples in `jcm/config/physics/echam.yaml` and `jcm/config/physics/speedy.yaml`. The `params` / `*_params` blocks intentionally fall back to `.default()` and are absent from the yaml, so CLI overrides need Hydra's `+` append prefix — without it both files were emitting the example `python -m jcm.main physics=... physics.terms.X.params.Y=...` form, which errors with `Key 'params' is not in struct`.

## Test plan
- [x] `python -m jcm.main --cfg job physics=echam +physics.terms.tiedtke_convection.params.entrpen=4e-4` resolves with `entrpen: 0.0004` under `tiedtke_convection`.
- [x] `python -m jcm.main --cfg job physics=speedy +physics.terms.speedy_convection.convection_params.entrpen=4e-4` resolves with `entrpen: 0.0004` under `speedy_convection`.
- [x] `echam_physics(radiation_scheme="rrtmgp")`, `.remove("hines")`, and `.replace("radiation", RRTMGPRadiation())` all return a `ComposablePhysics` whose term list matches the documented behaviour.
- [ ] CI: existing test suite (docs change should be a no-op for unit tests; the yaml comment edits don't change resolved configs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
