### PR TITLE
Prepare v2.0.0b1 beta release

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,8 @@ combined with the composable physics API:
 
 ```python
 from jcm.physics.echam.echam_terms import echam_physics
-from jcm.physics.radiation.rrtmgp import RRTMGPRadiation
 
 physics = echam_physics(radiation_scheme="rrtmgp")
-physics = echam_physics().replace("radiation", RRTMGPRadiation())
 physics = echam_physics().remove("hines")
 ```
 

--- a/docs/source/echam_physics.rst
+++ b/docs/source/echam_physics.rst
@@ -903,7 +903,8 @@ Assumptions and Limitations
 **Time Steps**:
 
 - Recommended time step: 30 minutes for T31 resolution
-- All physics sub-schemes share the model timestep (set via ``Parameters.with_timestep()``)
+- Physics terms read the model timestep from the enclosing
+  ``ComposablePhysics`` at runtime.
 - Shorter time steps needed for higher resolutions
 
 **Forcing Data**:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,6 +27,8 @@ Contents
    getting_started
    speedy_physics
    echam_physics
+   release_notes
+   v1_to_v2
    speedy_translation
    api
    design

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -1,0 +1,62 @@
+Release Notes
+=============
+
+v2.0.0b1
+--------
+
+This is the first beta for the v2.0 release line. It is intended for early
+users who want the new ECHAM/RRTMGP workflow, composable physics API, and
+pluggable dynamical-core interface before the stable v2.0.0 tag.
+
+Install the beta explicitly:
+
+.. code-block:: console
+
+   $ pip install "jcm==2.0.0b1"
+
+Because ``2.0.0b1`` is a Python pre-release, normal ``pip install --upgrade
+jcm`` users will continue to receive the latest stable release unless they opt
+in with ``--pre`` or an exact version pin.
+
+Highlights
+^^^^^^^^^^
+
+- Added the :class:`jcm.dycore.base.DynamicalCore` protocol and moved Dinosaur
+  behind the shipped :class:`jcm.dycore.dinosaur.DinosaurDycore` backend.
+- Refreshed the v2 documentation around dycore ownership, operator-split
+  physics, composable physics, and the ECHAM target configuration.
+- Made ECHAM the beta target for climate-quality integrations, especially
+  ``physics=echam-rrtmgp grid=echam_t63_l47_hybrid``.
+- Added persistent checkpoint/resume support for long and preemptible runs.
+- Added ozone climatology forcing for ECHAM-RRTMGP.
+- Consolidated shared physical constants behind
+  :mod:`jcm.constants`, with runtime overrides via
+  :func:`jcm.constants.set_constants` before model construction.
+- Stabilized ECHAM cloud, convection, vertical diffusion, gravity-wave,
+  aerosol, and surface-process wiring for the T63L47 beta target.
+- Updated the Python package version to the canonical PEP 440 pre-release
+  string ``2.0.0b1``.
+
+Beta Fixes
+^^^^^^^^^^
+
+- ``echam_physics(radiation_scheme="rrtmgp")`` now configures the enclosing
+  ``ComposablePhysics.band_config`` for RRTMGP bands, matching the Hydra
+  runner path and avoiding broadband aerosol optics in Python-created RRTMGP
+  compositions.
+- Example notebooks were checked for v2 API drift; the ECHAM demo now uses
+  ``predictions.to_xarray()``, ``Model(coords=..., terrain=...)``, and
+  ``Parameters.float_zeros()``.
+
+Known Beta Caveats
+^^^^^^^^^^^^^^^^^^
+
+- The pluggable dycore interface is present, but the shipped production backend
+  remains Dinosaur. The Hydra CLI currently selects Dinosaur explicitly.
+- Column-vectorized ECHAM physics still assumes a two-dimensional horizontal
+  layout. Non-lat/lon dycores need an adapter or flattening step before using
+  the shipped column physics packages.
+- The beta is intended for named early users and API feedback. Pin the exact
+  beta version in user environments and update deliberately between beta tags.
+
+

