### PR TITLE
feat: ECHAM lmidatm stability stack — first clean 365d T63L47 ECHAM-RRTMGP year

### DIFF
--- a/jcm/config/diffusion/default.yaml
+++ b/jcm/config/diffusion/default.yaml
@@ -1,3 +1,13 @@
-# SPEEDY-default uniform-order hyperdiffusion. ``scale=1`` keeps the
-# original timescales (24h temp, 12h vor_q, 2h div).
+# Hyperdiffusion configuration.
+#
+# ``kind: auto`` (default) picks a profile from the grid: L47 hybrid grids
+# get the matching ECHAM ``lmidatm`` level-dependent profile
+# (del² at top 4 levels, ..., del⁸ below); everything else gets SPEEDY's
+# uniform-order default.
+#
+# Override with ``kind: default`` (SPEEDY uniform, 24h temp / 12h vor_q
+# / 2h div), ``kind: echam_t63_l47`` (T63 lmidatm 7h base), or
+# ``kind: echam_t85_l47`` (T85 lmidatm 3h base). ``scale`` multiplies
+# the chosen profile's timescales.
+kind: auto
 scale: 1.0

--- a/jcm/config/init/jw.yaml
+++ b/jcm/config/init/jw.yaml
@@ -1,3 +1,7 @@
-# Jablonowski-Williamson lapse-rate temperature with 60% RH humidity.
-# Better moist-physics initial condition than isothermal-rest.
+# Jablonowski-Williamson lapse-rate temperature with default 60% RH humidity.
+# Override ``init.rh=0.0`` for a fully-dry JW init (useful during spin-up
+# debugging — radiation + surface fluxes will moisten the atmosphere
+# themselves and avoid a moist-init day-12 NaN). Better moist-physics
+# initial condition than isothermal-rest.
 kind: jw
+rh: 0.6

--- a/jcm/config/run/longrun.yaml
+++ b/jcm/config/run/longrun.yaml
@@ -12,20 +12,22 @@ output: longrun.nc
 log_level: INFO
 
 # Production sponge config — settled on after the 2026-05-14/15 T63L47
-# sweep. ``target_T_K=270`` adds an absolute-target relaxation that
+# sweep. ``target_T_K=250`` adds an absolute-target relaxation that
 # catches the m=0 (zonal-mean) mode that pure zonal-mean damping by
 # construction can't touch; without it the lev46 zonal mean drifts
 # ~4 K/hr from a JW-dry cold-cap init and NaN's before the first save.
-# Top-5 vs top-10 sponge depth is nearly indistinguishable after spin-up
-# (verified day-365 column-mean Ts within 0.5 K) so we keep the smaller
-# footprint. ``damp_temperature`` is True by default on UpperSponge —
-# explicit here for clarity.
+# Top-10 sponge depth ramps the damping smoothly into the stratosphere
+# (with ``enspodi=2`` the timescale doubles per level away from TOA,
+# so the level-10 sponge is ~768 h, essentially inactive); paired with
+# the colder ``target_T_K=250`` it gives the cleanest year-1 mesospheric
+# climatology in the 2026-05-14/15 three-way sweep. ``damp_temperature``
+# is True by default on UpperSponge — explicit here for clarity.
 sponge:
-  levels: 5
+  levels: 10
   timescale_h: 1.5
   enspodi: 2.0
   damp_temperature: true
-  target_T_K: 270.0
+  target_T_K: 250.0
 
 chunk_days: 30
 output_prefix: longrun

--- a/jcm/config/run/longrun.yaml
+++ b/jcm/config/run/longrun.yaml
@@ -1,19 +1,33 @@
-# Long ICON run: chunked into 90-day pieces with health checks between each
-# chunk, monthly snapshots inside each chunk, conservative timestep, sponge
-# enabled. Replaces the old ``utils/run_echam_longrun.py`` script.
+# Long ECHAM run: 30-day chunks with health checks between each chunk,
+# 5-day saves inside each chunk, conservative timestep, sponge enabled
+# with T-damping toward an absolute target so the JW-dry init can spin
+# up against realistic ozone without a runaway at the model top.
+# Replaces the old ``utils/run_echam_longrun.py`` script. See
+# ``feat: ECHAM lmidatm stability stack`` PR for the calibration.
 time_step: 12
-save_interval: 30
+save_interval: 5
 total_time: 365
-output_averages: false
+output_averages: true
 output: longrun.nc
 log_level: INFO
 
+# Production sponge config — settled on after the 2026-05-14/15 T63L47
+# sweep. ``target_T_K=270`` adds an absolute-target relaxation that
+# catches the m=0 (zonal-mean) mode that pure zonal-mean damping by
+# construction can't touch; without it the lev46 zonal mean drifts
+# ~4 K/hr from a JW-dry cold-cap init and NaN's before the first save.
+# Top-5 vs top-10 sponge depth is nearly indistinguishable after spin-up
+# (verified day-365 column-mean Ts within 0.5 K) so we keep the smaller
+# footprint. ``damp_temperature`` is True by default on UpperSponge —
+# explicit here for clarity.
 sponge:
   levels: 5
-  timescale_h: 3.0
+  timescale_h: 1.5
   enspodi: 2.0
+  damp_temperature: true
+  target_T_K: 270.0
 
-chunk_days: 90
+chunk_days: 30
 output_prefix: longrun
 
 mode: full

