### PR TITLE
[codex] Stabilize ECHAM cloud physics ordering

### DIFF
--- a/docs/source/echam_physics.rst
+++ b/docs/source/echam_physics.rst
@@ -242,20 +242,20 @@ Cloud Cover
      - Description
      - Default
    * - ``crt``
-     - Critical RH at surface for cloud formation
-     - 0.9
+     - Critical RH aloft for cloud formation
+     - 0.75
    * - ``crs``
-     - Critical RH at model top for cloud formation
-     - 0.7
+     - Critical RH near the surface for cloud formation
+     - 0.975
    * - ``nex``
-     - Power-law exponent for vertical RH profile
-     - 4.0
+     - Exponent for the ECHAM ``mo_cover`` RH profile
+     - 2.0
    * - ``t_ice``
      - Temperature for pure ice phase (K)
      - 238.15
    * - ``csatsc``
      - Saturation factor for stratocumulus
-     - 0.97
+     - 0.7
 
 .. admonition:: Gap vs. ICON-A
 

--- a/jcm/physics/clouds/cloud_data.py
+++ b/jcm/physics/clouds/cloud_data.py
@@ -90,3 +90,14 @@ class CloudData:
         }
         new_data.update(kwargs)
         return CloudData(**new_data)
+
+
+def radiation_cloud_fields(state, diagnostics):
+    """Return cloud fields for radiation from the current cloud diagnostic.
+
+    Radiation must use the post-cloud-scheme condensate carried on
+    ``diagnostics["clouds"]``. Reading ``state.tracers["qc"/"qi"]`` here
+    reverts to the pre-physics values for the current split step.
+    """
+    clouds = diagnostics["clouds"]
+    return clouds.qc, clouds.qi, clouds.cloud_fraction

--- a/jcm/physics/clouds/cloud_data.py
+++ b/jcm/physics/clouds/cloud_data.py
@@ -93,11 +93,15 @@ class CloudData:
 
 
 def radiation_cloud_fields(state, diagnostics):
-    """Return cloud fields for radiation from the current cloud diagnostic.
+    """Return ECHAM-ordered cloud fields for radiation.
 
