### PR TITLE
Use PyPI dependencies for release build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dinosaur @ git+https://github.com/neuralgcm/dinosaur@main
+dinosaur
 flax>=0.12.0
 jax-datetime
 tree-math

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ myst-parser  # Markdown source for design/* docs
 
 # Radiation scheme
 jax-solar  # Requires Python 3.11+
-jax-rrtmgp @ git+https://github.com/climate-analytics-lab/jax-rrtmgp@main
+jax-rrtmgp


### PR DESCRIPTION
## Summary
- replace the Dinosaur git dependency with the PyPI package `dinosaur`
- replace the jax-rrtmgp git dependency with the PyPI package `jax-rrtmgp`

## Verification
- isolated venv resolved `dinosaur==1.3.6` and `jax-rrtmgp==0.1.0`
- `jcm` imports cleanly and Dinosaur exposes `compute_diagnostic_state_hybrid`
- `python -m build --wheel --sdist` succeeds
- built wheel metadata contains plain `Requires-Dist: dinosaur` and `Requires-Dist: jax-rrtmgp`
- `JAX_PLATFORMS=cpu .venv/bin/python -m pytest jcm/model_test.py jcm/physics/echam/echam_terms_test.py -q` passed: 29 passed, 2 skipped