### PR TITLE
fix: hybrid surface pressure round-trip + non-monthly forcing time axes

### DIFF
--- a/jcm/dycore/dinosaur/state_bridge.py
+++ b/jcm/dycore/dinosaur/state_bridge.py
@@ -152,7 +152,19 @@ def physics_state_to_dynamics_state(
     temperature = physics_state.temperature - dynamics.reference_temperature[:, jnp.newaxis, jnp.newaxis]
     temperature_modal = dynamics.coords.horizontal.to_modal(temperature)
 
-    log_surface_pressure = jnp.log(physics_state.normalized_surface_pressure)
+    # ``normalized_surface_pressure`` is P_s / p0 regardless of coord family
+    # (see :func:`dynamics_state_to_physics_state`). dinosaur stores
+    # ``log(P_s / p0)`` for sigma but ``log(P_s)`` (in nondim Pa) for hybrid, so
+    # the hybrid branch must multiply by ``p0_nondim`` before the log — the exact
+    # inverse of the division done on the forward path. Without this, an injected
+    # hybrid PhysicsState collapses surface pressure by a factor of ~p0.
+    if isinstance(dynamics.coords.vertical, HybridCoordinates):
+        from jcm.constants import p0 as P0_PA
+        p0_nondim = dynamics.physics_specs.nondimensionalize(P0_PA * units.pascal)
+        sp_nondim = physics_state.normalized_surface_pressure * p0_nondim
+    else:
+        sp_nondim = physics_state.normalized_surface_pressure
+    log_surface_pressure = jnp.log(sp_nondim)
     modal_log_sp = dynamics.coords.horizontal.to_modal(log_surface_pressure)
 
     tracers_modal = {'specific_humidity': q_modal}

--- a/jcm/dycore/dinosaur/state_bridge_test.py
+++ b/jcm/dycore/dinosaur/state_bridge_test.py
@@ -65,5 +65,49 @@ class TestStateBridgeRoundTripSlow(unittest.TestCase):
         ))
 
 
+@pytest.mark.slow
+class TestHybridSurfacePressureRoundTrip(unittest.TestCase):
+    """Hybrid-coordinate surface pressure must survive a PhysicsState round-trip.
+
+    Regression for the asymmetry where ``dynamics_state_to_physics_state``
+    divides hybrid ``sp`` by ``p0`` (exposing ``P_s/p0``) but the inverse logged
+    that normalized value directly. For hybrid coords dinosaur stores
+    ``log(P_s)`` (nondim Pa), so the inverse must multiply by ``p0`` first;
+    without it surface pressure collapses by a factor of ~p0.
+    """
+
+    def test_hybrid_round_trip_preserves_surface_pressure(self):
+        from jcm.model import Model
+        from jcm.physics.echam.echam_levels import get_echam_levels
+        from jcm.physics.echam.echam_terms import echam_physics
+        from jcm.utils import get_coords
+
+        coords = get_coords(get_echam_levels(47), spectral_truncation=21)
+        model = Model(
+            coords=coords,
+            physics=echam_physics(radiation_scheme="grey", checkpoint_terms=False),
+            time_step=180.0,
+        )
+        primitive = model.dycore.primitive
+        tracer_specs = {spec.name: spec for spec in model.physics.required_tracers()}
+
+        state = model.dycore.to_physics_state(model._prepare_initial_dycore_state())
+        # A clearly non-trivial normalized surface pressure (P_s/p0 ≈ 0.97).
+        seeded = state.copy(
+            normalized_surface_pressure=state.normalized_surface_pressure * 0.97,
+        )
+
+        modal = physics_state_to_dynamics_state(seeded, primitive, tracer_specs=tracer_specs)
+        recovered = dynamics_state_to_physics_state(modal, primitive, tracer_specs=tracer_specs)
+
+        # The load-bearing assertion: surface pressure survives the round-trip.
+        # Pre-fix, ``recovered`` is smaller than ``seeded`` by ~p0 (~1e5).
+        self.assertTrue(jnp.allclose(
+            recovered.normalized_surface_pressure,
+            seeded.normalized_surface_pressure,
+            rtol=1e-4,
+        ))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/jcm/forcing.py
+++ b/jcm/forcing.py
@@ -361,11 +361,16 @@ class ForcingData:
         elif ds["stl"].shape[:2] == coords.horizontal.nodal_shape:
             # Source already at target resolution — skip the lat/lon interp
             # pipeline (which can introduce NaN through pole padding when
-            # lat values match exactly). Only the time-axis interpolation
-            # is needed for monthly → daily.
-            ds = interpolate_to_daily(ds)
+            # lat values match exactly). Only do the monthly -> daily time
+            # interpolation for a 12-month climatology; native daily or
+            # multi-year axes are passed through to the TimeSeries/BY_DATE
+            # alignment unchanged (interpolate_to_daily requires exactly 12
+            # monthly timestamps and would otherwise raise).
+            if _is_monthly_climatology(ds):
+                ds = interpolate_to_daily(ds)
         else:
-            ds = upsample_forcings_ds(interpolate_to_daily(ds), grid=coords.horizontal)
+            base = interpolate_to_daily(ds) if _is_monthly_climatology(ds) else ds
+            ds = upsample_forcings_ds(base, grid=coords.horizontal)
 
         # Build the shared time axis (seconds since MODEL_EPOCH) for every
         # time-varying variable in this file, plus the alignment mode.
@@ -476,6 +481,19 @@ class ForcingData:
 # ---------------------------------------------------------------------------
 # Time selection helpers
 # ---------------------------------------------------------------------------
