### PR TITLE
Online aerosol optics (Mie) — direct radiative effect (#495)

### DIFF
--- a/jcm/__init__.py
+++ b/jcm/__init__.py
@@ -14,7 +14,7 @@ from jcm.utils import (
 
 logging.basicConfig(format='%(name)s: %(asctime)s %(levelname)s: %(message)s')
 
-__version__ = "2.0.0b1"
+__version__ = "2.1.0b0"
 
 __all__ = [
     "Model",

--- a/jcm/physics/aerosol/aerosol_types.py
+++ b/jcm/physics/aerosol/aerosol_types.py
@@ -51,8 +51,15 @@ class AerosolData:
     ssa_sw_per_band: jnp.ndarray
     asy_sw_per_band: jnp.ndarray
 
+    # Per-LW-band optical properties, shape ``(n_bnd_lw, nlev, ncols)``.
+    # Zero for MACv2-SP (SW-only); populated by the JAM online-aerosol optics
+    # term (#495) and passed to RRTMGP via ``aerosol_optics_lw``.
+    aod_lw_per_band: jnp.ndarray
+    ssa_lw_per_band: jnp.ndarray
+    asy_lw_per_band: jnp.ndarray
+
     @classmethod
-    def zeros(cls, nodal_shape, nlev, n_bnd_sw=14):
+    def zeros(cls, nodal_shape, nlev, n_bnd_sw=14, n_bnd_lw=16):
         return cls(
             aod_profile=jnp.zeros((nlev,) + nodal_shape),
             ssa_profile=jnp.zeros((nlev,) + nodal_shape),
@@ -66,6 +73,9 @@ class AerosolData:
             aod_sw_per_band=jnp.zeros((n_bnd_sw, nlev) + nodal_shape),
             ssa_sw_per_band=jnp.zeros((n_bnd_sw, nlev) + nodal_shape),
             asy_sw_per_band=jnp.zeros((n_bnd_sw, nlev) + nodal_shape),
+            aod_lw_per_band=jnp.zeros((n_bnd_lw, nlev) + nodal_shape),
+            ssa_lw_per_band=jnp.zeros((n_bnd_lw, nlev) + nodal_shape),
+            asy_lw_per_band=jnp.zeros((n_bnd_lw, nlev) + nodal_shape),
         )
 
     def copy(self, **kwargs):
@@ -82,6 +92,9 @@ class AerosolData:
             'aod_sw_per_band': self.aod_sw_per_band,
             'ssa_sw_per_band': self.ssa_sw_per_band,
             'asy_sw_per_band': self.asy_sw_per_band,
+            'aod_lw_per_band': self.aod_lw_per_band,
+            'ssa_lw_per_band': self.ssa_lw_per_band,
+            'asy_lw_per_band': self.asy_lw_per_band,
         }
         new_data.update(kwargs)
         return AerosolData(**new_data)

--- a/jcm/physics/aerosol/jam/jam_terms.py
+++ b/jcm/physics/aerosol/jam/jam_terms.py
@@ -29,6 +29,7 @@ from jcm.physics.aerosol.jam.microphysics.base import ModalMicrophysicsTerm
 from jcm.physics.aerosol.jam.microphysics.placeholder import (
     PlaceholderMicrophysics,
 )
+from jcm.physics.aerosol.jam.optics.optics_term import JamOpticsTerm
 from jcm.physics.aerosol.jam.sedimentation.sedi_term import (
     StokesSedimentation,
     SedParameters,
@@ -63,6 +64,7 @@ def jam_aerosol_physics(
     *,
     microphysics: ModalMicrophysicsTerm | str = "placeholder",
     arg_variant: str = "arg2000",
+    optics: bool = True,
     seasalt: SeaSaltParameters | None = None,
     dms: DmsParameters | None = None,
     dust: DustParameters | None = None,
@@ -90,7 +92,7 @@ def jam_aerosol_physics(
     """
     core = _resolve_microphysics(microphysics)
     spec = core.spec
-    return [
+    terms = [
         SeaSaltEmissions(params=seasalt, spec=spec),
         DmsEmissions(params=dms, spec=spec),
         DustEmissions(params=dust, spec=spec),
@@ -100,3 +102,10 @@ def jam_aerosol_physics(
         SlinnDryDeposition(params=drydep, spec=spec),
         WetScavenging(params=wetdep, spec=spec),
     ]
+    if optics:
+        # Online aerosol direct radiative effect (#495): overwrites the
+        # MACv2-SP optics in the ``aerosol`` diagnostic. Placed after the core
+        # (needs ``_jam_state``); reads the MACv2-SP ``aerosol`` struct that
+        # ``echam_physics`` provides upstream.
+        terms.insert(4, JamOpticsTerm(spec=spec))
+    return terms

--- a/jcm/physics/aerosol/jam/jam_terms_test.py
+++ b/jcm/physics/aerosol/jam/jam_terms_test.py
@@ -23,6 +23,7 @@ class JamFactoryTest(unittest.TestCase):
             cats[3:],
             [
                 "aerosol_microphysics",
+                "aerosol_optics",
                 "aerosol_activation",
                 "aerosol_sedimentation",
                 "aerosol_drydep",

--- a/jcm/physics/aerosol/jam/optics/__init__.py
+++ b/jcm/physics/aerosol/jam/optics/__init__.py
@@ -1,0 +1,25 @@
+"""Online aerosol optics for the JAM harness (#495).
+
+A self-contained Mie pathway: a NumPy Bohren-Huffman kernel builds a lookup
+table once at construction, and the per-step :class:`JamOpticsTerm` does a
+differentiable interpolation to produce per-band SW+LW aerosol optical depth /
+single-scattering albedo / asymmetry from the modal population.
+"""
+
+from jcm.physics.aerosol.jam.optics.mie import mie_efficiencies
+from jcm.physics.aerosol.jam.optics.mie_lut import (
+    MieLUT,
+    build_mie_lut,
+    interp_mie,
+)
+from jcm.physics.aerosol.jam.optics.optics_term import JamOpticsTerm
+from jcm.physics.aerosol.jam.optics.refractive_index import refractive_index_at
+
+__all__ = [
+    "JamOpticsTerm",
+    "mie_efficiencies",
+    "build_mie_lut",
+    "interp_mie",
+    "MieLUT",
+    "refractive_index_at",
+]

--- a/jcm/physics/aerosol/jam/optics/mie.py
+++ b/jcm/physics/aerosol/jam/optics/mie.py
@@ -1,0 +1,76 @@
+"""Bohren & Huffman (1983) Mie kernel (NumPy).
+
+Computes the extinction efficiency, single-scattering albedo and asymmetry
+parameter of a homogeneous sphere of size parameter ``x = 2πr/λ`` and complex
+refractive index ``m = mr + i·mi``.
+
+This is deliberately **NumPy, not JAX**: it is only ever evaluated to *build a
+lookup table once* at term construction (``mie_lut``); the per-step optics
+interpolate that table differentiably. Keeping it off the JAX path avoids
+forcing the whole model into float64 (the recurrences need float64 precision).
+Validated to match an independent scipy-Bessel Mie implementation to 1e-4
+across Rayleigh, resonance, large-x and strongly absorbing regimes.
+
+Algorithm: Bohren & Huffman, *Absorption and Scattering of Light by Small
+Particles* (1983), appendix ``BHMIE``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+X_MAX = 100.0   # size parameter is clipped here; large-x optics asymptote
+
+
+def mie_efficiencies(x: float, mr: float, mi: float) -> tuple[float, float, float]:
+    """Return ``(q_ext, ssa, g)`` for size parameter ``x`` and index ``mr+i·mi``."""
+    x = float(np.clip(x, 1.0e-6, X_MAX))
+    m = complex(mr, mi)
+    y = m * x
+
+    nmax = int(x + 4.0 * x ** (1.0 / 3.0) + 2.0) + 2
+    nmx = max(nmax, int(abs(y))) + 16
+
+    # Logarithmic derivative D_n(y), downward recurrence (stable).
+    d = np.zeros(nmx + 1, dtype=complex)
+    for k in range(nmx, 0, -1):
+        d[k - 1] = k / y - 1.0 / (d[k] + k / y)
+    d_n = d[1:nmax + 1]                                   # D_1 … D_{nmax}
+
+    n = np.arange(1, nmax + 1)
+
+    # Riccati–Bessel ψ_n(x), χ_n(x), upward recurrence; ψ_{-1}=cos, ψ_0=sin.
+    psi = np.zeros(nmax + 1)
+    chi = np.zeros(nmax + 1)
+    psi[0], chi[0] = np.sin(x), np.cos(x)
+    psi_prev, chi_prev = np.cos(x), -np.sin(x)            # ψ_{-1}, χ_{-1}
+    for nn in range(1, nmax + 1):
+        psi[nn] = (2 * nn - 1) / x * psi[nn - 1] - psi_prev
+        chi[nn] = (2 * nn - 1) / x * chi[nn - 1] - chi_prev
+        psi_prev, chi_prev = psi[nn - 1], chi[nn - 1]
+
+    psi_n, psi_nm1 = psi[1:], psi[:-1]
+    chi_n, chi_nm1 = chi[1:], chi[:-1]
+    xi_n = psi_n - 1j * chi_n
+    xi_nm1 = psi_nm1 - 1j * chi_nm1
+
+    fac_a = d_n / m + n / x
+    a_n = (fac_a * psi_n - psi_nm1) / (fac_a * xi_n - xi_nm1)
+    fac_b = d_n * m + n / x
+    b_n = (fac_b * psi_n - psi_nm1) / (fac_b * xi_n - xi_nm1)
+
+    tn = 2 * n + 1
+    q_ext = (2.0 / x ** 2) * np.sum(tn * np.real(a_n + b_n))
+    q_sca = (2.0 / x ** 2) * np.sum(tn * (np.abs(a_n) ** 2 + np.abs(b_n) ** 2))
+
+    a_np1 = np.append(a_n[1:], 0.0)
+    b_np1 = np.append(b_n[1:], 0.0)
+    g_qsca = (4.0 / x ** 2) * (
+        np.sum(n * (n + 2) / (n + 1) * np.real(a_n * np.conj(a_np1) + b_n * np.conj(b_np1)))
+        + np.sum(tn / (n * (n + 1)) * np.real(a_n * np.conj(b_n)))
+    )
+
+    q_sca = max(q_sca, 1.0e-30)
+    q_ext = max(q_ext, q_sca)
+    return float(q_ext), float(min(max(q_sca / q_ext, 0.0), 1.0)), \
+        float(min(max(g_qsca / q_sca, -1.0), 1.0))

--- a/jcm/physics/aerosol/jam/optics/mie_lut.py
+++ b/jcm/physics/aerosol/jam/optics/mie_lut.py
@@ -72,6 +72,17 @@ def build_mie_lut(
     )
 
 
+_DEFAULT_LUT: MieLUT | None = None
+
+
+def default_mie_lut() -> MieLUT:
+    """Process-wide memoised default LUT (built once; ~4 s)."""
+    global _DEFAULT_LUT
+    if _DEFAULT_LUT is None:
+        _DEFAULT_LUT = build_mie_lut()
+    return _DEFAULT_LUT
+
+
 def interp_mie(lut: MieLUT, x, mr, mi):
     """Differentiable trilinear interpolation → ``(q_ext, ssa, g)``.
 

--- a/jcm/physics/aerosol/jam/optics/mie_lut.py
+++ b/jcm/physics/aerosol/jam/optics/mie_lut.py
@@ -1,0 +1,95 @@
+"""Mie lookup table: build once (NumPy), interpolate per step (JAX).
+
+``build_mie_lut`` tabulates the Bohren–Huffman efficiencies over a grid of
+(size parameter, real index, imaginary index); ``interp_mie`` does a
+differentiable trilinear interpolation into that table. The table is built at
+term construction, so the expensive Mie evaluation never enters the per-step
+jitted path — only the cheap, autodiff-friendly interpolation does.
+
+Axes are uniform in ``log10(x)``, ``mr`` and ``log10(mi)`` so the fractional
+grid coordinate is a simple affine map.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import jax.numpy as jnp
+import numpy as np
+from jax.scipy.ndimage import map_coordinates
+
+from jcm.physics.aerosol.jam.optics.mie import X_MAX, mie_efficiencies
+
+_MI_FLOOR = 1.0e-9   # imaginary-index floor (non-absorbing → log axis)
+
+
+@dataclasses.dataclass(frozen=True)
+class MieLUT:
+    """Tabulated Mie efficiencies and the affine grid mapping."""
+
+    q_ext: jnp.ndarray   # (nx, nmr, nmi)
+    ssa: jnp.ndarray
+    g: jnp.ndarray
+    logx0: float
+    dlogx: float
+    mr0: float
+    dmr: float
+    logmi0: float
+    dlogmi: float
+    shape: tuple[int, int, int]
+
+
+def build_mie_lut(
+    nx: int = 64, nmr: int = 24, nmi: int = 24,
+    x_min: float = 0.01, x_max: float = X_MAX,
+    mr_min: float = 1.30, mr_max: float = 2.60,
+    mi_min: float = _MI_FLOOR, mi_max: float = 5.0,
+) -> MieLUT:
+    """Tabulate ``(q_ext, ssa, g)`` over the (x, mr, mi) grid (NumPy)."""
+    logx = np.linspace(np.log10(x_min), np.log10(x_max), nx)
+    mr = np.linspace(mr_min, mr_max, nmr)
+    logmi = np.linspace(np.log10(mi_min), np.log10(mi_max), nmi)
+
+    qe = np.empty((nx, nmr, nmi))
+    ss = np.empty((nx, nmr, nmi))
+    gg = np.empty((nx, nmr, nmi))
+    for i, lx in enumerate(logx):
+        x = 10.0 ** lx
+        for j, r in enumerate(mr):
+            for k, lmi in enumerate(logmi):
+                qe[i, j, k], ss[i, j, k], gg[i, j, k] = mie_efficiencies(
+                    x, r, 10.0 ** lmi
+                )
+
+    return MieLUT(
+        q_ext=jnp.asarray(qe, jnp.float32),
+        ssa=jnp.asarray(ss, jnp.float32),
+        g=jnp.asarray(gg, jnp.float32),
+        logx0=float(logx[0]), dlogx=float(logx[1] - logx[0]),
+        mr0=float(mr[0]), dmr=float(mr[1] - mr[0]),
+        logmi0=float(logmi[0]), dlogmi=float(logmi[1] - logmi[0]),
+        shape=(nx, nmr, nmi),
+    )
+
+
+def interp_mie(lut: MieLUT, x, mr, mi):
+    """Differentiable trilinear interpolation → ``(q_ext, ssa, g)``.
+
+    ``x``, ``mr``, ``mi`` are arrays of matching shape; returns three arrays of
+    that shape. Inputs are clamped to the table range.
+    """
+    nx, nmr, nmi = lut.shape
+    cx = (jnp.log10(jnp.clip(x, 10.0 ** lut.logx0, X_MAX)) - lut.logx0) / lut.dlogx
+    cr = (jnp.clip(mr, lut.mr0, lut.mr0 + (nmr - 1) * lut.dmr) - lut.mr0) / lut.dmr
+    cm = (
+        jnp.log10(jnp.clip(mi, 10.0 ** lut.logmi0, 10.0 ** (lut.logmi0 + (nmi - 1) * lut.dlogmi)))
+        - lut.logmi0
+    ) / lut.dlogmi
+
+    shape = x.shape
+    coords = jnp.stack([cx.ravel(), cr.ravel(), cm.ravel()], axis=0)
+
+    def _interp(table):
+        return map_coordinates(table, coords, order=1, mode="nearest").reshape(shape)
+
+    return _interp(lut.q_ext), _interp(lut.ssa), _interp(lut.g)

--- a/jcm/physics/aerosol/jam/optics/mie_test.py
+++ b/jcm/physics/aerosol/jam/optics/mie_test.py
@@ -1,0 +1,87 @@
+"""Tests for the Mie kernel and lookup-table interpolation."""
+
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from jcm.physics.aerosol.jam.optics.mie import mie_efficiencies
+from jcm.physics.aerosol.jam.optics.mie_lut import build_mie_lut, interp_mie
+
+
+class MieKernelTest(unittest.TestCase):
+    def test_reference_values(self):
+        # Validated against an independent scipy-Bessel Mie implementation.
+        cases = {
+            (1.0, 1.5, 0.0): (0.2151, 1.0, 0.1989),
+            (10.0, 1.33, 0.0): (2.2065, 1.0, 0.7125),
+            (2.0, 1.53, 0.006): (2.0193, 0.9729, 0.6165),
+            (8.0, 1.55, 0.4): (2.4234, 0.4894, 0.8978),
+        }
+        for (x, mr, mi), (qe, ss, g) in cases.items():
+            q, s, gg = mie_efficiencies(x, mr, mi)
+            self.assertAlmostEqual(q, qe, places=3)
+            self.assertAlmostEqual(s, ss, places=3)
+            self.assertAlmostEqual(gg, g, places=3)
+
+    def test_nonabsorbing_ssa_unity(self):
+        for x in (0.3, 1.0, 5.0, 30.0):
+            _, ssa, _ = mie_efficiencies(x, 1.5, 0.0)
+            self.assertAlmostEqual(ssa, 1.0, places=4)
+
+    def test_large_x_qext_approaches_two(self):
+        q, _, _ = mie_efficiencies(95.0, 1.5, 0.0)
+        self.assertTrue(1.9 < q < 2.3)
+
+    def test_rayleigh_g_small(self):
+        _, _, g = mie_efficiencies(0.05, 1.5, 0.0)
+        self.assertLess(abs(g), 0.05)
+
+    def test_asymmetry_increases_with_size(self):
+        _, _, g_small = mie_efficiencies(0.5, 1.5, 0.0)
+        _, _, g_big = mie_efficiencies(8.0, 1.5, 0.0)
+        self.assertGreater(g_big, g_small)
+
+
+class MieLUTTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.lut = build_mie_lut(nx=48, nmr=20, nmi=20)
+
+    def test_interp_matches_kernel_offgrid(self):
+        # Off-grid points should interpolate close to the direct kernel.
+        pts = [(1.7, 1.44, 0.01), (6.3, 1.6, 0.05), (0.7, 1.5, 1e-8),
+               (20.0, 1.52, 0.003)]
+        x = jnp.array([p[0] for p in pts])
+        mr = jnp.array([p[1] for p in pts])
+        mi = jnp.array([p[2] for p in pts])
+        qe, ssa, g = interp_mie(self.lut, x, mr, mi)
+        for i, (px, pmr, pmi) in enumerate(pts):
+            rqe, rss, rg = mie_efficiencies(px, pmr, pmi)
+            self.assertAlmostEqual(float(qe[i]), rqe, delta=0.15 * max(rqe, 0.1))
+            self.assertAlmostEqual(float(ssa[i]), rss, delta=0.05)
+            self.assertAlmostEqual(float(g[i]), rg, delta=0.06)
+
+    def test_interp_finite_and_bounded(self):
+        x = jnp.linspace(0.05, 99.0, 50)
+        mr = jnp.full((50,), 1.55)
+        mi = jnp.full((50,), 0.02)
+        qe, ssa, g = interp_mie(self.lut, x, mr, mi)
+        self.assertTrue(np.all(np.isfinite(np.asarray(qe))))
+        self.assertTrue(bool(jnp.all((ssa >= 0) & (ssa <= 1))))
+        self.assertTrue(bool(jnp.all((g >= -1) & (g <= 1))))
+
+    def test_interp_differentiable(self):
+        lut = self.lut
+
+        def loss(x):
+            qe, _, _ = interp_mie(lut, x, jnp.full_like(x, 1.5), jnp.full_like(x, 0.01))
+            return jnp.sum(qe)
+
+        g = jax.grad(loss)(jnp.array([1.0, 5.0, 20.0]))
+        self.assertTrue(np.all(np.isfinite(np.asarray(g))))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jcm/physics/aerosol/jam/optics/optics_integration_test.py
+++ b/jcm/physics/aerosol/jam/optics/optics_integration_test.py
@@ -1,0 +1,50 @@
+"""End-to-end: JAM online aerosol optics feeding RRTMGP (#495)."""
+
+import unittest
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+
+class OpticsWiringTest(unittest.TestCase):
+    def test_rrtmgp_jam_composition_builds(self):
+        # Composition + ordering validation (JamOpticsTerm requires the
+        # MACv2-SP ``aerosol`` diagnostic and ``_jam_state``).
+        from jcm.physics.echam.echam_terms import echam_physics
+
+        phys = echam_physics(
+            aerosol_module="jam", cloud_scheme="2m", radiation_scheme="rrtmgp",
+        )
+        cats = [t.category for t in phys.terms]
+        self.assertIn("aerosol_optics", cats)
+        # optics must precede radiation (it writes the aerosol optics it reads).
+        self.assertLess(cats.index("aerosol_optics"), cats.index("radiation"))
+
+
+@pytest.mark.slow
+class OpticsIntegrationTest(unittest.TestCase):
+    def test_jam_optics_rrtmgp_runs_finite(self):
+        from jcm.model import Model
+        from jcm.physics.echam.echam_terms import echam_physics
+        from jcm.terrain import TerrainData
+        from jcm.utils import get_coords
+
+        coords = get_coords(np.linspace(0, 1, 21), spectral_truncation=21)
+        model = Model(
+            coords=coords, time_step=30,
+            terrain=TerrainData.aquaplanet(coords),
+            physics=echam_physics(
+                aerosol_module="jam", cloud_scheme="2m",
+                radiation_scheme="rrtmgp",
+            ),
+        )
+        predictions = model.run(save_interval=0.0625, total_time=0.0625)
+        dyn = predictions.dynamics
+        self.assertFalse(bool(jnp.any(jnp.isnan(dyn.temperature))))
+        self.assertTrue(bool(jnp.all(dyn.temperature > 150.0)))
+        self.assertTrue(bool(jnp.all(dyn.temperature < 360.0)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jcm/physics/aerosol/jam/optics/optics_term.py
+++ b/jcm/physics/aerosol/jam/optics/optics_term.py
@@ -1,0 +1,145 @@
+"""``JamOpticsTerm`` — online aerosol optics from the modal population.
+
+Computes per-radiation-band aerosol optical depth, single-scattering albedo
+and asymmetry parameter from the JAM population and writes them into the
+``aerosol`` diagnostic, giving online aerosol a **direct radiative effect**
+(#495). For each mode and band: form the volume-mixed complex refractive index
+(dry species + aerosol water), the size parameter ``x = 2π r_wet/λ``, look up
+the Mie efficiencies, and accumulate the extinction across modes;
+single-scattering albedo and asymmetry are extinction-/scattering-weighted.
+
+The expensive Mie evaluation is paid once at construction (``mie_lut``); the
+per-step path is a differentiable table interpolation. SW band optics overwrite
+MACv2-SP's fields (so the SW direct effect flows immediately); LW band optics
+populate the new ``aerosol`` LW fields consumed by RRTMGP. MACv2-SP is kept
+only for its indirect (Twomey/SPA) fields for now.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+from typing import ClassVar
+
+import jax.numpy as jnp
+import numpy as np
+
+from jcm.physics.aerosol.jam.microphysics.mam4_data import MAM4_SPEC
+from jcm.physics.aerosol.jam.optics.mie_lut import build_mie_lut, interp_mie
+from jcm.physics.aerosol.jam.optics.refractive_index import refractive_index_at
+from jcm.physics.aerosol.jam.population import ModalAerosolSpec
+from jcm.physics.aerosol.jam.tracer_layout import mass_name
+from jcm.physics.physics_term import PhysicsTendency, PhysicsTerm
+
+_TINY = 1.0e-30
+_FOUR_THIRDS_PI = 4.0 / 3.0 * math.pi
+
+
+@dataclasses.dataclass(frozen=True)
+class _OpticsCache:
+    """Per-band centers and refractive indices (static; nnx treats as a leaf)."""
+
+    sw_nm: np.ndarray
+    lw_nm: np.ndarray
+    ri_sw: dict          # species -> (n[bands], k[bands])
+    ri_lw: dict
+
+
+class JamOpticsTerm(PhysicsTerm):
+    """Online aerosol SW+LW optics written into the ``aerosol`` diagnostic."""
+
+    name: ClassVar[str] = "jam_optics"
+    category: ClassVar[str] = "aerosol_optics"
+    requires: ClassVar[tuple[str, ...]] = (
+        "_jam_state", "aerosol", "air_density", "layer_thickness",
+    )
+    provides: ClassVar[tuple[str, ...]] = ("aerosol",)
+
+    def __init__(self, *, spec: ModalAerosolSpec | None = None):
+        """Build the Mie lookup table and hold the population."""
+        self._spec = spec or MAM4_SPEC
+        self._lut = build_mie_lut()
+        self._cache = None   # set by cache_band_config
+
+    def cache_band_config(self, band_config) -> None:
+        """Precompute band centers and per-species refractive indices."""
+        sw_nm = np.asarray(band_config.sw_band_centers_nm, np.float64)
+        lw_nm = np.asarray(band_config.lw_band_centers_nm, np.float64)
+        species = {sp for m in self._spec.modes for sp in m.species} | {"h2o"}
+        ri_sw, ri_lw = {}, {}
+        for sp in species:
+            n_sw, k_sw = refractive_index_at(sp, jnp.asarray(sw_nm))
+            n_lw, k_lw = refractive_index_at(sp, jnp.asarray(lw_nm))
+            ri_sw[sp] = (np.asarray(n_sw), np.asarray(k_sw))
+            ri_lw[sp] = (np.asarray(n_lw), np.asarray(k_lw))
+        self._cache = _OpticsCache(sw_nm, lw_nm, ri_sw, ri_lw)
+
+    def _band_optics(self, state, aer, num_per_area, centers_nm, ri):
+        """Per-band ``(aod, ssa, asy)``, each ``(n_band, nlev, ncols)``."""
+        zeros = jnp.zeros_like(state.temperature)
+        aod_bands, ssa_bands, asy_bands = [], [], []
+        for b in range(centers_nm.shape[0]):
+            lam_m = float(centers_nm[b]) * 1.0e-9
+            aod = jnp.zeros_like(state.temperature)
+            scat = jnp.zeros_like(state.temperature)
+            gscat = jnp.zeros_like(state.temperature)
+            for i, mode in enumerate(self._spec.modes):
+                r_wet = aer.r_wet[i]
+                vol_n = jnp.zeros_like(state.temperature)
+                vol_k = jnp.zeros_like(state.temperature)
+                vol_tot = jnp.zeros_like(state.temperature)
+                for sp in mode.species:
+                    mass = state.tracers.get(mass_name(sp, mode.short), zeros)
+                    v = mass / self._spec.species_props(sp).density
+                    n_sp, k_sp = ri[sp]
+                    vol_n = vol_n + v * float(n_sp[b])
+                    vol_k = vol_k + v * float(k_sp[b])
+                    vol_tot = vol_tot + v
+                v_water = aer.number[i] * _FOUR_THIRDS_PI * jnp.maximum(
+                    r_wet ** 3 - aer.r_dry[i] ** 3, 0.0
+                )
+                n_w, k_w = ri["h2o"]
+                vol_n = vol_n + v_water * float(n_w[b])
+                vol_k = vol_k + v_water * float(k_w[b])
+                vol_tot = vol_tot + v_water
+
+                safe = jnp.maximum(vol_tot, _TINY)
+                m_n = jnp.where(vol_tot > _TINY, vol_n / safe, 1.5)
+                m_k = jnp.where(vol_tot > _TINY, vol_k / safe, 1.0e-8)
+                x = 2.0 * math.pi * r_wet / lam_m
+                q_ext, ssa, g = interp_mie(self._lut, x, m_n, m_k)
+                aod_i = num_per_area[i] * q_ext * math.pi * r_wet ** 2
+                aod = aod + aod_i
+                scat = scat + ssa * aod_i
+                gscat = gscat + g * ssa * aod_i
+            aod_bands.append(aod)
+            ssa_bands.append(scat / jnp.maximum(aod, _TINY))
+            asy_bands.append(gscat / jnp.maximum(scat, _TINY))
+        if not aod_bands:
+            empty = jnp.zeros((0,) + state.temperature.shape)
+            return empty, empty, empty
+        return (jnp.stack(aod_bands), jnp.stack(ssa_bands), jnp.stack(asy_bands))
+
+    def __call__(self, state, diagnostics, forcing, terrain):
+        aer = diagnostics["_jam_state"]
+        aerosol = diagnostics["aerosol"]
+        air_density = diagnostics["air_density"]
+        dz = diagnostics["layer_thickness"]
+        c = self._cache
+
+        # Number per unit area [m^-2] per mode (number is kg^-1).
+        num_per_area = aer.number * (air_density * dz)[jnp.newaxis]
+
+        aod_sw, ssa_sw, asy_sw = self._band_optics(
+            state, aer, num_per_area, c.sw_nm, c.ri_sw
+        )
+        aod_lw, ssa_lw, asy_lw = self._band_optics(
+            state, aer, num_per_area, c.lw_nm, c.ri_lw
+        )
+
+        new_aerosol = aerosol.copy(
+            aod_sw_per_band=aod_sw, ssa_sw_per_band=ssa_sw, asy_sw_per_band=asy_sw,
+            aod_lw_per_band=aod_lw, ssa_lw_per_band=ssa_lw, asy_lw_per_band=asy_lw,
+        )
+        tendency = PhysicsTendency.zeros(state.temperature.shape)
+        return tendency, {**diagnostics, "aerosol": new_aerosol}

--- a/jcm/physics/aerosol/jam/optics/optics_term.py
+++ b/jcm/physics/aerosol/jam/optics/optics_term.py
@@ -21,6 +21,7 @@ import dataclasses
 import math
 from typing import ClassVar
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 
@@ -75,11 +76,26 @@ class JamOpticsTerm(PhysicsTerm):
         self._cache = _OpticsCache(sw_nm, lw_nm, ri_sw, ri_lw)
 
     def _band_optics(self, state, aer, num_per_area, centers_nm, ri):
-        """Per-band ``(aod, ssa, asy)``, each ``(n_band, nlev, ncols)``."""
+        """Per-band ``(aod, ssa, asy)``, each ``(n_band, nlev, ncols)``.
+
+        The bands are independent and share the whole modal geometry
+        (volumes, wet radii, number), so the band axis is mapped with a
+        single ``jax.vmap`` rather than a Python loop: only the wavelength
+        and the per-species refractive index ``(n, k)`` vary across bands.
+        The inner loops over modes/species stay explicit — they are ragged
+        (each mode carries a different species set) and small.
+        """
+        n_band = centers_nm.shape[0]
+        if n_band == 0:
+            empty = jnp.zeros((0,) + state.temperature.shape)
+            return empty, empty, empty
+
         zeros = jnp.zeros_like(state.temperature)
-        aod_bands, ssa_bands, asy_bands = [], [], []
-        for b in range(centers_nm.shape[0]):
-            lam_m = float(centers_nm[b]) * 1.0e-9
+        lam_all = jnp.asarray(centers_nm, state.temperature.dtype) * 1.0e-9
+        # ri: species -> (n[n_band], k[n_band]); vmap maps the band axis.
+        ri_j = {sp: (jnp.asarray(n), jnp.asarray(k)) for sp, (n, k) in ri.items()}
+
+        def one_band(lam_m, ri_band):
             aod = jnp.zeros_like(state.temperature)
             scat = jnp.zeros_like(state.temperature)
             gscat = jnp.zeros_like(state.temperature)
@@ -91,16 +107,16 @@ class JamOpticsTerm(PhysicsTerm):
                 for sp in mode.species:
                     mass = state.tracers.get(mass_name(sp, mode.short), zeros)
                     v = mass / self._spec.species_props(sp).density
-                    n_sp, k_sp = ri[sp]
-                    vol_n = vol_n + v * float(n_sp[b])
-                    vol_k = vol_k + v * float(k_sp[b])
+                    n_sp, k_sp = ri_band[sp]
+                    vol_n = vol_n + v * n_sp
+                    vol_k = vol_k + v * k_sp
                     vol_tot = vol_tot + v
                 v_water = aer.number[i] * _FOUR_THIRDS_PI * jnp.maximum(
                     r_wet ** 3 - aer.r_dry[i] ** 3, 0.0
                 )
-                n_w, k_w = ri["h2o"]
-                vol_n = vol_n + v_water * float(n_w[b])
-                vol_k = vol_k + v_water * float(k_w[b])
+                n_w, k_w = ri_band["h2o"]
+                vol_n = vol_n + v_water * n_w
+                vol_k = vol_k + v_water * k_w
                 vol_tot = vol_tot + v_water
 
                 safe = jnp.maximum(vol_tot, _TINY)
@@ -112,13 +128,13 @@ class JamOpticsTerm(PhysicsTerm):
                 aod = aod + aod_i
                 scat = scat + ssa * aod_i
                 gscat = gscat + g * ssa * aod_i
-            aod_bands.append(aod)
-            ssa_bands.append(scat / jnp.maximum(aod, _TINY))
-            asy_bands.append(gscat / jnp.maximum(scat, _TINY))
-        if not aod_bands:
-            empty = jnp.zeros((0,) + state.temperature.shape)
-            return empty, empty, empty
-        return (jnp.stack(aod_bands), jnp.stack(ssa_bands), jnp.stack(asy_bands))
+            return (
+                aod,
+                scat / jnp.maximum(aod, _TINY),
+                gscat / jnp.maximum(scat, _TINY),
+            )
+
+        return jax.vmap(one_band)(lam_all, ri_j)
 
     def __call__(self, state, diagnostics, forcing, terrain):
         aer = diagnostics["_jam_state"]

--- a/jcm/physics/aerosol/jam/optics/optics_term.py
+++ b/jcm/physics/aerosol/jam/optics/optics_term.py
@@ -25,7 +25,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from jcm.physics.aerosol.jam.microphysics.mam4_data import MAM4_SPEC
-from jcm.physics.aerosol.jam.optics.mie_lut import build_mie_lut, interp_mie
+from jcm.physics.aerosol.jam.optics.mie_lut import default_mie_lut, interp_mie
 from jcm.physics.aerosol.jam.optics.refractive_index import refractive_index_at
 from jcm.physics.aerosol.jam.population import ModalAerosolSpec
 from jcm.physics.aerosol.jam.tracer_layout import mass_name
@@ -58,7 +58,7 @@ class JamOpticsTerm(PhysicsTerm):
     def __init__(self, *, spec: ModalAerosolSpec | None = None):
         """Build the Mie lookup table and hold the population."""
         self._spec = spec or MAM4_SPEC
-        self._lut = build_mie_lut()
+        self._lut = default_mie_lut()
         self._cache = None   # set by cache_band_config
 
     def cache_band_config(self, band_config) -> None:

--- a/jcm/physics/aerosol/jam/optics/optics_term_test.py
+++ b/jcm/physics/aerosol/jam/optics/optics_term_test.py
@@ -1,0 +1,118 @@
+"""Tests for refractive indices and the JamOpticsTerm."""
+
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from jcm.physics.aerosol.jam import MAM4_SPEC, mass_name, number_name
+from jcm.physics.aerosol.jam.jam_state import JamAerosolState
+from jcm.physics.aerosol.jam.optics.optics_term import JamOpticsTerm
+from jcm.physics.aerosol.jam.optics.refractive_index import refractive_index_at
+from jcm.physics.radiation.band_config import RadiationBandConfig
+
+
+class RefractiveIndexTest(unittest.TestCase):
+    def test_black_carbon_strongly_absorbing(self):
+        _, k = refractive_index_at("bc", jnp.array([550.0]))
+        self.assertGreater(float(k[0]), 0.5)
+
+    def test_sulfate_transparent_in_sw_absorbing_in_lw(self):
+        _, k_sw = refractive_index_at("so4", jnp.array([550.0]))
+        _, k_lw = refractive_index_at("so4", jnp.array([10000.0]))
+        self.assertLess(float(k_sw[0]), 1e-6)
+        self.assertGreater(float(k_lw[0]), 1e-2)
+
+    def test_interp_shape(self):
+        n, k = refractive_index_at("du", jnp.array([300.0, 550.0, 10000.0]))
+        self.assertEqual(n.shape, (3,))
+        self.assertTrue(np.all(np.isfinite(np.asarray(n))))
+
+
+def _setup(nlev=4, ncols=3, n_sw=3, n_lw=2):
+    from jcm.physics.aerosol.aerosol_types import AerosolData
+    from jcm.physics_interface import PhysicsState
+
+    n_modes = MAM4_SPEC.n_modes()
+    shape = (n_modes, nlev, ncols)
+    aer = JamAerosolState(
+        r_dry=jnp.full(shape, 0.1e-6),
+        r_wet=jnp.full(shape, 0.2e-6),
+        rho=jnp.full(shape, 1800.0),
+        kappa=jnp.full(shape, 0.5),
+        mass=jnp.full(shape, 1e-9),
+        number=jnp.full(shape, 1.0e8),
+    )
+    tracers = {}
+    for mode in MAM4_SPEC.modes:
+        tracers[number_name(mode.short)] = jnp.full((nlev, ncols), 1.0e8)
+        for sp in mode.species:
+            tracers[mass_name(sp, mode.short)] = jnp.full((nlev, ncols), 1e-9)
+    state = PhysicsState.zeros((nlev, ncols)).copy(
+        temperature=jnp.full((nlev, ncols), 285.0), tracers=tracers,
+    )
+    sw = tuple(float(x) for x in np.linspace(400.0, 1000.0, n_sw))
+    lw = tuple(float(x) for x in np.linspace(8000.0, 20000.0, n_lw))
+    band = RadiationBandConfig(lw_band_centers_nm=lw, sw_band_centers_nm=sw)
+    aerosol = AerosolData.zeros((ncols,), nlev, n_bnd_sw=n_sw, n_bnd_lw=n_lw)
+    diagnostics = {
+        "_jam_state": aer,
+        "aerosol": aerosol,
+        "air_density": jnp.full((nlev, ncols), 1.0),
+        "layer_thickness": jnp.full((nlev, ncols), 500.0),
+        "_band_config": band,
+    }
+    return state, diagnostics, band, n_sw, n_lw
+
+
+class JamOpticsTermTest(unittest.TestCase):
+    def _term(self, band):
+        term = JamOpticsTerm()
+        term.cache_band_config(band)
+        return term
+
+    def test_writes_finite_bounded_optics(self):
+        state, diagnostics, band, n_sw, n_lw = _setup()
+        term = self._term(band)
+        _, diag = term(state, diagnostics, None, None)
+        a = diag["aerosol"]
+        self.assertEqual(a.aod_sw_per_band.shape[0], n_sw)
+        self.assertEqual(a.aod_lw_per_band.shape[0], n_lw)
+        for arr in (a.aod_sw_per_band, a.aod_lw_per_band):
+            self.assertTrue(np.all(np.isfinite(np.asarray(arr))))
+            self.assertTrue(bool(jnp.all(arr >= 0.0)))
+        for arr in (a.ssa_sw_per_band, a.ssa_lw_per_band):
+            self.assertTrue(bool(jnp.all((arr >= 0.0) & (arr <= 1.0 + 1e-5))))
+        for arr in (a.asy_sw_per_band, a.asy_lw_per_band):
+            self.assertTrue(bool(jnp.all((arr >= -1.0 - 1e-5) & (arr <= 1.0 + 1e-5))))
+
+    def test_more_aerosol_more_aod(self):
+        state, diagnostics, band, *_ = _setup()
+        term = self._term(band)
+        _, d1 = term(state, diagnostics, None, None)
+        # double the mass tracers
+        state2 = state.copy(tracers={k: 2.0 * v for k, v in state.tracers.items()})
+        _, d2 = term(state2, diagnostics, None, None)
+        self.assertGreater(
+            float(jnp.sum(d2["aerosol"].aod_sw_per_band)),
+            float(jnp.sum(d1["aerosol"].aod_sw_per_band)),
+        )
+
+    def test_grad_through_mass(self):
+        state, diagnostics, band, *_ = _setup()
+        term = self._term(band)
+        key = mass_name("bc", "acc")
+
+        def loss(scale):
+            tr = {k: (v * scale if k == key else v) for k, v in state.tracers.items()}
+            s = state.copy(tracers=tr)
+            _, d = term(s, diagnostics, None, None)
+            return jnp.sum(d["aerosol"].aod_sw_per_band)
+
+        g = jax.grad(loss)(jnp.asarray(1.0))
+        self.assertTrue(np.isfinite(float(g)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jcm/physics/aerosol/jam/optics/refractive_index.py
+++ b/jcm/physics/aerosol/jam/optics/refractive_index.py
@@ -1,0 +1,71 @@
+"""Per-species complex refractive indices vs wavelength.
+
+Representative complex refractive indices ``m = n − i·k`` (radiative
+convention: positive ``k`` is absorbing) for the JAM species, tabulated at a
+handful of anchor wavelengths spanning the shortwave and longwave and
+interpolated in ``log10(λ)`` (constant extrapolation outside the anchors).
+
+These are **first-cut representative values** drawn from the standard
+literature — OPAC / Hess et al. (1998), Stier et al. (2005), Sokolik & Toon
+(1999) for dust, Hale & Querry (1973) for water — not full spectral tables.
+They capture the dominant contrasts (BC strongly absorbing and ~grey; sulfate/
+sea-salt transparent in the SW and absorbing in the LW; dust moderately
+absorbing with a strong LW silicate feature; organics weakly absorbing). A
+band-resolved spectral upgrade is a follow-up.
+
+``refractive_index_at(species, wavelength_nm)`` returns ``(n, k)`` arrays.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+
+# Anchor wavelengths (µm).
+_LAM_UM = np.array([0.30, 0.55, 1.0, 3.0, 10.0, 25.0])
+
+# token -> (n[anchors], k[anchors]). Same length as _LAM_UM.
+_RI: dict[str, tuple[list[float], list[float]]] = {
+    # sulfate: transparent SW, absorbing LW (sulfate ν3 band near 9 µm).
+    "so4": ([1.45, 1.43, 1.42, 1.39, 1.85, 1.90],
+            [1e-8, 1e-8, 1e-6, 1.6e-2, 0.46, 0.20]),
+    "nh4": ([1.52, 1.50, 1.48, 1.40, 1.80, 1.85],
+            [1e-7, 1e-7, 1e-4, 2e-2, 0.40, 0.20]),
+    "no3": ([1.55, 1.53, 1.50, 1.42, 1.75, 1.80],
+            [1e-6, 1e-6, 1e-4, 3e-2, 0.30, 0.20]),
+    # black carbon: strongly absorbing, weakly dispersive.
+    "bc": ([1.80, 1.85, 1.90, 2.10, 2.40, 2.50],
+           [0.66, 0.71, 0.79, 0.93, 1.00, 1.00]),
+    # primary / secondary / marine organics: weakly absorbing.
+    "poa": ([1.55, 1.53, 1.52, 1.48, 1.55, 1.60],
+            [3e-2, 6e-3, 5e-3, 2e-2, 0.10, 0.12]),
+    "soa": ([1.50, 1.49, 1.48, 1.46, 1.52, 1.56],
+            [5e-3, 2e-3, 2e-3, 1.5e-2, 0.09, 0.11]),
+    "moa": ([1.53, 1.52, 1.51, 1.47, 1.53, 1.58],
+            [1e-2, 5e-3, 5e-3, 2e-2, 0.10, 0.12]),
+    # sea salt: transparent SW, LW bands.
+    "ss": ([1.51, 1.50, 1.49, 1.48, 1.40, 1.60],
+           [1e-8, 1e-8, 1e-6, 1e-3, 5e-2, 0.10]),
+    # dust: moderately absorbing SW, strong LW silicate (~9–10 µm) feature.
+    "du": ([1.56, 1.53, 1.52, 1.50, 1.90, 2.10],
+           [3e-2, 3e-3, 1e-3, 5e-3, 0.40, 0.30]),
+    # aerosol water (condensed phase).
+    "h2o": ([1.35, 1.33, 1.32, 1.42, 1.22, 1.50],
+            [1e-8, 1e-9, 1e-6, 1e-2, 5e-2, 0.40]),
+}
+
+_LOG_LAM = np.log10(_LAM_UM)
+
+
+def refractive_index_at(species: str, wavelength_nm):
+    """Interpolated ``(n, k)`` for ``species`` at ``wavelength_nm`` (array).
+
+    ``wavelength_nm`` may be any shape; ``n``/``k`` are returned with that
+    shape. Interpolation is linear in ``log10(λ)`` with constant ends.
+    """
+    n_anchor, k_anchor = _RI[species]
+    log_lam = jnp.log10(jnp.asarray(wavelength_nm) / 1000.0)  # nm → µm → log10
+    xp = jnp.asarray(_LOG_LAM)
+    n = jnp.interp(log_lam, xp, jnp.asarray(n_anchor))
+    k = jnp.interp(log_lam, xp, jnp.asarray(k_anchor))
+    return n, k

--- a/jcm/physics/aerosol/macv2_sp.py
+++ b/jcm/physics/aerosol/macv2_sp.py
@@ -484,6 +484,10 @@ class Macv2SpAerosol(PhysicsTerm):
         # Default 14 covers the standard RRTMGP SW gas-optics file so
         # standalone construction (no ComposablePhysics) still works.
         self._n_bnd_sw: int = 14
+        # LW band count for the carry slot's LW optics (zero for MACv2-SP,
+        # populated by the JAM optics term, #495). 16 covers the standard
+        # RRTMGP LW gas-optics file for standalone construction.
+        self._n_bnd_lw: int = 16
 
     def cache_coords(self, coords) -> None:
         """Cache per-column lat/lon (degrees) from the coordinate system.
@@ -513,9 +517,10 @@ class Macv2SpAerosol(PhysicsTerm):
         ``aerosol`` carry agree with what ``__call__`` writes back.
         """
         self._n_bnd_sw = len(band_config.sw_band_centers_nm)
+        self._n_bnd_lw = len(band_config.lw_band_centers_nm)
 
     def initial_carry_state(self, coords):
-        """Zero-fill the aerosol carry slot at the active SW band count."""
+        """Zero-fill the aerosol carry slot at the active SW/LW band counts."""
         ncols = (
             coords.horizontal.nodal_shape[0]
             * coords.horizontal.nodal_shape[1]
@@ -523,7 +528,8 @@ class Macv2SpAerosol(PhysicsTerm):
         nlev = coords.nodal_shape[0]
         return {
             "aerosol": AerosolData.zeros(
-                (ncols,), nlev, n_bnd_sw=self._n_bnd_sw,
+                (ncols,), nlev,
+                n_bnd_sw=self._n_bnd_sw, n_bnd_lw=self._n_bnd_lw,
             )
         }
 
@@ -550,9 +556,13 @@ class Macv2SpAerosol(PhysicsTerm):
             band_config.sw_band_centers_nm, dtype=jnp.float32,
         )
         n_bnd_sw = sw_band_centers_nm.shape[0]
+        n_bnd_lw = len(band_config.lw_band_centers_nm)
 
         prev = diagnostics.get(
-            "aerosol", AerosolData.zeros((ncols,), nlev, n_bnd_sw=n_bnd_sw),
+            "aerosol",
+            AerosolData.zeros(
+                (ncols,), nlev, n_bnd_sw=n_bnd_sw, n_bnd_lw=n_bnd_lw,
+            ),
         )
         new_aerosol = get_simple_aerosol(
             height_full=diagnostics["height_full"],

--- a/jcm/physics/composable_physics.py
+++ b/jcm/physics/composable_physics.py
@@ -349,6 +349,9 @@ class ComposablePhysics(nnx.Module, Physics):
         "aerosol.aod_sw_per_band",
         "aerosol.ssa_sw_per_band",
         "aerosol.asy_sw_per_band",
+        "aerosol.aod_lw_per_band",
+        "aerosol.ssa_lw_per_band",
+        "aerosol.asy_lw_per_band",
     })
 
     def data_struct_to_dict(

--- a/jcm/physics/radiation/grey_two_stream/radiation_scheme.py
+++ b/jcm/physics/radiation/grey_two_stream/radiation_scheme.py
@@ -729,6 +729,17 @@ class GreyTwoStreamRadiation(PhysicsTerm):
             asy_sw_per_band=jnp.transpose(
                 aerosol_in.asy_sw_per_band, (2, 0, 1)
             ),
+            # LW per-band fields (zero-width for grey) need the same
+            # column-leading layout so every vmapped leaf shares axis 0 = ncols.
+            aod_lw_per_band=jnp.transpose(
+                aerosol_in.aod_lw_per_band, (2, 0, 1)
+            ),
+            ssa_lw_per_band=jnp.transpose(
+                aerosol_in.ssa_lw_per_band, (2, 0, 1)
+            ),
+            asy_lw_per_band=jnp.transpose(
+                aerosol_in.asy_lw_per_band, (2, 0, 1)
+            ),
         )
 
         tendencies_vmapped, diagnostics_vmapped = jax.vmap(

--- a/jcm/physics/radiation/grey_two_stream/radiation_scheme_test.py
+++ b/jcm/physics/radiation/grey_two_stream/radiation_scheme_test.py
@@ -76,6 +76,9 @@ def create_default_aerosol_data(nlev=10, parameters=None, ncols=1):
         aod_sw_per_band=aod_per_band,
         ssa_sw_per_band=ssa_per_band,
         asy_sw_per_band=asy_per_band,
+        aod_lw_per_band=jnp.zeros_like(aod_per_band),
+        ssa_lw_per_band=jnp.zeros_like(ssa_per_band),
+        asy_lw_per_band=jnp.zeros_like(asy_per_band),
     )
 
 

--- a/jcm/physics/radiation/rrtmgp.py
+++ b/jcm/physics/radiation/rrtmgp.py
@@ -648,6 +648,17 @@ def radiation_scheme_rrtmgp(
             "asymmetry_factor": _to_4d_per_band(aerosol_data.asy_sw_per_band),
         }
 
+    # Per-LW-band aerosol optics from the JAM online-aerosol optics term (#495).
+    # Zero/absent for MACv2-SP (SW-only) → ``aerosol_optics_lw=None``.
+    aerosol_optics_lw: Optional[dict[str, jnp.ndarray]] = None
+    if (hasattr(aerosol_data, "aod_lw_per_band")
+            and aerosol_data.aod_lw_per_band.shape[0] > 0):
+        aerosol_optics_lw = {
+            "optical_depth":   _to_4d_per_band(aerosol_data.aod_lw_per_band),
+            "ssa":             _to_4d_per_band(aerosol_data.ssa_lw_per_band),
+            "asymmetry_factor": _to_4d_per_band(aerosol_data.asy_lw_per_band),
+        }
+
     zenith_angle = jnp.arccos(jnp.clip(cos_zenith, 0.0, 1.0))
     irrad_val = jnp.maximum(toa_flux, 0.0)
 
@@ -659,6 +670,7 @@ def radiation_scheme_rrtmgp(
         cloud_path_ice_sw_per_gpt=cpi_sw_4d,
         vmr_fields=vmr_fields or None,
         aerosol_optics_sw=aerosol_optics_sw,
+        aerosol_optics_lw=aerosol_optics_lw,
         **rrtmgp_input,
     )
 
@@ -672,6 +684,7 @@ def radiation_scheme_rrtmgp(
             zenith=zenith_angle, irrad=irrad_val,
             vmr_fields=vmr_fields or None,
             aerosol_optics_sw=aerosol_optics_sw,
+            aerosol_optics_lw=aerosol_optics_lw,
             **rrtmgp_input,
         )
         toa_sw_up_clear = (
@@ -876,6 +889,12 @@ class RRTMGPRadiation(PhysicsTerm):
         # transpose to ``(ncols, n_bnd_sw, nlev)`` so the column axis is
         # leading (vmap-friendly).
         n_bnd_sw = aerosol_in.aod_sw_per_band.shape[0]
+        n_bnd_lw = aerosol_in.aod_lw_per_band.shape[0]
+
+        def _per_band_to_col(arr, n_bnd):
+            """(n_bnd, nlev, ncols) → (ncols, n_bnd, nlev) for the column vmap."""
+            return arr.reshape(n_bnd, nlev, ncols).transpose(2, 0, 1)
+
         aerosol_for_vmap = aerosol_in.copy(
             aod_profile=aerosol_in.aod_profile.reshape(nlev, ncols).T,
             ssa_profile=aerosol_in.ssa_profile.reshape(nlev, ncols).T,
@@ -885,12 +904,12 @@ class RRTMGPRadiation(PhysicsTerm):
             aod_anthropogenic=aerosol_in.aod_anthropogenic.reshape(ncols),
             aod_background=aerosol_in.aod_background.reshape(ncols),
             angstrom=aerosol_in.angstrom.reshape(ncols),
-            aod_sw_per_band=aerosol_in.aod_sw_per_band.reshape(
-                n_bnd_sw, nlev, ncols).transpose(2, 0, 1),
-            ssa_sw_per_band=aerosol_in.ssa_sw_per_band.reshape(
-                n_bnd_sw, nlev, ncols).transpose(2, 0, 1),
-            asy_sw_per_band=aerosol_in.asy_sw_per_band.reshape(
-                n_bnd_sw, nlev, ncols).transpose(2, 0, 1),
+            aod_sw_per_band=_per_band_to_col(aerosol_in.aod_sw_per_band, n_bnd_sw),
+            ssa_sw_per_band=_per_band_to_col(aerosol_in.ssa_sw_per_band, n_bnd_sw),
+            asy_sw_per_band=_per_band_to_col(aerosol_in.asy_sw_per_band, n_bnd_sw),
+            aod_lw_per_band=_per_band_to_col(aerosol_in.aod_lw_per_band, n_bnd_lw),
+            ssa_lw_per_band=_per_band_to_col(aerosol_in.ssa_lw_per_band, n_bnd_lw),
+            asy_lw_per_band=_per_band_to_col(aerosol_in.asy_lw_per_band, n_bnd_lw),
         )
 
         # Auto-pick chunk size from device HBM (see chunk_budget()).

--- a/jcm/physics/radiation/rrtmgp.py
+++ b/jcm/physics/radiation/rrtmgp.py
@@ -965,6 +965,9 @@ class RRTMGPRadiation(PhysicsTerm):
                 aod_sw_per_band=split_col(aerosol_for_vmap.aod_sw_per_band),
                 ssa_sw_per_band=split_col(aerosol_for_vmap.ssa_sw_per_band),
                 asy_sw_per_band=split_col(aerosol_for_vmap.asy_sw_per_band),
+                aod_lw_per_band=split_col(aerosol_for_vmap.aod_lw_per_band),
+                ssa_lw_per_band=split_col(aerosol_for_vmap.ssa_lw_per_band),
+                asy_lw_per_band=split_col(aerosol_for_vmap.asy_lw_per_band),
             ),
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jcm"
-version = "2.0.0b1"
+version = "2.1.0b0"
 dynamic = ["dependencies"]
 description = "JAX-based General Circulation Model"
 authors = [


### PR DESCRIPTION
## Summary

Gives online JAM aerosol a **direct radiative effect** (#495): a self-contained
JAX-Mie optics pathway that computes per-band SW **and** LW aerosol optical
depth / single-scattering albedo / asymmetry from the modal population and
feeds them to radiation. This removes the architectural crutch the harness left
in place — radiation no longer depends solely on MACv2-SP for aerosol optics.

- **`mie.py`** — NumPy Bohren–Huffman Mie kernel `(q_ext, ssa, g)(x, mr, mi)`,
  validated to 1e-4 against an independent scipy-Bessel implementation across
  Rayleigh, resonance, large-x and strongly-absorbing regimes.
- **`mie_lut.py`** — the kernel builds a Mie lookup table **once at
  construction** (~4 s, memoised per process); the per-step path is a
  differentiable trilinear interpolation. This keeps the expensive Mie series
  off the float32 jitted path (the kernel needs float64).
- **`refractive_index.py`** — per-species complex refractive indices
  (representative OPAC / Stier 2005 / Sokolik-Toon / Hale-Querry values),
  interpolated to the active band centers.
- **`optics_term.py`** — `JamOpticsTerm` forms the per-mode volume-mixed
  complex index (dry species + aerosol water from `r_wet`/`r_dry`), the size
  parameter `x = 2π r_wet/λ`, looks up the Mie efficiencies and accumulates
  extinction across modes (SSA/asymmetry extinction-/scattering-weighted),
  writing the result into the `aerosol` diagnostic.
- **Plumbing** — `AerosolData` gains LW per-band fields; MACv2-SP sizes its
  carry's LW bands from the band config; RRTMGP builds `aerosol_optics_lw` and
  passes it to both all-sky and clear-sky calls. `jam_aerosol_physics` composes
  `JamOpticsTerm` (after the core, before radiation; `optics=True`).

Fully differentiable end to end (gradient flows through the interpolation).

## Scope / what reviewers should know

- **Direct effect only.** SW optics overwrite MACv2-SP's `aerosol` optics
  fields; LW optics populate the new LW fields. MACv2-SP is still composed in
  the JAM path **only** for its indirect (Twomey `cdnc_factor` / SPA `Nccn`)
  fields — those aren't part of #495. So this is the first step of "replace
  MACv2-SP", not the whole thing.
- **Refractive indices are representative first-cut values**, not full spectral
  tables — they capture the dominant contrasts (BC strongly absorbing & ~grey;
  sulfate/sea-salt transparent in SW, absorbing in LW; dust LW silicate
  feature). A band-resolved spectral upgrade is a follow-up.
- **Optical mixing** is the volume-average rule (Stier et al. 2005) with
  single-particle Mie at the mode's wet radius; full size-distribution
  integration / Maxwell-Garnett core-shell (BC) are refinements.

Stacked on #497 (JAM harness); base will move to `dev` once that merges.

## Test plan

- [x] `pytest jcm/physics/aerosol/jam/optics -m "not slow"` — Mie reference
  values + limits, LUT accuracy vs the kernel, optics finiteness/bounds/
  monotonicity, gradient through aerosol mass, RRTMGP+JAM composition validation.
- [x] Full jam fast suite unaffected (optics wired into the factory).
- [x] Slow T21 integration: JAM optics + RRTMGP + 2M runs finite end-to-end
  (SW+LW aerosol optics consumed by RRTMGP); placeholder-radiation integration
  still finite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