-    Radiation must use the post-cloud-scheme condensate carried on
-    ``diagnostics["clouds"]``. Reading ``state.tracers["qc"/"qi"]`` here
-    reverts to the pre-physics values for the current split step.
+    ECHAM ``physc`` calls ``cover`` before radiation, then passes the
+    diagnosed cloud fraction plus the pre-cloud-step ``xlm1`` / ``xim1``
+    condensate fields into radiation. Large-scale cloud microphysics runs
+    later. Mirror that here: fresh cloud fraction comes from
+    ``diagnostics["clouds"]``, while condensate comes from state tracers.
     """
     clouds = diagnostics["clouds"]
-    return clouds.qc, clouds.qi, clouds.cloud_fraction
+    cloud_water = state.tracers.get("qc", jnp.zeros_like(state.temperature))
+    cloud_ice = state.tracers.get("qi", jnp.zeros_like(state.temperature))
+    return cloud_water, cloud_ice, clouds.cloud_fraction

--- a/jcm/physics/clouds/cloud_data_test.py
+++ b/jcm/physics/clouds/cloud_data_test.py
@@ -6,34 +6,34 @@ from jcm.physics.clouds.cloud_data import CloudData, radiation_cloud_fields
 from jcm.physics_interface import PhysicsState
 
 
-def test_radiation_cloud_fields_use_current_cloud_diagnostics():
-    """Radiation should see post-cloud-scheme condensate, not stale tracers."""
+def test_radiation_cloud_fields_match_echam_cover_then_radiation_order():
+    """Radiation uses fresh cover but pre-cloud-step condensate tracers."""
     nlev, ncols = 3, 2
     shape = (nlev, ncols)
-    stale_qc = jnp.full(shape, 1.0e-9)
-    stale_qi = jnp.full(shape, 2.0e-9)
-    current_qc = jnp.arange(nlev * ncols, dtype=jnp.float32).reshape(shape) * 1e-5
-    current_qi = current_qc + 1e-4
-    current_cf = jnp.clip(current_qc * 1e4, 0.0, 1.0)
+    tracer_qc = jnp.full(shape, 1.0e-9)
+    tracer_qi = jnp.full(shape, 2.0e-9)
+    post_cloud_qc = jnp.arange(nlev * ncols, dtype=jnp.float32).reshape(shape) * 1e-5
+    post_cloud_qi = post_cloud_qc + 1e-4
+    diagnosed_cf = jnp.clip(post_cloud_qc * 1e4, 0.0, 1.0)
 
     state = PhysicsState.zeros(
         shape,
         temperature=jnp.ones(shape) * 280.0,
         specific_humidity=jnp.ones(shape) * 1e-3,
-        tracers={"qc": stale_qc, "qi": stale_qi},
+        tracers={"qc": tracer_qc, "qi": tracer_qi},
     )
     clouds = CloudData.zeros((ncols,), nlev).copy(
-        qc=current_qc,
-        qi=current_qi,
-        cloud_fraction=current_cf,
+        qc=post_cloud_qc,
+        qi=post_cloud_qi,
+        cloud_fraction=diagnosed_cf,
     )
 
     cloud_water, cloud_ice, cloud_fraction = radiation_cloud_fields(
         state, {"clouds": clouds},
     )
 
-    assert jnp.allclose(cloud_water, current_qc)
-    assert jnp.allclose(cloud_ice, current_qi)
-    assert jnp.allclose(cloud_fraction, current_cf)
-    assert not jnp.allclose(cloud_water, stale_qc)
-    assert not jnp.allclose(cloud_ice, stale_qi)
+    assert jnp.allclose(cloud_water, tracer_qc)
+    assert jnp.allclose(cloud_ice, tracer_qi)
+    assert jnp.allclose(cloud_fraction, diagnosed_cf)
+    assert not jnp.allclose(cloud_water, post_cloud_qc)
+    assert not jnp.allclose(cloud_ice, post_cloud_qi)

--- a/jcm/physics/clouds/cloud_data_test.py
+++ b/jcm/physics/clouds/cloud_data_test.py
@@ -1,0 +1,39 @@
+"""Tests for shared cloud diagnostics."""
+
+import jax.numpy as jnp
+
+from jcm.physics.clouds.cloud_data import CloudData, radiation_cloud_fields
+from jcm.physics_interface import PhysicsState
+
+
+def test_radiation_cloud_fields_use_current_cloud_diagnostics():
+    """Radiation should see post-cloud-scheme condensate, not stale tracers."""
+    nlev, ncols = 3, 2
+    shape = (nlev, ncols)
+    stale_qc = jnp.full(shape, 1.0e-9)
+    stale_qi = jnp.full(shape, 2.0e-9)
+    current_qc = jnp.arange(nlev * ncols, dtype=jnp.float32).reshape(shape) * 1e-5
+    current_qi = current_qc + 1e-4
+    current_cf = jnp.clip(current_qc * 1e4, 0.0, 1.0)
+
+    state = PhysicsState.zeros(
+        shape,
+        temperature=jnp.ones(shape) * 280.0,
+        specific_humidity=jnp.ones(shape) * 1e-3,
+        tracers={"qc": stale_qc, "qi": stale_qi},
+    )
+    clouds = CloudData.zeros((ncols,), nlev).copy(
+        qc=current_qc,
+        qi=current_qi,
+        cloud_fraction=current_cf,
+    )
+
+    cloud_water, cloud_ice, cloud_fraction = radiation_cloud_fields(
+        state, {"clouds": clouds},
+    )
+
+    assert jnp.allclose(cloud_water, current_qc)
+    assert jnp.allclose(cloud_ice, current_qi)
+    assert jnp.allclose(cloud_fraction, current_cf)
+    assert not jnp.allclose(cloud_water, stale_qc)
+    assert not jnp.allclose(cloud_ice, stale_qi)

--- a/jcm/physics/clouds/echam_1m.py
+++ b/jcm/physics/clouds/echam_1m.py
@@ -743,11 +743,17 @@ def cloud_microphysics(
     # Humidity: gains from evaporation/sublimation
     dqdt = rain_evap + snow_sublim
     
-    # Temperature: latent heat effects
+    # Temperature: latent heat effects. ECHAM's thermodynamic tendency does
+    # not include rain/snow production from autoconversion or aggregation;
+    # those are phase-preserving condensate-to-precip conversions. Only
+    # evaporation/sublimation, melt/freeze, and liquid riming by snow change
+    # phase enthalpy here.
     dtedt = (
-        - alhc / cp * (rain_evap - qc_auto - qc_accr)  # Liquid phase changes
-        - alhs / cp * (snow_sublim - qi_auto - qi_aggr - qc_rime)  # Ice phase changes  
-        - alhf / cp * (snow_melt - rain_freeze)  # Melting/freezing
+        - alhc / cp * rain_evap
+        - alhs / cp * snow_sublim
+        - alhf / cp * snow_melt
+        + alhf / cp * rain_freeze
+        + alhf / cp * qc_rime
     )
     
     # 6. Sedimentation (using simple approach for now)

--- a/jcm/physics/clouds/echam_1m.py
+++ b/jcm/physics/clouds/echam_1m.py
@@ -798,10 +798,11 @@ def cloud_microphysics(
     # where pmref = air_density * layer_thickness (layer mass per unit area)
     layer_mass = air_density * layer_thickness  # kg/m²
 
-    # Rain production per level: autoconversion + accretion + snow melting
-    rain_prod = (qc_auto + qc_accr + snow_melt) * cloud_fraction
-    # Snow production per level: ice autoconversion + aggregation + riming + rain freezing
-    snow_prod = (qi_auto + qi_aggr + qc_rime + rain_freeze) * cloud_fraction
+    # Rain/snow production rates are already grid-mean kg/kg/s. The
+    # autoconversion/accretion helpers convert from in-cloud to grid-mean
+    # internally, and melt/freeze rates operate on grid-mean precip stores.
+    rain_prod = qc_auto + qc_accr + snow_melt
+    snow_prod = qi_auto + qi_aggr + qc_rime + rain_freeze
 
     # Column-integrated surface flux (kg/m²/s)
     precip_rain = jnp.sum(rain_prod * layer_mass)

--- a/jcm/physics/clouds/echam_1m_test.py
+++ b/jcm/physics/clouds/echam_1m_test.py
@@ -475,6 +475,37 @@ class TestFullMicrophysics:
         assert tendencies.dqcdt[0] < 0.0
         assert tendencies.dqrdt[0] > 0.0
         assert jnp.allclose(tendencies.dtedt[0], 0.0, atol=1e-12)
+
+    def test_surface_rain_uses_grid_mean_production_rate(self):
+        """Precip diagnostics must not multiply grid-mean rates by cf again."""
+        config = MicrophysicsParameters.default()
+        temperature = jnp.array([285.0])
+        pressure = jnp.array([85000.0])
+        air_density = jnp.array([1.0])
+        layer_thickness = jnp.array([500.0])
+
+        from .sundqvist import saturation_specific_humidity
+        specific_humidity = jax.vmap(saturation_specific_humidity)(
+            pressure, temperature
+        )
+
+        tendencies, state = cloud_microphysics(
+            temperature=temperature,
+            specific_humidity=specific_humidity,
+            pressure=pressure,
+            cloud_water=jnp.array([1.0e-3]),
+            cloud_ice=jnp.array([0.0]),
+            cloud_fraction=jnp.array([0.5]),
+            air_density=air_density,
+            layer_thickness=layer_thickness,
+            droplet_number=jnp.array([100e6]),
+            dt=300.0,
+            config=config,
+        )
+
+        expected_rain = jnp.sum(tendencies.dqrdt * air_density * layer_thickness)
+        assert state.precip_rain > 0.0
+        assert jnp.allclose(state.precip_rain, expected_rain, rtol=1e-6)
     
     def test_cold_cloud_process(self):
         """Test ice microphysics"""

--- a/jcm/physics/clouds/echam_1m_test.py
+++ b/jcm/physics/clouds/echam_1m_test.py
@@ -446,6 +446,35 @@ class TestFullMicrophysics:
         assert jnp.any(tendencies.dqrdt > 0)  # Rain increases
         assert jnp.all(tendencies.dqsdt == 0)  # No snow in warm conditions
         assert state.precip_snow == 0  # No snow at surface
+
+    def test_warm_autoconversion_has_no_direct_latent_heating(self):
+        """Warm qc -> rain production is phase-preserving in ``mo_cloud``."""
+        config = MicrophysicsParameters.default()
+        temperature = jnp.array([285.0])
+        pressure = jnp.array([85000.0])
+
+        from .sundqvist import saturation_specific_humidity
+        specific_humidity = jax.vmap(saturation_specific_humidity)(
+            pressure, temperature
+        )
+
+        tendencies, _ = cloud_microphysics(
+            temperature=temperature,
+            specific_humidity=specific_humidity,
+            pressure=pressure,
+            cloud_water=jnp.array([1.0e-3]),
+            cloud_ice=jnp.array([0.0]),
+            cloud_fraction=jnp.array([1.0]),
+            air_density=jnp.array([1.0]),
+            layer_thickness=jnp.array([500.0]),
+            droplet_number=jnp.array([100e6]),
+            dt=300.0,
+            config=config,
+        )
+
+        assert tendencies.dqcdt[0] < 0.0
+        assert tendencies.dqrdt[0] > 0.0
+        assert jnp.allclose(tendencies.dtedt[0], 0.0, atol=1e-12)
     
     def test_cold_cloud_process(self):
         """Test ice microphysics"""
@@ -484,6 +513,35 @@ class TestFullMicrophysics:
         assert jnp.any(tendencies.dqsdt > 0)  # Snow increases
         assert jnp.all(tendencies.dqrdt == 0)  # No rain in cold conditions
         assert state.precip_rain == 0  # No rain at surface
+
+    def test_ice_autoconversion_has_no_direct_latent_heating(self):
+        """Cold qi -> snow production is phase-preserving in ``mo_cloud``."""
+        config = MicrophysicsParameters.default()
+        temperature = jnp.array([245.0])
+        pressure = jnp.array([50000.0])
+
+        from .sundqvist import saturation_specific_humidity
+        specific_humidity = jax.vmap(saturation_specific_humidity)(
+            pressure, temperature
+        )
+
+        tendencies, _ = cloud_microphysics(
+            temperature=temperature,
+            specific_humidity=specific_humidity,
+            pressure=pressure,
+            cloud_water=jnp.array([0.0]),
+            cloud_ice=jnp.array([8.0e-4]),
+            cloud_fraction=jnp.array([1.0]),
+            air_density=jnp.array([0.7]),
+            layer_thickness=jnp.array([500.0]),
+            droplet_number=jnp.array([50e6]),
+            dt=300.0,
+            config=config,
+        )
+
+        assert tendencies.dqidt[0] < 0.0
+        assert tendencies.dqsdt[0] > 0.0
+        assert jnp.allclose(tendencies.dtedt[0], 0.0, atol=1e-12)
     
     def test_mixed_phase_process(self):
         """Test mixed-phase microphysics"""

--- a/jcm/physics/clouds/sundqvist.py
+++ b/jcm/physics/clouds/sundqvist.py
@@ -24,8 +24,8 @@ class CloudParameters:
     """Configuration parameters for shallow cloud scheme"""
     
     # Cloud fraction parameters
-    crt: float           # Critical relative humidity at surface  
-    crs: float           # Critical relative humidity at TOA  
+    crt: float           # Critical relative humidity aloft
+    crs: float           # Critical relative humidity near surface
     nex: float           # Exponent for RH threshold profile
     csatsc: float        # Saturation factor for stratocumulus
     
@@ -42,8 +42,8 @@ class CloudParameters:
     t_mix_max: float     # Upper bound of mixed phase (K)
 
     @classmethod
-    def default(cls, crt=0.9, crs=0.7, nex=4.0,
-                 csatsc=0.97, ceffmin=10.0,
+    def default(cls, crt=0.75, crs=0.975, nex=2.0,
+                 csatsc=0.7, ceffmin=10.0,
                  ceffmax=150.0, epsilon=1.0e-12,
                  t_ice=238.15, t_mix_min=238.15, t_mix_max=273.15) -> 'CloudParameters':
         """Return default cloud parameters"""
@@ -59,6 +59,24 @@ class CloudParameters:
             t_mix_min=jnp.array(t_mix_min),
             t_mix_max=jnp.array(t_mix_max)
         )
+
+
+def critical_relative_humidity(
+    pressure: jnp.ndarray,
+    surface_pressure: float,
+    config: CloudParameters,
+) -> jnp.ndarray:
+    """ECHAM critical RH profile from ``mo_cover.f90``.
+
+    ECHAM names ``crs`` as the near-surface value and ``crt`` as the
+    free-tropospheric value. The exponent uses surface pressure divided by
+    full-level pressure, not a linear sigma interpolation.
+    """
+    pressure_safe = jnp.maximum(pressure, 1.0)
+    surface_pressure_safe = jnp.maximum(surface_pressure, 1.0)
+    return config.crt + (config.crs - config.crt) * jnp.exp(
+        1.0 - (surface_pressure_safe / pressure_safe) ** config.nex
+    )
 
 
 class CloudState(NamedTuple):
@@ -172,16 +190,9 @@ def calculate_cloud_fraction(
     rel_humidity = specific_humidity / (qs + config.epsilon)
     rel_humidity = jnp.clip(rel_humidity, 0.0, 1.0)
     
-    # Calculate critical relative humidity threshold
-    # Varies from crt at surface to crs at TOA
-    # Following Lohmann & Roeckner (1996) formulation
-    sigma = pressure / surface_pressure  # Normalized pressure (1 at surface, 0 at TOA)
-    # RHc = crt at surface (sigma=1) and crs at TOA (sigma→0)
-    # Using exponential interpolation: at sigma=1, exp(0)=1 so rhc=crt
-    # as sigma→0, exp(-nex)→0 so rhc→crs
-    rhc = config.crs + (config.crt - config.crs) * jnp.exp(
-        -config.nex * (1.0 - sigma)
-    )
+    # Calculate critical relative humidity threshold following ECHAM
+    # ``mo_cover.f90``.
+    rhc = critical_relative_humidity(pressure, surface_pressure, config)
     
     # Calculate cloud fraction using quadratic relationship
     # b_0 = (RH - RH_crit) / (1 - RH_crit)

--- a/jcm/physics/clouds/sundqvist_test.py
+++ b/jcm/physics/clouds/sundqvist_test.py
@@ -9,7 +9,7 @@ from .sundqvist import (
     CloudParameters, saturation_vapor_pressure_water, saturation_vapor_pressure_ice,
     saturation_specific_humidity, calculate_cloud_fraction,
     partition_cloud_phase, condensation_evaporation,
-    shallow_cloud_scheme, _qs_and_dqs_dt,
+    shallow_cloud_scheme, critical_relative_humidity, _qs_and_dqs_dt,
 )
 from jcm.constants import tmelt, eps, alhc, cp
 
@@ -214,6 +214,44 @@ class TestSaturationFunctions:
 
 class TestCloudFraction:
     """Test cloud fraction calculations"""
+
+    def test_critical_rh_matches_echam_mo_cover(self):
+        """Pin ``mo_cover.f90`` critical-RH profile and parameter meanings."""
+        config = CloudParameters.default()
+        pressure = jnp.array([100000.0, 95000.0, 70000.0, 50000.0, 20000.0])
+        p_sfc = 100000.0
+
+        rhc = critical_relative_humidity(pressure, p_sfc, config)
+        expected = config.crt + (config.crs - config.crt) * jnp.exp(
+            1.0 - (p_sfc / pressure) ** config.nex
+        )
+
+        assert abs(float(config.crs) - 0.975) < 1e-7
+        assert abs(float(config.crt) - 0.75) < 1e-7
+        assert abs(float(config.nex) - 2.0) < 1e-7
+        assert jnp.allclose(rhc, expected)
+        assert jnp.isclose(rhc[0], config.crs)
+        assert rhc[-1] < 0.751
+
+    def test_cloud_fraction_uses_echam_threshold_profile(self):
+        """A 70 kPa, 84.5% RH layer should cloud under ECHAM T63 defaults.
+
+        This RH is above the ``mo_cover`` threshold but below the old
+        sigma-interpolation threshold, so it catches the ordering/formula
+        regression directly through ``calculate_cloud_fraction``.
+        """
+        config = CloudParameters.default()
+        pressure = jnp.array([70000.0])
+        temperature = jnp.array([260.0])
+        p_sfc = 100000.0
+
+        qs = jax.vmap(saturation_specific_humidity)(pressure, temperature)
+        specific_humidity = 0.845 * qs
+        cf, _ = calculate_cloud_fraction(
+            temperature, specific_humidity, pressure, p_sfc, config
+        )
+
+        assert cf[0] > 0.03
     
     def test_cloud_fraction_basic(self):
         """Test basic cloud fraction calculation"""

--- a/jcm/physics/convection/tiedtke_nordeng/tiedtke_nordeng.py
+++ b/jcm/physics/convection/tiedtke_nordeng/tiedtke_nordeng.py
@@ -960,18 +960,20 @@ class TiedtkeConvection(PhysicsTerm):
 
     Reads the moist-air diagnostics produced by
     :class:`~jcm.physics.diagnostics.moist_air_state.MoistAirColumnState`
-    (``pressure_full``, ``layer_thickness``, ``air_density``) and the
-    model timestep from ``diagnostics["_dt_seconds"]`` (injected by
-    ``ComposablePhysics``). Writes the :class:`ConvectionData` sub-struct
-    under the public ``"convection"`` key.
+    (``pressure_full``, ``layer_thickness``, ``air_density``), the
+    current cloud diagnostics from ``diagnostics["clouds"]``, and the
+    model timestep from ``diagnostics["_dt_seconds"]``. Writes the
+    :class:`ConvectionData` sub-struct under the public ``"convection"``
+    key and advances ``clouds.qc`` / ``clouds.qi`` for downstream
+    microphysics in the same split step.
     """
 
     name: ClassVar[str] = "tiedtke_convection"
     category: ClassVar[str] = "convection"
     requires: ClassVar[tuple[str, ...]] = (
-        "pressure_full", "layer_thickness", "air_density",
+        "pressure_full", "layer_thickness", "air_density", "clouds",
     )