--- a/docs/source/v1_to_v2.rst
+++ b/docs/source/v1_to_v2.rst
@@ -1,0 +1,140 @@
+v1 to v2 Migration Guide
+========================
+
+This short guide covers the API changes most likely to affect existing v1
+scripts and notebooks.
+
+Install the Beta
+----------------
+
+Pin the beta explicitly:
+
+.. code-block:: console
+
+   $ pip install "jcm==2.0.0b1"
+
+or opt into pre-releases generally:
+
+.. code-block:: console
+
+   $ pip install --pre --upgrade jcm
+
+Model Construction
+------------------
+
+Most simple SPEEDY scripts still construct a model from coordinates:
+
+.. code-block:: python
+
+   from jcm.model import Model
+   from jcm.physics.speedy.speedy_coords import get_speedy_coords
+
+   coords = get_speedy_coords()
+   model = Model(coords=coords, time_step=30.0)
+
+The old geometry-style construction has been replaced by explicit coordinates
+and terrain:
+
+.. code-block:: python
+
+   from jcm.model import Model
+   from jcm.terrain import TerrainData
+   from jcm.physics.speedy.speedy_coords import get_speedy_coords
+
+   coords = get_speedy_coords()
+   terrain = TerrainData.aquaplanet(coords)
+   model = Model(coords=coords, terrain=terrain)
+
+If you need backend-specific configuration, construct the Dinosaur dycore
+explicitly. ``dt_seconds`` is in seconds; ``Model(time_step=...)`` is in
+minutes, so the two values must represent the same duration.
+
+.. code-block:: python
+
+   from jcm.dycore.dinosaur import DinosaurDycore
+   from jcm.model import Model
+
+   dycore = DinosaurDycore(coords=coords, terrain=terrain, dt_seconds=1800.0)
+   model = Model(dycore=dycore, time_step=30.0)
+
+Output Conversion
+-----------------
+
+``Model.run()``, ``Model.resume()``, and ``Model.run_from_state()`` return a
+``ModelPredictions`` wrapper. Convert it directly:
+
+.. code-block:: python
+
+   predictions = model.run(save_interval=1.0, total_time=10.0)
+   ds = predictions.to_xarray()
+
+Do not pass the physics package to ``to_xarray``.
+
+Composable Physics
+------------------
+
+Physics packages are now assembled from ``PhysicsTerm`` instances. SPEEDY keeps
+its package-level ``Parameters`` object:
+
+.. code-block:: python
+
+   from jcm.physics.speedy.params import Parameters
+   from jcm.physics.speedy.speedy_terms import speedy_physics
+
+   params = Parameters.default()
+   physics = speedy_physics(parameters=params)
+
+ECHAM uses per-scheme parameter structs rather than a monolithic ECHAM
+``Parameters`` object:
+
+.. code-block:: python
+
+   from jcm.physics.echam.echam_terms import echam_physics
+   from jcm.physics.convection.tiedtke_nordeng import ConvectionParameters
+
+   convection = ConvectionParameters.default(tau=10800.0)
+   physics = echam_physics(convection=convection, radiation_scheme="rrtmgp")
+
+Swap or remove process terms through the composable API:
+
+.. code-block:: python
+
+   physics = echam_physics().remove("hines")
+   physics = echam_physics(radiation_scheme="emulated")
+
+For RRTMGP production runs, the CLI path remains the recommended default:
+
+.. code-block:: console
+
+   $ python -m jcm.main physics=echam-rrtmgp grid=echam_t63_l47_hybrid
+
+Forcing and Calendars
+---------------------
+
+The model selects time-varying forcing before physics runs. Physics terms no
+longer receive ``DateData`` directly. Use ``ForcingData.from_file(...,
+coords=coords)`` and pass the result to ``Model.run`` or ``Model.resume``.
+
+``save_interval`` and ``total_time`` accept day counts or calendar strings:
+
+.. code-block:: python
+
+   predictions = model.run(save_interval="1 day", total_time="1 year")
+
+Physical Constants
+------------------
+
+Shared physical constants now live in :mod:`jcm.constants`. To override them,
+call :func:`jcm.constants.set_constants` before constructing the model:
+
+.. code-block:: python
+
+   import jcm.constants as constants
+
+   constants.set_constants(grav=9.80665, rearth=6.371229e6)
+   model = Model(coords=coords)
+
+Read constants through module attribute access, for example
+``constants.grav``. Avoid ``from jcm.constants import grav`` in code that needs
+to honour runtime overrides.
+