--- a/jcm/diffusion.py
+++ b/jcm/diffusion.py
@@ -71,12 +71,36 @@ class DiffusionFilter:
         toward 3 h (T85 sits between T63 and T127). Levels 1-4 use del²,
         5-7 del⁴, 8-9 del⁶, 10+ del⁸. Applied equally to div/vor_q/temp.
         """
+        return cls._echam_l47(base_tau_h=3.0)
+
+    @classmethod
+    def echam_t63_l47(cls):
+        """Level-dependent hyperdiffusion profile matching ECHAM6.3 T63 lmidatm.
+
+        Per ``setdyn.f90``: ``dampth = 7 h`` for ``nn = 63`` selects the base
+        vorticity timescale; the level-order profile from ``mo_hdiff.f90::sudif``
+        for ``(nn = 63, nlev = 47)`` is ``[del², del², del², del², del⁴, del⁴,
+        del⁴, del⁶, del⁶, del⁸, ...]`` (levels 1-4 del², 5-7 del⁴, 8-9 del⁶,
+        10+ del⁸). Equivalent to ``echam_t85_l47()`` but with the T63 7-hour
+        base timescale instead of the T85 3-hour value, and so applied at
+        ``physics=echam`` runs on a T63L47 grid.
+        """
+        return cls._echam_l47(base_tau_h=7.0)
+
+    @classmethod
+    def _echam_l47(cls, base_tau_h: float):
+        """Shared constructor for ECHAM lmidatm L47 hyperdiffusion profiles.
+
+        ``base_tau_h`` is the ECHAM ``dampth`` value in hours (T63→7, T85→3,
+        T127→1.5, T255→0.5; see ``setdyn.f90``).
+        """
         orders = [1] * 4 + [2] * 3 + [3] * 2 + [4] * 38  # 4+3+2+38 = 47
         level_orders = jnp.asarray(orders, dtype=jnp.int32)
-        base_tau = 3 * 60 * 60  # 3 h -- between T63 (7h) and T127 (1.5h)
+        base_tau = base_tau_h * 3600.0
         return cls(
             # Effective timescale for each variable is ``base_tau * factor``;
-            # factors match ECHAM's difvo / difd / dift proportions.
+            # factors match ECHAM's difvo / difd / dift proportions
+            # (``mo_hdiff.f90``: ``difd = 5*difvo``, ``dift = 0.4*difvo``).
             div_timescale=base_tau / 5.0,        # divergence 5x stronger
             div_order=1,
             vor_q_timescale=base_tau,            # vorticity baseline
@@ -110,8 +134,16 @@ def level_dependent_scaling(
 
     For each level ``k`` with order ``p_k``:
 
-        scale_k = time_step / (timescale * |eigenvalues[-1]| ** p_k)
-        scaling[k, 0, n] = exp( - scale_k * (-eigenvalues[n]) ** p_k )
+        scaling[k, 0, n] = exp( -(dt/timescale) * (|eig[n]| / |eig[-1]|) ** p_k )
+
+    Algebraically equivalent to the textbook formulation
+    ``exp(-dt/(τ·|eig_max|^p) · |eig|^p)`` but float-stable: the
+    eigenvalues ``|eig|`` are O(1e-10) (nondimensional Laplacian
+    eigenvalues for spherical harmonics), so for ``p=4`` the textbook
+    form computes ``|eig_max|^4 ≈ 1e-40``, which underflows in float32
+    to 0 → ``dt/0 = inf`` → ``inf · 0 = NaN`` in the leading-edge
+    coefficient. Computing the ``|eig|/|eig_max|`` ratio first keeps the
+    intermediate in ``[0, 1]``.
 
     Args:
         eigenvalues: Negative-definite Laplacian eigenvalues from
@@ -125,13 +157,12 @@ def level_dependent_scaling(
         ``(nlev, 1, lat_modes)`` scaling.
 
     """
-    pos_eig = -eigenvalues                                          # (lat_modes,)
-    pos_eig_max = jnp.abs(eigenvalues[-1])                          # scalar
+    pos_eig = jnp.abs(eigenvalues)                                  # (lat_modes,)
+    pos_eig_max = pos_eig[-1]                                       # scalar
     p = orders_per_level[:, None].astype(jnp.float32)               # (nlev, 1)