-    provides: ClassVar[tuple[str, ...]] = ("convection",)
+    provides: ClassVar[tuple[str, ...]] = ("convection", "clouds")
 
     def __init__(self, params: ConvectionParameters | None = None):
         """Hold the scheme-native :class:`ConvectionParameters`."""
@@ -1064,6 +1066,19 @@ class TiedtkeConvection(PhysicsTerm):
             qi_conv=tendencies_all.qi_conv.T,
         )
 
-        return tendency, {**diagnostics, "convection": convection}
+        clouds = diagnostics["clouds"].copy(
+            qc=jnp.maximum(
+                diagnostics["clouds"].qc + tendency.tracers["qc"] * dt,
+                0.0,
+            ),
+            qi=jnp.maximum(
+                diagnostics["clouds"].qi + tendency.tracers["qi"] * dt,
+                0.0,
+            ),
+        )
 
-
+        return tendency, {
+            **diagnostics,
+            "convection": convection,
+            "clouds": clouds,
+        }

--- a/jcm/physics/convection/tiedtke_nordeng/tiedtke_nordeng_test.py
+++ b/jcm/physics/convection/tiedtke_nordeng/tiedtke_nordeng_test.py
@@ -132,7 +132,7 @@ def test_wrapper_advances_cloud_diagnostics_for_downstream_microphysics(monkeypa
         cloud_fraction=jnp.ones(shape) * 0.5,
     )
     diagnostics = {
-        "_date": SimpleNamespace(dt_seconds=dt),
+        "_dt_seconds": dt,
         "pressure_full": jnp.ones(shape) * 80000.0,
         "layer_thickness": jnp.ones(shape) * 500.0,
         "air_density": jnp.ones(shape),

--- a/jcm/physics/convection/tiedtke_nordeng/tiedtke_nordeng_test.py
+++ b/jcm/physics/convection/tiedtke_nordeng/tiedtke_nordeng_test.py
@@ -5,14 +5,20 @@ Date: 2025-01-09
 
 import jax.numpy as jnp
 import jax
+from types import SimpleNamespace
 
+import jcm.physics.convection.tiedtke_nordeng.tiedtke_nordeng as convection_module
+from jcm.physics.clouds.cloud_data import CloudData
 from jcm.physics.convection.tiedtke_nordeng.tiedtke_nordeng import (
     tiedtke_nordeng_convection,
     find_cloud_base,
     calculate_cape_cin,
     ConvectionParameters,
-    saturation_mixing_ratio
+    ConvectionTendencies,
+    TiedtkeConvection,
+    saturation_mixing_ratio,
 )
+from jcm.physics_interface import PhysicsState
 from jcm.physics.convection.tiedtke_nordeng.downdraft import calculate_downdraft
 from jcm.physics.convection.tiedtke_nordeng.updraft import calculate_updraft
 from jcm.physics.convection.tiedtke_nordeng.flux_tendencies import mass_flux_closure
@@ -80,6 +86,69 @@ def create_test_atmosphere(nlev=40, unstable=True):
         'u_wind': u_wind,
         'v_wind': v_wind
     }