--- a/jcm/__init__.py
+++ b/jcm/__init__.py
@@ -14,7 +14,7 @@ from jcm.utils import (
 
 logging.basicConfig(format='%(name)s: %(asctime)s %(levelname)s: %(message)s')
 
-__version__ = "2.0.0_beta"
+__version__ = "2.0.0b1"
 
 __all__ = [
     "Model",

--- a/jcm/physics/echam/echam_terms.py
+++ b/jcm/physics/echam/echam_terms.py
@@ -43,8 +43,9 @@ from jcm.physics.gravity_waves.sso import LottMillerSso, SSOParameters
 from jcm.physics.physics_term import PhysicsTerm
 from jcm.physics.radiation.grey_two_stream import GreyTwoStreamRadiation
 from jcm.physics.radiation.nn_emulator_scheme import NNEmulatorRadiation
+from jcm.physics.radiation.band_config import RadiationBandConfig
 from jcm.physics.radiation.radiation_types import RadiationParameters
-from jcm.physics.radiation.rrtmgp import RRTMGPRadiation
+from jcm.physics.radiation.rrtmgp import RRTMGPRadiation, _ensure_rrtmgp
 from jcm.physics.surface.echam.surface_physics import EchamSurface
 from jcm.physics.surface.echam.surface_types import SurfaceParameters
 from jcm.physics.vertical_diffusion.tte_tke import TteTkeVerticalDiffusion
@@ -135,6 +136,14 @@ def echam_physics(
             "Choose 'grey', 'rrtmgp', 'emulated', or pass a radiation "
             "PhysicsTerm."
         )
+    # Aerosol and cloud optics need the same band metadata as the selected
+    # radiation term, so Python-created RRTMGP compositions must carry the
+    # multi-band config just like the Hydra runner path.
+    band_config = (
+        RadiationBandConfig.from_rrtmgp(_ensure_rrtmgp())
+        if isinstance(rad_term, RRTMGPRadiation)
+        else RadiationBandConfig.broadband()
+    )
 
     if cloud_scheme == "1m":
         micro_term = Echam1MMicrophysics(params=microphysics_p)
@@ -168,4 +177,5 @@ def echam_physics(
         ],
         checkpoint_terms=checkpoint_terms,
         vectorize_columns=True,
+        band_config=band_config,
     )

--- a/notebooks/01_jcm_demo.ipynb
+++ b/notebooks/01_jcm_demo.ipynb
@@ -3941,7 +3941,7 @@
    "source": [
     "def create_cotangent(primal):\n",
     "    cotangent = jtu.tree_map(jnp.zeros_like, primal)\n",
-    "    cotangent.physics.shortwave_rad.ftop = jtu.tree_map(jnp.ones_like, cotangent.physics.shortwave_rad.ftop)\n",
+    "    cotangent.physics['_shortwave_rad'].ftop = jtu.tree_map(jnp.ones_like, cotangent.physics['_shortwave_rad'].ftop)\n",
     "    return cotangent\n",
     "\n",
     "grad, = vjp_fn(create_cotangent(primal))"
@@ -3984,7 +3984,7 @@
    "outputs": [],
    "source": [
     "import xarray as xr\n",
-    "xr.DataArray(jvp_at_x.physics.surface_flux.hfluxn[0, :, :, 0], dims=['lon', 'lat'],\n",
+    "xr.DataArray(jvp_at_x.physics['_surface_flux'].hfluxn[0, :, :, 0], dims=['lon', 'lat'],\n",
     "                coords={'lat': pred_ds.lat, 'lon': pred_ds.lon}).plot(x='lon', y='lat', size=3, aspect=2)"
    ]
   },

--- a/notebooks/02_optimization_example.ipynb
+++ b/notebooks/02_optimization_example.ipynb
@@ -23,7 +23,8 @@
     "import jax\n",
     "import jax.numpy as jnp\n",
     "from jcm.physics.speedy.speedy_terms import speedy_physics\n",
-    "from jcm.physics.speedy.params import Parameters"
+    "from jcm.physics.speedy.params import Parameters\n",
+    "from jcm.physics.speedy.speedy_coords import get_speedy_coords"
    ]
   },
   {
@@ -44,7 +45,7 @@
     "\n",
     "    \"\"\"\n",
     "    return Model(time_step = time_step, \n",
-    "                 layers = layers,\n",
+    "                 coords = get_speedy_coords(layers=layers),\n",
     "                 physics = speedy_physics(parameters=parameters))\n",
     "\n",
     "def average_pred(predictions):\n",

--- a/notebooks/04_jcm_era5_example.ipynb
+++ b/notebooks/04_jcm_era5_example.ipynb
@@ -13,7 +13,17 @@
     "3. Convert the interpolated ERA5 fields into a `PhysicsState` dataclass\n",
     "4. Run a short simulation\n",
     "\n",
-    "**Prerequisites:** `jcm`, `jax`, `xarray`, `numpy`, `pandas`,`gcsfs`"
+    "**Prerequisites:** `jcm`, `jax`, `xarray`, `numpy`, `pandas`, and `gcsfs` for reading the public WeatherBench2 Zarr store."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "install-gcsfs",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install gcsfs"
    ]
   },
   {

--- a/notebooks/04_jcm_slides.ipynb
+++ b/notebooks/04_jcm_slides.ipynb
@@ -3489,13 +3489,15 @@
    ],
    "source": [
     "from jcm.model import Model\n",
+    "from jcm.physics.speedy.speedy_coords import get_speedy_coords\n",
     "\n",
     "# Initialize a default (aquaplanet) model\n",
-    "model = Model()\n",
+    "coords = get_speedy_coords()\n",
+    "model = Model(coords=coords)\n",
     "\n",
     "predictions = model.run(save_interval=5, total_time=30)\n",
     "\n",
-    "model.predictions_to_xarray(predictions)"
+    "predictions.to_xarray()"
    ]
   },
   {
@@ -3510,7 +3512,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "from jcm.terrain import TerrainData\nfrom jcm.forcing import ForcingData\nfrom jcm.physics.speedy.speedy_coords import get_speedy_coords\n\n# Load the terrain and forcing data (interpolated to the default model grid)\ncoords = get_speedy_coords()\nrealistic_terrain = TerrainData.from_file('../jcm/data/bc/t30/clim/terrain.nc', coords=coords)\nrealistic_forcing = ForcingData.from_file('../jcm/data/bc/t30/clim/forcing.nc', target_resolution=31)"
+   "source": "from jcm.terrain import TerrainData\nfrom jcm.forcing import ForcingData\nfrom jcm.physics.speedy.speedy_coords import get_speedy_coords\n\n# Load the terrain and forcing data (interpolated to the default model grid)\ncoords = get_speedy_coords()\nrealistic_terrain = TerrainData.from_file('../jcm/data/bc/t30/clim/terrain.nc', coords=coords)\nrealistic_forcing = ForcingData.from_file('../jcm/data/bc/t30/clim/forcing.nc', coords=coords)"
   },
   {
    "cell_type": "code",
@@ -3647,7 +3649,7 @@
    "source": [
     "def create_cotangent(primal):\n",
     "    cotangent = jtu.tree_map(jnp.zeros_like, primal)\n",
-    "    cotangent.physics.shortwave_rad.ftop = jtu.tree_map(jnp.ones_like, cotangent.physics.shortwave_rad.ftop)\n",
+    "    cotangent.physics['_shortwave_rad'].ftop = jtu.tree_map(jnp.ones_like, cotangent.physics['_shortwave_rad'].ftop)\n",
     "    return cotangent\n",
     "\n",
     "grad, = vjp_fn(create_cotangent(primal))"
@@ -3780,7 +3782,7 @@
    ],
    "source": [
     "import xarray as xr\n",
-    "xr.DataArray(jvp_at_x.physics.surface_flux.hfluxn[0, :, :, 0], dims=['lon', 'lat'],\n",
+    "xr.DataArray(jvp_at_x.physics['_surface_flux'].hfluxn[0, :, :, 0], dims=['lon', 'lat'],\n",
     "                coords={'lat': pred_ds.lat, 'lon': pred_ds.lon}).plot(x='lon', y='lat', size=3, aspect=2)"
    ]
   },