-    scale_per_level = time_step / (timescale * pos_eig_max ** p)    # (nlev, 1)
-    pow_eig = pos_eig[None, :] ** p                                 # (nlev, lat_modes)
-    # Insert lon-modes singleton so we can broadcast against (nlev, M, N)
-    return jnp.exp(-scale_per_level * pow_eig)[:, None, :]
+    norm_eig = pos_eig[None, :] / pos_eig_max                       # (1, lat_modes), in [0, 1]
+    pow_norm = norm_eig ** p                                        # (nlev, lat_modes)
+    return jnp.exp(-(time_step / timescale) * pow_norm)[:, None, :]
 
 
 def uniform_scaling(
@@ -143,8 +174,10 @@ def uniform_scaling(
     """Uniform-order damping scaling, shape ``(lat_modes,)``.
 
     Equivalent to ``dinosaur.filtering.horizontal_diffusion_filter`` with a
-    single ``(timescale, order)``.
+    single ``(timescale, order)``. Float-stable rewrite — see
+    :func:`level_dependent_scaling` for the underflow note (matters
+    once ``order >= 4``).
     """
-    pos_eig_max = jnp.abs(eigenvalues[-1])
-    scale = time_step / (timescale * pos_eig_max ** order)
-    return jnp.exp(-scale * (-eigenvalues) ** order)
+    pos_eig = jnp.abs(eigenvalues)
+    norm_eig = pos_eig / pos_eig[-1]
+    return jnp.exp(-(time_step / timescale) * norm_eig ** order)

--- a/jcm/diffusion_test.py
+++ b/jcm/diffusion_test.py
@@ -1,0 +1,90 @@
+"""Tests for ``jcm.diffusion`` scaling helpers."""
+
+import unittest
+
+import jax.numpy as jnp
+import numpy as np
+
+from jcm.diffusion import DiffusionFilter, level_dependent_scaling, uniform_scaling
+
+
+# Realistic dimensional Laplacian eigenvalues for a triangular T63 grid in
+# JCM's nondimensional units. ``laplacian_eigenvalues`` from the dinosaur
+# Grid is O(1e-10) here — small enough that ``|eig|^p`` for p>=4 underflows
+# in float32 if computed naively (``1e-10 ** 4 = 1e-40``), which is the
+# regression these tests pin down.
+_T63_NLAT_MODES = 65
+_EIG_T63 = -jnp.linspace(0.0, 1.0248212624113382e-10, _T63_NLAT_MODES) ** 1
+
+
+class LevelDependentScalingTest(unittest.TestCase):
+    """Pin behaviour of :func:`level_dependent_scaling`."""
+
+    def test_no_nan_at_high_orders(self):
+        """Regression: order=4 (del⁸) used to NaN due to float32 underflow.
+
+        Original implementation computed ``|eig_max|^p`` directly: for the
+        T63 nondimensional eigenvalues (max |eig| ~1e-10) and p=4 this is
+        1e-40, which underflows in float32 → ``dt / 0 = inf`` → ``inf · 0 =
+        NaN``. The fix normalises ``|eig| / |eig_max|`` *before* raising
+        to ``p`` so the intermediate stays in [0, 1]. NaN here means the
+        diffusion step silently zeroed out the bottom of the atmosphere
+        every timestep — caught only when the model NaN'd within one
+        save_interval (run_logs/probe_diffEchams_only_260514_230440.log).
+        """
+        nlev = 47
+        # Profile from the ECHAM lmidatm sudif L47 table: del² at top 4
+        # levels, then del⁴, del⁶, del⁸ — exactly what
+        # ``DiffusionFilter.echam_t63_l47()`` ships with.
+        orders = jnp.asarray([1] * 4 + [2] * 3 + [3] * 2 + [4] * 38, dtype=jnp.int32)
+        s = level_dependent_scaling(_EIG_T63, timescale=17.5 * 3600.0, orders_per_level=orders, time_step=720.0)
+        self.assertEqual(s.shape, (nlev, 1, _T63_NLAT_MODES))
+        self.assertFalse(bool(jnp.isnan(s).any()))
+
+    def test_largest_mode_damping_matches_dt_over_tau(self):
+        """At |eig| = |eig_max|, per-step factor must equal ``exp(-dt/τ)``."""
+        orders = jnp.asarray([2] * 5, dtype=jnp.int32)
+        s = level_dependent_scaling(_EIG_T63, timescale=24 * 3600.0, orders_per_level=orders, time_step=720.0)
+        expected = float(np.exp(-720.0 / (24 * 3600.0)))
+        for k in range(5):
+            self.assertAlmostEqual(float(s[k, 0, -1]), expected, places=6)
+
+    def test_smallest_mode_no_damping(self):
+        """At |eig| = 0 the per-step factor must be 1 (no damping)."""
+        orders = jnp.asarray([1, 4], dtype=jnp.int32)
+        s = level_dependent_scaling(_EIG_T63, timescale=24 * 3600.0, orders_per_level=orders, time_step=720.0)
+        for k in range(2):
+            self.assertAlmostEqual(float(s[k, 0, 0]), 1.0, places=6)
+
+
+class UniformScalingTest(unittest.TestCase):
+
+    def test_no_nan_at_order_8(self):
+        """Same float32-underflow regression as ``level_dependent_scaling``."""
+        s = uniform_scaling(_EIG_T63, timescale=24 * 3600.0, order=4, time_step=720.0)
+        self.assertFalse(bool(jnp.isnan(s).any()))
+
+    def test_largest_mode_damping_matches_dt_over_tau(self):
+        s = uniform_scaling(_EIG_T63, timescale=24 * 3600.0, order=2, time_step=720.0)
+        expected = float(np.exp(-720.0 / (24 * 3600.0)))
+        self.assertAlmostEqual(float(s[-1]), expected, places=6)
+
+
+class EchamL47FactoryTest(unittest.TestCase):
+
+    def test_t63_uses_7h_base_timescale(self):
+        d = DiffusionFilter.echam_t63_l47()
+        self.assertAlmostEqual(d.vor_q_timescale, 7 * 3600.0, places=3)
+        self.assertAlmostEqual(d.div_timescale, 7 * 3600.0 / 5.0, places=3)
+        self.assertAlmostEqual(d.temp_timescale, 7 * 3600.0 / 0.4, places=3)
+        # ECHAM lmidatm L47 sudif profile
+        np.testing.assert_array_equal(np.asarray(d.level_orders_temp), [1] * 4 + [2] * 3 + [3] * 2 + [4] * 38)
+
+    def test_t85_uses_3h_base_timescale(self):
+        d = DiffusionFilter.echam_t85_l47()
+        self.assertAlmostEqual(d.vor_q_timescale, 3 * 3600.0, places=3)
+        np.testing.assert_array_equal(d.level_orders_temp, d.level_orders_div)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jcm/physics/composable_physics.py
+++ b/jcm/physics/composable_physics.py
@@ -336,6 +336,19 @@ class ComposablePhysics(nnx.Module, Physics):
         "_speedy_coords",
     })
 
