### PR TITLE
fix(#310): stop bc tests from rewriting tracked t30 boundary files

### DIFF
--- a/jcm/data/bc/compile_test.py
+++ b/jcm/data/bc/compile_test.py
@@ -1,9 +1,0 @@
-import unittest
-from jcm.data.bc.compile import main
-
-class TestCompileUnit(unittest.TestCase):
-
-    def test_compile(self):
-        # Just test that the compile main function runs without error
-        exit_code = main([])
-        self.assertEqual(exit_code, 0)

--- a/jcm/data/bc/interpolate_test.py
+++ b/jcm/data/bc/interpolate_test.py
@@ -1,9 +1,130 @@
+"""Tests for ``jcm/data/bc/interpolate.py``.
+
+Covers the helpers actually consumed by ``jcm.terrain`` and ``jcm.forcing``
+(``interpolate_to_daily``, ``upsample_forcings_ds``, ``upsample_terrain_ds``).
+The previous ``main()`` smoke test was dropped (issue #310) because it
+wrote ``forcing_daily.nc`` / ``forcing_t31.nc`` / ``terrain_t31.nc`` to
+the working directory on every pytest run while asserting nothing about
+the output.
+"""
+
 import unittest
-from jcm.data.bc.interpolate import main
 
-class TestInterpolateUnit(unittest.TestCase):
+import numpy as np
+import pandas as pd
+import xarray as xr
 
-    def test_interpolate(self):
-        # Just test that the interpolate main function runs without error (even if run multiple times)
-        self.assertEqual(main(['31']), 0)
-        self.assertEqual(main(['31']), 0)
+from jcm.data.bc.interpolate import (
+    interpolate_to_daily,
+    upsample_forcings_ds,
+    upsample_terrain_ds,
+)
+from jcm.physics.speedy.physical_constants import SIGMA_LAYER_BOUNDARIES
+from jcm.utils import get_coords
+
+
+def _t21_grid():
+    return get_coords(SIGMA_LAYER_BOUNDARIES[7], spectral_truncation=21).horizontal
+
+
+def _monthly_source(n_lon: int = 8, n_lat: int = 4) -> xr.Dataset:
+    times = pd.date_range("1981-01-01", periods=12, freq="MS")
+    lon = np.linspace(0.0, 360.0, n_lon, endpoint=False)
+    lat = np.linspace(-80.0, 80.0, n_lat)
+    rng = np.random.default_rng(0)
+    return xr.Dataset(
+        {
+            "sst": (("lon", "lat", "time"), rng.uniform(size=(n_lon, n_lat, 12))),
+            "orog": (("lon", "lat"), rng.uniform(size=(n_lon, n_lat))),
+        },
+        coords={"lon": lon, "lat": lat, "time": times},
+    )
+
+
+class TestInterpolateToDaily(unittest.TestCase):
+
+    def test_produces_365_days(self):
+        ds = _monthly_source()
+        daily = interpolate_to_daily(ds)
+        self.assertEqual(len(daily["time"]), 365)
+        # Static (non-time) variables pass through unchanged.
+        np.testing.assert_array_equal(daily["orog"].values, ds["orog"].values)
+        # Time-varying variables keep their non-time shape.
+        self.assertEqual(daily["sst"].shape[:-1], ds["sst"].shape[:-1])
+
+    def test_rejects_wrong_number_of_timestamps(self):
+        ds = _monthly_source().isel(time=slice(0, 6))
+        with self.assertRaises(ValueError):
+            interpolate_to_daily(ds)
+
+    def test_rejects_non_monthly_frequency(self):
+        ds = _monthly_source().assign_coords(
+            time=pd.date_range("1981-01-01", periods=12, freq="D"),
+        )
+        with self.assertRaises(ValueError):
+            interpolate_to_daily(ds)
+
+
+class TestUpsampleForcings(unittest.TestCase):
+
+    def _source(self, n_lon: int = 8, n_lat: int = 4) -> xr.Dataset:
+        lon = np.linspace(0.0, 360.0, n_lon, endpoint=False)
+        lat = np.linspace(-80.0, 80.0, n_lat)
+        rng = np.random.default_rng(1)
+        # Fraction variables seeded above 1 to exercise the upper clip;
+        # ``sst`` seeded with negatives to exercise the >=0 clip.
+        return xr.Dataset(
+            {
+                "icec":     (("lon", "lat"), rng.uniform(0.5, 1.5, (n_lon, n_lat))),
+                "soilw_am": (("lon", "lat"), rng.uniform(0.5, 1.5, (n_lon, n_lat))),
+                "alb":      (("lon", "lat"), rng.uniform(0.5, 1.5, (n_lon, n_lat))),
+                "sst":      (("lon", "lat"), rng.uniform(-5.0, 5.0, (n_lon, n_lat))),
+            },
+            coords={"lon": lon, "lat": lat},
+        )
+
+    def test_clips_fractions_to_unit_interval(self):
+        out = upsample_forcings_ds(self._source(), _t21_grid())
+        for v in ("icec", "soilw_am", "alb"):
+            self.assertGreaterEqual(float(out[v].min()), 0.0, msg=v)
+            self.assertLessEqual(float(out[v].max()), 1.0, msg=v)
+
+    def test_clips_other_vars_to_nonnegative(self):
+        out = upsample_forcings_ds(self._source(), _t21_grid())
+        self.assertGreaterEqual(float(out["sst"].min()), 0.0)
+
+    def test_output_lands_on_target_grid(self):
+        out = upsample_forcings_ds(self._source(), _t21_grid())
+        # T21 nodal grid is 64 lon × 32 lat.
+        self.assertEqual(out.sizes["lon"], 64)
+        self.assertEqual(out.sizes["lat"], 32)
+
+
+class TestUpsampleTerrain(unittest.TestCase):
+
+    def _source(self, n_lon: int = 8, n_lat: int = 4) -> xr.Dataset:
+        lon = np.linspace(0.0, 360.0, n_lon, endpoint=False)
+        lat = np.linspace(-80.0, 80.0, n_lat)
+        rng = np.random.default_rng(2)
+        return xr.Dataset(
+            {
+                "lsm":  (("lon", "lat"), rng.uniform(-0.5, 1.5, (n_lon, n_lat))),
+                "orog": (("lon", "lat"), rng.uniform(-200.0, 3000.0, (n_lon, n_lat))),
+            },
+            coords={"lon": lon, "lat": lat},
+        )
+
+    def test_clips_lsm_to_unit_interval(self):
+        out = upsample_terrain_ds(self._source(), _t21_grid())
+        self.assertGreaterEqual(float(out["lsm"].min()), 0.0)
+        self.assertLessEqual(float(out["lsm"].max()), 1.0)
+
+    def test_preserves_negative_orography(self):
+        # Real terrain has below-sea-level points (Dead Sea, etc.); the
+        # upsampler intentionally does not clip orog.
+        out = upsample_terrain_ds(self._source(), _t21_grid())
+        self.assertLess(float(out["orog"].min()), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jcm/physics/echam/IMPLEMENTATION_ROADMAP.md
+++ b/jcm/physics/echam/IMPLEMENTATION_ROADMAP.md
@@ -52,11 +52,6 @@ must hold across every commit.
 
 ### Smaller nits
 
-- [ ] ``data/bc/t30/clim/{forcing,terrain}.nc`` get rewritten by the
-      pytest runs (xarray re-serialising netCDF metadata). They should
-      not be touched by tests. Until then, ``git checkout -- jcm/data/bc/``
-      after each test sweep before ``git add``.
-
 ## Done
 
 - 2026-05-07: Phase 0 — bit-exact reference trajectory tests.


### PR DESCRIPTION
## Summary

- Delete `jcm/data/bc/compile_test.py`. It called `compile.main([])`, whose outputs land at `jcm/data/bc/t30/clim/{forcing,terrain}.nc` — i.e. the in-tree package data. xarray's NetCDF writer is non-deterministic across runs (history attr, encoding key order, HDF5 chunking), so every pytest sweep left those files dirty in `git status` while asserting nothing about their contents. `compile.py` is a one-shot regeneration tool and has no production importer; we don't need a smoke test gating it.
- Replace `jcm/data/bc/interpolate_test.py`'s `main()` smoke test (which wrote `forcing_daily.nc / forcing_t31.nc / terrain_t31.nc` to `Path.cwd()` on every run) with eight focused unit tests on `interpolate_to_daily`, `upsample_forcings_ds`, `upsample_terrain_ds` — the helpers `jcm/terrain.py` and `jcm/forcing.py` actually consume. Coverage: monthly→daily resampling, bad-input validation, [0, 1] clipping of fraction variables, non-negativity of other forcings, lsm clipping, preservation of below-sea-level orography. All synthetic in-memory datasets, zero disk writes.
- Drop the matching workaround note from `jcm/physics/echam/IMPLEMENTATION_ROADMAP.md`.

Closes #310.

## Test plan
- [x] `pytest jcm/data/bc/interpolate_test.py -v` → 8 passed
- [x] `git status -s jcm/data/bc/` empty after the test run
- [x] No `forcing_daily.nc / forcing_t31.nc / terrain_t31.nc` produced in the working directory by the new tests
- [ ] CI green on the standard fast + coverage gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)