--- a/notebooks/05_jcm_echam_demo.ipynb
+++ b/notebooks/05_jcm_echam_demo.ipynb
@@ -3371,7 +3371,7 @@
     "# create non-hybrid coords\n",
     "# from dinosaur.coordinate_systems import CoordinateSystem\n",
     "# _coords = CoordinateSystem(model.coords.horizontal, model.coords.vertical.to_approx_sigma_coords(40))\n",
-    "pred_ds = predictions.to_xarray(physics)\n",
+    "pred_ds = predictions.to_xarray()\n",
     "pred_ds"
    ]
   },
@@ -3529,8 +3529,8 @@
     }
    ],
    "source": [
-    "pred_ds['diagnostics.pressure_full'].mean('lon').plot(x='lat', y='level', col='time', col_wrap=3, aspect=6, yincrease=False)\n",
-    "pred_ds['diagnostics.pressure_full'].isel(level=3).plot(x='lon', y='lat', col='time', col_wrap=3, aspect=2)"
+    "pred_ds['pressure_full'].mean('lon').plot(x='lat', y='level', col='time', col_wrap=3, aspect=6, yincrease=False)\n",
+    "pred_ds['pressure_full'].isel(level=3).plot(x='lon', y='lat', col='time', col_wrap=3, aspect=2)"
    ]
   },
   {
@@ -3610,8 +3610,8 @@
     }
    ],
    "source": [
-    "pred_ds['shortwave_rad.cloudc'].plot(x='lon', y='lat', col='time', col_wrap=3, aspect=2)\n",
-    "pred_ds['shortwave_rad.qcloud'].plot(x='lon', y='lat', col='time', col_wrap=3, aspect=2)"
+    "pred_ds['clouds.cloud_fraction'].mean('level').plot(x='lon', y='lat', col='time', col_wrap=3, aspect=2)\n",
+    "pred_ds['radiation.toa_sw_down'].plot(x='lon', y='lat', col='time', col_wrap=3, aspect=2)"
    ]
   },
   {
@@ -3632,7 +3632,6 @@
     "predictions = model.resume(\n",
     "    total_time=30,\n",
     "    output_averages=True,\n",
-    "    forcing=realistic_forcing,\n",
     ")"
    ]
   },