+    # Sub-struct fields that survive the flatten step but should be dropped
+    # before reaching xarray. These are typically per-RRTMGP-band optical
+    # properties — they're plumbing for the radiation coupling, have a
+    # 14-element ``sw_band`` axis that ``data_to_xarray`` has no dim entry
+    # for, and balloon save_intervals netCDFs by ~3× without adding
+    # scientific value. Filter is applied to the full dotted key
+    # (e.g. ``aerosol.aod_sw_per_band``).
+    _EXCLUDED_OUTPUT_KEYS: ClassVar[frozenset[str]] = frozenset({
+        "aerosol.aod_sw_per_band",
+        "aerosol.ssa_sw_per_band",
+        "aerosol.asy_sw_per_band",
+    })
+
     def data_struct_to_dict(
         self, struct: Any, nodal_shape=None, sep: str = "."
     ) -> dict[str, Any]:
@@ -375,7 +388,10 @@ class ComposablePhysics(nnx.Module, Physics):
                 except (ValueError, AttributeError):
                     continue
                 for sk, sv in sub.items():
-                    items[f"{out_key}{sep}{sk}"] = sv
+                    full_key = f"{out_key}{sep}{sk}"
+                    if full_key in self._EXCLUDED_OUTPUT_KEYS:
+                        continue
+                    items[full_key] = sv
 
         # Reshape column-vectorized diagnostics (a flattened ncols axis,
         # produced when ``vectorize_columns=True``) back to ``(lon, lat)``

--- a/jcm/physics/dissipation/upper_sponge.py
+++ b/jcm/physics/dissipation/upper_sponge.py
@@ -1,26 +1,40 @@
-"""Upper sponge layer — Rayleigh drag on horizontal wind at top levels.
+"""Upper sponge layer — Rayleigh drag on horizontal wind + relaxation
+of temperature toward its zonal mean at the top model levels.
 
 Analog of ECHAM's ``uspnge`` (``mo_upper_sponge.f90``), reworked as a
-composable ``PhysicsTerm``. Applies linear relaxation to (u, v) at a
-configurable number of top model levels with a timescale that intensifies
-toward TOA:
+composable ``PhysicsTerm``. Applies linear relaxation at a configurable
+number of top model levels with a timescale that intensifies toward
+TOA::
 
     du/dt += -u / tau(k)
     dv/dt += -v / tau(k)
+    dT/dt += -(T - T_zonal_mean) / tau(k)        (when damp_temperature)
 
     tau(k_top)   = sponge_timescale_s
     tau(k_top+i) = sponge_timescale_s * enspodi ** i       (i = 1..n_sponge_levels-1)
     tau(k >= n_sponge_levels) = infinity                   (no damping)
 
-With the ECHAM defaults (spdrag = 0.926e-4 s⁻¹ → 3 h, enspodi = 1.0) all
-sponge levels share the same timescale. Our defaults use ``enspodi = 2.0``
-so the damping softens by a factor of 2 per level away from TOA; this
-gives a smoother transition into the freely-evolving troposphere.
+The temperature relaxation is toward the zonal-mean profile at each
+sponge level — mathematically equivalent (in gridpoint space) to ECHAM's
+spectral implicit step that damps only the m≠0 components of T at the
+sponge levels (``mo_upper_sponge.f90`` lines 99-110, applied to ``stp``
+when ``mymsp(is) /= 0``). The zonal mean is preserved so radiation can
+still set the global stratospheric equilibrium structure; only the
+wave/Gibbs-ringing component of T is damped.
 
-Unlike the ECHAM version we do **not** restrict to non-zonal-mean waves —
-we damp the full wind field at the top levels. In steady state that costs
-some stratospheric jet but is cheap to implement and robust. Temperature
-is not damped: let radiation set the stratospheric equilibrium.
+With the ECHAM defaults (spdrag = 0.926e-4 s⁻¹ → 3 h, enspodi = 1.0,
+nlvspd1 = nlvspd2 = 1) all sponge levels share the same timescale and
+the sponge acts on level 1 only. This module's defaults use enspodi
+= 2.0 so the damping softens by a factor of 2 per level away from TOA;
+this gives a smoother transition into the freely-evolving troposphere
+and matches what we tend to ramp up via Hydra at runtime.
+
+Note on (u, v): unlike ECHAM (which damps only m≠0 modes of u, v
+spectrally) we damp the full wind field at the sponge levels. In steady
+state that costs some stratospheric jet strength but is cheap to
+implement and operationally robust. If preserving the zonal-mean wind
+becomes important for stratospheric climatology, switch the wind path
+to use the same zonal-mean relaxation we now apply to T.
 """
 
 from __future__ import annotations
@@ -37,7 +51,7 @@ from jcm.terrain import TerrainData
 
 
 class UpperSponge(PhysicsTerm):
-    """Rayleigh drag on (u, v) at the top N model levels."""
+    """Rayleigh drag on (u, v) and zonal-mean relaxation of T at top N levels."""
 
     name: ClassVar[str] = "upper_sponge"
     category: ClassVar[str] = "dissipation"
@@ -47,6 +61,8 @@ class UpperSponge(PhysicsTerm):
         n_sponge_levels: int = 5,
         sponge_timescale_s: float = 3 * 3600.0,
         enspodi: float = 2.0,
+        damp_temperature: bool = True,
+        target_T_K: float | None = None,
     ):
         """Configure the sponge.
 
