### PR TITLE
physics: drop DateData from compute_tendencies; dt on ComposablePhysics, step on radiation carry

### DIFF
--- a/jcm/model.py
+++ b/jcm/model.py
@@ -390,6 +390,13 @@ class Model:
         
         self.physics = physics or speedy_physics()
         self.physics.cache_coords(self.coords)
+        # Hand the model's timestep to the physics. ``ComposablePhysics``
+        # injects it into the diagnostics dict every step under
+        # ``"_dt_seconds"`` so any term that integrates by ``dt``
+        # (chemistry, microphysics, vertical diffusion, …) reads a
+        # single source of truth instead of going through date plumbing.
+        if hasattr(self.physics, "dt_seconds"):
+            self.physics.dt_seconds = float(self.dt_si.m)
 
         self.diffusion = diffusion or DiffusionFilter.default()
 
@@ -647,6 +654,12 @@ class Model:
         dynamics_step = self._get_dynamics_step_fn()
 
         def step(state, physics_state):
+            # Forcing selection still needs the calendar (forcing files
+            # are date-aligned and ``forcing.solar`` is reconstructed
+            # from the orbital geometry of the current ``dt``). Physics
+            # does not — once ``forcing.select`` has populated
+            # ``forcing.solar`` and pre-sliced every TimeSeries leaf
+            # there's nothing date-shaped left for terms to read.
             date = self._date_from_sim_time(state.sim_time)
             forcing_now = forcing.select(date, calendar=self.calendar)
             dyn_tendency, new_physics_state = compute_physics_step(
@@ -656,7 +669,6 @@ class Model:
                 physics=self.physics,
                 forcing=forcing_now,
                 terrain=self.terrain,
-                date=date,
                 physics_state=physics_state,
             )
             # Forward-Euler add of the physics dynamics tendency. The

--- a/jcm/model.py
+++ b/jcm/model.py
@@ -654,12 +654,6 @@ class Model:
         dynamics_step = self._get_dynamics_step_fn()
 
         def step(state, physics_state):