+
+
+def test_wrapper_advances_cloud_diagnostics_for_downstream_microphysics(monkeypatch):
+    """Convective qc/qi tendencies must be visible before microphysics runs."""
+    nlev, ncols = 4, 2
+    dt = 60.0
+    shape = (nlev, ncols)
+    old_qc = jnp.ones(shape) * 1.0e-5
+    old_qi = jnp.ones(shape) * 2.0e-5
+
+    dqc_col = jnp.array([1.0e-7, 2.0e-7, 0.0, -1.0e-7])
+    dqi_col = jnp.array([0.0, 1.0e-7, 2.0e-7, -1.0e-7])
+
+    def fake_convection(
+        temperature, humidity, pressure, layer_thickness, air_density,
+        u_wind, v_wind, qc, qi, dt_seconds, params, land_fraction,
+    ):
+        zeros = jnp.zeros_like(temperature)
+        return ConvectionTendencies(
+            dtedt=zeros,
+            dqdt=zeros,
+            dudt=zeros,
+            dvdt=zeros,
+            qc_conv=dqc_col * dt_seconds,
+            qi_conv=dqi_col * dt_seconds,
+            precip_conv=jnp.array(0.0),
+            dqc_dt=dqc_col,
+            dqi_dt=dqi_col,
+        ), None
+
+    monkeypatch.setattr(
+        convection_module, "tiedtke_nordeng_convection", fake_convection,
+    )
+
+    state = PhysicsState.zeros(
+        shape,
+        temperature=jnp.ones(shape) * 280.0,
+        specific_humidity=jnp.ones(shape) * 1.0e-3,
+        tracers={"qc": old_qc, "qi": old_qi},
+    )
+    clouds = CloudData.zeros((ncols,), nlev).copy(
+        qc=old_qc,
+        qi=old_qi,
+        cloud_fraction=jnp.ones(shape) * 0.5,
+    )
+    diagnostics = {
+        "_date": SimpleNamespace(dt_seconds=dt),
+        "pressure_full": jnp.ones(shape) * 80000.0,
+        "layer_thickness": jnp.ones(shape) * 500.0,
+        "air_density": jnp.ones(shape),
+        "clouds": clouds,
+    }
+    terrain = SimpleNamespace(fmask=jnp.zeros(ncols))
+
+    tendency, diagnostics_out = TiedtkeConvection()(
+        state, diagnostics, forcing=None, terrain=terrain,
+    )
+
+    expected_qc = jnp.maximum(old_qc + tendency.tracers["qc"] * dt, 0.0)
+    expected_qi = jnp.maximum(old_qi + tendency.tracers["qi"] * dt, 0.0)
+    assert jnp.allclose(diagnostics_out["clouds"].qc, expected_qc)
+    assert jnp.allclose(diagnostics_out["clouds"].qi, expected_qi)
+    assert jnp.allclose(diagnostics_out["convection"].qc_conv, dqc_col[:, None] * dt)
 
 
 class TestMassFluxCFLCap:

