### PR TITLE
[codex] Prepare v2 beta docs and package metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,318 +1,181 @@
 # JAX-GCM (JCM)
 
-<img src="logo.png" alt="Logo" width="200">
+[![Docs](https://readthedocs.org/projects/jax-gcm/badge/?version=latest)](https://jax-gcm.readthedocs.io/en/latest/)
+[![Tests](https://github.com/climate-analytics-lab/jax-gcm/actions/workflows/run_test.yaml/badge.svg?branch=dev)](https://github.com/climate-analytics-lab/jax-gcm/actions/workflows/run_test.yaml)
+[![Lint](https://github.com/climate-analytics-lab/jax-gcm/actions/workflows/run_linter.yaml/badge.svg?branch=dev)](https://github.com/climate-analytics-lab/jax-gcm/actions/workflows/run_linter.yaml)
+[![PyPI](https://img.shields.io/pypi/v/jcm.svg)](https://pypi.org/project/jcm/)
+[![Python](https://img.shields.io/pypi/pyversions/jcm.svg)](https://pypi.org/project/jcm/)
+[![License](https://img.shields.io/github/license/climate-analytics-lab/jax-gcm.svg)](LICENSE)
 
-A fully differentiable General Circulation Model (GCM) for climate science and machine learning applications, written entirely in JAX.
+<img src="logo.png" alt="JAX-GCM logo" width="180">
 
-## Overview
+JAX-GCM is a differentiable atmospheric general circulation model written
+in JAX. It couples the
+[Dinosaur](https://github.com/neuralgcm/dinosaur) spectral dynamical core
+to modular SPEEDY, Held-Suarez, and ECHAM-style physics packages, with
+support for gradient-based calibration, ML-physics experiments, and
+accelerated CPU/GPU/TPU runs.
 
-JCM is a physical climate model that combines the [Dinosaur](https://github.com/google-research/dinosaur) dynamical core with JAX implementations of atmospheric physics parameterizations. The entire model is differentiable, enabling gradient-based optimization, data assimilation, and ML-enhanced climate modeling.
+The current beta focus is the ECHAM T63L47 hybrid-coordinate stack with
+RRTMGP radiation:
 
-### Key Features
+```bash
+python -m jcm.main physics=echam-rrtmgp grid=echam_t63_l47_hybrid run=longrun
+```
 
-- **Fully Differentiable**: Automatic differentiation through the entire model using JAX
-- **GPU/TPU Accelerated**: JIT compilation and hardware acceleration via JAX
-- **Modular Physics**: SPEEDY and ECHAM physics packages with radiation, convection, clouds, and surface processes
-- **Composable**: Mix and match parameterizations across physics packages (e.g., SPEEDY convection + ECHAM radiation)
-- **Flexible Grids**: Spectral dynamical core supporting multiple resolutions (T21 to T425), including hybrid (a + b·P_s) vertical coordinates
-- **Climate-Quality Target Config**: T63L47 hybrid grid with ECHAM physics and RRTMGP radiation (`physics=echam-rrtmgp grid=echam_t63_l47_hybrid`) for production-grade runs
-- **ML-Ready**: Designed for hybrid physics-ML workflows and parameter optimization
+## Highlights
+
+- Fully differentiable JAX implementation compatible with `jit`, `grad`, and `vmap`
+- Operator-split physics coupled to a spectral primitive-equation dycore
+- SPEEDY, Held-Suarez, and composable ECHAM physics configurations
+- ECHAM T63L47 hybrid-coordinate target setup with grey, RRTMGP, or neural-emulated radiation
+- xarray/netCDF output, chunked long-run health checks, and resumable checkpoints
+- Docker and Kubernetes deployment examples for GPU batch runs
 
 ## Installation
 
-Easily install using pip with all the associated requirements:
+Install the latest release:
 
 ```bash
 pip install jcm
 ```
 
-Or, from conda forge:
-```bash
-conda install -c conda-forge jcm
-```
-
-Or, clone the repository and install in development mode:
+For the development branch:
 
 ```bash
 git clone https://github.com/climate-analytics-lab/jax-gcm.git
 cd jax-gcm
+git switch dev
 pip install -e .
 ```
 
-### Requirements
-
-- Python ≥ 3.11
-- JAX
-- [Dinosaur](https://github.com/google-research/dinosaur) (dynamical core)
-- XArray (for I/O and data handling)
-
-See `requirements.txt` for the complete list of dependencies.
+JCM requires Python 3.11 or newer. The full dependency set is listed in
+[`requirements.txt`](requirements.txt), including JAX, Flax, Dinosaur,
+Hydra, xarray, and optional RRTMGP support.
 
 ## Quick Start
 
-Run a simple aquaplanet simulation:
+Run a short SPEEDY aquaplanet integration from Python:
 
 ```python
 from jcm.model import Model
 from jcm.physics.speedy.speedy_coords import get_speedy_coords
 
-# Build coords (pass spmd_mesh=(x, y, z) here to enable multi-device sharding)
 coords = get_speedy_coords(layers=8, spectral_truncation=31)
+model = Model(coords=coords, time_step=30.0)
 
-# Create a model with default configuration
-model = Model(
-    coords=coords,
-    time_step=30.0,  # minutes
-)
-
-# Run a 120-day simulation
-predictions = model.run(
-    save_interval=10.0,  # save every 10 days
-    total_time=120.0     # total simulation time in days
-)
-
-# Convert output to xarray Dataset for analysis
+predictions = model.run(save_interval=10.0, total_time=120.0)
 ds = predictions.to_xarray()
 print(ds)
 ```
 
-## Command-line interface
-
-Most simulations can be launched with the bundled Hydra CLI without writing
-any Python:
+Most production runs use the Hydra CLI:
 
 ```bash
 # Default 10-day SPEEDY aquaplanet
 python -m jcm.main
 
-# Targeted production setup: ECHAM physics on T63L47 hybrid coords with RRTMGP radiation
+# ECHAM T63L47 with production RRTMGP radiation
 python -m jcm.main physics=echam-rrtmgp grid=echam_t63_l47_hybrid
 
-# ECHAM physics with the default grey two-stream radiation (cheaper, good for tuning)
+# Cheaper ECHAM development run with grey two-stream radiation
 python -m jcm.main physics=echam grid=echam_t63_l47_hybrid
 
-# Held-Suarez 30-day integration
-python -m jcm.main physics=held_suarez grid=held_suarez_t31_l8 \
-    run.total_time=30 run.save_interval=1
-
-# Override individual physics parameters (the leading `+` is required because
-# `params` defaults to the scheme's `.default()` and is not in the yaml).
-python -m jcm.main physics=echam +physics.terms.tiedtke_convection.params.entrpen=4e-4
-
-# Long ECHAM + RRTMGP run with chunked health checks
-python -m jcm.main physics=echam-rrtmgp grid=echam_t63_l47_hybrid run=longrun
-
-# Same, but resumable across preemptions: model state is saved to
-# ``run.checkpoint_path`` after each chunk; if the file already exists at
-# launch, the run picks up at the recorded sim-day.
+# Chunked, resumable long run
 python -m jcm.main physics=echam-rrtmgp grid=echam_t63_l47_hybrid run=longrun \
     run.checkpoint_path=/scratch/$JOB_ID.ckpt
 
-# Single-column physics evolution from a saved JCM run
-python -m jcm.main run.mode=scm run.state_file=path/to/state.nc \
-    run.column.lat_deg=0 run.column.lon_deg=180
+# Inspect available config groups and the composed config
+python -m jcm.main --help
+python -m jcm.main --cfg job grid=echam_t63_l47_hybrid
 ```
 
-Inspect the available config groups and the fully-composed config:
+Config groups live under [`jcm/config/`](jcm/config/) (`physics`, `grid`,
+`run`, `init`, `terrain`, `forcing`, and `diffusion`).
 
-```bash
-python -m jcm.main --help                  # config-group choices + Hydra usage
-python -m jcm.main --cfg job               # print the composed config
-python -m jcm.main --cfg job grid=echam_t63_l47_hybrid   # with overrides
+## Physics Packages
+
+**SPEEDY** provides a compact climate-physics package for development,
+testing, and optimization examples: simplified convection, large-scale
+condensation, radiation, surface fluxes, vertical diffusion, and
+orographic drag.
+
+**ECHAM** is the beta release target for climate-quality integrations. It
+includes Tiedtke-Nordeng convection, Sundqvist cloud cover, 1M/2M cloud
+microphysics, TTE-TKE vertical diffusion, multi-tile surface physics,
+gravity-wave drag, MACv2-SP aerosols, simple chemistry, and selectable
+radiation backends (`grey`, `rrtmgp`, `emulated`). See
+[`docs/source/echam_physics.rst`](docs/source/echam_physics.rst) for
+scheme notes, references, and current performance guidance.
+
+Individual parameterizations are `PhysicsTerm` modules and can be
+combined with the composable physics API:
+
+```python
+from jcm.physics.echam.echam_terms import echam_physics
+from jcm.physics.radiation.rrtmgp import RRTMGPRadiation
+
+physics = echam_physics(radiation_scheme="rrtmgp")
+physics = echam_physics().replace("radiation", RRTMGPRadiation())
+physics = echam_physics().remove("hines")
 ```
 
-Config groups live under `jcm/config/` (`physics`, `grid`, `run`, `init`,
-`terrain`, `forcing`, `diffusion`).
+## Notebooks
 
-## Running in Docker
+Examples live in [`notebooks/`](notebooks/):
 
-The bundled `Dockerfile` is built on `nvidia/cuda` and ships `jax[cuda12]`,
-so the same image runs accelerated on GPU hosts and falls back to CPU
-elsewhere (no TPU support). Its entrypoint is the JCM Hydra CLI, which
-makes it straightforward to launch non-interactive simulations on
-Kubernetes, GCP, NRP or any other batch/queued compute. Build once:
+- `01_jcm_demo.ipynb`: SPEEDY aquaplanet and basic xarray analysis
+- `02_optimization_example.ipynb`: differentiable parameter optimization
+- `03_generate_speedy_default_stats.ipynb`: bundled SPEEDY reference statistics
+- `04_jcm_era5_example.ipynb`: ERA5-style initial state workflow
+- `04_jcm_slides.ipynb`: presentation overview
+- `05_jcm_echam_demo.ipynb`: ECHAM and composable physics demo
+- `06_macv2_aerosols.py`: MACv2-SP aerosol parameter workflow
+
+## Docker And Deployment
+
+Build the CUDA-enabled image locally:
 
 ```bash
 docker build -t jcm .
-```
-
-### Default run
-
-```bash
-# On a GPU host
-docker run --rm --gpus all jcm
-
-# Or without GPUs (CPU fallback)
-docker run --rm jcm
-```
-
-This runs the default 10-day SPEEDY aquaplanet configuration.
-
-### Hydra overrides
-
-Anything after the image name is forwarded to `python -m jcm.main`, so the
-full Hydra CLI (config groups, dotted overrides, multirun) is available:
-
-```bash
-# Switch physics package and grid (recommended ECHAM + RRTMGP setup)
 docker run --rm --gpus all jcm physics=echam-rrtmgp grid=echam_t63_l47_hybrid
-
-# Override individual run options
-docker run --rm --gpus all jcm run.time_step=20 run.total_time=30 run.save_interval=1
-
-# Parameter sweep (multirun)
-docker run --rm --gpus all jcm -m run.time_step=10,20,30
 ```
 
-### Persisting outputs
-
-By default outputs land in `outputs/YYYY-MM-DD/HH-MM-SS/` *inside the
-container* and are lost when it exits. Mount a host directory at
-`/app/outputs` to keep them:
+Mount `/app/outputs` to persist Hydra output directories:
 
 ```bash
 docker run --rm --gpus all -v "$(pwd)/outputs:/app/outputs" jcm \
     physics=echam-rrtmgp grid=echam_t63_l47_hybrid run.total_time=30
 ```
 
-After the run finishes the netCDF state file is available on the host
-under `./outputs/`.
-
-### Interactive shell
-
-Override the entrypoint to drop into a shell for debugging or exploration:
-
-```bash
-docker run --rm -it --entrypoint bash jcm
-```
-
-### Kubernetes example
-
-Ready-to-use manifests for the NRP Nautilus cluster (Job, interactive
-pod, PVC) live under [`deploy/k8s/`](deploy/k8s/). For other clusters,
-pass Hydra overrides via the container `args` field, request a GPU,
-and mount a persistent volume for outputs:
-
-```yaml
-spec:
-  containers:
-    - name: jcm
-      image: your-registry/jcm:latest
-      args: ["physics=echam-rrtmgp", "grid=echam_t63_l47_hybrid", "run.total_time=30"]
-      resources:
-        limits:
-          nvidia.com/gpu: 1
-      volumeMounts:
-        - name: outputs
-          mountPath: /app/outputs
-```
-
-## Example notebooks
-
-Example notebooks are available in the `notebooks/` directory:
-
-- **`01_jcm_demo.ipynb`**: Basic model simulation with SPEEDY physics
-- **`02_optimization_example.ipynb`**: Parameter optimization examples
-- **`03_generate_speedy_default_stats.ipynb`**: Regenerate the bundled SPEEDY reference statistics
-- **`04_jcm_era5_example.ipynb`**: Initialising and verifying runs against ERA5
-- **`04_jcm_slides.ipynb`**: Presentation-ready overview
-- **`05_jcm_echam_demo.ipynb`**: Running with ECHAM physics and composable physics
-- **`06_macv2_aerosols.py`**: Driving ECHAM with MACv2-SP aerosol parameters
-
-## Physics Packages
-
-JCM provides two physics packages and a composable framework for mixing parameterizations across them.
-
-### SPEEDY Physics
-
-The SPEEDY (Simplified Parameterizations, primitivE-Equation DYnamics) physics package includes:
-
-- Convection (simplified mass-flux scheme)
-- Large-scale condensation
-- Shortwave and longwave radiation
-- Surface fluxes (land, ocean, sea ice)
-- Vertical diffusion
-- Orographic drag
-
-### ECHAM Physics
-
-The ECHAM physics package is a JAX port of the MPI-M ECHAM6 / ICON-A
-atmospheric physics. It is the recommended package for climate-quality
-runs and is the target for the `T63L47` hybrid-coordinate setup
-(`grid=echam_t63_l47_hybrid`):
-
-- Tiedtke-Nordeng mass-flux convection
-- Sundqvist diagnostic cloud fraction
-- 1-moment (default) or 2-moment cloud microphysics (Lohmann & Roeckner)
-- Radiation, selectable per run via `radiation_scheme`:
-  - Grey two-stream (default, fast)
-  - RRTMGP correlated-k (production accuracy, `physics=echam-rrtmgp`)
-  - Neural-network RRTMGP emulator (RRTMGP accuracy at grey-like cost)
-- TTE-TKE vertical diffusion (Pithan & Brinkop)
-- Multi-tile surface scheme (ocean, sea ice, land)
-- Hines (1997) non-orographic + Lott-Miller (1997) sub-grid orographic gravity-wave drag
-- MACv2-SP aerosol scheme (Stevens et al., 2017) with aerosol-cloud coupling
-- Simple chemistry (ozone, CO2, CH4)
-
-See [`docs/source/echam_physics.rst`](docs/source/echam_physics.rst) for
-the per-scheme references and performance numbers on T63L47.
-
-> **Note:** ECHAM physics was previously called "ICON" in JCM. The
-> `jcm.physics.icon` namespace and `physics=icon` config group have been
-> renamed to `jcm.physics.echam` and `physics=echam` (PR #457).
-
-### Composable Physics
-
-Individual parameterizations are wired together via the composable physics API. Both `speedy_physics()` and `echam_physics()` return a `ComposablePhysics` whose terms can be swapped (`replace`), removed (`remove`) or extended (`+`):
-
-```python
-from jcm.physics.echam.echam_terms import echam_physics
-
-# Recommended T63L47 production setup — full RRTMGP correlated-k radiation
-physics = echam_physics(radiation_scheme="rrtmgp")
-
-# Cheaper alternative: NN radiation emulator at RRTMGP-like accuracy
-physics = echam_physics(radiation_scheme="emulated")
-
-# Drop a term by category, e.g. for sensitivity studies
-physics = echam_physics().remove("hines")
-
-# Or swap an individual term in by category
-from jcm.physics.radiation.rrtmgp import RRTMGPRadiation
-physics = echam_physics().replace("radiation", RRTMGPRadiation())
-```
-
-Each `PhysicsTerm` stores its own tunable parameters as `flax.nnx.Param`, enabling per-scheme gradient-based optimization.
+Kubernetes examples for the NRP Nautilus cluster are in
+[`deploy/k8s/`](deploy/k8s/).
 
 ## Documentation
 
-For more details, see the [documentation](https://jax-gcm.readthedocs.io) (or build locally):
+Read the hosted documentation at
+[jax-gcm.readthedocs.io](https://jax-gcm.readthedocs.io/en/latest/) or
+build it locally:
 
 ```bash
 cd docs
 make html
 ```
 
-Then open `docs/build/html/index.html` in your browser.
+Then open `docs/build/html/index.html`.
 
-## Testing
+## Testing And Development
 
-Run the test suite with pytest:
+Run the fast suite locally:
 
 ```bash
-# Run all tests
-pytest
-
-# Run specific test file
-pytest jcm/model_test.py
-
-# Run with verbose output
-pytest -v
+pytest -m "not slow"
+ruff check .
 ```
 
-## Contributing
-
-Contributions are welcome! Please feel free to submit issues or pull requests. Note, the latest development work should target the `dev` branch. Clean, working releases are periodically merged into `main` and tagged. 
+The GitHub test workflow enforces coverage on push and pull requests. New
+work should target the `dev` branch; clean release points are merged to
+`main` and tagged.
 
 ## Citation
 
@@ -329,14 +192,4 @@ If you use JAX-GCM in your research, please cite:
 
 ## License
 
-This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
-
-## Acknowledgments
-
-- **Dinosaur**: JAX-GCM builds on the [Dinosaur](https://github.com/google-research/dinosaur) dynamical core developed by Google Research
-- **SPEEDY**: Physics parameterizations adapted from the [SPEEDY](https://users.ictp.it/~kucharsk/speedy-net.html) model by F. Molteni
-- **SPEEDY.f90**: We referenced the [Fortran 90 version](https://github.com/samhatfield/speedy.f90) of SPEEDY by Sam Hatfield and Leo Saffin for our specific implementation.
-
-## Contact
-
-For questions or collaboration inquiries, please open an issue or contact dwatsonparris@ucsd.edu.
+JAX-GCM is licensed under Apache 2.0. See [`LICENSE`](LICENSE).

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,8 +9,8 @@ import jcm
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'Jax-GCM'
-copyright = '2025 Jax-GCM team'
+project = 'JAX-GCM'
+copyright = '2025 JAX-GCM team'
 author = 'J. Varan Madan, Ellen Davenport, Nicholas Ho, Rebecca Gjini, Duncan Watson-Parris'
 release = jcm.__version__
 

--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -95,9 +95,9 @@ The physics code follows functional programming principles:
 
    def compute_convection(
        state: PhysicsState,
-       physics_data: PhysicsData,
+       diagnostics: dict,
        parameters: Parameters,
-   ) -> tuple[PhysicsTendency, ConvectionData]:
+   ) -> tuple[PhysicsTendency, dict]:
        """Pure function computing convective tendencies."""
        # No global state, no mutations
        tendencies = ...
@@ -114,10 +114,11 @@ The physics code follows functional programming principles:
            SpeedyFlags(),
            SpeedyForcing(...),
            SpeedyConvection(params.convection),
-           SpeedyCondensation(params.condensation),
+           SpeedyLargeScaleCondensation(params.condensation),
            SpeedyShortwaveRadiation(params.shortwave_radiation),
-           SpeedyLongwaveRadiation(...),
+           SpeedyDownwardLongwaveRadiation(...),
            SpeedySurfaceFlux(params.surface_flux),
+           SpeedyUpwardLongwaveRadiation(...),
            SpeedyVerticalDiffusion(params.vertical_diffusion),
        ])
 
@@ -138,19 +139,20 @@ The model is composable at multiple levels through the ``ComposablePhysics`` fra
 .. code-block:: python
 
    from jcm.physics.speedy.speedy_terms import speedy_physics
-   from jcm.physics.echam.echam_terms import echam_physics, EchamRadiationRRTMGP
+   from jcm.physics.echam.echam_terms import echam_physics
+   from jcm.physics.radiation.rrtmgp import RRTMGPRadiation
 
    # Use pre-built SPEEDY defaults
    physics = speedy_physics()
 
-   # Use ICON with NN radiation emulator
+   # Use ECHAM with the NN radiation emulator
    physics = echam_physics(radiation_scheme="emulated")
 
-   # Replace SPEEDY's shortwave radiation with an ICON scheme
-   physics = speedy_physics().replace("radiation_sw", EchamRadiationRRTMGP())
+   # Replace SPEEDY radiation with the RRTMGP backend
+   physics = speedy_physics().replace("radiation", RRTMGPRadiation())
 
    # Remove a term
-   physics = echam_physics().remove("gravity_waves")
+   physics = echam_physics().remove("hines")
 
 Each ``PhysicsTerm`` is a ``flax.nnx.Module`` that stores its own tunable parameters as ``nnx.Param`` attributes and coordinate caches as ``nnx.Variable``. Terms communicate through a ``diagnostics`` dict threaded through the term list. The dict serves a dual role: keys without a leading underscore are exposed as user-facing diagnostic output (written to xarray); keys prefixed with ``_`` (e.g. ``_radiation``, ``_convection``) are internal inter-term state and are filtered out of the user-facing output.
 
@@ -293,7 +295,7 @@ The codebase maintains high standards to support future complexity:
    # Tests are co-located with source in process directories
    pytest jcm/physics/convection/speedy_convection_test.py
    pytest jcm/physics/radiation/speedy_shortwave_test.py
-   pytest jcm/physics/radiation/icon/radiation_test.py
+   pytest jcm/physics/radiation/grey_two_stream/radiation_scheme_test.py
    # ... etc
 
 **Documentation**: All public APIs are documented with clear docstrings.
@@ -313,7 +315,7 @@ beside existing ones without nesting:
 
    jcm/physics/
    ├── radiation/
-   │   ├── grey_two_stream/      # ICON-style grey two-stream package
+   │   ├── grey_two_stream/      # fast grey two-stream package
    │   ├── rrtmgp.py             # RRTMGP wrapper
    │   ├── nn_emulator.py        # NN radiation emulator
    │   ├── speedy_shortwave.py
@@ -332,13 +334,13 @@ beside existing ones without nesting:
    ├── gravity_waves/             # hines/ (Hines 1997), sso/ (Lott-Miller 1997), simple/
    ├── aerosol/macv2_sp.py       # Stevens MACv2-SP simple plumes
    ├── chemistry/simple_chemistry.py
-   ├── surface/                  # speedy + icon (multi-tile bundle in icon/)
+   ├── surface/                  # SPEEDY and ECHAM surface schemes
    ├── speedy/                   # SPEEDY infrastructure (params, coords)
-   └── icon/                     # ICON infrastructure (params, coords)
+   └── echam/                    # ECHAM infrastructure (params, coords)
 
 Model-specific *infrastructure* (parameter containers, coordinate caches,
-data structs) lives under ``speedy/`` and ``icon/``. Everything else is
-named after the scheme so an "ICON" port and a "CAM" port of the same
+data structs) lives under ``speedy/`` and ``echam/``. Everything else is
+named after the scheme so an ECHAM port and a CAM port of the same
 parameterization sit side-by-side without per-model subfolders.
 
 Future Directions

--- a/docs/source/design/composable_physics.md
+++ b/docs/source/design/composable_physics.md
@@ -176,7 +176,7 @@ category into the single replacement, inserted at the position of the
 first one — so you can swap an entire process category in one call:
 
 ```python
-# SPEEDY with ICON's RRTMGP radiation
+# SPEEDY with RRTMGP radiation
 physics = speedy_physics().replace("radiation", RRTMGPRadiation())
 
 # ECHAM with a custom convection scheme
@@ -358,7 +358,7 @@ jcm/physics/
 ├── physics_term.py             # PhysicsTerm base class
 ├── composable_physics.py       # ComposablePhysics container
 ├── radiation/
-│   ├── grey_two_stream/        # ICON-style grey two-stream package
+│   ├── grey_two_stream/        # fast grey two-stream package
 │   ├── rrtmgp.py               # RRTMGP wrapper
 │   ├── nn_emulator.py          # NN radiation emulator
 │   ├── speedy_shortwave.py
@@ -377,12 +377,12 @@ jcm/physics/
 ├── gravity_waves/{hines,sso,simple}/
 ├── aerosol/macv2_sp.py         # Stevens MACv2-SP simple plumes
 ├── chemistry/simple_chemistry.py
-├── surface/                    # speedy + icon (multi-tile bundle in icon/)
+├── surface/                    # SPEEDY and ECHAM surface schemes
 ├── speedy/                     # SPEEDY infrastructure (params, coords)
-└── icon/                       # ICON infrastructure (params, coords)
+└── echam/                      # ECHAM infrastructure (params, coords)
 ```
 
 Model-specific *infrastructure* (parameter containers, coordinate
-caches, data structs) lives under `speedy/` and `icon/`. Everything
-else is named after the scheme so an "ICON" port and a "CAM" port of
+caches, data structs) lives under `speedy/` and `echam/`. Everything
+else is named after the scheme so an ECHAM port and a CAM port of
 the same parameterisation sit side-by-side.

--- a/docs/source/developer.rst
+++ b/docs/source/developer.rst
@@ -1,9 +1,3 @@
-.. role:: py:class(xref)
-.. role:: py:meth(xref)
-.. role:: py:func(xref)
-.. role:: py:attr(xref)
-.. role:: py:mod(xref)
-
 Developer Guide
 ===============
 
@@ -71,7 +65,7 @@ Before submitting your PR, ensure:
    ☐ Documentation is updated if needed
    ☐ The PR description clearly explains what and why
    ☐ The PR is linked to a relevant issue
-   ☐ Code is rebased on the latest main branch
+   ☐ Code is rebased on the latest dev branch
 
 Testing Your Changes
 ^^^^^^^^^^^^^^^^^^^^^
@@ -86,11 +80,14 @@ Run the test suite to ensure your changes don't break existing functionality:
    # Run specific test file
    $ pytest jcm/model_test.py
 
-   # Run with verbose output
-   $ pytest -v
-
    # Run only fast tests (skip slow integration tests)
    $ pytest -m "not slow"
+
+   # Match the CI fast-test coverage gate
+   $ pytest -m "not slow" --cov=jcm --cov-fail-under=90
+
+   # Run the linter
+   $ ruff check .
 
 Write tests for your changes in the appropriate test file (e.g., ``jcm/module_name_test.py``). We aim for high unit test coverage to support the increasing complexity of physics going forward.
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -18,6 +18,7 @@ or for the development version:
 
    $ git clone https://github.com/climate-analytics-lab/jax-gcm.git
    $ cd jax-gcm
+   $ git switch dev
    $ pip install -e .
 
 Requirements
@@ -39,12 +40,12 @@ module or directly::
 
    ./jcm/main.py                                               # direct invocation
    python -m jcm.main                                          # equivalent module form
-   ./jcm/main.py physics=echam grid=echam_t85_l47_hybrid         # ICON T85x47
-   python -m jcm.main physics=echam grid=echam_t85_l47_hybrid    # equivalent
+   python -m jcm.main physics=echam-rrtmgp grid=echam_t63_l47_hybrid
+   python -m jcm.main physics=echam grid=echam_t63_l47_hybrid
    python -m jcm.main physics=held_suarez grid=held_suarez_t31_l8 \
        run.total_time=30 run.save_interval=1
-   python -m jcm.main physics=echam physics.params.convection.entrpen=4e-4
-   python -m jcm.main run=longrun                              # chunked health-check run
+   python -m jcm.main physics=echam +physics.terms.tiedtke_convection.params.entrpen=4e-4
+   python -m jcm.main physics=echam-rrtmgp grid=echam_t63_l47_hybrid run=longrun
    python -m jcm.main run.mode=scm run.state_file=path/to/state.nc \
        run.column.lat_deg=0 run.column.lon_deg=180
 
@@ -52,7 +53,7 @@ Inspect the available config groups and the fully-composed config::
 
    python -m jcm.main --help                                   # config-group choices
    python -m jcm.main --cfg job                                # composed config
-   python -m jcm.main --cfg job grid=echam_t85_l47_hybrid       # with overrides
+   python -m jcm.main --cfg job grid=echam_t63_l47_hybrid       # with overrides
 
 Config groups live under ``jcm/config/``: ``physics``, ``grid``, ``run``,
 ``init``, ``terrain``, ``forcing``, ``diffusion``.
@@ -358,7 +359,7 @@ against the model's calendar through the same machinery the regular
 forcing uses.
 
 Nudging is physics-agnostic — it acts on the dynamical core state, so
-the same setup works under SPEEDY, ICON, or any other physics package.
+the same setup works under SPEEDY, ECHAM, or any other physics package.
 
 Multi-Device Parallelization
 -----------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,13 +1,21 @@
-Welcome to Jax-GCM's documentation!
+Welcome to JAX-GCM's documentation!
 ====================================
 
-Jax-GCM is a Python library for climate modeling. It uses a `Dinosaur <https://github.com/neuralgcm/dinosaur?tab=readme-ov-file>`_ dycore and physics based on `Speedy <https://github.com/samhatfield/speedy.f90>`_.
+JAX-GCM is a differentiable atmospheric general circulation model written
+in JAX. It couples the `Dinosaur <https://github.com/neuralgcm/dinosaur>`_
+spectral dynamical core to modular SPEEDY, Held-Suarez, and ECHAM-style
+physics packages.
 
-Check out the Getting Started section for further information, including how to install the project.
+For the current beta release line, the main target configuration is ECHAM
+physics on the T63L47 hybrid grid with RRTMGP radiation
+(``physics=echam-rrtmgp grid=echam_t63_l47_hybrid``). The SPEEDY package
+remains the lightweight default for quick tests, tutorials, and
+optimization examples.
 
 .. note::
 
-   This project is under active development.
+   New development targets the ``dev`` branch. Tagged release candidates
+   and clean releases are promoted through ``main``.
 
 Contents
 --------
@@ -23,4 +31,3 @@ Contents
    api
    design
    developer
-

--- a/docs/source/speedy_physics.rst
+++ b/docs/source/speedy_physics.rst
@@ -619,7 +619,7 @@ Comparison with Other Physics Packages
 
    * - Feature
      - SPEEDY
-     - ICON
+     - ECHAM
      - Comprehensive GCMs
    * - Complexity
      - Intermediate
@@ -643,11 +643,11 @@ Comparison with Other Physics Packages
      - Prognostic+Microphysics
    * - Aerosols
      - Fixed climatology
-     - Interactive
+     - Prescribed MACv2-SP
      - Fully interactive
    * - Use Case
      - Dynamics, ML
-     - Research
+     - Climate-quality beta runs
      - Climate projections
 
 Next Steps

--- a/jcm/__init__.py
+++ b/jcm/__init__.py
@@ -14,7 +14,7 @@ from jcm.utils import (
 
 logging.basicConfig(format='%(name)s: %(asctime)s %(levelname)s: %(message)s')
 
-__version__ = "1.1.1"
+__version__ = "2.0.0_beta"
 
 __all__ = [
     "Model",

--- a/notebooks/04_jcm_era5_example.ipynb
+++ b/notebooks/04_jcm_era5_example.ipynb
@@ -5,7 +5,7 @@
    "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {},
    "source": [
-    "# JCM v1.0 — Running the Base Model with ERA5 Initial Conditions\n",
+    "# JCM Beta — Running the Base Model with ERA5 Initial Conditions\n",
     "\n",
     "This notebook demonstrates how to:\n",
     "1. Load ERA5 reanalysis data (via WeatherBench2)\n",
@@ -28,7 +28,7 @@
     "import pandas as pd\n",
     "\n",
     "from jcm.model import Model\n",
-    "from jcm.utils import get_speedy_coords\n",
+    "from jcm.physics.speedy.speedy_coords import get_speedy_coords\n",
     "from jcm.physics_interface import PhysicsState"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,11 @@
 [build-system]
-requires = ["setuptools>=40.4", "setuptools_scm"]
+requires = ["setuptools>=40.4"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "jcm"
-dynamic = ["version", "dependencies"]
+version = "2.0.0_beta"
+dynamic = ["dependencies"]
 description = "JAX-based General Circulation Model"
 authors = [
     {email = "dwatsonparris@ucsd.edu"}
@@ -13,20 +14,28 @@ license = {text = "Apache"}
 requires-python = ">=3.11"
 keywords = ["climate", "machine-learning"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Topic :: Scientific/Engineering",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Apache Software License",
 ]
 
-[tool.setuptools]
-packages = ["jcm"]
+[tool.setuptools.packages.find]
+include = ["jcm*"]
+namespaces = true
+
+[tool.setuptools.package-data]
+jcm = [
+    "config/**/*.yaml",
+    "data/**/*.nc",
+    "data/**/*.npy",
+    "data/**/*.npz",
+    "*.csv",
+    "physics/speedy/*.csv",
+]
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}
-
-[tool.setuptools_scm]
-fallback_version = "999"
 
 [tool.pytest.ini_options]
 python_files = "*_test.py"


### PR DESCRIPTION
## Summary

Prepares the repository for the v2 beta release line:

- trims and refocuses the README around the ECHAM T63L47 + RRTMGP beta target
- adds README badges for docs, tests, lint, PyPI, Python versions, and license
- updates Sphinx landing/getting-started/design/developer pages for current `dev`, ECHAM naming, T63L47 examples, current Hydra override syntax, and CI commands
- updates the ERA5 notebook title/import to remove stale v1 wording and old `jcm.utils.get_speedy_coords` usage
- bumps `jcm.__version__` and project metadata to `2.0.0_beta`
- switches package metadata to deterministic static versioning for this beta and ensures wheels include subpackages plus YAML/netCDF/NumPy data files

Note: Python packaging normalizes `2.0.0_beta` to the PEP 440 artifact version `2.0.0b0`.

## Validation

```bash
JAX_PLATFORMS=cpu sphinx-build -b html docs/source docs/build/html
JAX_PLATFORMS=cpu pip wheel . --no-deps --no-build-isolation -w /private/tmp/jcm-wheel-check-v2
git diff --check
```

Results:

- Sphinx build succeeded cleanly
- Wheel build succeeded as `jcm-2.0.0b0-py3-none-any.whl`
- Verified the wheel includes ECHAM code, Hydra config YAML, bundled netCDF data, `.npy/.npz` test data, and SPEEDY CSV tables
- `git diff --check` passed