-            # Forcing selection still needs the calendar (forcing files
-            # are date-aligned and ``forcing.solar`` is reconstructed
-            # from the orbital geometry of the current ``dt``). Physics
-            # does not — once ``forcing.select`` has populated
-            # ``forcing.solar`` and pre-sliced every TimeSeries leaf
-            # there's nothing date-shaped left for terms to read.
             date = self._date_from_sim_time(state.sim_time)
             forcing_now = forcing.select(date, calendar=self.calendar)
             dyn_tendency, new_physics_state = compute_physics_step(

--- a/jcm/physics/chemistry/simple_chemistry.py
+++ b/jcm/physics/chemistry/simple_chemistry.py
@@ -387,7 +387,7 @@ class SimpleChemistry(PhysicsTerm):
 
     Reads ``pressure_full`` and ``surface_pressure`` from the moist-air
     diagnostics dict and the model timestep from
-    ``diagnostics["_date"].dt_seconds``.
+    ``diagnostics["_dt_seconds"]`` (injected by ``ComposablePhysics``).
     """
 
     name: ClassVar[str] = "simple_chemistry"
@@ -410,7 +410,7 @@ class SimpleChemistry(PhysicsTerm):
     ) -> tuple[PhysicsTendency, dict]:
         """Update chemistry sub-struct from the previous step's values."""
         params = self.params.get_value()
-        dt = diagnostics["_date"].dt_seconds
+        dt = diagnostics["_dt_seconds"]
 
         chemistry = diagnostics["chemistry"]
         _tend, new_state = simple_chemistry(

--- a/jcm/physics/clouds/echam_1m.py
+++ b/jcm/physics/clouds/echam_1m.py
@@ -1136,10 +1136,10 @@ class Echam1MMicrophysics(PhysicsTerm):
 
     Reads ``pressure_full``, ``air_density``, ``layer_thickness`` from
     the moist-air diagnostics dict and the model timestep from
-    ``diagnostics["_date"].dt_seconds``. Writes ``precip_rain``,
-    ``precip_snow``, ``droplet_number`` back into the public
-    ``"clouds"`` key (preserving the upstream ``cloud_fraction`` /
-    ``qc`` / ``qi`` fields).
+    ``diagnostics["_dt_seconds"]`` (injected by ``ComposablePhysics``).
+    Writes ``precip_rain``, ``precip_snow``, ``droplet_number`` back
+    into the public ``"clouds"`` key (preserving the upstream
+    ``cloud_fraction`` / ``qc`` / ``qi`` fields).
     """
 
     name: ClassVar[str] = "echam_1m_microphysics"
@@ -1173,7 +1173,7 @@ class Echam1MMicrophysics(PhysicsTerm):
     ) -> tuple[PhysicsTendency, dict]:
         """Compute microphysics tendencies + precip/droplet diagnostics."""
         nlev, ncols = state.temperature.shape
-        dt = diagnostics["_date"].dt_seconds
+        dt = diagnostics["_dt_seconds"]
         params = self.params.get_value()
 
         pressure_full = diagnostics["pressure_full"]

--- a/jcm/physics/clouds/lohmann_2m.py
+++ b/jcm/physics/clouds/lohmann_2m.py
@@ -3667,7 +3667,7 @@ class Lohmann2MMicrophysics(PhysicsTerm):
     ) -> tuple[PhysicsTendency, dict]:
         """Compute 2M microphysics tendencies and update ``"clouds"``."""
         nlev, ncols = state.temperature.shape
-        dt = diagnostics["_date"].dt_seconds
+        dt = diagnostics["_dt_seconds"]
         params_2m = self.params.get_value()
 
         pressure_full = diagnostics["pressure_full"]

--- a/jcm/physics/clouds/sundqvist.py
+++ b/jcm/physics/clouds/sundqvist.py
@@ -543,7 +543,7 @@ class SundqvistCloudFraction(PhysicsTerm):
     ) -> tuple[PhysicsTendency, dict]:
         """Compute cloud-fraction tendencies + diagnostics."""
         nlev, ncols = state.temperature.shape
-        dt = diagnostics["_date"].dt_seconds
+        dt = diagnostics["_dt_seconds"]
         params = self.params.get_value()
 
         pressure_full = diagnostics["pressure_full"]

--- a/jcm/physics/composable_physics.py
+++ b/jcm/physics/composable_physics.py
@@ -29,7 +29,6 @@ from flax import nnx
 from jcm.physics_interface import Physics, PhysicsState, PhysicsTendency
 from jcm.forcing import ForcingData
 from jcm.terrain import TerrainData
-from jcm.date import DateData
 from jcm.physics.physics_term import PhysicsTerm, TracerSpec
 
 
@@ -56,6 +55,7 @@ class ComposablePhysics(nnx.Module, Physics):
         terms: list[PhysicsTerm],
         checkpoint_terms: bool = True,
         vectorize_columns: bool = False,
+        dt_seconds: float = 1800.0,
     ):
         """Initialize ComposablePhysics.
 
@@ -66,11 +66,19 @@ class ComposablePhysics(nnx.Module, Physics):
             vectorize_columns: Whether to reshape state from 3D to column
                 format before iterating terms. Use True for column-based
                 physics (ECHAM, etc.), False for grid-based (SPEEDY).
+            dt_seconds: Physics timestep in seconds. Injected into the
+                diagnostics dict as ``"_dt_seconds"`` at the top of every
+                ``compute_tendencies`` call so terms that integrate by
+                ``dt`` (chemistry, microphysics, vertical diffusion, …)
+                read a single source of truth without needing model-wide
+                date plumbing. ``Model.__init__`` overrides this to its
+                own ``dt_si`` after the physics object is constructed.
 
         """
         self.terms = nnx.List(terms)
         self.checkpoint_terms = checkpoint_terms
         self.vectorize_columns = vectorize_columns
+        self.dt_seconds = float(dt_seconds)
         self._validate_ordering()
 
     # ------------------------------------------------------------------
@@ -105,7 +113,6 @@ class ComposablePhysics(nnx.Module, Physics):
         state: PhysicsState,
         forcing: ForcingData,
         terrain: TerrainData,
-        date: DateData,
         prev_physics_data=None,
     ) -> tuple[PhysicsTendency, dict[str, jnp.ndarray]]:
         """Compute total physics tendencies by iterating over terms.
@@ -114,7 +121,6 @@ class ComposablePhysics(nnx.Module, Physics):
             state: Current atmospheric state.
             forcing: Boundary condition forcing data.
             terrain: Terrain boundary conditions.
-            date: Current model date/time info.
             prev_physics_data: Previous step's diagnostics dict for caching
                 expensive computations (e.g. radiation sub-stepping).
                 None on the first step.
@@ -125,18 +131,19 @@ class ComposablePhysics(nnx.Module, Physics):
         """
         if self.vectorize_columns:
             tendencies, diagnostics = self._compute_tendencies_columns(
-                state, forcing, terrain, date, prev_physics_data,
+                state, forcing, terrain, prev_physics_data,
             )
         else:
             tendencies, diagnostics = self._compute_tendencies_3d(
-                state, forcing, terrain, date, prev_physics_data,
+                state, forcing, terrain, prev_physics_data,
             )
-        # Strip pure-plumbing keys (date snapshot, sliced forcing, parameter
-        # snapshot) before returning. These are re-injected at the top of the
-        # next compute_tendencies call from authoritative sources, so they
-        # don't need to ride in the saved trajectory and would otherwise bloat
-        # the prediction dict and break tree_map averaging tests against
-        # legacy ``PhysicsData``-shaped output.
+        # Strip pure-plumbing keys (timestep snapshot, sliced forcing,
+        # parameter snapshot) before returning. These are re-injected at
+        # the top of the next ``compute_tendencies`` call from
+        # authoritative sources, so they don't need to ride in the saved
+        # trajectory and would otherwise bloat the prediction dict and
+        # break tree_map averaging tests against the legacy
+        # ``PhysicsData``-shaped output.
         diagnostics = {
             k: v for k, v in diagnostics.items()
             if k not in self._INTERNAL_DIAGNOSTIC_KEYS
@@ -144,14 +151,14 @@ class ComposablePhysics(nnx.Module, Physics):
         return tendencies, diagnostics
 
     def _compute_tendencies_3d(
-        self, state, forcing, terrain, date, prev_physics_data=None,
+        self, state, forcing, terrain, prev_physics_data=None,
     ):
         """Iterate terms on the full 3D grid (e.g. SPEEDY)."""
         diagnostics: dict[str, jnp.ndarray] = {}
         if prev_physics_data is not None:
             diagnostics = {**prev_physics_data}
 
-        diagnostics["_date"] = date
+        diagnostics["_dt_seconds"] = self.dt_seconds
 
         tendencies = PhysicsTendency.zeros(state.temperature.shape)
 
@@ -163,7 +170,7 @@ class ComposablePhysics(nnx.Module, Physics):
         return tendencies, diagnostics
 
     def _compute_tendencies_columns(
-        self, state, forcing, terrain, date, prev_physics_data=None,
+        self, state, forcing, terrain, prev_physics_data=None,
     ):
         """Column-vectorized term iteration.
 
@@ -180,7 +187,7 @@ class ComposablePhysics(nnx.Module, Physics):
         if prev_physics_data is not None:
             diagnostics = {**prev_physics_data}
 
-        diagnostics["_date"] = date
+        diagnostics["_dt_seconds"] = self.dt_seconds
 
         tracer_tends = {
             name: jnp.zeros((nlev, ncols))
@@ -248,10 +255,9 @@ class ComposablePhysics(nnx.Module, Physics):
         )
         probe_forcing = ForcingData.zeros(nodal_shape)
         probe_terrain = TerrainData.aquaplanet(coords)
-        probe_date = DateData.zeros()
 
         _, diagnostics = self.compute_tendencies(
-            probe_state, probe_forcing, probe_terrain, probe_date,
+            probe_state, probe_forcing, probe_terrain,
         )
         return tree_map(jnp.zeros_like, diagnostics)
 
@@ -294,11 +300,11 @@ class ComposablePhysics(nnx.Module, Physics):
             carry.update(slot)
         return carry
 
-    # Underscore-prefixed keys that are pure plumbing (date stamps, sliced
+    # Underscore-prefixed keys that are pure plumbing (timestep, sliced
     # forcing snapshots, parameter snapshots) and must NOT be flattened into
     # the user-facing xarray output.
     _INTERNAL_DIAGNOSTIC_KEYS: ClassVar[frozenset[str]] = frozenset({
-        "_date",
+        "_dt_seconds",
         "_forcing_2d",
         "_echam_params",
         "_echam_coords",
@@ -317,9 +323,9 @@ class ComposablePhysics(nnx.Module, Physics):
           communication (``_radiation``, ``_humidity``, ...) — flattened into
           ``<name>.<field>`` user-facing keys (matches the legacy SPEEDY /
           ECHAM ``PhysicsData`` xarray layout).
-        - Infrastructure objects (``_date``, ``_echam_params``, ...) that are
-          listed in :attr:`_INTERNAL_DIAGNOSTIC_KEYS` or that fail array-only
-          flattening — silently dropped from user output.
+        - Infrastructure objects (``_dt_seconds``, ``_echam_params``, ...)
+          that are listed in :attr:`_INTERNAL_DIAGNOSTIC_KEYS` or that fail
+          array-only flattening — silently dropped from user output.
         """
         if struct is None:
             return {}
@@ -408,6 +414,7 @@ class ComposablePhysics(nnx.Module, Physics):
             terms=list(self.terms) + other_terms,
             checkpoint_terms=self.checkpoint_terms,
             vectorize_columns=self.vectorize_columns,
+            dt_seconds=self.dt_seconds,
         )
 
     def __radd__(self, other):
@@ -440,6 +447,7 @@ class ComposablePhysics(nnx.Module, Physics):
             terms=new_terms,
             checkpoint_terms=self.checkpoint_terms,
             vectorize_columns=self.vectorize_columns,
+            dt_seconds=self.dt_seconds,
         )
 
     def remove(self, category: str) -> ComposablePhysics:
@@ -448,6 +456,7 @@ class ComposablePhysics(nnx.Module, Physics):
             terms=[t for t in self.terms if t.category != category],
             checkpoint_terms=self.checkpoint_terms,
             vectorize_columns=self.vectorize_columns,
+            dt_seconds=self.dt_seconds,
         )
 
     # ------------------------------------------------------------------

--- a/jcm/physics/composable_physics_slow_test.py
+++ b/jcm/physics/composable_physics_slow_test.py
@@ -18,7 +18,6 @@ from flax import nnx
 from jcm.physics_interface import PhysicsState
 from jcm.forcing import ForcingData
 from jcm.terrain import TerrainData
-from jcm.date import DateData
 from jcm.utils import get_coords
 
 
@@ -82,12 +81,9 @@ class TestComposableSpeedyIntegration(unittest.TestCase):
         composable = speedy_physics(checkpoint_terms=False)
         composable.cache_coords(self.coords)
         state = self._make_state()
-        date = DateData.zeros()
 
         def loss_fn(physics):
-            tend, _ = physics.compute_tendencies(
-                state, self.forcing, self.terrain, date,
-            )
+            tend, _ = physics.compute_tendencies(state, self.forcing, self.terrain)
             return jnp.sum(tend.temperature ** 2)
 
         grads = nnx.grad(loss_fn)(composable)

--- a/jcm/physics/composable_physics_test.py
+++ b/jcm/physics/composable_physics_test.py
@@ -19,7 +19,6 @@ from jcm.physics.composable_physics import ComposablePhysics
 from jcm.physics_interface import PhysicsState, PhysicsTendency
 from jcm.forcing import ForcingData
 from jcm.terrain import TerrainData
-from jcm.date import DateData
 
 
 # ---------------------------------------------------------------------------
@@ -171,9 +170,8 @@ class TestComposablePhysics(unittest.TestCase):
         state = _make_test_state()
         forcing = _make_test_forcing()
         terrain = _make_test_terrain()
-        date = DateData.zeros()
 
-        tend, diag = physics.compute_tendencies(state, forcing, terrain, date)
+        tend, diag = physics.compute_tendencies(state, forcing, terrain)
 
         # Check all diagnostic keys are present
         self.assertIn("heating_rate", diag)
@@ -257,10 +255,9 @@ class TestDifferentiabilityGate(unittest.TestCase):
         state = _make_test_state()
         forcing = _make_test_forcing()
         terrain = _make_test_terrain()
-        date = DateData.zeros()
 
         def loss_fn(physics):
-            tend, _ = physics.compute_tendencies(state, forcing, terrain, date)
+            tend, _ = physics.compute_tendencies(state, forcing, terrain)
             return (
                 jnp.sum(tend.temperature ** 2)
                 + jnp.sum(tend.specific_humidity ** 2)
@@ -296,13 +293,12 @@ class TestDifferentiabilityGate(unittest.TestCase):
         )
         forcing = ForcingData.zeros(shape[1:])
         terrain = _make_test_terrain(shape[1:])
-        date = DateData.zeros()
 
         # loss = sum((alpha * T)^2) = alpha^2 * T^2 * n_elements
         # d(loss)/d(alpha) = 2 * alpha * T^2 * n_elements
         # With alpha=1.0, T=3.0, n=1: d(loss)/d(alpha) = 2 * 1 * 9 * 1 = 18.0
         def loss_fn(physics):
-            tend, _ = physics.compute_tendencies(state, forcing, terrain, date)
+            tend, _ = physics.compute_tendencies(state, forcing, terrain)
             return jnp.sum(tend.temperature ** 2)
 
         grads = nnx.grad(loss_fn)(physics)
@@ -320,14 +316,13 @@ class TestDifferentiabilityGate(unittest.TestCase):
         state = _make_test_state()
         forcing = _make_test_forcing()
         terrain = _make_test_terrain()
-        date = DateData.zeros()
 
         graphdef, param_state = nnx.split(physics)
 
         def loss_fn(param_state):
             physics_restored = nnx.merge(graphdef, param_state)
             tend, _ = physics_restored.compute_tendencies(
-                state, forcing, terrain, date
+                state, forcing, terrain,
             )
             return jnp.sum(tend.temperature ** 2) + jnp.sum(tend.specific_humidity ** 2)
 
@@ -373,7 +368,6 @@ class TestDifferentiabilityGate(unittest.TestCase):
         )
         forcing = ForcingData.zeros(shape[1:])
         terrain = _make_test_terrain(shape[1:])
-        date = DateData.zeros()
 
         # Only look at u_wind loss (produced by DiagnosticConsumer)
         # u_wind_tend = gamma * heating_rate = gamma * alpha * T
@@ -381,7 +375,7 @@ class TestDifferentiabilityGate(unittest.TestCase):
         # d(loss)/d(alpha) = 2 * gamma^2 * alpha * T^2
         # With gamma=1, alpha=1, T=2: d(loss)/d(alpha) = 2 * 1 * 1 * 4 = 8
         def loss_fn(physics):
-            tend, _ = physics.compute_tendencies(state, forcing, terrain, date)
+            tend, _ = physics.compute_tendencies(state, forcing, terrain)
             return jnp.sum(tend.u_wind ** 2)
 
         grads = nnx.grad(loss_fn)(physics)
@@ -427,10 +421,9 @@ class TestDifferentiabilityGate(unittest.TestCase):
         )
         forcing = ForcingData.zeros(shape[1:])
         terrain = _make_test_terrain(shape[1:])
-        date = DateData.zeros()
 
         def loss_fn(physics):
-            tend, _ = physics.compute_tendencies(state, forcing, terrain, date)
+            tend, _ = physics.compute_tendencies(state, forcing, terrain)
             return jnp.sum(tend.temperature ** 2)
 
         # This should work — nnx.grad differentiates Param but not Variable
@@ -457,9 +450,8 @@ class TestColumnVectorization(unittest.TestCase):
         state = _make_test_state(shape)
         forcing = _make_test_forcing(shape[1:])
         terrain = _make_test_terrain(shape[1:])
-        date = DateData.zeros()
 
-        tend, diag = physics.compute_tendencies(state, forcing, terrain, date)
+        tend, diag = physics.compute_tendencies(state, forcing, terrain)
 
         # Output should be 3D again
         self.assertEqual(tend.temperature.shape, shape)
@@ -487,9 +479,8 @@ class TestColumnVectorization(unittest.TestCase):
         )
         forcing = _make_test_forcing(shape[1:])
         terrain = _make_test_terrain(shape[1:])
-        date = DateData.zeros()
 
-        tend, _ = physics.compute_tendencies(state, forcing, terrain, date)
+        tend, _ = physics.compute_tendencies(state, forcing, terrain)
         self.assertEqual(tend.temperature.shape, shape)
 
     def test_column_vectorization_with_prev_data(self):
@@ -505,11 +496,10 @@ class TestColumnVectorization(unittest.TestCase):
         state = _make_test_state(shape)
         forcing = _make_test_forcing(shape[1:])
         terrain = _make_test_terrain(shape[1:])
-        date = DateData.zeros()
 
         prev_data = {"_cached_value": jnp.array(42.0)}
         tend, diag = physics.compute_tendencies(
-            state, forcing, terrain, date, prev_physics_data=prev_data,
+            state, forcing, terrain, prev_physics_data=prev_data,
         )
         # prev_data should be carried forward
         self.assertIn("_cached_value", diag)
@@ -530,10 +520,9 @@ class TestColumnVectorization(unittest.TestCase):
         state = _make_test_state(shape)
         forcing = _make_test_forcing(shape[1:])
         terrain = _make_test_terrain(shape[1:])
-        date = DateData.zeros()
 
-        tend_3d, _ = physics_3d.compute_tendencies(state, forcing, terrain, date)
-        tend_col, _ = physics_col.compute_tendencies(state, forcing, terrain, date)
+        tend_3d, _ = physics_3d.compute_tendencies(state, forcing, terrain)
+        tend_col, _ = physics_col.compute_tendencies(state, forcing, terrain)
 
         npt.assert_allclose(tend_3d.temperature, tend_col.temperature, rtol=1e-6)
         npt.assert_allclose(tend_3d.u_wind, tend_col.u_wind, rtol=1e-6)
@@ -586,21 +575,21 @@ class TestComposablePhysicsUtilities(unittest.TestCase):
 
     def test_data_struct_to_dict_filters_internal_keys(self):
         """Underscore-prefixed array keys are exposed without the underscore;
-        underscore-prefixed plumbing keys (`_date`, etc.) stay hidden.
+        underscore-prefixed plumbing keys (`_dt_seconds`, etc.) stay hidden.
         """
         physics = ComposablePhysics(terms=[LinearHeating()])
         struct = {
             "_internal": jnp.array(1.0),
             "public_key": jnp.array(2.0),
-            "_date": DateData.zeros(),
+            "_dt_seconds": 1800.0,
         }
         result = physics.data_struct_to_dict(struct)
         self.assertIn("public_key", result)
         # Underscore-prefixed array key surfaces as the key without underscore.
         self.assertIn("internal", result)
-        # `_date` is plumbing — stays hidden.
-        self.assertNotIn("_date", result)
-        self.assertNotIn("date", result)
+        # `_dt_seconds` is plumbing — stays hidden.
+        self.assertNotIn("_dt_seconds", result)
+        self.assertNotIn("dt_seconds", result)
         # Original underscore key is not preserved.
         self.assertNotIn("_internal", result)
 

--- a/jcm/physics/convection/tiedtke_nordeng/tiedtke_nordeng.py
+++ b/jcm/physics/convection/tiedtke_nordeng/tiedtke_nordeng.py
@@ -961,9 +961,9 @@ class TiedtkeConvection(PhysicsTerm):
     Reads the moist-air diagnostics produced by
     :class:`~jcm.physics.diagnostics.moist_air_state.MoistAirColumnState`
     (``pressure_full``, ``layer_thickness``, ``air_density``) and the
-    model timestep from ``diagnostics["_date"].dt_seconds``. Writes the
-    :class:`ConvectionData` sub-struct under the public ``"convection"``
-    key.
+    model timestep from ``diagnostics["_dt_seconds"]`` (injected by
+    ``ComposablePhysics``). Writes the :class:`ConvectionData` sub-struct
+    under the public ``"convection"`` key.
     """
 
     name: ClassVar[str] = "tiedtke_convection"
@@ -999,7 +999,7 @@ class TiedtkeConvection(PhysicsTerm):
     ) -> tuple[PhysicsTendency, dict]:
         """Compute convective tendencies; write ``convection`` diagnostics."""
         nlev, ncols = state.temperature.shape
-        dt = diagnostics["_date"].dt_seconds
+        dt = diagnostics["_dt_seconds"]
         params = self.params.get_value()
 
         pressure_full = diagnostics["pressure_full"]

--- a/jcm/physics/echam/chemistry_integration_test.py
+++ b/jcm/physics/echam/chemistry_integration_test.py
@@ -17,7 +17,6 @@ from jcm.physics_interface import PhysicsState
 from jcm.forcing import ForcingData
 from jcm.terrain import TerrainData
 from jcm.utils import get_coords
-from jcm.date import DateData
 
 
 class TestChemistryIntegration(TestCase):
@@ -58,16 +57,11 @@ class TestChemistryIntegration(TestCase):
             stl_am=jnp.ones((nlon, nlat)) * 280.0,  # Land temperature
             sea_surface_temperature=jnp.ones((nlon, nlat)) * 288.0,  # SST
         )
-        
-        # Create date
-        self.date = DateData.zeros()
     
     def test_chemistry_initialization(self):
         """Test that chemistry tracers are properly initialized"""
         # Run physics once to initialize chemistry
-        tendencies, physics_data = self.physics.compute_tendencies(
-            self.state, self.forcing, self.terrain, self.date
-        )
+        tendencies, physics_data = self.physics.compute_tendencies(self.state, self.forcing, self.terrain)
         
         # Check that chemistry data exists
         self.assertIsNotNone(physics_data["chemistry"])
@@ -92,18 +86,14 @@ class TestChemistryIntegration(TestCase):
     def test_chemistry_evolution(self):
         """Test that chemistry tracers evolve over time"""
         # Run physics once
-        tendencies1, physics_data1 = self.physics.compute_tendencies(
-            self.state, self.forcing, self.terrain, self.date
-        )
+        tendencies1, physics_data1 = self.physics.compute_tendencies(self.state, self.forcing, self.terrain)
         
         # Save initial chemistry state
         physics_data1["chemistry"].ozone_vmr.copy()
         physics_data1["chemistry"].methane_vmr.copy()
         
         # Run physics again (chemistry should evolve)
-        tendencies2, physics_data2 = self.physics.compute_tendencies(
-            self.state, self.forcing, self.terrain, self.date
-        )
+        tendencies2, physics_data2 = self.physics.compute_tendencies(self.state, self.forcing, self.terrain)
         
         # Check that chemistry has evolved (might be subtle differences)
         # Note: With current implementation, changes might be small
@@ -123,14 +113,10 @@ class TestChemistryIntegration(TestCase):
         )
         
         # Run physics with original state
-        _, physics_data_cold = self.physics.compute_tendencies(
-            self.state, self.forcing, self.terrain, self.date
-        )
+        _, physics_data_cold = self.physics.compute_tendencies(self.state, self.forcing, self.terrain)
         
         # Run physics with warm state
-        _, physics_data_warm = self.physics.compute_tendencies(
-            warm_state, self.forcing, self.terrain, self.date
-        )
+        _, physics_data_warm = self.physics.compute_tendencies(warm_state, self.forcing, self.terrain)
         
         # Both should have valid chemistry
         self.assertTrue(jnp.all(jnp.isfinite(physics_data_cold["chemistry"].ozone_vmr)))
@@ -150,9 +136,7 @@ class TestChemistryIntegration(TestCase):
     def test_chemistry_vertical_structure(self):
         """Test that chemistry has reasonable vertical structure"""
         # Run physics
-        _, physics_data = self.physics.compute_tendencies(
-            self.state, self.forcing, self.terrain, self.date
-        )
+        _, physics_data = self.physics.compute_tendencies(self.state, self.forcing, self.terrain)
         
         # Get chemistry profiles (average over horizontal)
         nlev, ncols = physics_data["chemistry"].ozone_vmr.shape
@@ -174,9 +158,7 @@ class TestChemistryIntegration(TestCase):
         # So we test gradients instead, which is the main JAX feature we need
         
         # Test without JIT first to ensure basic functionality
-        tendencies, physics_data = self.physics.compute_tendencies(
-            self.state, self.forcing, self.terrain, self.date
-        )
+        tendencies, physics_data = self.physics.compute_tendencies(self.state, self.forcing, self.terrain)
         
         # Should produce valid results
         self.assertTrue(jnp.all(jnp.isfinite(physics_data["chemistry"].ozone_vmr)))
@@ -185,9 +167,7 @@ class TestChemistryIntegration(TestCase):
         # Test that we can compute gradients (though they might be zero)
         def loss_fn(temperature):
             state = self.state.copy(temperature=temperature)
-            _, physics_data = self.physics.compute_tendencies(
-                state, self.forcing, self.terrain, self.date
-            )
+            _, physics_data = self.physics.compute_tendencies(state, self.forcing, self.terrain)
             return jnp.sum(physics_data["chemistry"].ozone_vmr)
         
         # Compute gradient

--- a/jcm/physics/echam/echam_terms_test.py
+++ b/jcm/physics/echam/echam_terms_test.py
@@ -14,7 +14,6 @@ from flax import nnx
 from jcm.physics_interface import PhysicsState
 from jcm.forcing import ForcingData
 from jcm.terrain import TerrainData
-from jcm.date import DateData
 from jcm.utils import get_coords
 from jcm.physics.physics_term import PhysicsTerm
 
@@ -39,7 +38,6 @@ def _make_echam_test_setup(nlev=8, nlat=64, nlon=32):
     coords = get_coords(sigma_boundaries, nodal_shape=(nlat, nlon))
     terrain = TerrainData.aquaplanet(coords)
     forcing = ForcingData.zeros((nlat, nlon))
-    date = DateData.zeros()
 
     shape_3d = (nlev, nlat, nlon)
     key = jax.random.PRNGKey(42)
@@ -70,7 +68,7 @@ def _make_echam_test_setup(nlev=8, nlat=64, nlon=32):
         },
     )
 
