### PR TITLE
docs: refresh v2 API and dycore design

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@
 <img src="logo.png" alt="JAX-GCM logo" width="180">
 
 JAX-GCM is a differentiable atmospheric general circulation model written
-in JAX. It couples the
-[Dinosaur](https://github.com/neuralgcm/dinosaur) spectral dynamical core
-to modular SPEEDY, Held-Suarez, and ECHAM-style physics packages, with
-support for gradient-based calibration, ML-physics experiments, and
+in JAX. Its pluggable dynamical-core interface currently ships with the
+[Dinosaur](https://github.com/neuralgcm/dinosaur) spectral backend and
+couples it to modular SPEEDY, Held-Suarez, and ECHAM-style physics packages,
+with support for gradient-based calibration, ML-physics experiments, and
 accelerated CPU/GPU/TPU runs.
 
-The current beta focus is the ECHAM T63L47 hybrid-coordinate stack with
+The v2.0 release focus is the ECHAM T63L47 hybrid-coordinate stack with
 RRTMGP radiation:
 
 ```bash
@@ -26,7 +26,8 @@ python -m jcm.main physics=echam-rrtmgp grid=echam_t63_l47_hybrid run=longrun
 ## Highlights
 
 - Fully differentiable JAX implementation compatible with `jit`, `grad`, and `vmap`
-- Operator-split physics coupled to a spectral primitive-equation dycore
+- Pluggable dynamical-core protocol with a shipped Dinosaur spectral backend
+- Dycore-agnostic, operator-split gridpoint physics coupling
 - SPEEDY, Held-Suarez, and composable ECHAM physics configurations
 - ECHAM T63L47 hybrid-coordinate target setup with grey, RRTMGP, or neural-emulated radiation
 - xarray/netCDF output, chunked long-run health checks, and resumable checkpoints
@@ -100,7 +101,7 @@ testing, and optimization examples: simplified convection, large-scale
 condensation, radiation, surface fluxes, vertical diffusion, and
 orographic drag.
 
-**ECHAM** is the beta release target for climate-quality integrations. It
+**ECHAM** is the v2.0 release target for climate-quality integrations. It
 includes Tiedtke-Nordeng convection, Sundqvist cloud cover, 1M/2M cloud
 microphysics, TTE-TKE vertical diffusion, multi-tile surface physics,
 gravity-wave drag, MACv2-SP aerosols, simple chemistry, and selectable

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -7,6 +7,9 @@ API
 
    jcm.model
    jcm.model.Model
+   jcm.dycore
+   jcm.dycore.base.DynamicalCore
+   jcm.dycore.dinosaur.DinosaurDycore
    jcm.physics_interface
    jcm.physics_interface.PhysicsState
    jcm.physics_interface.PhysicsTendency

--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -17,50 +17,90 @@ Core Architecture
 Model Structure
 ^^^^^^^^^^^^^^^
 
-The :py:class:`jcm.model.Model` class serves as the central orchestrator, linking the Dinosaur dynamical core with physics implementations through a clean interface. See :doc:`design/operator_split_physics` for the per-step coupling between the dynamics integrator and physics.
+The :py:class:`jcm.model.Model` class is the central orchestrator. It links a
+pluggable dynamical-core backend to a physics package without reaching into the
+backend's native state representation. See :doc:`design/operator_split_physics`
+for the per-step coupling between the dycore and physics.
 
 .. code-block:: text
 
-   ┌──────────────────────────────────────────────┐
-   │             Model                            │
-   │  ┌────────────────────────────────────────┐  │
-   │  │   Dinosaur Dynamical Core              │  │
-   │  │   (Spectral, Primitive Equations)      │  │
-   │  └────────────────────────────────────────┘  │
-   │                  ↕                           │
-   │  ┌────────────────────────────────────────┐  │
-   │  │   Physics Interface                    │  │
-   │  │   (PhysicsState ↔ PhysicsTendency)     │  │
-   │  └────────────────────────────────────────┘  │
-   │                  ↕                           │
-   │  ┌────────────────────────────────────────┐  │
-   │  │   ComposablePhysics                    │  │
-   │  │   (ordered list of PhysicsTerm)        │  │
-   │  │   built by speedy_physics(),           │  │
-   │  │   echam_physics(), held_suarez_physics()│  │
-   │  └────────────────────────────────────────┘  │
-   └──────────────────────────────────────────────┘
+   ┌───────────────────────────────────────────────┐
+   │ Model                                         │
+   │                                               │
+   │   DynamicalCore                               │
+   │   native state ↔ gridpoint PhysicsState       │
+   │          │                                    │
+   │          ▼                                    │
+   │   physics_interface                           │
+   │   verify state → tendencies → verify tendency │
+   │          │                                    │
+   │          ▼                                    │
+   │   ComposablePhysics                           │
+   │   ordered PhysicsTerm modules                 │
+   └───────────────────────────────────────────────┘
+
+Pluggable Dynamical Cores
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The :py:class:`jcm.dycore.base.DynamicalCore` protocol owns every operation
+that depends on a dycore's native representation: initial-state construction,
+one-step integration, terrain preparation, conversion to gridpoint
+:py:class:`~jcm.physics_interface.PhysicsState`, simulation-time accounting,
+and xarray output. The shipped
+:py:class:`jcm.dycore.dinosaur.dycore.DinosaurDycore` backend wraps Dinosaur's
+spectral primitive-equation state, IMEX-RK step, and spectral filters.
+
+The physics-dynamics boundary is gridpoint space on the dycore's native
+horizontal layout, so physics never sees spectral coefficients. The protocol
+permits non-lat/lon layouts, although the current column-vectorized
+``ComposablePhysics`` path still expects exactly two horizontal dimensions;
+a backend with an element-plus-GLL layout must flatten or adapt that layout
+before using the shipped column physics packages. Backends perform any output
+regridding in ``to_xarray()``, outside the per-step physics path.
+
+For convenience, ``Model(coords=...)`` constructs ``DinosaurDycore``
+automatically. Expert callers can construct and pass a backend explicitly:
+
+.. code-block:: python
+
+   from jcm.dycore.dinosaur import DinosaurDycore
+   from jcm.model import Model
+   from jcm.physics.speedy.speedy_coords import get_speedy_coords
+   from jcm.terrain import TerrainData
+
+   coords = get_speedy_coords()
+   dycore = DinosaurDycore(
+       coords=coords,
+       terrain=TerrainData.aquaplanet(coords),
+       dt_seconds=1800.0,
+   )
+   model = Model(dycore=dycore, time_step=30.0)
+
+The v2.0 Hydra CLI currently constructs the Dinosaur backend explicitly;
+selecting a different registered backend is a Python-API workflow. When
+constructing a backend explicitly, its ``dt_seconds`` must match the
+``Model(time_step=...)`` value.
 
 The Physics Interface
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The :py:class:`jcm.physics_interface.Physics` abstract base class defines a clean contract between the dynamical core and physics packages:
+The :py:class:`jcm.physics_interface.Physics` base class defines the contract
+between the gridpoint state supplied by the dycore and a physics package:
 
 .. code-block:: python
 
    class Physics:
-       def __call__(
+       def compute_tendencies(
            self,
            state: PhysicsState,
-           physics_data: PhysicsData,
            forcing: ForcingData,
            terrain: TerrainData,
-       ) -> tuple[PhysicsTendency, PhysicsData]:
+           prev_physics_data=None,
+       ) -> tuple[PhysicsTendency, PhysicsCarryState]:
            """Compute physics tendencies for the current state.
 
            Args:
                state: Current atmospheric state (temperature, winds, etc.)
-               physics_data: Diagnostic data from previous timesteps
                forcing: Boundary conditions for the *current step*. The
                    Model collapses every `TimeSeries` leaf and populates
                    `forcing.solar` via ``forcing.select(date, calendar)``
@@ -68,12 +108,14 @@ The :py:class:`jcm.physics_interface.Physics` abstract base class defines a clea
                    spatial fields and a precomputed `SolarGeometry` —
                    no time axis, no `DateData`.
                terrain: Orography / land-sea mask information
+               prev_physics_data: Cross-step physics carry from the
+                   preceding timestep.
 
            Returns:
                tendencies: Changes to apply to the state
-               updated_data: Updated diagnostic information
+               updated_data: Updated diagnostics and cross-step carry
            """
-           pass
+           raise NotImplementedError
 
 This interface enables:
 
@@ -148,8 +190,8 @@ The model is composable at multiple levels through the ``ComposablePhysics`` fra
    # Use ECHAM with the NN radiation emulator
    physics = echam_physics(radiation_scheme="emulated")
 
-   # Replace SPEEDY radiation with the RRTMGP backend
-   physics = speedy_physics().replace("radiation", RRTMGPRadiation())
+   # Replace ECHAM radiation with the RRTMGP backend
+   physics = echam_physics().replace("radiation", RRTMGPRadiation())
 
    # Remove a term
    physics = echam_physics().remove("hines")
@@ -279,6 +321,7 @@ For Experts
 Every component can be customized or extended:
 
 - **Custom Physics**: Add a new ``PhysicsTerm`` — see :doc:`design/writing_a_physics_scheme` for the one-file plugin contract.
+- **Custom Dynamical Core**: Implement the :py:class:`jcm.dycore.base.DynamicalCore` protocol and pass the backend to ``Model(dycore=...)``.
 - **Custom Forcing**: Create specialized boundary condition handlers
 - **Custom Diagnostics**: Add new output variables and computations
 - **Integration**: Couple with other models or ML components

--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -78,8 +78,9 @@ automatically. Expert callers can construct and pass a backend explicitly:
 
 The v2.0 Hydra CLI currently constructs the Dinosaur backend explicitly;
 selecting a different registered backend is a Python-API workflow. When
-constructing a backend explicitly, its ``dt_seconds`` must match the
-``Model(time_step=...)`` value.
+constructing a backend explicitly, its ``dt_seconds`` and
+``Model(time_step=...)`` (minutes) must represent the same duration after unit
+conversion.
 
 The Physics Interface
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -182,7 +183,10 @@ The model is composable at multiple levels through the ``ComposablePhysics`` fra
 
    from jcm.physics.speedy.speedy_terms import speedy_physics
    from jcm.physics.echam.echam_terms import echam_physics
-   from jcm.physics.radiation.rrtmgp import RRTMGPRadiation
+   from jcm.physics.convection.tiedtke_nordeng.tiedtke_nordeng import (
+       ConvectionParameters,
+       TiedtkeConvection,
+   )
 
    # Use pre-built SPEEDY defaults
    physics = speedy_physics()
@@ -190,8 +194,11 @@ The model is composable at multiple levels through the ``ComposablePhysics`` fra
    # Use ECHAM with the NN radiation emulator
    physics = echam_physics(radiation_scheme="emulated")
 
-   # Replace ECHAM radiation with the RRTMGP backend
-   physics = echam_physics().replace("radiation", RRTMGPRadiation())
+   # Replace one term with a separately configured instance
+   convection = TiedtkeConvection(
+       params=ConvectionParameters.default(tau=10800.0),
+   )
+   physics = echam_physics().replace("convection", convection)
 
    # Remove a term
    physics = echam_physics().remove("hines")

--- a/docs/source/design/composable_physics.md
+++ b/docs/source/design/composable_physics.md
@@ -176,15 +176,16 @@ category into the single replacement, inserted at the position of the
 first one — so you can swap an entire process category in one call:
 
 ```python
-# ECHAM with RRTMGP radiation
-physics = echam_physics().replace("radiation", RRTMGPRadiation())
-
 # ECHAM with a custom convection scheme
 physics = echam_physics().replace("convection", MyConvection())
 
 # Strip clouds entirely, then add Rayleigh damping
 physics = echam_physics().remove("clouds") + RayleighDamping()
 ```
+
+Replacing a wavelength-dependent radiation backend also requires updating the
+enclosing composition's `band_config` to match that backend. The RRTMGP Hydra
+configurations perform this setup automatically.
 
 When users compose from scratch (`term_a + term_b + term_c`), they
 accept responsibility for ordering correctness — `_validate_ordering`

--- a/docs/source/design/composable_physics.md
+++ b/docs/source/design/composable_physics.md
@@ -9,7 +9,7 @@ parameterisation that reads the prognostic state and a shared
 into the dict for downstream terms to consume.
 
 ```text
-Model.compute_physics_step
+Model._get_op_split_step_fn
    └─ ComposablePhysics.compute_tendencies(state, forcing, terrain, prev_carry)
         diagnostics = {**prev_carry}    ← cross-step physics carry seed
         for term in terms:
@@ -176,8 +176,8 @@ category into the single replacement, inserted at the position of the
 first one — so you can swap an entire process category in one call:
 
 ```python
-# SPEEDY with RRTMGP radiation
-physics = speedy_physics().replace("radiation", RRTMGPRadiation())
+# ECHAM with RRTMGP radiation
+physics = echam_physics().replace("radiation", RRTMGPRadiation())
 
 # ECHAM with a custom convection scheme
 physics = echam_physics().replace("convection", MyConvection())

--- a/docs/source/design/operator_split_physics.md
+++ b/docs/source/design/operator_split_physics.md
@@ -3,31 +3,29 @@
 ## Overview
 
 JCM evaluates physics exactly once per dynamics timestep `dt`, outside
-the IMEX-RK stages, and applies the resulting tendency as a Lie split
-ahead of the dynamics integral:
+the dycore's internal integration stages, and applies the resulting
+tendency as a Lie split ahead of the dynamics integral:
 
 ```text
 state ─┐
-       ├── compute_physics_step ─► dyn_tendency, new_physics_state
+       ├── dycore.to_physics_state
+       │
+       ├── compute_physics_step_gridpoint ─► physics_tendency, new_physics_state
        │
        ▼
-state + dt · dyn_tendency
+   dycore.step(state, physics_tendency)
        │
-       ▼
-   IMEX-RK SIL3 dynamics over dt   ← primitive equations (+ optional nudging)
-       │                              + upper sponge, hyperdiffusion filters
-       ▼
-   filters (mean-Ps fix, level-dependent hyperdiffusion on
-            divergence / vorticity-tracers / temperature)
+       ├── apply tendency in the backend's native representation
+       ├── advance backend dynamics over dt
+       └── apply backend-specific filters / remapping
        │
        ▼
 state_next
 ```
 
 The splitting error is `O(dt)` (Lie split (a), `state → physics →
-dynamics → next`). The dynamics IMEX-RK is the only step that advances
-`sim_time` — `dyn_tendency` carries `sim_time = 0` so the forward-Euler
-add does not perturb it.
+dynamics → next`). The dycore step is the only operation that advances
+`sim_time`.
 
 This mirrors operational GCM practice (ECHAM, CAM, IFS, E3SM): physics
 runs once per `dt` as forcing to the dynamics, rather than at each RK
@@ -52,9 +50,7 @@ Neither is implemented today. Classical Strang is a worthwhile
 follow-up if a coarser-`dt` regime exposes the splitting error; at the
 current climate-rate `dt = 12-30 min`, the Santos 2021 analysis
 (JAMES 13, e2020MS002359) finds coupling error dominates self-feedback
-error and Lie/Strang are both adequate. The single-evaluation symmetric
-form was attempted in this PR's history but reverted after Codex review
-correctly flagged the order issue (PR #481 review thread).
+error and Lie/Strang are both adequate.
 
 ## Key components
 
@@ -63,40 +59,39 @@ correctly flagged the order issue (PR #481 review thread).
 Builds the per-`dt` step closure `(state, physics_state) -> (state_next,
 physics_state_next)`. Internals:
 
-1. Resolve the current step's date and forcing slice from `state.sim_time`.
-2. Call `compute_physics_step` for `(dyn_tendency, new_physics_state)`.
-3. Lie apply: `state + dt·tend → dynamics_step` (full forward-Euler add
-   then full-`dt` IMEX-RK).
-4. Run the post-step filters (conserve global-mean surface pressure,
-   level-dependent hyperdiffusion on divergence / vorticity+tracers /
-   temperature).
+1. Resolve the current step's date and forcing slice from
+   `dycore.sim_time(state)`.
+2. Project the backend-native state with `dycore.to_physics_state`.
+3. Call `compute_physics_step_gridpoint` for
+   `(physics_tendency, new_physics_state)`.
+4. Pass the native state and gridpoint tendency to `dycore.step`.
 
 The step is a pure function of `(state, physics_state)`. The
 `physics_state` carry is a JAX pytree and is the only cross-step state
 the integrator threads.
 
-### `Model._get_dynamics_step_fn` (`jcm/model.py`)
+### `DynamicalCore.step` (`jcm/dycore/base.py`)
 
-Builds the IMEX-RK SIL3 integrator over the dynamics composition. The
-dynamics composition is the primitive equations plus, optionally, a
-Newtonian nudging tendency. Sponge and hyperdiffusion stay inside the
-IMEX-RK stage loop / `step_with_filters` path — they are stiff /
-fast-linear couplings that benefit from intermediate-state evaluation
-and would lose stability if migrated to op-split.
+Owns one backend-specific dynamics step, including conversion of the
+gridpoint `PhysicsTendency` into the backend's native representation.
+The backend also owns its integrator, hyperdiffusion, filters, vertical
+remapping, and other representation-specific operations.
 
-This is the function a future pysces backend (#388) would replace.
-Its interface is `state -> state'` over `dt` with no physics knowledge.
+The shipped `DinosaurDycore` converts the tendency to a spectral
+primitive-equation tendency, applies the forward-Euler physics update,
+runs IMEX-RK SIL3, then applies the surface-pressure conservation and
+spectral diffusion filters.
 
-### `compute_physics_step` (`jcm/physics_interface.py`)
+### `compute_physics_step_gridpoint` (`jcm/physics_interface.py`)
 
-Converts the spectral dynamics `State` to a nodal `PhysicsState`, runs
-`verify_state` (non-negativity clamp on tracers), calls
+Accepts an already-gridpoint `PhysicsState`, runs `verify_state`
+(non-negativity clamp on tracers), calls
 `Physics.compute_tendencies(state, forcing, terrain,
 prev_physics_data=physics_state)`, applies `verify_tendencies` (caps
-negative-going tracer tendencies at `-state/dt`), and converts the
-result back to a dinosaur dynamics tendency.
+negative-going tracer tendencies at `-state/dt`), and returns the
+gridpoint tendency unchanged by any backend-specific conversion.
 
-Returns `(dynamics_tendency, new_physics_state)`. The new carry is the
+Returns `(physics_tendency, new_physics_state)`. The new carry is the
 dict the physics call writes to (radiation cache, prior-step TKE,
 cloud / aerosol / chemistry diagnostics, …) — exactly the input shape
 of the next step.
@@ -139,8 +134,8 @@ in-stage scheme.
 
 `Model` holds two slots of cross-step state:
 
-- `_final_modal_state` — dinosaur spectral state at the end of the
-  last `run()` / `resume()` call.
+- `_final_dycore_state` — backend-native state at the end of the last
+  `run()` / `resume()` call.
 - `_final_physics_state` — the cross-step physics carry at the end of
   the last call.
 
@@ -171,10 +166,10 @@ directly for callers that need explicit control.
   matches the post-step output on iteration 1 for any diagnostic keys
   whose owning term has not overridden `initial_carry_state`.
 
-The isothermal probe (rather than a zero-state probe) avoids the
-`0/0 = NaN` cascade that motivated the cache-cleanup in PR #469. The
-result of `get_empty_data` is never used as live state — only as a
-shape template.
+The isothermal probe (rather than a zero-state probe) avoids a
+`0/0 = NaN` cascade in schemes that cannot diagnose a valid state from
+all-zero thermodynamic inputs. The result of `get_empty_data` is never
+used as live state — only as a shape template.
 
 ### Coupling within physics
 
@@ -190,10 +185,11 @@ process pairs but introduces order-dependence. Process-parallel is
 adequate at JCM's climate-rate `dt`; sequential coupling is available
 as a follow-up for terms that need it (cf. E3SM's CLUBB+MG2 loop).
 
-### Filters and dycore composition
+### Dinosaur filters
 
-The post-step filter chain runs on `(pre_step_state, post_dynamics_state)`
-in this order:
+Filtering is a dycore concern, not part of the shared physics interface.
+The shipped `DinosaurDycore` runs this post-step spectral filter chain on
+`(pre_step_state, post_dynamics_state)`:
 
 1. `conserve_global_mean_surface_pressure` — pins the 0,0,0 spectral
    mode of `log_surface_pressure` to its pre-step value.
@@ -202,12 +198,12 @@ in this order:
    (specific humidity + microphysics tracers + GHG VMRs).
 4. `diffuse_temp` — hyperdiffusion on temperature variation.
 
-The level-dependent scaling is precomputed once at `Model.__init__`
-and inlined as a JIT constant.
+The level-dependent scaling is precomputed once at
+`DinosaurDycore.__init__` and inlined as a JIT constant.
 
-A final `verify_state` clamp runs in `_post_process` at the
-modal→nodal output boundary to mask any spectral Gibbs-ringing of
-negative tracer tendencies before user-visible output.
+A final `verify_state` clamp runs in `Model._post_process` after
+`dycore.to_physics_state` to mask any negative tracer values before
+user-visible output.
 
 ## Tests
 
@@ -230,8 +226,8 @@ Op-split coverage in `jcm/model_test.py::TestOperatorSplitPhysics`:
   snapshot `predictions.physics` is the carry the integration
   consumed, not a freshly-seeded copy (the P2 fix).
 
-The legacy in-stage path was removed in Phase 4 (`TestLegacyPathRemoved`);
-no flag remains to switch back. The deleted symbols are
+The legacy in-stage path has been removed; no flag remains to switch
+back. The deleted symbols are
 `_step_tendencies`, `physics_forcing_eqn`, `DiagnosticsCollector`,
 `averaged_trajectory_from_step`, `get_physical_tendencies`,
 `_get_step_fn_factory`, `_get_integrate_fn`, and the `use_op_split`
@@ -284,10 +280,10 @@ called exactly once per dynamics timestep.**
 Two structural differences from JCM:
 
 1. **Dynamics integrator.** ECHAM uses leapfrog + semi-implicit
-   (spectral); JCM uses IMEX-RK SIL3 (also spectral, via dinosaur).
+   (spectral); JCM's shipped Dinosaur backend uses IMEX-RK SIL3.
    The split point is the same — operator-split physics — but the
    dynamics integrator on each side differs. ECHAM's split is forced
-   by leapfrog's single RHS evaluation per `dt`; JCM's SIL3 has
+   by leapfrog's single RHS evaluation per `dt`; Dinosaur's SIL3 has
    substages and *could* in principle evaluate physics at each one,
    so for JCM operator-splitting is a real design choice. CAM (HOMME
    spectral element), E3SM (HOMME with sub-cycled advection), and IFS

--- a/docs/source/design/writing_a_physics_scheme.md
+++ b/docs/source/design/writing_a_physics_scheme.md
@@ -234,8 +234,8 @@ from my_package.rayleigh_damping import RayleighDamping
 # Append: add the term at the end of the default ECHAM stack.
 physics = echam_physics() + RayleighDamping()
 
-# Replace: swap out the existing gravity_waves terms.
-physics = echam_physics().replace("gravity_waves", RayleighDamping())
+# Replace: swap out the existing non-orographic Hines drag term.
+physics = echam_physics().replace("hines", RayleighDamping())
 
 # Remove: drop a category, then build whatever you want on top.
 physics = echam_physics().remove("clouds") + RayleighDamping()

--- a/docs/source/echam_physics.rst
+++ b/docs/source/echam_physics.rst
@@ -38,7 +38,13 @@ The ECHAM physics package includes the following components, executed in sequenc
 Process Coupling
 ^^^^^^^^^^^^^^^^
 
-Following ICON-A, radiation, vertical diffusion with surface processes, and gravity wave drag operate in a **parallel split** (each receives the same input state, and tendencies are summed). These initial processes and convection/cloud processes are coupled via **serial split** (output of one feeds into the next).
+JAX-GCM's outer ``ComposablePhysics`` coupling is **process-parallel**:
+every term receives the same prognostic input state and the returned tendencies
+are summed. Terms execute in a validated order and may consume diagnostics
+produced by earlier terms, but they do not see earlier tendency contributions
+applied to the prognostic state until the next model step. Tightly coupled
+calculations that require internal sequential updates are implemented inside a
+single process term.
 
 Each parameterization is described in detail below.
 
@@ -746,27 +752,20 @@ To customize physics parameters:
 .. code-block:: python
 
    from jcm.physics.echam.echam_terms import echam_physics
-   from jcm.physics.echam.parameters import Parameters
+   from jcm.physics.convection.tiedtke_nordeng.tiedtke_nordeng import ConvectionParameters
+   from jcm.physics.radiation.radiation_types import RadiationParameters
 
-   # Get default parameters
-   params = Parameters.default()
-
-   # Modify convection parameters
-   params = params.with_convection(
+   convection = ConvectionParameters.default(
        tau=7200.0,        # Slower CAPE closure (2 hours)
        entrpen=2.0e-4     # Stronger entrainment
    )
 
-   # Modify radiation parameters
-   params = params.with_radiation(
+   radiation = RadiationParameters.default(
        solar_constant=1360.0
    )
 
-   # Ensure all physics timesteps match model dt
-   params = params.with_timestep(dt_seconds=1800.0)
-
-   # Create composable ECHAM physics with all standard terms
-   physics = echam_physics(parameters=params)
+   # Pass per-scheme parameter structs to the ECHAM factory
+   physics = echam_physics(convection=convection, radiation=radiation)
 
 
 Composable Physics API
@@ -774,34 +773,34 @@ Composable Physics API
 
 The ECHAM physics is composable: each parameterization is a
 ``PhysicsTerm`` (``flax.nnx.Module``), and ``echam_physics()`` returns a
-``ComposableEchamPhysics`` (a subclass of ``ComposablePhysics``) with the
-standard ordering wired up. Schemes can be swapped in or out without
-touching the orchestrator:
+``ComposablePhysics`` configured for column vectorization with the standard
+ordering wired up. Schemes can be swapped in or out without touching the
+orchestrator:
 
 .. code-block:: python
 
    from jcm.physics.echam.echam_terms import echam_physics
 
    # Create composable ECHAM physics with all standard terms
-   physics = echam_physics(parameters=params)
+   physics = echam_physics()
 
    # Use neural network radiation emulator instead of grey radiation
    physics = echam_physics(radiation_scheme="emulated")
 
-   # Remove gravity waves for a simplified configuration
-   physics = echam_physics().remove("gravity_waves")
+   # Remove non-orographic Hines gravity-wave drag
+   physics = echam_physics().remove("hines")
 
    # Replace a single term
-   from jcm.physics.echam.echam_terms import EchamRadiationRRTMGP
-   physics = echam_physics().replace("radiation", EchamRadiationRRTMGP())
+   from jcm.physics.radiation.rrtmgp import RRTMGPRadiation
+   physics = echam_physics().replace("radiation", RRTMGPRadiation())
 
 Each ECHAM term is a ``PhysicsTerm`` subclass (``flax.nnx.Module``) with lazy
 imports — the underlying ECHAM physics functions are imported at call time,
 keeping startup fast and avoiding circular dependencies.
 
-The ``ComposableEchamPhysics`` subclass automatically handles ECHAM's column
-vectorization: it reshapes the 3D state to ``(nlev, ncols)`` format before
-iterating terms, and reshapes accumulated tendencies back to 3D afterward.
+The returned ``ComposablePhysics`` enables column vectorization: it reshapes
+the 3D state to ``(nlev, ncols)`` before iterating terms, and reshapes
+accumulated tendencies back to 3D afterward.
 
 Module Locations
 ^^^^^^^^^^^^^^^^
@@ -838,8 +837,9 @@ respective process directories:
    * - Diagnostics (WMO tropopause)
      - ``jcm.physics.diagnostics.wmo_tropopause``
 
-ECHAM-specific infrastructure (parameters, coordinates, ``PhysicsData``)
-remains at ``jcm.physics.echam``.
+ECHAM-specific infrastructure such as coordinate helpers and the package
+factory remains at ``jcm.physics.echam``; individual scheme parameter
+types live beside their implementations.
 
 
 Scientific References

--- a/docs/source/echam_physics.rst
+++ b/docs/source/echam_physics.rst
@@ -790,9 +790,19 @@ orchestrator:
    # Remove non-orographic Hines gravity-wave drag
    physics = echam_physics().remove("hines")
 
-   # Replace a single term
-   from jcm.physics.radiation.rrtmgp import RRTMGPRadiation
-   physics = echam_physics().replace("radiation", RRTMGPRadiation())
+   # Replace a single term with a separately configured instance
+   from jcm.physics.convection.tiedtke_nordeng.tiedtke_nordeng import (
+       ConvectionParameters,
+       TiedtkeConvection,
+   )
+   convection = TiedtkeConvection(
+       params=ConvectionParameters.default(tau=10800.0),
+   )
+   physics = echam_physics().replace("convection", convection)
+
+When replacing a wavelength-dependent radiation backend, the enclosing
+``ComposablePhysics.band_config`` must also be configured for that backend.
+The RRTMGP Hydra configurations perform this setup automatically.
 
 Each ECHAM term is a ``PhysicsTerm`` subclass (``flax.nnx.Module``) with lazy
 imports — the underlying ECHAM physics functions are imported at call time,

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -26,7 +26,7 @@ Requirements
 
 - Python ≥ 3.11
 - JAX
-- Dinosaur (dynamical core)
+- Dinosaur (the dynamical-core backend shipped with v2.0)
 - XArray (for I/O and data handling)
 
 See ``requirements.txt`` for the complete list of dependencies.
@@ -178,6 +178,29 @@ You can customize various aspects of the model:
       physics=physics
    )
 
+**Dynamical core**: Pass a backend explicitly when you need backend-specific
+configuration. ``Model(coords=...)`` remains the shorthand for constructing
+the shipped Dinosaur backend with default settings. The v2.0 Hydra CLI also
+uses Dinosaur; explicit backend selection is currently a Python-API workflow.
+Keep the backend's ``dt_seconds`` equal to ``Model(time_step=...)``.
+
+.. code-block:: python
+
+   from jcm.diffusion import DiffusionFilter
+   from jcm.dycore.dinosaur import DinosaurDycore
+   from jcm.model import Model
+   from jcm.physics.speedy.speedy_coords import get_speedy_coords
+   from jcm.terrain import TerrainData
+
+   coords = get_speedy_coords()
+   dycore = DinosaurDycore(
+       coords=coords,
+       terrain=TerrainData.aquaplanet(coords),
+       dt_seconds=1800.0,
+       diffusion=DiffusionFilter.default(),
+   )
+   model = Model(dycore=dycore, time_step=30.0)
+
 **Initial Conditions**: Start from a specific state
 
 .. code-block:: python
@@ -309,15 +332,15 @@ to suppress internal variability that's unrelated to the question you're
 asking — useful for comparing model fields to specific dates of
 observations, or for reducing noise in calibration runs.
 
-Nudging is implemented as a Newtonian relaxation in spectral space:
+Nudging is implemented as a gridpoint-space ``PhysicsTerm``:
 
 .. math::
 
    \frac{\mathrm{d}X}{\mathrm{d}t}\bigg|_\mathrm{nudge}
    = \frac{X_\mathrm{ref} - X}{\tau}
 
-where ``X`` is one of the dycore state variables (vorticity, divergence,
-temperature, log surface pressure) and ``τ`` is the relaxation timescale.
+where ``X`` is a gridpoint wind or temperature field and ``τ`` is the
+relaxation timescale.
 The most common pattern is to nudge winds above the boundary layer and
 let everything else evolve freely, so the model gets the right
 synoptic-scale circulation while its physics still has the freedom to

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -182,7 +182,8 @@ You can customize various aspects of the model:
 configuration. ``Model(coords=...)`` remains the shorthand for constructing
 the shipped Dinosaur backend with default settings. The v2.0 Hydra CLI also
 uses Dinosaur; explicit backend selection is currently a Python-API workflow.
-Keep the backend's ``dt_seconds`` equal to ``Model(time_step=...)``.
+The backend's ``dt_seconds`` and ``Model(time_step=...)`` (minutes) must
+represent the same duration after unit conversion.
 
 .. code-block:: python
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,11 +2,11 @@ Welcome to JAX-GCM's documentation!
 ====================================
 
 JAX-GCM is a differentiable atmospheric general circulation model written
-in JAX. It couples the `Dinosaur <https://github.com/neuralgcm/dinosaur>`_
-spectral dynamical core to modular SPEEDY, Held-Suarez, and ECHAM-style
-physics packages.
+in JAX. Its pluggable dynamical-core interface currently ships with the
+`Dinosaur <https://github.com/neuralgcm/dinosaur>`_ spectral backend and
+couples it to modular SPEEDY, Held-Suarez, and ECHAM-style physics packages.
 
-For the current beta release line, the main target configuration is ECHAM
+For the v2.0 release line, the main target configuration is ECHAM
 physics on the T63L47 hybrid grid with RRTMGP radiation
 (``physics=echam-rrtmgp grid=echam_t63_l47_hybrid``). The SPEEDY package
 remains the lightweight default for quick tests, tutorials, and

--- a/docs/source/speedy_physics.rst
+++ b/docs/source/speedy_physics.rst
@@ -444,6 +444,7 @@ To customize physics parameters:
 
    from jcm.physics.speedy.speedy_terms import speedy_physics
    from jcm.physics.speedy.params import Parameters
+   from jcm.physics.speedy.speedy_coords import get_speedy_coords
    from jcm.model import Model
 
    # Get default parameters
@@ -468,7 +469,7 @@ To customize physics parameters:
    physics = speedy_physics(parameters=params)
 
    # Use in model
-   model = Model(physics=physics)
+   model = Model(coords=get_speedy_coords(), physics=physics)
 
 Viewing All Parameters
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -494,10 +495,6 @@ The SPEEDY physics is also available as composable ``PhysicsTerm`` instances:
 
    # Create composable SPEEDY physics with all standard terms
    physics = speedy_physics(parameters=params)
-
-   # Replace radiation with a different scheme
-   from jcm.physics.echam.echam_terms import EchamRadiationRRTMGP
-   physics = speedy_physics().replace("radiation_sw", EchamRadiationRRTMGP())
 
    # Remove a term
    physics = speedy_physics().remove("vertical_diffusion")

--- a/jcm/dycore/__init__.py
+++ b/jcm/dycore/__init__.py
@@ -13,7 +13,7 @@ cubed-sphere spectral-element backend, etc. There is no horizontal regrid at the
 physics-dynamics seam; lat/lon regridding (when it happens) is a dycore-internal step
 on the way to xarray output.
 
-See ``docs/source/design/writing_a_dycore.md`` for the full guide.
+See ``docs/source/design.rst`` for the architecture overview.
 """
 
 from jcm.dycore.base import DynamicalCore, Predictions

--- a/jcm/dycore/base.py
+++ b/jcm/dycore/base.py
@@ -18,6 +18,12 @@ schemes (solar zenith, MACv2-SP, SST forcing) cache against the dycore-supplied
 ``coords.horizontal.latitudes`` / ``longitudes`` arrays, which are shaped to match
 ``horizontal_shape``.
 
+The protocol permits any ``horizontal_shape``. The current
+``ComposablePhysics(vectorize_columns=True)`` implementation still expects
+exactly two horizontal dimensions, so a backend with an element-plus-GLL
+layout must flatten or adapt that layout before using the shipped
+column-vectorized physics packages.
+
 This protocol is the only sanctioned bridge between the dycore's internal state and
 the rest of jax-gcm. ``Model`` never reaches past it; physics packages never see
 spectral coefficients (or whatever the dycore's native representation happens to be).

--- a/jcm/dycore/registry.py
+++ b/jcm/dycore/registry.py
@@ -2,8 +2,9 @@
 
 Backends register themselves at import time via the :func:`register_dycore`
 decorator. :func:`build_dycore` looks up a registered name and invokes the
-factory with the supplied kwargs; this is what the Hydra runner calls when it
-sees ``cfg.dycore.kind`` (Phase 4).
+factory with the supplied kwargs. The v2.0 Hydra runner still constructs the
+shipped Dinosaur backend explicitly; the registry is currently used by
+Python-API integrations and tests.
 
 The registry is deliberately minimal: it carries names and factories and nothing
 else. Anything that needs to vary per-backend (config schema, default kwargs,

--- a/jcm/physics_interface.py
+++ b/jcm/physics_interface.py
@@ -234,11 +234,13 @@ class Physics:
         return {}
 
     def get_empty_data(self, coords) -> Any:
-        """Return a zero-shape diagnostics dict (deprecated).
+        """Return a zero-filled diagnostics structure.
 
-        Used by the legacy ``output_averages=True`` path as the
-        stacked-running-mean accumulator seed. Will be removed in Phase
-        4 of issue #471 when the legacy path is deleted.
+        ``Model`` uses this as the structural template for the cross-step
+        physics carry and as the running-mean accumulator seed when
+        ``output_averages=True``. Implementations should return the same
+        pytree structure that ``compute_tendencies`` returns as its updated
+        physics data.
         """
         return None
 


### PR DESCRIPTION
## Summary
- document the pluggable `DynamicalCore` architecture and explicit `DinosaurDycore` usage
- update operator-split, nudging, physics composition, and ECHAM/SPEEDY examples to the current v2 API
- expose dycore classes in the API reference and clarify current Hydra/backend limitations

## Verification
- `git diff --check`
- `ruff check jcm/dycore/__init__.py jcm/dycore/base.py jcm/dycore/registry.py jcm/physics_interface.py`
- `python -m py_compile jcm/dycore/__init__.py jcm/dycore/base.py jcm/dycore/registry.py jcm/physics_interface.py`

Sphinx build was not run because `sphinx-build` is unavailable in the local environment.