@@ -3681,12 +3680,20 @@
     "import jax\n",
     "import jax.numpy as jnp\n",
     "import jax.tree_util as jtu\n",
+    "from importlib import resources\n",
+    "from jcm.forcing import ForcingData\n",
     "from jcm.physics.speedy.speedy_terms import speedy_physics\n",
     "from jcm.physics.speedy.params import Parameters\n",
+    "from jcm.physics.speedy.speedy_coords import get_speedy_coords\n",
+    "\n",
+    "speedy_coords = get_speedy_coords()\n",
+    "data_dir = resources.files('jcm.data.bc.t30.clim')\n",
+    "realistic_terrain = TerrainData.from_file(data_dir / 'terrain.nc', coords=speedy_coords)\n",
+    "realistic_forcing = ForcingData.from_file(data_dir / 'forcing.nc', coords=speedy_coords)\n",
     "\n",
     "# Key step - create a function that makes a model given parameters\n",
     "def model_run_wrapper(params):\n",
-    "    model = Model(geometry=realistic_geometry, physics=speedy_physics(parameters=params))\n",
+    "    model = Model(coords=speedy_coords, terrain=realistic_terrain, physics=speedy_physics(parameters=params))\n",
     "\n",
     "    return model.run(save_interval=1, total_time=1, forcing=realistic_forcing, output_averages=True)"
    ]