-    return coords, state, forcing, terrain, date
+    return coords, state, forcing, terrain
 
 
 class TestEchamComposablePhysics(unittest.TestCase):
@@ -78,7 +76,7 @@ class TestEchamComposablePhysics(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        self.coords, self.state, self.forcing, self.terrain, self.date = (
+        self.coords, self.state, self.forcing, self.terrain = (
             _make_echam_test_setup()
         )
 
@@ -181,8 +179,7 @@ class TestEchamComposablePhysics(unittest.TestCase):
         replaced = composable.replace("radiation", new_rad)
         replaced.cache_coords(self.coords)
 
-        tend, _ = replaced.compute_tendencies(
-            self.state, self.forcing, self.terrain, self.date,
+        tend, _ = replaced.compute_tendencies(self.state, self.forcing, self.terrain,
         )
         # Check shape is correct (NaNs expected with random state)
         self.assertEqual(

--- a/jcm/physics/echam/parameters_test.py
+++ b/jcm/physics/echam/parameters_test.py
@@ -98,13 +98,16 @@ def test_physics_terms_compute_tendencies():
         sea_surface_temperature=jnp.ones((nlat, nlon)) * 288.0,
         sice_am=jnp.zeros((nlat, nlon)),
     )
+    # ``forcing.select`` still wants a ``DateData`` to populate
+    # ``forcing.solar`` and align ``TimeSeries`` leaves; physics itself
+    # no longer takes one.
     date = DateData.set_date(
         jdt.Datetime.from_pydatetime(datetime(2020, 6, 21))
     )
     forcing = forcing.select(date)
 
     tendencies, _ = physics.compute_tendencies(
-        state, forcing=forcing, terrain=terrain, date=date,
+        state, forcing=forcing, terrain=terrain,
     )
 
     assert tendencies.temperature.shape == (nlev, nlat, nlon)

--- a/jcm/physics/gravity_waves/simple/simple_gwd.py
+++ b/jcm/physics/gravity_waves/simple/simple_gwd.py
@@ -426,8 +426,8 @@ class SimpleGwd(PhysicsTerm):
     factory. Operates on column-vectorized state ``(nlev, ncols)``. Reads
     ``pressure_full``, ``height_full``, ``air_density`` from the moist-air
     diagnostics dict and the model timestep from
-    ``diagnostics["_date"].dt_seconds``. Writes only u/v/T tendencies; no
-    Data sub-struct.
+    ``diagnostics["_dt_seconds"]`` (injected by ``ComposablePhysics``).
+    Writes only u/v/T tendencies; no Data sub-struct.
     """
 
     name: ClassVar[str] = "simple_gwd"
@@ -450,7 +450,7 @@ class SimpleGwd(PhysicsTerm):
     ) -> tuple[PhysicsTendency, dict]:
         """Compute u/v/T tendencies from the simple GWD scheme."""
         nlev, ncols = state.temperature.shape
-        dt = diagnostics["_date"].dt_seconds
+        dt = diagnostics["_dt_seconds"]
         params = self.params.get_value()
 
         # Placeholder fixed std-dev of sub-grid orography. The real

--- a/jcm/physics/gravity_waves/sso/lott_miller.py
+++ b/jcm/physics/gravity_waves/sso/lott_miller.py
@@ -865,7 +865,7 @@ class LottMillerSso(PhysicsTerm):
     ) -> tuple[PhysicsTendency, dict]:
         """Compute u/v/T tendencies from Lott-Miller SSO."""
         nlev, ncols = state.temperature.shape
-        dt = diagnostics["_date"].dt_seconds
+        dt = diagnostics["_dt_seconds"]
         params = self.params.get_value()
 
         pressure_full = diagnostics["pressure_full"]

--- a/jcm/physics/held_suarez/held_suarez_test.py
+++ b/jcm/physics/held_suarez/held_suarez_test.py
@@ -18,7 +18,6 @@ class TestHeldSuarezUnit(unittest.TestCase):
             physics = model.physics,
             forcing = None,
             terrain = None,
-            date = None,
             physics_state = model._build_initial_physics_carry(),
         )
 

--- a/jcm/physics/physics_term.py
+++ b/jcm/physics/physics_term.py
@@ -85,7 +85,7 @@ class PhysicsTerm(nnx.Module):
     #
     # Override ``initial_carry_state`` directly only when zero is the
     # wrong seed (e.g. ``TteTkeVerticalDiffusion`` floors TKE at ECHAM's
-    # 0.01 m²/s² lower bound). Pure plumbing keys (``_date``,
+    # 0.01 m²/s² lower bound). Pure plumbing keys (``_dt_seconds``,
     # ``_forcing_2d``, …) repopulate every step and must NOT appear here.
     carry_slots: ClassVar[dict[str, type]] = {}
 

--- a/jcm/physics/radiation/__init__.py
+++ b/jcm/physics/radiation/__init__.py
@@ -27,11 +27,13 @@ def radiation_should_compute(
 
     If ``radiation_interval > 0``, recompute every
     ``round(interval / dt)`` steps; otherwise (the default) recompute
-    every step.
+    every step. The step counter is the radiation term's own
+    ``RadiationData.step`` carry slot — incremented each call by the
+    radiation term — so this gate no longer depends on the model-wide
+    date/step plumbing.
     """
-    date = diagnostics["_date"]
-    dt = date.dt_seconds
-    step = date.model_step
+    step = diagnostics["radiation"].step
+    dt = diagnostics["_dt_seconds"]
     interval = parameters.radiation_interval
     steps_per_call = jnp.where(
         interval > 0,

--- a/jcm/physics/radiation/grey_two_stream/radiation_scheme.py
+++ b/jcm/physics/radiation/grey_two_stream/radiation_scheme.py
@@ -537,6 +537,9 @@ def radiation_scheme(
         shortwave_heating=sw_heating_rate
     )
     
+    # `step` is owned by the ``GreyTwoStreamRadiation`` PhysicsTerm carry —
+    # the standalone scheme always emits 0 here and the term increments
+    # the carry slot after the cond on every call.
     diagnostics = RadiationData(
         cos_zenith=cos_zenith[jnp.newaxis],
         surface_albedo_vis=surface_albedo_vis,
@@ -557,6 +560,7 @@ def radiation_scheme(
         surface_lw_up=surface_lw_up,
         toa_sw_up_clear=toa_sw_up_clear,
         toa_lw_up_clear=toa_lw_up_clear,
+        step=jnp.int32(0),
     )
 
     return tendencies, diagnostics
@@ -653,6 +657,11 @@ class GreyTwoStreamRadiation(PhysicsTerm):
             radiation_should_compute(diagnostics, params),
             _compute, _use_cached,
         )
+        # Advance the radiation-local step counter on every call (both
+        # compute and cached paths). This is the carry-side replacement
+        # for the old ``_date.model_step`` plumbing: ``radiation_should_compute``
+        # reads it back next step to decide compute-vs-cache.
+        new_radiation = new_radiation.copy(step=radiation.step + 1)
         # Mirror the all-sky and clear-sky TOA fluxes onto the
         # ``"clouds"`` sub-struct so users can read everything CRE-
         # related (= toa_*_clear − toa_*_all) from a single diagnostic.
@@ -779,6 +788,10 @@ class GreyTwoStreamRadiation(PhysicsTerm):
             toa_lw_up_clear=_column_vector(
                 diagnostics_vmapped.toa_lw_up_clear, ncols,
             ),
+            # Placeholder — the enclosing ``__call__`` overwrites this
+            # via ``new_radiation.copy(step=radiation.step + 1)`` after
+            # the compute-vs-cache cond, so the value here is unused.
+            step=jnp.int32(0),
         )
 
         tendency = PhysicsTendency(

--- a/jcm/physics/radiation/nn_emulator_scheme.py
+++ b/jcm/physics/radiation/nn_emulator_scheme.py
@@ -169,6 +169,10 @@ def radiation_scheme_emulated(
         # see stale data in the diagnostic key.
         toa_sw_up_clear=jnp.zeros_like(sw_flux_up[0]),
         toa_lw_up_clear=jnp.zeros_like(lw_flux_up[0]),
+        # ``step`` is owned by the enclosing ``NNEmulatorRadiation``
+        # carry — the standalone scheme emits 0 and the term bumps it
+        # after its compute-vs-cache cond.
+        step=jnp.int32(0),
     )
 
     return tendencies, diagnostics
@@ -255,6 +259,11 @@ class NNEmulatorRadiation(PhysicsTerm):
             radiation_should_compute(diagnostics, params),
             _compute, _use_cached,
         )
+        # Advance the radiation-local step counter on every call (both
+        # compute and cached paths). Mirrors the carry-side step bump
+        # in the grey two-stream / RRTMGP radiation terms so the
+        # sub-stepping gate sees the same cadence regardless of scheme.
+        new_radiation = new_radiation.copy(step=radiation.step + 1)
         # Mirror TOA fluxes onto the clouds sub-struct for CRE
         # diagnostics. The emulator only produces all-sky values, so
         # the clear-sky fields stay at zero until the 2-call clear-sky
@@ -385,6 +394,9 @@ class NNEmulatorRadiation(PhysicsTerm):
             toa_lw_up_clear=_column_vector_emulated(
                 diagnostics_vmapped.toa_lw_up_clear, ncols,
             ),
+            # Placeholder — the enclosing ``__call__`` overwrites
+            # ``step`` after the compute-vs-cache cond.
+            step=jnp.int32(0),
         )
 
         tendency = PhysicsTendency(

--- a/jcm/physics/radiation/radiation_types.py
+++ b/jcm/physics/radiation/radiation_types.py
@@ -172,6 +172,15 @@ class RadiationData:
     toa_sw_up_clear: jnp.ndarray     # Clear-sky TOA upward SW [W/m²] (ncols,)
     toa_lw_up_clear: jnp.ndarray     # Clear-sky TOA OLR [W/m²] (ncols,)
 
+    # Internal step counter incremented by the radiation term on every
+    # call (both compute and cached paths). Drives the sub-stepping gate
+    # (see ``radiation_should_compute``) and seeds the McICA RNG so its
+    # samples remain reproducible per (step, column). Lives on the carry
+    # so radiation no longer needs the model-wide step counter — the
+    # operator-split cross-step pass-through already threads this struct
+    # from one ``dt`` to the next.
+    step: jnp.ndarray                # Radiation step counter [int32] scalar
+
     @classmethod
     def zeros(cls, nodal_shape, nlev):
         return cls(
@@ -194,6 +203,7 @@ class RadiationData:
             toa_sw_down=jnp.zeros(nodal_shape),
             toa_sw_up_clear=jnp.zeros(nodal_shape),
             toa_lw_up_clear=jnp.zeros(nodal_shape),
+            step=jnp.int32(0),
         )
 
     def copy(self, **kwargs):
@@ -217,6 +227,7 @@ class RadiationData:
             'toa_sw_down': self.toa_sw_down,
             'toa_sw_up_clear': self.toa_sw_up_clear,
             'toa_lw_up_clear': self.toa_lw_up_clear,
+            'step': self.step,
         }
         new_data.update(kwargs)
         return RadiationData(**new_data)

--- a/jcm/physics/radiation/rrtmgp.py
+++ b/jcm/physics/radiation/rrtmgp.py
@@ -410,6 +410,10 @@ def prepare_icon_data(
         # outside the beam-split context.
         toa_sw_up_clear=jnp.zeros_like(toa_sw_up),
         toa_lw_up_clear=jnp.zeros_like(toa_lw_up),
+        # ``step`` is owned by the enclosing ``RRTMGPRadiation`` carry —
+        # the standalone scheme emits 0 and the term bumps the counter
+        # after its compute-vs-cache cond.
+        step=jnp.int32(0),
     )
     return tendencies, diagnostics
 
@@ -764,6 +768,12 @@ class RRTMGPRadiation(PhysicsTerm):
             radiation_should_compute(diagnostics, params),
             _compute, _use_cached,
         )
+        # Advance the radiation-local step counter on every call (both
+        # compute and cached paths). The McICA seed in ``_compute_full``
+        # folds this counter in for per-(step, column) reproducibility,
+        # so the increment must happen even on cached steps to keep the
+        # sub-column sequence aligned with the chosen sub-stepping cadence.
+        new_radiation = new_radiation.copy(step=radiation.step + 1)
         # Mirror the all-sky and clear-sky TOA fluxes onto the
         # ``"clouds"`` sub-struct for cloud-radiative-effect diagnostics.
         clouds = diagnostics["clouds"].copy(
@@ -785,9 +795,12 @@ class RRTMGPRadiation(PhysicsTerm):
         latitudes = self._lats.get_value()
         longitudes = self._lons.get_value()
         solar = forcing.solar
-        # Scalar model step + per-column index drive the McICA seed
-        # via ``mcica.column_key`` inside ``radiation_scheme_rrtmgp``.
-        model_step = diagnostics["_date"].model_step
+        # Scalar radiation step counter + per-column index drive the
+        # McICA seed via ``mcica.column_key`` inside
+        # ``radiation_scheme_rrtmgp``. The counter lives on the
+        # radiation carry slot, advanced in ``__call__`` after the
+        # compute-vs-cache cond.
+        model_step = diagnostics["radiation"].step
         column_indices = jnp.arange(ncols, dtype=jnp.int32)
 
         cloud_water = state.tracers.get(
@@ -960,6 +973,9 @@ class RRTMGPRadiation(PhysicsTerm):
             toa_lw_up_clear=_column_vector_rrtmgp(
                 diagnostics_vmapped.toa_lw_up_clear, ncols,
             ),
+            # Placeholder — the enclosing ``__call__`` overwrites
+            # ``step`` after the compute-vs-cache cond.
+            step=jnp.int32(0),
         )
 
         tendency = PhysicsTendency(

--- a/jcm/physics/radiation/speedy_shortwave_test.py
+++ b/jcm/physics/radiation/speedy_shortwave_test.py
@@ -189,7 +189,7 @@ class TestShortWaveRadiation(unittest.TestCase):
             jdt.Datetime.from_pydatetime(jdt.to_datetime('2001-08-08'))
         )
 
-        physics_data = PhysicsData.zeros(xy,kx,surface_flux=surface_flux, humidity=humidity, convection=convection, condensation=condensation, shortwave_rad=sw_data, model_step=date_data.model_step, dt_seconds=date_data.dt_seconds, speedy_coords=speedy_c)
+        physics_data = PhysicsData.zeros(xy,kx,surface_flux=surface_flux, humidity=humidity, convection=convection, condensation=condensation, shortwave_rad=sw_data, dt_seconds=date_data.dt_seconds, speedy_coords=speedy_c)
         state = PhysicsState.zeros(zxy, specific_humidity=qa, geopotential=geopotential, normalized_surface_pressure=psa)
         # Mirror the per-step pipeline: solar geometry comes from
         # ForcingData.select(date) instead of being read off PhysicsData.date.
@@ -262,7 +262,7 @@ class TestShortWaveRadiation(unittest.TestCase):
         zxy = (kx, ix, il)
         # Provide a date that is equivalent to tyear=0.25
         date_data = DateData.set_date(model_time=jdt.to_datetime('2000-03-21'))
-        physics_data = PhysicsData.zeros(xy,kx,model_step=date_data.model_step, dt_seconds=date_data.dt_seconds,speedy_coords=speedy_coords)
+        physics_data = PhysicsData.zeros(xy,kx, dt_seconds=date_data.dt_seconds,speedy_coords=speedy_coords)
         state = PhysicsState.zeros(zxy)
         # Mirror Model._get_step_fn_factory: solar geometry comes off
         # `forcing.solar`, populated by `select(date)`.
@@ -282,7 +282,7 @@ class TestShortWaveRadiation(unittest.TestCase):
         zxy = (kx, ix, il)
         # Provide a date that is equivalent to tyear=0.25
         date_data = DateData.set_date(model_time=jdt.to_datetime('2000-03-21'))
-        physics_data = PhysicsData.zeros(xy,kx,model_step=date_data.model_step, dt_seconds=date_data.dt_seconds, speedy_coords=speedy_coords)
+        physics_data = PhysicsData.zeros(xy,kx, dt_seconds=date_data.dt_seconds, speedy_coords=speedy_coords)
 
         state = PhysicsState(jnp.zeros(zxy), jnp.zeros(zxy), jnp.zeros(zxy), jnp.zeros(zxy), jnp.zeros(zxy), jnp.zeros(xy))
 
@@ -298,7 +298,7 @@ class TestShortWaveRadiation(unittest.TestCase):
         zxy = (kx, ix, il)
         # Provide a date that is equivalent to tyear=0.25
         date_data = DateData.set_date(model_time=jdt.to_datetime('2000-03-21'))
-        physics_data = PhysicsData.zeros(xy,kx,model_step=date_data.model_step, dt_seconds=date_data.dt_seconds, speedy_coords=speedy_coords)
+        physics_data = PhysicsData.zeros(xy,kx, dt_seconds=date_data.dt_seconds, speedy_coords=speedy_coords)
 
         state = PhysicsState(jnp.zeros(zxy), jnp.zeros(zxy), jnp.zeros(zxy), jnp.zeros(zxy), jnp.zeros(zxy), jnp.zeros(xy))
 
@@ -315,7 +315,7 @@ class TestShortWaveRadiation(unittest.TestCase):
         zxy = (kx, ix, il)
         date_data = DateData.set_date(model_time=jdt.to_datetime('2000-04-01 12:00:00'))
 
-        physics_data = PhysicsData.zeros(xy,kx,model_step=date_data.model_step, dt_seconds=date_data.dt_seconds, speedy_coords=speedy_coords)
+        physics_data = PhysicsData.zeros(xy,kx, dt_seconds=date_data.dt_seconds, speedy_coords=speedy_coords)
         state = PhysicsState(jnp.zeros(zxy), jnp.zeros(zxy), jnp.zeros(zxy), jnp.zeros(zxy), jnp.zeros(zxy), jnp.zeros(xy))
         forcing_now = forcing.select(date_data, calendar='gregorian')
         physics_data = get_zonal_average_fields(state, physics_data, forcing_now, terrain)
@@ -330,7 +330,7 @@ class TestShortWaveRadiation(unittest.TestCase):
         zxy = (kx, ix, il)
         # Provide a date that is equivalent to tyear=0.25
         date_data = DateData.set_date(model_time=jdt.to_datetime('2000-03-21'))
-        physics_data = PhysicsData.zeros(xy,kx,model_step=date_data.model_step, dt_seconds=date_data.dt_seconds,speedy_coords=speedy_coords)
+        physics_data = PhysicsData.zeros(xy,kx, dt_seconds=date_data.dt_seconds,speedy_coords=speedy_coords)
         state = PhysicsState.zeros(zxy)
         forcing_now = forcing.select(date_data, calendar='gregorian')
         physics_data = get_zonal_average_fields(state, physics_data, forcing_now, terrain)
@@ -370,7 +370,7 @@ class TestShortWaveRadiation(unittest.TestCase):
             jdt.Datetime.from_pydatetime(jdt.to_datetime('2001-08-08'))
         )
 
-        physics_data = PhysicsData.zeros(xy,kx,surface_flux=surface_flux, humidity=humidity, convection=convection, condensation=condensation, shortwave_rad=sw_data, model_step=date_data.model_step, dt_seconds=date_data.dt_seconds, speedy_coords=speedy_coords)
+        physics_data = PhysicsData.zeros(xy,kx,surface_flux=surface_flux, humidity=humidity, convection=convection, condensation=condensation, shortwave_rad=sw_data, dt_seconds=date_data.dt_seconds, speedy_coords=speedy_coords)
         state = PhysicsState.zeros(zxy, specific_humidity=qa, geopotential=geopotential, normalized_surface_pressure=psa)
 
         # Calculate gradient
@@ -430,7 +430,7 @@ class TestShortWaveRadiation(unittest.TestCase):
             jdt.Datetime.from_pydatetime(jdt.to_datetime('2001-08-08'))
         )
 