--- a/jcm/physics/echam/parameters_test.py
+++ b/jcm/physics/echam/parameters_test.py
@@ -21,12 +21,14 @@ def test_per_scheme_defaults():
     clouds = CloudParameters.default()
     microphysics = MicrophysicsParameters.default()
 
-    # ECHAM-matching convention: crt at surface (0.9), crs aloft (0.7);
-    # ccraut = 15.0 (ECHAM default — Beheng-1994 coefficient, not the
+    # ECHAM-matching convention: crs near surface (0.975), crt aloft
+    # (0.75); ccraut = 15.0 (ECHAM default — Beheng-1994 coefficient, not the
     # KK2000 threshold the previous JAX port used).
     assert abs(float(convection.entrpen) - 1.0e-4) < 1e-7
-    assert abs(float(clouds.crt) - 0.9) < 1e-7
-    assert abs(float(clouds.crs) - 0.7) < 1e-7
+    assert abs(float(clouds.crt) - 0.75) < 1e-7
+    assert abs(float(clouds.crs) - 0.975) < 1e-7
+    assert abs(float(clouds.nex) - 2.0) < 1e-7
+    assert abs(float(clouds.csatsc) - 0.7) < 1e-7
     assert abs(float(microphysics.ccraut) - 15.0) < 1e-5
 
 