@@ -3710,7 +3717,7 @@
    "source": [
     "def create_cotangent(primal):\n",
     "    cotangent = jtu.tree_map(jnp.zeros_like, primal)\n",
-    "    cotangent.physics.shortwave_rad.ftop = jtu.tree_map(jnp.ones_like, cotangent.physics.shortwave_rad.ftop)\n",
+    "    cotangent.physics['_shortwave_rad'].ftop = jtu.tree_map(jnp.ones_like, cotangent.physics['_shortwave_rad'].ftop)\n",
     "    return cotangent\n",
     "\n",
     "grad, = vjp_fn(create_cotangent(primal))"
@@ -3817,7 +3824,7 @@
    "source": [
     "# Define a tangent vector for JVP\n",
     "params = Parameters.default()\n",
-    "tangent = Parameters.zeros()\n",
+    "tangent = Parameters.float_zeros()\n",
     "tangent.mod_radcon.albsea = jnp.array(1.)\n",
     "\n",
     "y, jvp_at_x = jax.jvp(model_run_wrapper, (params,), (tangent,))"
@@ -3851,7 +3858,7 @@
    ],
    "source": [
     "import xarray as xr\n",
-    "xr.DataArray(jvp_at_x.physics.surface_flux.hfluxn[0, :, :, 0], dims=['lon', 'lat'],\n",
+    "xr.DataArray(jvp_at_x.physics['_surface_flux'].hfluxn[0, :, :, 0], dims=['lon', 'lat'],\n",
     "                coords={'lat': pred_ds.lat, 'lon': pred_ds.lon}).plot(x='lon', y='lat', size=3, aspect=2)"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jcm"
-version = "2.0.0_beta"
+version = "2.0.0b1"
 dynamic = ["dependencies"]
 description = "JAX-based General Circulation Model"
 authors = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ hydra-core
 
 # I/O requirements
 xarray[io, parallel]
-gcsfs  # WeatherBench / ERA5 example notebook reads public gs:// zarr data
 
 # Testing requirements
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ hydra-core
 
 # I/O requirements
 xarray[io, parallel]
+gcsfs  # WeatherBench / ERA5 example notebook reads public gs:// zarr data
 
 # Testing requirements
 pytest-cov
@@ -19,4 +20,3 @@ myst-parser  # Markdown source for design/* docs
 # Radiation scheme
 jax-solar  # Requires Python 3.11+
 jax-rrtmgp @ git+https://github.com/climate-analytics-lab/jax-rrtmgp@main
-


### PR DESCRIPTION
## Summary
- update package metadata to the PEP 440 beta version `2.0.0b1`
- add release notes and a short v1-to-v2 migration guide to the docs
- refresh user-facing notebooks for the v2 APIs and add `gcsfs` for the ERA5/WeatherBench example
- configure RRTMGP band metadata in `echam_physics(radiation_scheme="rrtmgp")` to match the Hydra runner path

## Verification
- metadata smoke confirmed `jcm.__version__` and package metadata are both `2.0.0b1`
- RRTMGP factory smoke confirmed 14 SW bands and 16 LW bands
- `git diff --check`
- `ruff check .` passes, with existing config warnings only
- `make html` in `docs/`
- `JAX_PLATFORMS=cpu pytest jcm/physics/echam/echam_terms_test.py jcm/model_test.py -q` passed: 29 passed, 2 skipped, existing xarray FutureWarnings
- notebooks executed with `nbclient`: `01_jcm_demo`, `02_optimization_example`, `03_generate_speedy_default_stats`, `04_jcm_era5_example`, `04_jcm_slides`, and `05_jcm_echam_demo`

Note: `03_generate_speedy_default_stats` rewrote `jcm/data/test/t30/default_statistics.nc` during execution; that generated data change was reverted before committing.