-        physics_data = PhysicsData.zeros(xy,kx,surface_flux=surface_flux, humidity=humidity, convection=convection, condensation=condensation, shortwave_rad=sw_data, model_step=date_data.model_step, dt_seconds=date_data.dt_seconds, speedy_coords=speedy_coords)
+        physics_data = PhysicsData.zeros(xy,kx,surface_flux=surface_flux, humidity=humidity, convection=convection, condensation=condensation, shortwave_rad=sw_data, dt_seconds=date_data.dt_seconds, speedy_coords=speedy_coords)
         state = PhysicsState.zeros(zxy, specific_humidity=qa, geopotential=geopotential, normalized_surface_pressure=psa)
         forcing = ForcingData.zeros(xy)
         # Calculate gradient
@@ -471,7 +471,7 @@ class TestShortWaveRadiation(unittest.TestCase):
         date_data = DateData.set_date(
             jdt.Datetime.from_pydatetime(jdt.to_datetime('2001-08-08'))
         )
-        physics_data = PhysicsData.zeros(xy,kx,surface_flux=surface_flux, humidity=humidity, convection=convection, condensation=condensation, shortwave_rad=sw_data, model_step=date_data.model_step, dt_seconds=date_data.dt_seconds)
+        physics_data = PhysicsData.zeros(xy,kx,surface_flux=surface_flux, humidity=humidity, convection=convection, condensation=condensation, shortwave_rad=sw_data, dt_seconds=date_data.dt_seconds)
         state = PhysicsState.zeros(zxy, specific_humidity=qa, geopotential=geopotential, normalized_surface_pressure=psa)
         _, physics_data = get_clouds(state, physics_data, parameters, forcing, terrain)
 