@@ -58,15 +74,39 @@ class UpperSponge(PhysicsTerm):
             enspodi: Multiplicative increase in tau (softening) per level
                 away from TOA. enspodi = 1.0 reproduces ECHAM's uniform-
                 strength sponge; enspodi > 1 softens the sponge downward.
+            damp_temperature: When True (default, matches ECHAM lmidatm
+                behaviour), relax temperature toward its zonal mean at
+                the sponge levels with the same tau profile. The zonal
+                mean is preserved so radiation continues to set the global
+                stratospheric structure; only the wave / spectral-ringing
+                component of T is damped. Set False to skip T damping
+                entirely.
+            target_T_K: Optional absolute temperature target (K) for T
+                relaxation at the sponge levels — i.e. ``dT/dt -=
+                (T - target_T_K) / tau(k)``. This is an extra term *added
+                to* the zonal-mean relaxation (when ``damp_temperature``
+                is True) and addresses the m=0 spectral mode that
+                zonal-mean relaxation by construction can't touch. Useful
+                during spin-up from non-equilibrated initial conditions
+                (e.g. JW-dry init with realistic ozone) where the
+                top-layer zonal mean drifts uncontrolled toward an
+                unphysical equilibrium. Set ``None`` (default) to skip
+                the absolute target and behave like ECHAM's sponge — fine
+                for runs starting from radiatively-balanced ICs. Picking
+                a value: 250-270 K is a reasonable mesospheric target for
+                the model top (~1 Pa); aim for whatever the long-term
+                radiative-equilibrium would be at the topmost full level.
 
         """
         self.n_sponge_levels = n_sponge_levels
         self.sponge_timescale_s = sponge_timescale_s
         self.enspodi = enspodi
+        self.damp_temperature = damp_temperature
+        self.target_T_K = target_T_K
         self._coords_cached = False
 
     def cache_coords(self, coords) -> None:
-        """Precompute the 1/tau(k) damping profile for every level."""
+        """Precompute the 1/tau(k) damping profile and the (nlon, nlat) shape."""
         nlev = coords.nodal_shape[0]
         inv_tau = jnp.zeros(nlev)
         for i in range(self.n_sponge_levels):
@@ -75,6 +115,11 @@ class UpperSponge(PhysicsTerm):
             tau_i = self.sponge_timescale_s * (self.enspodi ** i)
             inv_tau = inv_tau.at[i].set(1.0 / tau_i)
         self._inv_tau = nnx.Variable(inv_tau)
+        # Cache the (nlon, nlat) shape so __call__ can reshape a flattened
+        # ncols axis back into (lon, lat) for zonal-mean computation under
+        # vectorize_columns=True.
+        self._nlon = int(coords.horizontal.nodal_shape[0])
+        self._nlat = int(coords.horizontal.nodal_shape[1])
         self._coords_cached = True
 
     def __call__(
@@ -84,7 +129,7 @@ class UpperSponge(PhysicsTerm):
         forcing: ForcingData,
         terrain: TerrainData,
     ) -> tuple[PhysicsTendency, dict]:
-        """Return Rayleigh-drag tendencies on u, v at the top levels."""
+        """Return Rayleigh-drag tendencies on u, v and zonal-mean T relaxation."""
         # state here is the column-vectorised state (nlev, ncols) when
         # called from ComposablePhysics with vectorize_columns=True, or
         # the full 3-D (nlev, nlon, nlat) when used without vectorisation.
@@ -96,7 +141,31 @@ class UpperSponge(PhysicsTerm):
 
         du = -state.u_wind * itau
         dv = -state.v_wind * itau
-        dT = jnp.zeros(shape)
+
+        if self.damp_temperature:
+            T = state.temperature
+            # Compute zonal-mean T at each (level, lat). Reshape ncols→(lon, lat)
+            # if the state is column-vectorised.
+            if T.ndim == 2:
+                # (nlev, ncols=nlon*nlat) — reshape, mean over lon, broadcast.
+                nlev = T.shape[0]
+                T_3d = T.reshape(nlev, self._nlon, self._nlat)
+                T_zonal = jnp.mean(T_3d, axis=1, keepdims=True)         # (nlev, 1, nlat)
+                T_anomaly_3d = T_3d - T_zonal
+                T_anomaly = T_anomaly_3d.reshape(nlev, self._nlon * self._nlat)
+            else:
+                # (nlev, nlon, nlat) — direct mean over the lon axis.
+                T_zonal = jnp.mean(T, axis=1, keepdims=True)            # (nlev, 1, nlat)
+                T_anomaly = T - T_zonal
+            dT = -T_anomaly * itau
+        else:
+            dT = jnp.zeros(shape)
+
+        if self.target_T_K is not None:
+            # Add an absolute-target relaxation that catches the m=0 mode
+            # the zonal-mean relaxation by construction can't touch.
+            dT = dT - (state.temperature - float(self.target_T_K)) * itau
+
         dq = jnp.zeros(shape)
         tracers = {name: jnp.zeros(shape) for name in state.tracers}
 

--- a/jcm/physics/echam/echam_levels.py
+++ b/jcm/physics/echam/echam_levels.py
@@ -1,13 +1,29 @@
-"""ICON vertical hybrid sigma-pressure coordinate definitions.
+"""ECHAM/ICON hybrid sigma-pressure level tables.
 
-This module provides ICON's vertical coordinate tables for various numbers
-of atmospheric levels, parsed from the official ICON vertical_coord_tables.
+The 47-level table here matches both ECHAM6.3 ``L47 lmidatm`` (verified
+bit-for-bit against a production ECHAM6.3-HAM T63L47 ``vct_a/vct_b``
+log on 2026-05-14) and ICON's standard ``L47`` table — these are
+shared heritage tables, not separate. The module was originally named
+after ICON because that's where the values came from in this codebase;
+the actual numerical values are equally the ECHAM6.3 lmidatm
+production grid (top at p=0, three trailing zero ``a`` boundaries
+intentionally degenerate at the top). When pairing this grid with
+ECHAM-style physics, the model needs ECHAM's ``lmidatm`` stability
+stack — upper sponge with T damping on m≠0 modes
+(``mo_upper_sponge.f90``) and level-dependent del²→del⁸ horizontal
+diffusion at the top 4 levels (``mo_hdiff.f90::sudif``) — otherwise
+the thin top layer (~2 Pa mass) runs away under any radiative
+imbalance, the failure mode documented in the
+``echam_rrtmgp_t63_real_orog_nan`` memory.
 
-The `a_boundaries` values stored here are in **Pascals** (Pa) — the native
-ICON convention. `dinosaur.primitive_equations.PrimitiveEquationsHybrid`
-expects `a` values to be nondimensionalized by its `hpa_quantity` unit
-(defaulting to hPa); the Model class overrides this to `units.pascal` when
-constructed with `HybridCoordinates` from this module.
+ECHAM stores the actual numerical table in initial-condition netCDFs
+(``vct_a``/``vct_b`` variables, ``nvclev`` dim) read at runtime by
+``mo_io.f90``; the source code itself contains no level numbers.
+
+The ``a_boundaries`` values are in **Pascals** (Pa).
+``dinosaur.primitive_equations.PrimitiveEquationsHybrid`` expects ``a``
+in its ``hpa_quantity`` unit (default hPa); ``Model`` overrides this
+to ``units.pascal`` when constructed with these ``HybridCoordinates``.
 """
 
 import jax.numpy as jnp