@@ -54,7 +56,7 @@ def test_echam_physics_per_scheme_kwargs():
     cloud_fraction_term = next(
         t for t in physics.terms if t.category == "cloud_fraction"
     )
-    assert abs(float(cloud_fraction_term.params.value.crt) - 0.9) < 1e-7
+    assert abs(float(cloud_fraction_term.params.value.crt) - 0.75) < 1e-7
 
 
 def test_physics_terms_compute_tendencies():

--- a/jcm/physics/radiation/grey_two_stream/radiation_scheme.py
+++ b/jcm/physics/radiation/grey_two_stream/radiation_scheme.py
@@ -597,8 +597,9 @@ class GreyTwoStreamRadiation(PhysicsTerm):
     """Grey two-stream radiation as a composable PhysicsTerm.
 
     Wraps :func:`radiation_scheme`. Reads pressure / height / density
-    from the moist-air diagnostics dict; reads cloud water / ice and
-    cloud fraction from the public ``"clouds"`` key;
+    from the moist-air diagnostics dict; reads cloud fraction from the
+    public ``"clouds"`` key and pre-cloud-step cloud water / ice from
+    state tracers, matching ECHAM's ``cover`` then ``radiation`` order;
     reads ozone / CO2 from ``"chemistry"``; reads aerosol optical
     properties from ``"aerosol"``; reads surface temperature from
     ``"surface"`` (still legacy until the surface migration) and

--- a/jcm/physics/radiation/grey_two_stream/radiation_scheme.py
+++ b/jcm/physics/radiation/grey_two_stream/radiation_scheme.py
@@ -576,6 +576,7 @@ import jax  # noqa: E402
 from flax import nnx  # noqa: E402
 
 from jcm.forcing import ForcingData  # noqa: E402
+from jcm.physics.clouds.cloud_data import radiation_cloud_fields  # noqa: E402
 from jcm.physics.radiation.radiation_types import RadiationData  # noqa: E402
 from jcm.physics.physics_term import PhysicsTerm  # noqa: E402
 from jcm.physics.radiation import (  # noqa: E402
@@ -596,8 +597,8 @@ class GreyTwoStreamRadiation(PhysicsTerm):
     """Grey two-stream radiation as a composable PhysicsTerm.
 
     Wraps :func:`radiation_scheme`. Reads pressure / height / density