@@ -565,7 +565,7 @@ class TestShortWaveRadiation(unittest.TestCase):
             jdt.Datetime.from_pydatetime(jdt.to_datetime('2001-08-08'))
         )
 
-        physics_data = PhysicsData.zeros(xy,kx,surface_flux=surface_flux, humidity=humidity, convection=convection, condensation=condensation, shortwave_rad=sw_data, model_step=date_data.model_step, dt_seconds=date_data.dt_seconds)
+        physics_data = PhysicsData.zeros(xy,kx,surface_flux=surface_flux, humidity=humidity, convection=convection, condensation=condensation, shortwave_rad=sw_data, dt_seconds=date_data.dt_seconds)
         state = PhysicsState.zeros(zxy, specific_humidity=qa, geopotential=geopotential, normalized_surface_pressure=psa)
         forcing = ForcingData.zeros(xy, fmask=fmask)
 

--- a/jcm/physics/speedy/physics_data.py
+++ b/jcm/physics/speedy/physics_data.py
@@ -68,24 +68,30 @@ class SWRadiationData:
     compute_shortwave: Flag to compute shortwave radiation
     """
 
-    qcloud: jnp.ndarray  
-    fsol: jnp.ndarray  
-    rsds: jnp.ndarray   
-    rsns: jnp.ndarray  
-    ozone: jnp.ndarray 
+    qcloud: jnp.ndarray
+    fsol: jnp.ndarray
+    rsds: jnp.ndarray
+    rsns: jnp.ndarray
+    ozone: jnp.ndarray
     ozupp: jnp.ndarray
-    zenit: jnp.ndarray 
-    stratz: jnp.ndarray 
-    gse: jnp.ndarray 
+    zenit: jnp.ndarray
+    stratz: jnp.ndarray
+    gse: jnp.ndarray
     icltop: jnp.ndarray
-    cloudc: jnp.ndarray 
-    cloudstr: jnp.ndarray 
-    ftop: jnp.ndarray  
-    dfabs: jnp.ndarray 
+    cloudc: jnp.ndarray
+    cloudstr: jnp.ndarray
+    ftop: jnp.ndarray
+    dfabs: jnp.ndarray
     compute_shortwave: jnp.bool
+    # SPEEDY's shortwave sub-stepping counter (every `nstrad` calls).
+    # `set_physics_flags` reads it, computes ``compute_shortwave``, then
+    # writes ``step+1`` back so the next step sees the advanced value.
+    # Threaded as part of the carry slot for ``_shortwave_rad`` — no
+    # model-wide step counter / date plumbing needed.
+    step: jnp.int32
 
     @classmethod
-    def zeros(cls, nodal_shape, num_levels, qcloud=None, fsol=None, rsds=None, rsns=None, ozone=None, ozupp=None, zenit=None, stratz=None, gse=None, icltop=None, cloudc=None, cloudstr=None, ftop=None, dfabs=None, compute_shortwave=None):
+    def zeros(cls, nodal_shape, num_levels, qcloud=None, fsol=None, rsds=None, rsns=None, ozone=None, ozupp=None, zenit=None, stratz=None, gse=None, icltop=None, cloudc=None, cloudstr=None, ftop=None, dfabs=None, compute_shortwave=None, step=None):
         return cls(
             qcloud = qcloud if qcloud is not None else jnp.zeros(nodal_shape),
             fsol = fsol if fsol is not None else jnp.zeros(nodal_shape),
@@ -101,11 +107,12 @@ class SWRadiationData:
             cloudstr = cloudstr if cloudstr is not None else jnp.zeros(nodal_shape),
             ftop = ftop if ftop is not None else jnp.zeros(nodal_shape),
             dfabs = dfabs if dfabs is not None else jnp.zeros((num_levels,)+nodal_shape),
-            compute_shortwave = compute_shortwave if compute_shortwave is not None else False
+            compute_shortwave = compute_shortwave if compute_shortwave is not None else False,
+            step = step if step is not None else jnp.int32(0),
         )
-    
+
     @classmethod
-    def ones(cls, nodal_shape, num_levels, qcloud=None, fsol=None, rsds=None, rsns=None, ozone=None, ozupp=None, zenit=None, stratz=None, gse=None, icltop=None, cloudc=None, cloudstr=None, ftop=None, dfabs=None, compute_shortwave=None):
+    def ones(cls, nodal_shape, num_levels, qcloud=None, fsol=None, rsds=None, rsns=None, ozone=None, ozupp=None, zenit=None, stratz=None, gse=None, icltop=None, cloudc=None, cloudstr=None, ftop=None, dfabs=None, compute_shortwave=None, step=None):
         return cls(
             qcloud = qcloud if qcloud is not None else jnp.ones(nodal_shape),
             fsol = fsol if fsol is not None else jnp.ones(nodal_shape),
@@ -121,10 +128,11 @@ class SWRadiationData:
             cloudstr = cloudstr if cloudstr is not None else jnp.ones(nodal_shape),
             ftop = ftop if ftop is not None else jnp.ones(nodal_shape),
             dfabs = dfabs if dfabs is not None else jnp.ones((num_levels,)+nodal_shape),
-            compute_shortwave = compute_shortwave if compute_shortwave is not None else True
+            compute_shortwave = compute_shortwave if compute_shortwave is not None else True,
+            step = step if step is not None else jnp.int32(1),
         )
 
-    def copy(self, qcloud=None, fsol=None, rsds=None, rsns=None, ozone=None, ozupp=None, zenit=None, stratz=None, gse=None, icltop=None, cloudc=None, cloudstr=None, ftop=None, dfabs=None, compute_shortwave=None):
+    def copy(self, qcloud=None, fsol=None, rsds=None, rsns=None, ozone=None, ozupp=None, zenit=None, stratz=None, gse=None, icltop=None, cloudc=None, cloudstr=None, ftop=None, dfabs=None, compute_shortwave=None, step=None):
         return SWRadiationData(
             qcloud=qcloud if qcloud is not None else self.qcloud,
             fsol=fsol if fsol is not None else self.fsol,
@@ -140,7 +148,8 @@ class SWRadiationData:
             cloudstr=cloudstr if cloudstr is not None else self.cloudstr,
             ftop=ftop if ftop is not None else self.ftop,
             dfabs=dfabs if dfabs is not None else self.dfabs,
-            compute_shortwave=compute_shortwave if compute_shortwave is not None else self.compute_shortwave
+            compute_shortwave=compute_shortwave if compute_shortwave is not None else self.compute_shortwave,
+            step=step if step is not None else self.step,
         )
     
     def isnan(self):
@@ -466,17 +475,19 @@ class PhysicsData:
     humidity: HumidityData
     condensation: CondensationData
     surface_flux: SurfaceFluxData
-    # `model_step` is the integer timestep counter used by the radiation
-    # toggle (`mod nstrad`); `dt_seconds` is the model timestep in seconds.
-    # The wall-clock side of the date is consumed by physics through
-    # `forcing.solar` (populated by `ForcingData.select(date)`).
-    model_step: jnp.int32
+    # Model timestep in seconds. Sourced from
+    # ``ComposablePhysics.dt_seconds`` each step via the
+    # ``diagnostics["_dt_seconds"]`` plumbing; consumed by
+    # ``speedy_orographic`` to translate the SPEEDY instantaneous
+    # T/q corrections into per-step tendencies. The shortwave
+    # sub-stepping counter (`mod nstrad`) lives on
+    # :attr:`SWRadiationData.step` and rides the radiation carry slot.
     dt_seconds: float
     land_model: LandModelData
     speedy_coords: SpeedyCoords
 
     @classmethod
-    def zeros(cls, nodal_shape, num_levels, shortwave_rad=None,longwave_rad=None, convection=None, mod_radcon=None, humidity=None, condensation=None, surface_flux=None, model_step=None, dt_seconds=None, land_model=None, speedy_coords=None):
+    def zeros(cls, nodal_shape, num_levels, shortwave_rad=None,longwave_rad=None, convection=None, mod_radcon=None, humidity=None, condensation=None, surface_flux=None, dt_seconds=None, land_model=None, speedy_coords=None):
         return cls(
             longwave_rad = longwave_rad if longwave_rad is not None else LWRadiationData.zeros(nodal_shape, num_levels),
             shortwave_rad = shortwave_rad if shortwave_rad is not None else SWRadiationData.zeros(nodal_shape, num_levels),
@@ -485,14 +496,13 @@ class PhysicsData:
             humidity = humidity if humidity is not None else HumidityData.zeros(nodal_shape, num_levels),
             condensation = condensation if condensation is not None else CondensationData.zeros(nodal_shape, num_levels),
             surface_flux = surface_flux if surface_flux is not None else SurfaceFluxData.zeros(nodal_shape),
-            model_step = model_step if model_step is not None else jnp.int32(0),
             dt_seconds = dt_seconds if dt_seconds is not None else 1800.0,
             land_model = land_model if land_model is not None else LandModelData.zeros(nodal_shape),
             speedy_coords = speedy_coords,
         )
 
     @classmethod
-    def ones(cls, nodal_shape, num_levels, shortwave_rad=None, longwave_rad=None, convection=None, mod_radcon=None, humidity=None, condensation=None, surface_flux=None, model_step=None, dt_seconds=None, land_model=None, speedy_coords=None):
+    def ones(cls, nodal_shape, num_levels, shortwave_rad=None, longwave_rad=None, convection=None, mod_radcon=None, humidity=None, condensation=None, surface_flux=None, dt_seconds=None, land_model=None, speedy_coords=None):
         return cls(
             longwave_rad = longwave_rad if longwave_rad is not None else LWRadiationData.ones(nodal_shape, num_levels),
             shortwave_rad = shortwave_rad if shortwave_rad is not None else SWRadiationData.ones(nodal_shape, num_levels),
@@ -501,13 +511,12 @@ class PhysicsData:
             humidity = humidity if humidity is not None else HumidityData.ones(nodal_shape, num_levels),
             condensation = condensation if condensation is not None else CondensationData.ones(nodal_shape, num_levels),
             surface_flux = surface_flux if surface_flux is not None else SurfaceFluxData.ones(nodal_shape),
-            model_step = model_step if model_step is not None else jnp.int32(0),
             dt_seconds = dt_seconds if dt_seconds is not None else 1800.0,
             land_model = land_model if land_model is not None else LandModelData.ones(nodal_shape),
             speedy_coords = speedy_coords,
         )
 
-    def copy(self, shortwave_rad=None,longwave_rad=None,convection=None, mod_radcon=None, humidity=None, condensation=None, surface_flux=None, model_step=None, dt_seconds=None, land_model=None, speedy_coords=None):
+    def copy(self, shortwave_rad=None,longwave_rad=None,convection=None, mod_radcon=None, humidity=None, condensation=None, surface_flux=None, dt_seconds=None, land_model=None, speedy_coords=None):
         return PhysicsData(
             shortwave_rad=shortwave_rad if shortwave_rad is not None else self.shortwave_rad,
             longwave_rad=longwave_rad if longwave_rad is not None else self.longwave_rad,
@@ -516,7 +525,6 @@ class PhysicsData:
             humidity=humidity if humidity is not None else self.humidity,
             condensation=condensation if condensation is not None else self.condensation,
             surface_flux=surface_flux if surface_flux is not None else self.surface_flux,
-            model_step=model_step if model_step is not None else self.model_step,
             dt_seconds=dt_seconds if dt_seconds is not None else self.dt_seconds,
             land_model=land_model if land_model is not None else self.land_model,
             speedy_coords=speedy_coords if speedy_coords is not None else self.speedy_coords
@@ -524,9 +532,9 @@ class PhysicsData:
 
     # Isnan function to check if any elements of PhysicsData are NaN. This function is used after getting the gradient of something with respect to
     # a PhysicsData input object, to check if the gradient is valid. We skip
-    # `model_step`/`dt_seconds` because they are integer/float scalars that
-    # are non-differentiable. We also skip the check on speedy_coords because
-    # it's a constant coordinate cache that should not have gradients.
+    # `dt_seconds` because it is a float scalar that is non-differentiable.
+    # We also skip the check on speedy_coords because it's a constant
+    # coordinate cache that should not have gradients.
     def isnan(self):
         return PhysicsData(
             shortwave_rad=self.shortwave_rad.isnan(),
@@ -536,7 +544,6 @@ class PhysicsData:
             humidity=self.humidity.isnan(),
             condensation=self.condensation.isnan(),
             surface_flux=self.surface_flux.isnan(),
-            model_step=0,
             dt_seconds=0,
             land_model=self.land_model.isnan(),
             speedy_coords=0

--- a/jcm/physics/speedy/speedy_terms.py
+++ b/jcm/physics/speedy/speedy_terms.py
@@ -14,7 +14,6 @@ from typing import ClassVar
 from flax import nnx
 
 from jcm.physics.physics_term import PhysicsTerm
-from jcm.date import DateData
 from jcm.physics.speedy.physics_data import (
     PhysicsData,
 )
@@ -46,12 +45,16 @@ def set_physics_flags(
 
     Currently only toggles the shortwave-radiation flag every ``nstrad`` steps
     so that the costly clouds + shortwave fluxes only recompute on radiation
-    sub-steps.
+    sub-steps. The step counter is the radiation carry slot's own
+    :attr:`SWRadiationData.step` — incremented each call so the gate
+    advances without any model-wide step plumbing.
     """
     from jcm.physics.speedy.physical_constants import nstrad