--- a/jcm/prescribed_state_model.py
+++ b/jcm/prescribed_state_model.py
@@ -13,11 +13,13 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
+import jax_datetime as jdt
 import tree_math
 from jax.tree_util import tree_map
 
 from dinosaur.coordinate_systems import CoordinateSystem
 
+from jcm.date import DEFAULT_CALENDAR, DateData
 from jcm.forcing import ForcingData, default_forcing
 from jcm.physics_interface import (
     Physics,
@@ -45,6 +47,67 @@ class PrescribedStatePredictions:
     physics_data: Any
     times: Any
 
+    def to_xarray(self):
+        """Dump states + tendencies + physics_data into an ``xr.Dataset``.
+
+        Minimal serialiser for offline diagnostics — does NOT use the
+        coord-aware ``data_to_xarray`` path that ``ModelPredictions``
+        uses (which would require threading ``coords`` + ``physics``
+        through the predictions struct). Variables are emitted with raw
+        positional dim names ``time, level, lon, lat`` and no units
+        metadata; the intent is to support quick NaN-checks and column
+        plots, not production climatology.
+
+        Use ``ModelPredictions.to_xarray()`` when you need the full
+        coord-aware serialisation (units, ``additional_coords``,
+        flipped level axis, etc.).
+        """
+        import numpy as np
+        import xarray as xr
+
+        # Hardcoded positional dim names matching the prescribed-mode
+        # vmap layout: (time, level, lon, lat) for column variables,
+        # (time, lon, lat) for surface fields.
+        def _dims_for(arr):
+            shape = np.shape(arr)
+            if len(shape) == 4:
+                return ("time", "level", "lon", "lat")
+            if len(shape) == 3:
+                return ("time", "lon", "lat")
+            if len(shape) == 2:
+                return ("time", "level")
+            if len(shape) == 1:
+                return ("time",)
+            return tuple(f"dim_{i}" for i in range(len(shape)))
+
+        data_vars: dict[str, tuple] = {}
+
+        def _add(prefix, struct):
+            for k, v in struct.asdict().items():
+                if isinstance(v, dict):
+                    for sk, sv in v.items():
+                        data_vars[f"{prefix}{k}.{sk}"] = (_dims_for(sv), np.asarray(sv))
+                else:
+                    data_vars[f"{prefix}{k}"] = (_dims_for(v), np.asarray(v))
+
+        _add("state.", self.states)
+        _add("tend.", self.tendencies)
+
+        if isinstance(self.physics_data, dict):
+            for k, v in self.physics_data.items():
+                if k.startswith("_"):
+                    continue
+                if hasattr(v, "asdict"):
+                    _add(f"diag.{k.lstrip('_')}.", v)
+                else:
+                    arr = np.asarray(v)
+                    data_vars[f"diag.{k}"] = (_dims_for(arr), arr)
+
+        return xr.Dataset(
+            data_vars=data_vars,
+            coords={"time": np.asarray(self.times)},
+        )
+
 
 class PrescribedStateModel:
     """Compute physics tendencies for a prescribed state time series.
@@ -64,12 +127,26 @@ class PrescribedStateModel:
         coords: CoordinateSystem,
         terrain: TerrainData | None = None,
         dt_seconds: float = 1800.0,
+        start_date: jdt.Datetime | None = None,
+        calendar: str = DEFAULT_CALENDAR,
     ) -> None:
-        """Initialise (see class docstring for argument descriptions)."""
+        """Initialise (see class docstring for argument descriptions).
+
+        ``start_date`` and ``calendar`` mirror :class:`jcm.model.Model` so
+        each prescribed state can collapse ``TimeSeries`` forcing leaves
+        (sea ice, SST, ozone climatology, ...) to the slice valid at that
+        state's ``sim_time`` before physics is evaluated. Without this,
+        from-file forcings stay as ``TimeSeries`` structs and physics
+        terms that arithmetic-combine them with plain arrays raise
+        ``TypeError: non-tree_math.VectorMixin argument is not a
+        scalar``.
+        """
         self.physics = physics
         self.coords = coords
         self.terrain = terrain if terrain is not None else TerrainData.aquaplanet(coords)
         self.dt_seconds = float(dt_seconds)
+        self.start_date = start_date if start_date is not None else jdt.to_datetime("2000-01-01")
+        self.calendar = calendar
         self.physics.cache_coords(coords)
         # Hand the timestep down to the composable-physics container so its
         # terms read a single ``dt`` source — mirrors the wiring in ``Model``
@@ -107,14 +184,37 @@ class PrescribedStateModel:
 
         physics = self.physics
         terrain = self.terrain
+        start_date = self.start_date
+        calendar = self.calendar
+        dt_seconds = self.dt_seconds
 
-        def step(state):
+        # ``times`` is days-since-``start_date``; convert to sim_time
+        # seconds so ``_date_for`` matches the wiring in
+        # ``Model._step_fn``.
+        sim_times = jnp.asarray(times) * 86400.0
+
+        def _date_for(sim_time):
+            sim_time = jax.lax.stop_gradient(sim_time)
+            return DateData.set_date(
+                model_time=start_date + jdt.Timedelta(
+                    days=jnp.floor(sim_time / 86400).astype(jnp.int32),
+                    seconds=jnp.round(sim_time % 86400).astype(jnp.int32),
+                ),
+                model_step=jnp.int32(sim_time / dt_seconds),
+                dt_seconds=dt_seconds,
+                calendar=calendar,
+            )
+
+        def step(state, sim_time):
             clamped = verify_state(state)
-            return physics.compute_tendencies(clamped, forcing, terrain)
+            # Collapse any TimeSeries forcing leaves to the slice valid
+            # at this state's sim_time (same wiring as Model._step_fn).
+            forcing_now = forcing.select(_date_for(sim_time), calendar=calendar)
+            return physics.compute_tendencies(clamped, forcing_now, terrain)
 
         @jax.jit
         def vmapped():
-            return jax.vmap(step)(states)
+            return jax.vmap(step)(states, sim_times)
 
         tendencies, physics_data = vmapped()
         return PrescribedStatePredictions(

--- a/jcm/runners.py
+++ b/jcm/runners.py
@@ -252,10 +252,14 @@ def maybe_add_sponge(physics, cfg: DictConfig):
     if sponge is None or sponge.get("levels", 0) <= 0:
         return physics
     from jcm.physics.dissipation import UpperSponge
+    raw_target_T_K = sponge.get("target_T_K", None)
+    target_T_K = None if raw_target_T_K is None else float(raw_target_T_K)
     return physics + UpperSponge(
         n_sponge_levels=int(sponge.levels),
         sponge_timescale_s=float(sponge.timescale_h) * 3600.0,
         enspodi=float(sponge.enspodi),
+        damp_temperature=bool(sponge.get("damp_temperature", True)),
+        target_T_K=target_T_K,
     )
 
 
@@ -288,9 +292,54 @@ def build_terrain(cfg: DictConfig, coords) -> TerrainData:
 # ---------------------------------------------------------------------------
 
 def build_diffusion(cfg: DictConfig) -> DiffusionFilter:
-    base = DiffusionFilter.default()
+    """Build a ``DiffusionFilter`` honouring ``cfg.diffusion`` + the grid.
+
+    Resolution selector: when ``cfg.diffusion.kind`` is ``"auto"`` (the
+    default) and the grid is an L47 hybrid, return the matching
+    ECHAM ``lmidatm`` level-dependent profile (del² at top 4 levels, del⁴
+    at 5-7, del⁶ at 8-9, del⁸ below) — that's the stability stack the
+    grid was tuned for in ECHAM. T63L47 picks the 7-hour base timescale;
+    T85L47 picks 3 h. Set ``cfg.diffusion.kind: default`` to force the
+    uniform SPEEDY del² profile (24h temp / 12h vor_q / 2h div), or
+    ``cfg.diffusion.kind: echam_t63_l47`` / ``echam_t85_l47`` to pin a
+    specific factory regardless of grid. ``cfg.diffusion.scale`` still
+    multiplies the chosen profile's timescales — keep the existing
+    SPEEDY-tuned configs working unchanged.
+    """
     diffusion = cfg.get("diffusion", None)
+    kind = "auto" if diffusion is None else str(diffusion.get("kind", "auto"))
     scale = 1.0 if diffusion is None else float(diffusion.get("scale", 1.0))
+
+    if kind == "auto":
+        # Pick by grid: ECHAM lmidatm profile for L47 hybrid grids, SPEEDY
+        # default otherwise. Match on the (vertical=hybrid, layers, truncation)
+        # triple so this fires for both echam_t63_l47_hybrid and
+        # echam_t85_l47_hybrid — and stays inert for SPEEDY T31L8 / Held-Suarez.
+        grid_cfg = cfg.get("grid", None)
+        layers = int(grid_cfg.get("layers", 0)) if grid_cfg is not None else 0
+        truncation = int(grid_cfg.get("spectral_truncation", 0)) if grid_cfg is not None else 0
+        vertical = str(grid_cfg.get("vertical", "")) if grid_cfg is not None else ""
+        if vertical == "hybrid" and layers == 47:
+            if truncation == 63:
+                base = DiffusionFilter.echam_t63_l47()
+            elif truncation == 85:
+                base = DiffusionFilter.echam_t85_l47()
+            else:
+                base = DiffusionFilter.default()
+        else:
+            base = DiffusionFilter.default()
+    elif kind == "default":
+        base = DiffusionFilter.default()
+    elif kind == "echam_t63_l47":
+        base = DiffusionFilter.echam_t63_l47()
+    elif kind == "echam_t85_l47":
+        base = DiffusionFilter.echam_t85_l47()
+    else:
+        raise ValueError(
+            f"Unknown diffusion.kind={kind!r}; expected one of "
+            "'auto', 'default', 'echam_t63_l47', 'echam_t85_l47'."
+        )
+
     if scale == 1.0:
         return base
     return DiffusionFilter(
@@ -300,6 +349,9 @@ def build_diffusion(cfg: DictConfig) -> DiffusionFilter:
         vor_q_order=base.vor_q_order,
         temp_timescale=base.temp_timescale * scale,
         temp_order=base.temp_order,
+        level_orders_div=base.level_orders_div,
+        level_orders_vor_q=base.level_orders_vor_q,
+        level_orders_temp=base.level_orders_temp,
     )
 
 
@@ -587,7 +639,7 @@ def _run_full(cfg: DictConfig, model: Model | None = None) -> ModelPredictions:
             output_averages=cfg.run.output_averages,
         )
     if cfg.init.kind == "jw":
-        inject_jw_profile(model)
+        inject_jw_profile(model, rh=float(cfg.init.get("rh", 0.6)))
         return model.resume(
             forcing=forcing,
             save_interval=cfg.run.save_interval,
@@ -752,7 +804,7 @@ def run_chunked(
         # the template values are immediately overwritten by the
         # checkpoint's contents.
         if cfg.init.kind == "jw":
-            inject_jw_profile(model)
+            inject_jw_profile(model, rh=float(cfg.init.get("rh", 0.6)))
         elif cfg.init.kind == "balanced_isothermal":
             inject_balanced_isothermal_profile(model)
         else:
@@ -782,7 +834,7 @@ def run_chunked(
         t0 = time.perf_counter()
         first_fresh_chunk = chunk_idx == 0 and not resumed_from_ckpt
         if first_fresh_chunk and cfg.init.kind == "jw":
-            inject_jw_profile(model)
+            inject_jw_profile(model, rh=float(cfg.init.get("rh", 0.6)))
             preds = model.resume(
                 forcing=forcing,
                 save_interval=save_interval,


### PR DESCRIPTION
## Summary

- The 2026-05-14 T63L47 ECHAM-RRTMGP sweep with realistic ozone NaN'd inside chunk 1 (100% T fraction at first save). Verified against an actual ECHAM6.3-HAM lmidatm production log that the vertical grid is the same one ECHAM ships; the cascade came from three pieces of ECHAM's `mo_upper_sponge.f90` / `mo_hdiff.f90` stability stack that JCM had partial analogs of but didn't actually wire up. This PR ports the missing pieces and is now stable for a full 365 sim-day year.
- `UpperSponge` now damps T toward its zonal mean at the sponge levels (matches ECHAM's spectral m≠0 step). Optional `target_T_K` adds an absolute-K relaxation that catches the m=0 mode — required for spin-up from JW-dry / cold-cap ICs, optional once the column is in radiative balance.
- `build_diffusion()` auto-selects `DiffusionFilter.echam_t63_l47()` / `echam_t85_l47()` for L47 hybrid grids (del² at top 4 levels, del⁴/⁶/⁸ below; 7 h / 3 h base per ECHAM `dampth(nn)`). Fixed a float32 underflow in `level_dependent_scaling` and `uniform_scaling` that silently NaN'd at diffusion order ≥ 4 — regression test added in `jcm/diffusion_test.py`.
- Default `run/longrun.yaml` settles on the 2026-05-15 stable production config: **top-10 sponge, `target_T_K=250`, analytic Fortuin-Kelder ozone** (set `forcing.ozone_file=…` per-run to use the realistic climatology profile), 5-day saves, 30-day chunks, `output_averages=true`. This is the `analyticoz_full` regime from the three-way sweep — the year-1 climatology plots favoured the analytic-ozone path over the realistic climatology one, and the colder top-of-sponge target gave the cleanest mesospheric structure.
- Drive-by fixes uncovered during the debug: `ComposablePhysics._EXCLUDED_OUTPUT_KEYS` strips the three per-band aerosol diagnostics (14-band axis breaks `data_to_xarray`); `PrescribedStateModel` now collapses `TimeSeries` forcing leaves via `forcing.select(date)` before the vmapped physics call and ships a minimal `to_xarray` so `save_predictions` works; `init=jw` plumbs `init.rh` properly.

## Test plan

- [x] Full fast test suite: 894 passed, 0 failed (`JAX_PLATFORMS=cpu pytest -n 12 -m 'not slow'`).
- [x] New `jcm/diffusion_test.py`: 7 tests, including the float32-underflow regression for `order >= 4`.
- [x] End-to-end 365-day T63L47 ECHAM-RRTMGP sweep at the new defaults: every 30-day chunk health-check OK, zero NaN, ~37 sim-days/hr on a single A100. Three configs (climoz_full top-10/T250, climoz_soft top-5/T270, analyticoz_full top-10/T250) all complete; climoz vs analytic difference is the expected ~5 K column-mean / ~7 W/m² OLR swap.
- [x] Climatology plots reviewed; analyticoz_full chosen as the new default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)