### PR TITLE
feat(#128): persistent model-state checkpointing for preemptible runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ python -m jcm.main physics=echam +physics.terms.tiedtke_convection.params.entrpe
 # Long ECHAM + RRTMGP run with chunked health checks
 python -m jcm.main physics=echam-rrtmgp grid=echam_t63_l47_hybrid run=longrun
 
+# Same, but resumable across preemptions: model state is saved to
+# ``run.checkpoint_path`` after each chunk; if the file already exists at
+# launch, the run picks up at the recorded sim-day.
+python -m jcm.main physics=echam-rrtmgp grid=echam_t63_l47_hybrid run=longrun \
+    run.checkpoint_path=/scratch/$JOB_ID.ckpt
+
 # Single-column physics evolution from a saved JCM run
 python -m jcm.main run.mode=scm run.state_file=path/to/state.nc \
     run.column.lat_deg=0 run.column.lon_deg=180

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -11,3 +11,4 @@ API
    jcm.physics_interface.PhysicsState
    jcm.physics_interface.PhysicsTendency
    jcm.physics_interface.Physics
+   jcm.checkpoint

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -261,6 +261,45 @@ actually needs from disk, so this stays memory-efficient even for very
 long forcing records.
 
 
+Checkpointing for preemptible runs
+----------------------------------
+
+Multi-day integrations on preemptible compute (spot instances, Slurm
+``--requeue`` queues, NRP Nautilus) can be killed at short notice. Set
+``run.checkpoint_path`` to make a chunked run resumable: after each
+chunk the runner persists the modal + physics state and the elapsed
+sim-day count to that file (atomic write via tmpfile + rename, so a
+kill mid-write leaves the previous checkpoint intact). When the same
+command is launched again with the file already in place, the run
+restores from the checkpoint and only steps the remaining chunks.
+
+.. code-block:: bash
+
+   python -m jcm.main physics=echam-rrtmgp grid=echam_t63_l47_hybrid \
+       run=longrun run.checkpoint_path=/scratch/$JOB_ID.ckpt
+
+The same primitives are available directly to bring-your-own-driver
+workflows via :py:mod:`jcm.checkpoint`:
+
+.. code-block:: python
+
+   from jcm.checkpoint import save_checkpoint, load_checkpoint
+
+   model.run(forcing=forcing, total_time=10)
+   save_checkpoint(model, '/scratch/run.ckpt', elapsed_days=10.0)
+
+   # ... later, in a fresh process ...
+   model = build_model(cfg)            # same coords + physics
+   model.bootstrap_state()             # populate template pytrees
+   elapsed = load_checkpoint(model, '/scratch/run.ckpt')
+   model.resume(forcing=forcing, total_time=20 - elapsed)
+
+The on-disk format is flax's msgpack codec applied to flattened lists
+of arrays — small (state pytrees are a few MB even at T63L47) and
+portable across hosts as long as the destination ``Model`` was built
+with the same coords and physics term composition.
+
+
 Nudging the model toward an external state
 -------------------------------------------
 

--- a/jcm/checkpoint.py
+++ b/jcm/checkpoint.py
@@ -1,0 +1,108 @@
+"""Model state checkpointing for long, preemptible runs.
+
+Persists ``Model._final_modal_state`` and ``Model._final_physics_state``
+plus an elapsed sim-day count to a single file using flax's msgpack
+serialization. ``run_chunked`` (in :mod:`jcm.runners`) integrates with
+these primitives via ``cfg.run.checkpoint_path`` — when set, it writes a
+checkpoint after each chunk and restores from one at startup if the file
+exists, so an integration interrupted by spot-instance preemption resumes
+without redoing completed chunks.
+
+The state pytrees are flattened to plain lists of arrays before
+serialization because flax's msgpack codec can't handle ``tree_math``
+structs (e.g. ``primitive_equations.State``) directly. The ``treedef``
+is reconstructed at load time from the destination model's bootstrapped
+templates — this makes a checkpoint portable only across runs with
+matching coords + physics term composition (where the leaf order and
+dtypes line up), which is the intended usage.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import flax.serialization
+import jax
+import numpy as np
+
+
+def _flatten_arrays(tree):
+    return [np.asarray(x) for x in jax.tree_util.tree_leaves(tree)]
+
+
+def save_checkpoint(model, path, *, elapsed_days: float) -> Path:
+    """Persist the model's current modal + physics state to ``path``.
+
+    Args:
+        model: A ``jcm.model.Model`` whose ``_final_modal_state`` and
+            ``_final_physics_state`` have been populated, either by a
+            prior ``run`` / ``resume`` call or by ``bootstrap_state``.
+        path: Output file path (parent directories are created).
+        elapsed_days: Sim-day count to record alongside the state so a
+            chunked driver can resume at the correct offset.
+
+    Returns:
+        ``Path(path)`` for chaining.
+    """
+    if model._final_modal_state is None or model._final_physics_state is None:
+        raise ValueError(
+            "Model has no state to checkpoint — call Model.run(...), "
+            "Model.resume(...), or Model.bootstrap_state(...) first."
+        )
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "elapsed_days": float(elapsed_days),
+        "modal_leaves": _flatten_arrays(model._final_modal_state),
+        "physics_leaves": _flatten_arrays(model._final_physics_state),
+    }
+    # Write to a sibling tmp file then rename atomically. If the run is
+    # killed mid-write (the whole point of checkpointing for preemptible
+    # workloads), the previous checkpoint is left intact rather than
+    # truncated to a half-serialized blob that would fail to load.
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_bytes(flax.serialization.to_bytes(payload))
+    tmp_path.replace(path)
+    return path
+
+
+def load_checkpoint(model, path) -> float:
+    """Restore ``_final_modal_state`` + ``_final_physics_state`` from ``path``.
+
+    The model must already have been bootstrapped (e.g. by an earlier
+    ``Model.run``, ``Model.bootstrap_state``, or one of the
+    ``inject_*_profile`` helpers in :mod:`jcm.runners`) so that its
+    state pytrees provide a treedef + per-leaf shape/dtype templates
+    that match the checkpoint.
+
+    Args:
+        model: A ``jcm.model.Model`` with populated final states to use
+            as deserialization templates. Their values are overwritten.
+        path: Checkpoint file path written by :func:`save_checkpoint`.
+
+    Returns:
+        The ``elapsed_days`` count recorded when the checkpoint was
+        saved.
+    """
+    if model._final_modal_state is None or model._final_physics_state is None:
+        raise ValueError(
+            "Model state is uninitialised — call Model.bootstrap_state(...) "
+            "before load_checkpoint so the destination has templates to "
+            "rebuild the pytrees from."
+        )
+    modal_leaves_template = _flatten_arrays(model._final_modal_state)
+    physics_leaves_template = _flatten_arrays(model._final_physics_state)
+    template = {
+        "elapsed_days": 0.0,
+        "modal_leaves": modal_leaves_template,
+        "physics_leaves": physics_leaves_template,
+    }
+    payload = flax.serialization.from_bytes(template, Path(path).read_bytes())
+
+    _, modal_treedef = jax.tree_util.tree_flatten(model._final_modal_state)
+    _, physics_treedef = jax.tree_util.tree_flatten(model._final_physics_state)
+    model._final_modal_state = jax.tree_util.tree_unflatten(
+        modal_treedef, payload["modal_leaves"])
+    model._final_physics_state = jax.tree_util.tree_unflatten(
+        physics_treedef, payload["physics_leaves"])
+    return float(payload["elapsed_days"])

--- a/jcm/checkpoint.py
+++ b/jcm/checkpoint.py
@@ -43,6 +43,7 @@ def save_checkpoint(model, path, *, elapsed_days: float) -> Path:
 
     Returns:
         ``Path(path)`` for chaining.
+
     """
     if model._final_modal_state is None or model._final_physics_state is None:
         raise ValueError(
@@ -83,6 +84,7 @@ def load_checkpoint(model, path) -> float:
     Returns:
         The ``elapsed_days`` count recorded when the checkpoint was
         saved.
+
     """
     if model._final_modal_state is None or model._final_physics_state is None:
         raise ValueError(

--- a/jcm/checkpoint_test.py
+++ b/jcm/checkpoint_test.py
@@ -1,0 +1,126 @@
+"""Tests for ``jcm/checkpoint.py``.
+
+Covers two contracts:
+
+1. ``save_checkpoint`` → fresh ``Model`` → ``bootstrap_state`` →
+   ``load_checkpoint`` reproduces the original state pytrees
+   element-wise (round-trip fidelity).
+2. A continuous N-day integration matches a ``(N/2 days, checkpoint,
+   load on a fresh Model, N/2 days)`` split to numerical roundoff
+   (resumption equivalence — the real use case from issue #128).
+
+Uses Held-Suarez physics for speed: no moisture, no radiation, deterministic
+forcing. ``setUpClass`` builds the model once per class so JAX compile cost is
+paid a single time across the suite.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from jcm.checkpoint import load_checkpoint, save_checkpoint
+from jcm.model import Model
+from jcm.physics.held_suarez.held_suarez_physics import held_suarez_physics
+from jcm.physics.held_suarez.utils import get_held_suarez_coords
+from jcm.terrain import TerrainData
+
+
+def _build_model() -> Model:
+    coords = get_held_suarez_coords()
+    return Model(
+        coords=coords,
+        terrain=TerrainData.from_coords(coords),
+        time_step=180,
+        physics=held_suarez_physics(),
+    )
+
+
+def _max_abs_diff(tree_a, tree_b) -> float:
+    diffs = jax.tree.leaves(
+        jax.tree.map(lambda a, b: jnp.max(jnp.abs(jnp.asarray(a) - jnp.asarray(b))),
+                     tree_a, tree_b)
+    )
+    return float(max(float(d) for d in diffs)) if diffs else 0.0
+
+
+class TestCheckpointRoundTrip(unittest.TestCase):
+
+    def test_save_load_reproduces_state(self):
+        model = _build_model()
+        model.run(save_interval=1, total_time=2)
+        modal_before = model._final_modal_state
+        physics_before = model._final_physics_state
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "ckpt.msgpack"
+            save_checkpoint(model, path, elapsed_days=2.0)
+            self.assertTrue(path.exists())
+
+            fresh = _build_model()
+            fresh.bootstrap_state()
+            elapsed = load_checkpoint(fresh, path)
+
+        self.assertAlmostEqual(elapsed, 2.0)
+        self.assertEqual(_max_abs_diff(modal_before, fresh._final_modal_state), 0.0)
+        self.assertEqual(_max_abs_diff(physics_before, fresh._final_physics_state), 0.0)
+
+    def test_save_without_state_raises(self):
+        model = _build_model()  # never run / bootstrapped
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(ValueError):
+                save_checkpoint(model, Path(tmp) / "x.msgpack", elapsed_days=0.0)
+
+    def test_load_without_template_raises(self):
+        # First produce a checkpoint to load.
+        donor = _build_model()
+        donor.run(save_interval=1, total_time=1)
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "ckpt.msgpack"
+            save_checkpoint(donor, path, elapsed_days=1.0)
+
+            target = _build_model()  # not bootstrapped — no templates
+            with self.assertRaises(ValueError):
+                load_checkpoint(target, path)
+
+
+class TestCheckpointResumptionEquivalence(unittest.TestCase):
+    """A split (run → ckpt → fresh model → load → resume) run matches a continuous run."""
+
+    def test_split_resume_matches_continuous(self):
+        # Baseline: continuous 4-day integration.
+        baseline = _build_model()
+        baseline.run(save_interval=1, total_time=4)
+        baseline_modal = baseline._final_modal_state
+        baseline_physics = baseline._final_physics_state
+
+        # Split: 2 days → checkpoint → new model → load → resume 2 days.
+        first_half = _build_model()
+        first_half.run(save_interval=1, total_time=2)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "ckpt.msgpack"
+            save_checkpoint(first_half, path, elapsed_days=2.0)
+
+            second_half = _build_model()
+            second_half.bootstrap_state()
+            elapsed = load_checkpoint(second_half, path)
+            self.assertAlmostEqual(elapsed, 2.0)
+
+            second_half.resume(save_interval=1, total_time=2)
+
+        modal_diff = _max_abs_diff(baseline_modal, second_half._final_modal_state)
+        physics_diff = _max_abs_diff(baseline_physics, second_half._final_physics_state)
+
+        # Equivalence is exact in the absence of host-side RNG: Held-
+        # Suarez and the dynamical core are deterministic given the same
+        # state and forcing. Allow only float32 accumulation noise.
+        self.assertLess(modal_diff, 1e-5, f"modal state diverged by {modal_diff}")
+        self.assertLess(physics_diff, 1e-5, f"physics state diverged by {physics_diff}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jcm/checkpoint_test.py
+++ b/jcm/checkpoint_test.py
@@ -20,7 +20,6 @@ from pathlib import Path
 
 import jax
 import jax.numpy as jnp
-import numpy as np
 
 from jcm.checkpoint import load_checkpoint, save_checkpoint
 from jcm.model import Model

--- a/jcm/config/run/default.yaml
+++ b/jcm/config/run/default.yaml
@@ -20,6 +20,13 @@ sponge:
 chunk_days: 0
 output_prefix: chunked_run
 
+# Checkpointing for preemptible chunked runs. When set, the model state
+# (modal + physics carry) and elapsed sim-day count are saved to this
+# path after each chunk; if the file already exists at startup the run
+# resumes from it, skipping completed chunks. Single file per run, flax
+# msgpack format. Leave ``null`` to disable.
+checkpoint_path: null
+
 # Runtime mode:
 #   full        — standard dynamical-core integration (Model.run)
 #   prescribed  — diagnose physics tendencies from a saved state file

--- a/jcm/model.py
+++ b/jcm/model.py
@@ -1011,22 +1011,39 @@ class Model:
             A ModelPredictions object containing the trajectory of post-processed model states.
 
         """
+        self.bootstrap_state(initial_state)
+        return self.resume(
+            forcing=forcing, save_interval=save_interval,
+            total_time=total_time, output_averages=output_averages,
+        )
+
+    def bootstrap_state(
+        self,
+        initial_state: PhysicsState | primitive_equations.State | None = None,
+    ) -> None:
+        """Populate ``_final_modal_state`` and ``_final_physics_state`` without integrating.
+
+        Equivalent to the prep that ``run`` does before its first
+        ``resume`` call, but exposed as a standalone method so callers
+        that need only the initial pytrees — checkpoint restore (where
+        ``flax.serialization.from_bytes`` requires a template), state
+        introspection, or a bring-your-own-stepper workflow — don't have
+        to spin up a zero-length integration to get them.
+        """
         if isinstance(initial_state, primitive_equations.State):
             tracer_specs = {spec.name: spec for spec in self.physics.required_tracers()}
-            self.initial_nodal_state = dynamics_state_to_physics_state(initial_state, self.primitive, tracer_specs=tracer_specs)
+            self.initial_nodal_state = dynamics_state_to_physics_state(
+                initial_state, self.primitive, tracer_specs=tracer_specs)
             self._final_modal_state = initial_state
         else:
             self.initial_nodal_state = initial_state
             self._final_modal_state = self._prepare_initial_modal_state(initial_state)
 
-        # ``run`` starts a fresh trajectory — discard any carry left
-        # over from a previous run on this model object so the next
-        # ``resume`` seeds physics from
-        # :meth:`_build_initial_physics_carry` rather than reusing a
-        # stale carry from a different initial state.
-        self._final_physics_state = None
-
-        return self.resume(
-            forcing=forcing, save_interval=save_interval,
-            total_time=total_time, output_averages=output_averages,
-        )
+        # Eagerly build the physics carry. ``resume`` would otherwise
+        # build it lazily on first call, but materialising it here
+        # makes the pytree available as a checkpoint-restore template
+        # and to any caller that wants to inspect / mutate the seed
+        # state before stepping. Equivalent to leaving it ``None`` and
+        # letting ``resume`` build it: ``resume`` skips its lazy-build
+        # branch when ``_final_physics_state`` is already populated.
+        self._final_physics_state = self._build_initial_physics_carry()

--- a/jcm/runners.py
+++ b/jcm/runners.py
@@ -653,6 +653,12 @@ def run_chunked(
     Each chunk is dumped to ``{output_prefix}_day{N}.nc`` and run through
     ``jcm.diagnostics.check_health``. The loop stops early on the first
     failed health check. Returns the per-chunk reports.
+
+    When ``cfg.run.checkpoint_path`` is set, the model state and elapsed
+    sim-day count are persisted after each chunk and (if the file
+    already exists at startup) restored before the loop begins, so a
+    preempted run resumes at the chunk boundary it last reached without
+    redoing the integration. See :mod:`jcm.checkpoint` and issue #128.
     """
     import time
 
@@ -665,20 +671,46 @@ def run_chunked(
 
     save_interval = float(cfg.run.save_interval)
     total_time = float(cfg.run.total_time)
-    n_chunks = int(total_time / chunk_days) + 1
+
+    ckpt_path = cfg.run.get("checkpoint_path", None)
 
     reports: list[dict] = []
     elapsed_sim_days = 0.0
     total_wall = 0.0
+    resumed_from_ckpt = False
 
-    for i in range(n_chunks):
-        remaining = total_time - elapsed_sim_days
-        cur_chunk = min(chunk_days, remaining)
+    if ckpt_path and Path(ckpt_path).exists():
+        from jcm.checkpoint import load_checkpoint
+
+        # Build state templates without integrating so flax.serialization
+        # has pytrees of the right shape and dtype to deserialize against.
+        # Mirrors the init-kind branching of the fresh-start path below;
+        # the template values are immediately overwritten by the
+        # checkpoint's contents.
+        if cfg.init.kind == "jw":
+            inject_jw_profile(model)
+        elif cfg.init.kind == "balanced_isothermal":
+            inject_balanced_isothermal_profile(model)
+        else:
+            model.bootstrap_state()
+
+        elapsed_sim_days = load_checkpoint(model, ckpt_path)
+        resumed_from_ckpt = True
+        print(
+            f"Resumed from checkpoint {ckpt_path} at sim-day "
+            f"{elapsed_sim_days:.1f}"
+        )
+
+    chunk_idx = int(elapsed_sim_days // chunk_days)
+    started_at_days = elapsed_sim_days
+    while elapsed_sim_days < total_time:
+        cur_chunk = min(chunk_days, total_time - elapsed_sim_days)
         if cur_chunk <= 0:
             break
 
         t0 = time.perf_counter()
-        if i == 0 and cfg.init.kind == "jw":
+        first_fresh_chunk = chunk_idx == 0 and not resumed_from_ckpt
+        if first_fresh_chunk and cfg.init.kind == "jw":
             inject_jw_profile(model)
             preds = model.resume(
                 forcing=forcing,
@@ -686,7 +718,7 @@ def run_chunked(
                 total_time=cur_chunk,
                 output_averages=cfg.run.output_averages,
             )
-        elif i == 0 and cfg.init.kind == "balanced_isothermal":
+        elif first_fresh_chunk and cfg.init.kind == "balanced_isothermal":
             inject_balanced_isothermal_profile(model)
             preds = model.resume(
                 forcing=forcing,
@@ -694,7 +726,7 @@ def run_chunked(
                 total_time=cur_chunk,
                 output_averages=cfg.run.output_averages,
             )
-        elif i == 0:
+        elif first_fresh_chunk:
             preds = model.run(
                 forcing=forcing,
                 save_interval=save_interval,
@@ -718,7 +750,7 @@ def run_chunked(
         elapsed_sim_days += cur_chunk
 
         ds = preds.to_xarray()
-        ok, report = check_health(ds, i, elapsed_sim_days)
+        ok, report = check_health(ds, chunk_idx, elapsed_sim_days)
         report["wall_seconds"] = chunk_wall
         reports.append(report)
         print_report(report)
@@ -726,6 +758,11 @@ def run_chunked(
         nc_path = f"{output_prefix}_day{int(elapsed_sim_days)}.nc"
         ds.to_netcdf(nc_path)
         print(f"  Saved {nc_path}")
+
+        if ckpt_path:
+            from jcm.checkpoint import save_checkpoint
+            save_checkpoint(model, ckpt_path, elapsed_days=elapsed_sim_days)
+            print(f"  Saved checkpoint to {ckpt_path}")
 
         if not ok:
             # Honour ``run.bail_on_unhealthy`` (default True). The full-year
@@ -744,13 +781,17 @@ def run_chunked(
                 break
             print(msg + "\nContinuing (bail_on_unhealthy=False).")
 
-        sdph = elapsed_sim_days / (total_wall / 3600)
-        print(
-            f"  Wall: {chunk_wall:.1f}s this chunk, {total_wall:.0f}s total "
-            f"({sdph:.0f} sim days/hr)"
-        )
+        # Throughput is reported over the post-resume window so the
+        # number reflects the run actually happening on this host.
+        days_this_invocation = elapsed_sim_days - started_at_days
+        if total_wall > 0:
+            sdph = days_this_invocation / (total_wall / 3600)
+            print(
+                f"  Wall: {chunk_wall:.1f}s this chunk, {total_wall:.0f}s total "
+                f"({sdph:.0f} sim days/hr)"
+            )
 
-    return reports
+        chunk_idx += 1
 
     return reports
 

--- a/jcm/runners.py
+++ b/jcm/runners.py
@@ -694,6 +694,13 @@ def run_chunked(
         else:
             model.bootstrap_state()
 
+        # ``inject_*_profile`` only populates ``_final_modal_state`` —
+        # the physics carry is normally built lazily by ``resume``.
+        # ``load_checkpoint`` needs both pytrees as deserialization
+        # templates, so build the carry now if the inject path took it.
+        if model._final_physics_state is None:
+            model._final_physics_state = model._build_initial_physics_carry()
+
         elapsed_sim_days = load_checkpoint(model, ckpt_path)
         resumed_from_ckpt = True
         print(

--- a/jcm/runners_test.py
+++ b/jcm/runners_test.py
@@ -212,6 +212,40 @@ class TestModeDispatch(unittest.TestCase):
             self.assertGreaterEqual(len(preds), 1)
             self.assertTrue(any(Path(tmpdir).glob("chunk_day*.nc")))
 
+    def test_chunked_run_resumes_from_checkpoint(self):
+        """``cfg.run.checkpoint_path`` makes a chunked run resumable.
+
+        Drives ``run_chunked`` once for 1 of 2 chunks, then re-invokes
+        with the same ``checkpoint_path`` and ``total_time=2`` and
+        verifies the second invocation only steps the remaining chunk.
+        """
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ckpt_path = f"{tmpdir}/run.ckpt"
+            base_overrides = [
+                "physics=held_suarez",
+                "grid=held_suarez_t31_l8",
+                "run.time_step=180",
+                "run.save_interval=1",
+                "run.chunk_days=1",
+                f"run.output_prefix={tmpdir}/chunk",
+                f"run.checkpoint_path={ckpt_path}",
+            ]
+
+            # First invocation: run only the first chunk (1 day total).
+            cfg1 = _compose(base_overrides + ["run.total_time=1"])
+            reports1 = run(cfg1)
+            self.assertEqual(len(reports1), 1)
+            self.assertTrue(Path(ckpt_path).exists())
+
+            # Second invocation: total 2 days, but the first chunk
+            # should be skipped because the checkpoint records day=1.
+            cfg2 = _compose(base_overrides + ["run.total_time=2"])
+            reports2 = run(cfg2)
+            self.assertEqual(len(reports2), 1, "should run only the remaining chunk")
+            self.assertAlmostEqual(reports2[0]["elapsed_days"], 2.0, places=5)
+
     def _write_state_file(self, path):
         # Run a tiny full simulation and dump it so the prescribed/scm modes
         # have a JCM-shaped state to load.

--- a/jcm/runners_test.py
+++ b/jcm/runners_test.py
@@ -246,6 +246,37 @@ class TestModeDispatch(unittest.TestCase):
             self.assertEqual(len(reports2), 1, "should run only the remaining chunk")
             self.assertAlmostEqual(reports2[0]["elapsed_days"], 2.0, places=5)
 
+    def test_chunked_resume_with_balanced_isothermal_init(self):
+        """Resume path bootstraps the physics carry for inject-based inits.
+
+        ``inject_balanced_isothermal_profile`` populates
+        ``_final_modal_state`` but leaves ``_final_physics_state`` for
+        ``Model.resume`` to lazy-build. The resume-from-checkpoint code
+        path must materialise the carry itself before calling
+        ``load_checkpoint``, otherwise the load raises on the
+        uninitialised template (codex review on PR #479). Held-Suarez is
+        the cheapest physics that supports ``init=balanced_isothermal``.
+        """
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ckpt_path = f"{tmpdir}/run.ckpt"
+            base_overrides = [
+                "physics=held_suarez",
+                "grid=held_suarez_t31_l8",
+                "init=balanced_isothermal",
+                "run.time_step=180",
+                "run.save_interval=1",
+                "run.chunk_days=1",
+                f"run.output_prefix={tmpdir}/chunk",
+                f"run.checkpoint_path={ckpt_path}",
+            ]
+            run(_compose(base_overrides + ["run.total_time=1"]))
+            self.assertTrue(Path(ckpt_path).exists())
+            reports2 = run(_compose(base_overrides + ["run.total_time=2"]))
+            self.assertEqual(len(reports2), 1)
+            self.assertAlmostEqual(reports2[0]["elapsed_days"], 2.0, places=5)
+
     def _write_state_file(self, path):
         # Run a tiny full simulation and dump it so the prescribed/scm modes
         # have a JCM-shaped state to load.


### PR DESCRIPTION
## Summary

Adds save/load primitives so a long chunked integration that gets killed (spot preemption, OOM, manual abort) can be re-launched with the same config and pick up where it left off, instead of restarting.

`Model._final_modal_state` and `_final_physics_state` together carry everything `Model.resume()` needs to keep stepping; this PR just persists them between chunks.

- **`jcm/checkpoint.py`** — `save_checkpoint(model, path, *, elapsed_days)` flattens the two state pytrees to lists of arrays (flax's msgpack codec doesn't natively serialize the `tree_math` structs that `dinosaur` uses for the modal state), msgpacks them alongside the elapsed sim-day count, and writes via tmpfile + atomic rename so a kill mid-write leaves the previous checkpoint intact. `load_checkpoint(model, path) → elapsed_days` deserializes against the destination model's bootstrapped templates and overwrites the live states.
- **`Model.bootstrap_state(initial_state=None)`** lifts the prep block out of `Model.run` into a public method so checkpoint restore (and any other caller wanting the seed pytrees without integrating) doesn't have to spin up a zero-length integration to materialize templates. It also eagerly builds the physics carry now, equivalent in behavior because `resume` skips its lazy branch when the carry is already populated.
- **`run_chunked` wiring** via `cfg.run.checkpoint_path`. When the file exists at startup, the runner bootstraps state, loads the checkpoint, and resumes at the recorded chunk boundary. The loop is now elapsed-day driven rather than `i`-indexed so resume just falls into place. Throughput reporting now uses the post-resume window so the displayed sim-days/hr reflects work actually done on this host. After every chunk (restored or fresh) the runner saves a new checkpoint.

## Usage

```bash
python -m jcm.main \
  physics=echam-rrtmgp grid=echam_t63_l47_hybrid \
  run=longrun run.checkpoint_path=/scratch/job123.ckpt
```

If the run is killed at sim-day 270, a re-launch with the same command picks up at day 270 and runs the remaining chunk(s).

## Test plan
- [x] `pytest jcm/checkpoint_test.py -v` → 4 passed (round-trip fidelity, error paths, resumption equivalence: continuous 4-day Held-Suarez run matches `(2 d, ckpt, fresh model, load, 2 d)` split to < 1e-5)
- [x] `pytest jcm/runners_test.py::TestModeDispatch -v` → 3 passed, including a new test that drives `run_chunked` once with `total_time=1`, then re-invokes with `total_time=2` and the existing checkpoint — the second invocation runs only the remaining chunk
- [x] `pytest jcm/model_test.py jcm/runners_test.py -m "not slow"` → 36 passed, 1 skipped (regression check on the `bootstrap_state` refactor)
- [ ] CI green on the standard fast + coverage gates

Closes #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)