-    compute_shortwave = (jnp.mod(physics_data.model_step, nstrad) == 0)
+    step = physics_data.shortwave_rad.step
+    compute_shortwave = (jnp.mod(step, nstrad) == 0)
     shortwave_data = physics_data.shortwave_rad.copy(
         compute_shortwave=compute_shortwave,
+        step=step + 1,
     )
     physics_data = physics_data.copy(shortwave_rad=shortwave_data)
     physics_tendencies = PhysicsTendency.zeros(state.temperature.shape)
@@ -88,13 +91,18 @@ def _data_from_diagnostics(
     Keys that haven't been populated yet will get their default zero values.
     ``nodal_shape`` and ``num_levels`` are passed explicitly (not from the
     diagnostics dict) so they remain static Python values under JIT.
+
+    ``dt_seconds`` is sourced from the ``"_dt_seconds"`` plumbing slot
+    that ``ComposablePhysics`` injects at the top of every
+    ``compute_tendencies`` call. The shortwave sub-stepping counter
+    lives on the radiation carry (see :func:`set_physics_flags`), so
+    no date / model-wide step is threaded into PhysicsData any more.
     """
-    date = diagnostics.get("_date", DateData.zeros())
+    dt_seconds = diagnostics.get("_dt_seconds", 1800.0)
 
     data = PhysicsData.zeros(
         nodal_shape, num_levels,
-        model_step=date.model_step,
-        dt_seconds=date.dt_seconds,
+        dt_seconds=dt_seconds,
         speedy_coords=coords,
     )
 

--- a/jcm/physics/speedy/speedy_terms_test.py
+++ b/jcm/physics/speedy/speedy_terms_test.py
@@ -77,9 +77,7 @@ class TestSpeedyNumericalEquivalence(unittest.TestCase):
         composable.cache_coords(self.coords)
 
         def loss_fn(physics):
-            tend, _ = physics.compute_tendencies(
-                self.state, self.forcing, self.terrain, self.date
-            )
+            tend, _ = physics.compute_tendencies(self.state, self.forcing, self.terrain)
             return jnp.sum(tend.temperature ** 2)
 
         grads = nnx.grad(loss_fn)(composable)
@@ -111,9 +109,7 @@ class TestSpeedyNumericalEquivalence(unittest.TestCase):
         replaced = composable.replace("convection", SpeedyConvection(new_conv_params))
 
         replaced.cache_coords(self.coords)
-        tend, _ = replaced.compute_tendencies(
-            self.state, self.forcing, self.terrain, self.date
-        )
+        tend, _ = replaced.compute_tendencies(self.state, self.forcing, self.terrain)
 
         # Should produce valid (non-NaN) tendencies
         self.assertFalse(jnp.any(jnp.isnan(tend.temperature)))

--- a/jcm/physics/surface/echam/surface_physics.py
+++ b/jcm/physics/surface/echam/surface_physics.py
@@ -458,7 +458,7 @@ class EchamSurface(PhysicsTerm):
     ) -> tuple[PhysicsTendency, dict]:
         """Compute lowest-level surface-flux tendencies and surface diagnostics."""
         nlev, ncols = state.temperature.shape
-        dt = diagnostics["_date"].dt_seconds
+        dt = diagnostics["_dt_seconds"]
         params = self.params.get_value()
 
         pressure_full = diagnostics["pressure_full"]

--- a/jcm/physics/vertical_diffusion/tte_tke/vertical_diffusion.py
+++ b/jcm/physics/vertical_diffusion/tte_tke/vertical_diffusion.py
@@ -478,7 +478,7 @@ class TteTkeVerticalDiffusion(PhysicsTerm):
     ) -> tuple[PhysicsTendency, dict]:
         """Compute vdiff tendencies and update ``vertical_diffusion``."""
         nlev, ncols = state.temperature.shape
-        dt = diagnostics["_date"].dt_seconds
+        dt = diagnostics["_dt_seconds"]
         params = self.params.get_value()
 
         pressure_full = diagnostics["pressure_full"]

--- a/jcm/physics_interface.py
+++ b/jcm/physics_interface.py
@@ -19,7 +19,6 @@ from dinosaur.filtering import horizontal_diffusion_filter
 from jax import tree_util
 from jcm.forcing import ForcingData
 from jcm.terrain import TerrainData
-from jcm.date import DateData
 from typing import Tuple, Any, Dict, TypeAlias
 from jcm.diffusion import DiffusionFilter
 import logging
@@ -193,14 +192,15 @@ class Physics:
         """
         return ()
 
-    def compute_tendencies(self, state: PhysicsState, forcing: ForcingData, terrain: TerrainData, date: DateData, prev_physics_data=None) -> Tuple[PhysicsTendency, Any]:
+    def compute_tendencies(self, state: PhysicsState, forcing: ForcingData, terrain: TerrainData, prev_physics_data=None) -> Tuple[PhysicsTendency, Any]:
         """Compute the physical tendencies given the current state and data structs.
 
         Args:
             state: Current state variables
-            forcing: Forcing data
+            forcing: Forcing data — pre-sliced for the current step;
+                ``forcing.solar`` carries the orbital geometry physics
+                needs, so no calendar is plumbed in here.
             terrain: Terrain data (boundary conditions)
-            date: Date data
             prev_physics_data: Previous step's physics carry (a
                 :data:`PhysicsCarryState`) — used by radiation sub-cycling,
                 the analytic TKE source update, etc. ``None`` means "no
@@ -588,7 +588,6 @@ def compute_physics_step(
     physics: Physics,
     forcing: ForcingData,
     terrain: TerrainData,
-    date: DateData,
     physics_state,
 ) -> tuple[State, Any]:
     """Compute the physics dynamics-tendency for an operator-split timestep.
@@ -606,9 +605,10 @@ def compute_physics_step(
             ``verify_tendencies`` to cap negative-going tracer
             tendencies).
         physics: ``Physics`` instance (e.g. :class:`ComposablePhysics`).
-        forcing: Time-sliced ``ForcingData`` for this step.
+        forcing: Time-sliced ``ForcingData`` for this step. ``solar``
+            already carries the per-step orbital geometry, so physics
+            never needs the calendar / model step.
         terrain: ``TerrainData`` (orography, land-sea mask, …).
-        date: ``DateData`` for the current step.
         physics_state: The cross-step physics carry — the dict returned
             by the previous step's ``compute_tendencies`` call, or the
             initial value produced by ``physics.initial_carry_state``.
@@ -627,7 +627,7 @@ def compute_physics_step(
     clamped_physics_state = verify_state(physics_grid_state)
 
     physics_tendency, new_physics_state = physics.compute_tendencies(
-        clamped_physics_state, forcing, terrain, date,
+        clamped_physics_state, forcing, terrain,
         prev_physics_data=physics_state,
     )
     physics_tendency = verify_tendencies(

--- a/jcm/prescribed_state_model.py
+++ b/jcm/prescribed_state_model.py
@@ -13,13 +13,11 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
-import jax_datetime as jdt
 import tree_math
 from jax.tree_util import tree_map
 
 from dinosaur.coordinate_systems import CoordinateSystem
 
-from jcm.date import DateData
 from jcm.forcing import ForcingData, default_forcing
 from jcm.physics_interface import (
     Physics,
@@ -38,7 +36,7 @@ class PrescribedStatePredictions:
         states: The prescribed atmospheric state time series.
         tendencies: Physics tendencies for each step.
         physics_data: Per-step diagnostics dict from the physics package.
-        times: Times in days since ``start_date``.
+        times: Times in days since the start of the run.
 
     """
 
@@ -56,7 +54,6 @@ class PrescribedStateModel:
         coords: ``CoordinateSystem`` used for grids and ``physics.cache_coords``.
         terrain: Optional ``TerrainData`` boundary conditions; defaults to the
             aquaplanet derived from ``coords``.
-        start_date: Starting date for time-series indexing (default 2000-01-01).
         dt_seconds: Physics timestep in seconds (default 1800).
 
     """
@@ -66,25 +63,19 @@ class PrescribedStateModel:
         physics: Physics,
         coords: CoordinateSystem,
         terrain: TerrainData | None = None,
-        start_date: jdt.Datetime = jdt.to_datetime("2000-01-01"),
         dt_seconds: float = 1800.0,
     ) -> None:
         """Initialise (see class docstring for argument descriptions)."""
         self.physics = physics
         self.coords = coords
         self.terrain = terrain if terrain is not None else TerrainData.aquaplanet(coords)
-        self.start_date = start_date
         self.dt_seconds = float(dt_seconds)
         self.physics.cache_coords(coords)
-
-    def _date_from_time_index(self, time_index) -> DateData:
-        sim_time_seconds = time_index * self.dt_seconds
-        seconds_int = jnp.round(sim_time_seconds).astype(jnp.int32)
-        return DateData.set_date(
-            model_time=self.start_date + jdt.Timedelta(seconds=seconds_int),
-            model_step=jnp.asarray(time_index).astype(jnp.int32),
-            dt_seconds=self.dt_seconds,
-        )
+        # Hand the timestep down to the composable-physics container so its
+        # terms read a single ``dt`` source — mirrors the wiring in ``Model``
+        # and ``SingleColumnModel``.
+        if hasattr(self.physics, "dt_seconds"):
+            self.physics.dt_seconds = self.dt_seconds
 
     def run(
         self,
@@ -116,23 +107,14 @@ class PrescribedStateModel:
 
         physics = self.physics
         terrain = self.terrain
-        start_date = self.start_date
-        dt_seconds = self.dt_seconds
 
-        def step(state, time_idx):
-            sim_time_seconds = time_idx * dt_seconds
-            seconds_int = jnp.round(sim_time_seconds).astype(jnp.int32)
-            date = DateData.set_date(
-                model_time=start_date + jdt.Timedelta(seconds=seconds_int),
-                model_step=jnp.asarray(time_idx).astype(jnp.int32),
-                dt_seconds=dt_seconds,
-            )
+        def step(state):
             clamped = verify_state(state)
-            return physics.compute_tendencies(clamped, forcing, terrain, date)
+            return physics.compute_tendencies(clamped, forcing, terrain)
 
         @jax.jit
         def vmapped():
-            return jax.vmap(step)(states, jnp.arange(n_times))
+            return jax.vmap(step)(states)
 
         tendencies, physics_data = vmapped()
         return PrescribedStatePredictions(

--- a/jcm/single_column_model.py
+++ b/jcm/single_column_model.py
@@ -342,21 +342,27 @@ class SingleColumnModel:
                 for name, _ in relaxed_var_params
             }
 
-        # Bootstrap the diagnostics-dict pytree shape by running one step.
+        # Seed the diagnostics-dict carry the same way ``Model`` does:
+        # the structural template comes from
+        # :meth:`ComposablePhysics.get_empty_data` (a zero-filled
+        # snapshot of the post-step output pytree) unioned with the
+        # declarative cross-step carry slots from
+        # :meth:`ComposablePhysics.initial_carry_state` (e.g. TKE
+        # floored at ECHAM's 0.01 m²/s² lower bound). Using a
+        # live ``compute_tendencies`` result here was the architectural
+        # bug `#470 <https://github.com/climate-analytics-lab/jax-gcm/issues/470>`_
+        # tracks — among other things, the radiation carry's ``step``
+        # counter gets advanced before the first real scan step, which
+        # shifts the sub-stepping cadence by one under ``nstrad > 1``.
         if initial_physics_data is None:
-            first_state = tree_map(lambda x: x[0], prescribed_states)
-            state_args = first_state.asdict()
-            state_args.pop("tracers", None)
-            for name, val in initial_relaxed_vars.items():
-                state_args[name] = val
-            state_args["tracers"] = initial_tracers
-            first_state_combined = type(first_state)(**state_args)
-            nlev = self.coords.nodal_shape[0]
-            grid_state = _column_state_to_grid(first_state_combined, nlev)
-            clamped = verify_state(grid_state)
-            _, initial_physics_data = self.physics.compute_tendencies(
-                clamped, forcing, self.terrain,
-            )
+            template = self.physics.get_empty_data(self.coords)
+            initial_carry = self.physics.initial_carry_state(self.coords)
+            if isinstance(initial_carry, dict) and isinstance(template, dict):
+                initial_physics_data = {**template, **initial_carry}
+            else:
+                initial_physics_data = (
+                    template if initial_carry is None else initial_carry
+                )
 
         if times is None:
             times = jnp.arange(n_times) * (self.dt_seconds / 86400.0)

--- a/jcm/single_column_model.py
+++ b/jcm/single_column_model.py
@@ -29,13 +29,11 @@ from typing import Any, Callable
 
 import jax
 import jax.numpy as jnp
-import jax_datetime as jdt
 import numpy as np
 import tree_math
 from jax import lax
 from jax.tree_util import tree_map
 
-from jcm.date import DateData
 from jcm.forcing import ForcingData
 from jcm.physics_interface import (
     Physics,
@@ -61,7 +59,7 @@ class SCMPredictions:
             empty when no relaxation is configured).
         tendencies: Physics tendencies at each step (1-D).
         physics_data: Per-step diagnostics dict from the physics package.
-        times: Times in days since ``start_date``.
+        times: Times in days since the start of the run.
 
     """
 
@@ -187,7 +185,6 @@ class SingleColumnModel:
             defaults to ``TerrainData.single_column()`` (flat, all ocean).
         forcing: Optional single-column ``ForcingData`` (shape ``(1, 1)``);
             defaults to ``ForcingData.zeros((1, 1))``.
-        start_date: Starting date for the time series (default 2000-01-01).
         dt_seconds: Physics timestep in seconds (default 1800).
         apply_tracer_tendencies: When ``False`` tracers are reported
             diagnostically but not advanced.
@@ -207,7 +204,6 @@ class SingleColumnModel:
         lon_deg: float = 0.0,
         terrain: TerrainData | None = None,
         forcing: ForcingData | None = None,
-        start_date: jdt.Datetime = jdt.to_datetime("2000-01-01"),
         dt_seconds: float = 1800.0,
         apply_tracer_tendencies: bool = True,
         relaxation_timescales: dict[str, float] | None = None,
@@ -217,7 +213,6 @@ class SingleColumnModel:
         self.vertical = vertical
         self.lat_deg = float(lat_deg)
         self.lon_deg = float(lon_deg)
-        self.start_date = start_date
         self.dt_seconds = float(dt_seconds)
         self.apply_tracer_tendencies = apply_tracer_tendencies
         self.relaxation_timescales = dict(relaxation_timescales or {})
@@ -227,19 +222,15 @@ class SingleColumnModel:
         self.forcing = forcing if forcing is not None else ForcingData.zeros((1, 1))
 
         self.physics.cache_coords(self.coords)
+        # Hand the SCM's timestep down to the composable-physics container so
+        # its terms read a single ``dt`` source (the same plumbing the full
+        # ``Model`` uses).
+        if hasattr(self.physics, "dt_seconds"):
+            self.physics.dt_seconds = self.dt_seconds
 
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
-
-    def _date(self, time_idx) -> DateData:
-        sim_time_seconds = time_idx * self.dt_seconds
-        seconds_int = jnp.round(sim_time_seconds).astype(jnp.int32)
-        return DateData.set_date(
-            model_time=self.start_date + jdt.Timedelta(seconds=seconds_int),
-            model_step=jnp.asarray(time_idx).astype(jnp.int32),
-            dt_seconds=self.dt_seconds,
-        )
 
     @staticmethod
     def _stack_states(states: list[PhysicsState]) -> PhysicsState:
@@ -256,16 +247,6 @@ class SingleColumnModel:
         terrain = self.terrain
         nlev = self.coords.nodal_shape[0]
         dt_seconds = self.dt_seconds
-        start_date = self.start_date
-
-        def compute_date(time_idx):
-            sim_time_seconds = time_idx * dt_seconds
-            seconds_int = jnp.round(sim_time_seconds).astype(jnp.int32)
-            return DateData.set_date(
-                model_time=start_date + jdt.Timedelta(seconds=seconds_int),
-                model_step=jnp.asarray(time_idx).astype(jnp.int32),
-                dt_seconds=dt_seconds,
-            )
 
         def step_fn(prescribed_column, tracers, relaxed_vars, physics_data, time_idx):
             full_state_args = prescribed_column.asdict()
@@ -278,7 +259,7 @@ class SingleColumnModel:
             grid_state = _column_state_to_grid(column_state, nlev)
             clamped = verify_state(grid_state)
             tendencies_grid, new_physics_data = physics.compute_tendencies(
-                clamped, forcing, terrain, compute_date(time_idx),
+                clamped, forcing, terrain,
                 prev_physics_data=physics_data,
             )
             tendencies = _squeeze_tendency(tendencies_grid)
@@ -374,7 +355,7 @@ class SingleColumnModel:
             grid_state = _column_state_to_grid(first_state_combined, nlev)
             clamped = verify_state(grid_state)
             _, initial_physics_data = self.physics.compute_tendencies(
-                clamped, forcing, self.terrain, self._date(0),
+                clamped, forcing, self.terrain,
             )
 
         if times is None:

--- a/jcm/single_column_model_test.py
+++ b/jcm/single_column_model_test.py
@@ -108,6 +108,29 @@ class TestSCMEcham(unittest.TestCase):
         self.assertIn('qc', predictions.tracer_states)
         self.assertIn('qi', predictions.tracer_states)
 
+    def test_radiation_step_counter_starts_at_zero(self):
+        """Regression: SCM bootstrap must not advance the radiation carry.
+
+        After step 0 the radiation term increments its own ``step`` slot
+        from 0→1. If the bootstrap (`initial_physics_data=None` path)
+        seeds the carry from a live ``compute_tendencies`` result
+        instead of a zero template, step 0 starts at 1 and the
+        sub-stepping cadence skews by one — caught by the codex review
+        on PR #476.
+        """
+        column_state = _make_column_state(nlev=8)
+        scm = SingleColumnModel(
+            physics=echam_physics(radiation_scheme='grey'),
+            vertical=SigmaCoordinates.equidistant(8),
+            lat_deg=0.0,
+            lon_deg=0.0,
+        )
+        # Three scan steps with the default ``initial_physics_data=None``
+        # path. After step N the carry's ``step`` field reads N+1.
+        predictions = scm.run([column_state] * 3)
+        rad_steps = predictions.physics_data['radiation'].step
+        self.assertEqual(tuple(int(s) for s in rad_steps), (1, 2, 3))
+
 
 class TestSCMHelpers(unittest.TestCase):
     """The SCM-oriented helpers in ``jcm.utils``."""


### PR DESCRIPTION
## Summary
After PR #448 moved the calendar-y side of forcing outside the physics loop, no physics term reads `.dt`, `.tyear`, `.model_year`, or `.model_day` anywhere — but `DateData` was still being threaded through `compute_physics_step` and `ComposablePhysics.compute_tendencies` purely so:

- 11 terms could pull `dt_seconds` (a constant — the model timestep), and
- 2 radiation gates could pull `model_step` (an integer step counter).

Both can live on what the operator-split refactor (#471) already gives us: a static config on the physics container, and a carry slot on the radiation term itself.

- **`dt_seconds` lives on `ComposablePhysics`.** New ctor arg, overridden by `Model.__init__` to `self.dt_si.m`; injected into the diagnostics dict each step as `"_dt_seconds"`. All 9 dt-consuming terms switch from `diagnostics["_date"].dt_seconds` to `diagnostics["_dt_seconds"]`.
- **`model_step` is gone — radiation tracks its own.** Added `step: jnp.int32` to `RadiationData` (ICON/ECHAM side) and `SWRadiationData` (SPEEDY side). Each radiation `__call__` does `new_radiation.copy(step=radiation.step + 1)` on both the compute and cached paths; `radiation_should_compute` and the RRTMGP McICA seed read from there. SPEEDY's `set_physics_flags` does the same on its carry slot. `PhysicsData.model_step` is removed entirely.
- **`compute_physics_step`, `Physics.compute_tendencies`, `ComposablePhysics.compute_tendencies` no longer take `date`.** `Model._get_op_split_step_fn` still computes a date for `forcing.select` (still needed — `forcing.solar` reconstruction and TimeSeries slicing live there) and for the nudging tendency, but no longer passes anything date-shaped into physics.
- **`SingleColumnModel` and `PrescribedStateModel` drop their `start_date` arg** and internal `DateData` plumbing; both wire their own `dt_seconds` down to the composable-physics container in the same setter pattern Model uses.

## Test plan
- [x] `JAX_PLATFORMS=cpu pytest -n 12 -m \"not slow\"` — **854 passed, 13 skipped**
- [x] `JAX_PLATFORMS=cpu pytest -n 12 -m \"slow\"` — **39 passed, 17 skipped**
- [x] `ruff check jcm/` — clean
- [ ] Reviewer sanity check on the SPEEDY radiation step counter: it now lives on `SWRadiationData.step` (advanced inside `set_physics_flags`) instead of `PhysicsData.model_step`. Same `mod nstrad` gate, same cadence — but worth a second pair of eyes since SPEEDY's `_data_from_diagnostics` no longer threads anything date-shaped at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)