-    from the moist-air diagnostics dict; reads cloud water / ice from
-    state tracers and cloud fraction from the public ``"clouds"`` key;
+    from the moist-air diagnostics dict; reads cloud water / ice and
+    cloud fraction from the public ``"clouds"`` key;
     reads ozone / CO2 from ``"chemistry"``; reads aerosol optical
     properties from ``"aerosol"``; reads surface temperature from
     ``"surface"`` (still legacy until the surface migration) and
@@ -685,13 +686,9 @@ class GreyTwoStreamRadiation(PhysicsTerm):
         longitudes = self._lons.get_value()
         solar = forcing.solar
 
-        cloud_water = state.tracers.get(
-            "qc", jnp.zeros_like(state.temperature),
+        cloud_water, cloud_ice, cloud_fraction = radiation_cloud_fields(
+            state, diagnostics,
         )
-        cloud_ice = state.tracers.get(
-            "qi", jnp.zeros_like(state.temperature),
-        )
-        cloud_fraction = diagnostics["clouds"].cloud_fraction
 
         chemistry = diagnostics["chemistry"]
         # Convert ppmv → VMR. CO2 is well-mixed; pass as scalar.

--- a/jcm/physics/radiation/nn_emulator_scheme.py
+++ b/jcm/physics/radiation/nn_emulator_scheme.py
@@ -188,6 +188,7 @@ import jax  # noqa: E402
 from flax import nnx  # noqa: E402
 
 from jcm.forcing import ForcingData  # noqa: E402
+from jcm.physics.clouds.cloud_data import radiation_cloud_fields  # noqa: E402
 from jcm.physics.physics_term import PhysicsTerm  # noqa: E402
 from jcm.physics.radiation import (  # noqa: E402
     cached_radiation_tendency,
@@ -288,13 +289,9 @@ class NNEmulatorRadiation(PhysicsTerm):
         longitudes = self._lons.get_value()
         solar = forcing.solar
 
-        cloud_water = state.tracers.get(
-            "qc", jnp.zeros_like(state.temperature),
+        cloud_water, cloud_ice, cloud_fraction = radiation_cloud_fields(
+            state, diagnostics,
         )
-        cloud_ice = state.tracers.get(
-            "qi", jnp.zeros_like(state.temperature),
-        )
-        cloud_fraction = diagnostics["clouds"].cloud_fraction
 
         chemistry = diagnostics["chemistry"]
         ozone_vmr = chemistry.ozone_vmr * 1e-6

--- a/jcm/physics/radiation/rrtmgp.py
+++ b/jcm/physics/radiation/rrtmgp.py
@@ -683,7 +683,8 @@ class RRTMGPRadiation(PhysicsTerm):
     ``RadiationParameters(rrtmgp_chunk_size=...)``.
 
     Reads pressure / height / density from the moist-air diagnostics
-    dict, cloud water / ice from ``diagnostics["clouds"]``, ozone / CO2 from
+    dict, cloud fraction from ``diagnostics["clouds"]`` and
+    pre-cloud-step cloud water / ice from state tracers, ozone / CO2 from
     ``"chemistry"``, aerosol from ``"aerosol"``, surface temperature
     from the legacy ``"surface"`` key, and surface albedos /
     emissivity from the public ``"radiation"`` key. Caches its own

--- a/jcm/physics/radiation/rrtmgp.py
+++ b/jcm/physics/radiation/rrtmgp.py
@@ -24,6 +24,7 @@ import jax.numpy as jnp
 from jax import lax
 
 from jax_solar import OrbitalTime, radiation_flux, get_solar_sin_altitude
+from jcm.physics.clouds.cloud_data import radiation_cloud_fields
 from jcm.physics.radiation.radiation_types import (
     RadiationParameters,
     RadiationTendencies,
@@ -682,7 +683,7 @@ class RRTMGPRadiation(PhysicsTerm):
     ``RadiationParameters(rrtmgp_chunk_size=...)``.
 
     Reads pressure / height / density from the moist-air diagnostics
-    dict, cloud water / ice from state tracers, ozone / CO2 from
+    dict, cloud water / ice from ``diagnostics["clouds"]``, ozone / CO2 from
     ``"chemistry"``, aerosol from ``"aerosol"``, surface temperature
     from the legacy ``"surface"`` key, and surface albedos /
     emissivity from the public ``"radiation"`` key. Caches its own
@@ -803,13 +804,9 @@ class RRTMGPRadiation(PhysicsTerm):
         model_step = diagnostics["radiation"].step
         column_indices = jnp.arange(ncols, dtype=jnp.int32)
 
-        cloud_water = state.tracers.get(
-            "qc", jnp.zeros_like(state.temperature),
+        cloud_water, cloud_ice, cloud_fraction = radiation_cloud_fields(
+            state, diagnostics,
         )
-        cloud_ice = state.tracers.get(
-            "qi", jnp.zeros_like(state.temperature),
-        )
-        cloud_fraction = diagnostics["clouds"].cloud_fraction
 
         chemistry = diagnostics["chemistry"]
         ozone_vmr = chemistry.ozone_vmr * 1e-6


### PR DESCRIPTION
## Summary

This PR rebases the ECHAM instability fixes onto the latest `dev` and tightens several ECHAM physics ordering/details:

- fixes the ECHAM critical relative humidity profile so `crt` and `crs` keep distinct values under the existing names
- fixes 1M microphysics latent heating signs and precipitation diagnostic cloud-fraction handling
- advances convective cloud condensate diagnostics for downstream large-scale cloud/microphysics
- matches ECHAM `cover` then `radiation` ordering: radiation uses fresh cloud fraction but pre-cloud-step `qc`/`qi` condensate tracers

## Validation

```bash
env PATH=/Users/dwatsonparris/miniforge3/envs/jcm/bin:/usr/bin:/bin:/usr/sbin:/sbin JAX_PLATFORMS=cpu pytest jcm/physics/clouds/cloud_data_test.py jcm/physics/clouds/sundqvist_test.py jcm/physics/convection/tiedtke_nordeng/tiedtke_nordeng_test.py jcm/physics/radiation/grey_two_stream/radiation_scheme_test.py --no-header --tb=line
```

Result: `60 passed, 1 warning`.