+
+
+def _is_monthly_climatology(ds) -> bool:
+    """Return ``True`` if ``ds`` has a 12-step (monthly-climatology) time axis.
+
+    ``interpolate_to_daily`` only accepts exactly 12 monthly timestamps (it pads
+    with adjacent-year Dec/Jan and raises otherwise). Native daily or multi-year
+    boundary files therefore must skip it and flow straight to the
+    ``TimeSeries``/``BY_DATE`` alignment. This mirrors ``interpolate_to_daily``'s
+    own contract (a length check), so a same-grid file is only treated as a
+    monthly climatology when it actually has 12 timesteps.
+    """
+    return "time" in ds.dims and ds.sizes.get("time") == 12
 
 
 def _time_axis_seconds_from_ds(ds) -> jnp.ndarray:

--- a/jcm/forcing_test.py
+++ b/jcm/forcing_test.py
@@ -758,5 +758,63 @@ class TestTimeSeriesAndSelect(unittest.TestCase):
         self.assertEqual(sst_now.shape, nodal_shape)
 
 
+class TestForcingNonMonthlyTimeAxis(unittest.TestCase):
+    """from_dataset must accept native daily / multi-year same-grid files.
+
+    Regression for the branch that unconditionally ran interpolate_to_daily
+    (which requires exactly 12 monthly timestamps) on same-grid files, so a
+    native daily or multi-year boundary file raised before reaching the
+    TimeSeries/BY_DATE alignment.
+    """
+
+    def _same_grid_dataset(self, n_times):
+        import pandas as pd
+        import xarray as xr
+        from jcm.utils import get_coords
+
+        coords = get_coords(np.linspace(0.0, 1.0, 9), spectral_truncation=21)
+        nlon, nlat = coords.horizontal.nodal_shape  # (64, 32)
+        time = pd.date_range("2000-01-01", periods=n_times, freq="D")
+
+        def f3(value):
+            return (("lon", "lat", "time"),
+                    np.full((nlon, nlat, n_times), value, dtype="float32"))
+
+        ds = xr.Dataset(
+            {
+                "stl": f3(280.0),
+                "icec": f3(0.0),
+                "sst": f3(290.0),
+                "soilw_am": f3(0.5),
+                "snowc": f3(0.0),
+                "alb": (("lon", "lat"), np.full((nlon, nlat), 0.1, dtype="float32")),
+            },
+            coords={"time": time},
+        )
+        return ds, coords, (nlon, nlat)
+
+    def test_is_monthly_climatology_helper(self):
+        from jcm.forcing import _is_monthly_climatology
+        ds12, _, _ = self._same_grid_dataset(12)
+        ds5, _, _ = self._same_grid_dataset(5)
+        ds24, _, _ = self._same_grid_dataset(24)
+        self.assertTrue(_is_monthly_climatology(ds12))
+        self.assertFalse(_is_monthly_climatology(ds5))   # native daily
+        self.assertFalse(_is_monthly_climatology(ds24))  # multi-year monthly
+
+    def test_same_grid_daily_axis_loads(self):
+        # 5 daily steps at the target grid: previously raised in
+        # interpolate_to_daily ("expected 12 monthly timestamps").
+        ds, coords, (nlon, nlat) = self._same_grid_dataset(5)
+        forcing = ForcingData.from_dataset(ds, coords=coords, validate=False)
+        self.assertEqual(forcing.alb0.shape, (nlon, nlat))
+
+    def test_same_grid_multiyear_axis_loads(self):
+        ds, coords, (nlon, nlat) = self._same_grid_dataset(24)
+        forcing = ForcingData.from_dataset(ds, coords=coords, align_mode="by_date",
+                                           validate=False)
+        self.assertEqual(forcing.alb0.shape, (nlon, nlat))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes the two bugs flagged by Codex review on the v2.0.0b1 release PR (#503). Both are pre-existing in `dev` (independent of the constants refactor) and are real; targeting `dev` so the release picks them up.

## 1. Hybrid surface pressure round-trip (was P1) — `state_bridge.py`

`dynamics_state_to_physics_state` divides hybrid surface pressure by `p0` to expose `normalized_surface_pressure = P_s/p0`, but the inverse `physics_state_to_dynamics_state` took `jnp.log(normalized_surface_pressure)` directly. dinosaur stores `log(P_s/p0)` for **sigma** but `log(P_s)` (nondim Pa) for **hybrid**, so the hybrid branch must multiply by `p0` before the log — the exact inverse of the forward division. Without it, a hybrid ECHAM run started or restarted from an injected `PhysicsState` (`Model.run(initial_state=PhysicsState(...))`) had its surface pressure collapsed by a factor of ~`p0` (~1e5). The sigma path is unchanged.

## 2. Non-monthly forcing time axes (was P2) — `forcing.py`

A same-grid forcing file with a native **daily** or **multi-year** time axis was still sent through `interpolate_to_daily(ds)`, which requires exactly 12 monthly timestamps and raises otherwise — so `from_file(..., coords=coords)` failed before reaching the `TimeSeries`/`BY_DATE` alignment that already advertises arbitrary time lengths. Both the same-grid and upsample branches now run the monthly→daily interpolation **only** for a genuine 12-month climatology (new `_is_monthly_climatology` helper, mirroring `interpolate_to_daily`'s own length contract); native daily / multi-year axes pass through unchanged.

## Tests

- `TestHybridSurfacePressureRoundTrip` — round-trips a hybrid `PhysicsState` and asserts surface pressure is preserved. **Verified it fails without fix 1** and passes with it.
- `TestForcingNonMonthlyTimeAxis` — `from_dataset` loads same-grid **daily** (5-step) and **multi-year** (24-step) files, plus the `_is_monthly_climatology` boundaries (12 → True; 5, 24 → False).
- Existing sigma round-trip + `physics_interface` + `forcing` suites still pass (59 tests), confirming no regression to the sigma path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
