### PR TITLE
feat(aerosol): gas-phase + aqueous sulfur chemistry feeding the MAM4-JAX core (#496)

### DIFF
--- a/jcm/constants.py
+++ b/jcm/constants.py
@@ -134,6 +134,11 @@ class PhysicalConstants(NamedTuple):
         """Molar mass of water (kg/mol) = eps·M_air."""
         return self.eps * self.m_air
 
+    @property
+    def avogadro(self) -> float:
+        """Avogadro constant (1/mol) = R*/k_B."""
+        return self.r_universal / self.ak
+
     @classmethod
     def default(cls) -> 'PhysicalConstants':
         """Return the default physical constants."""

--- a/jcm/physics/aerosol/jam/chemistry/__init__.py
+++ b/jcm/physics/aerosol/jam/chemistry/__init__.py
@@ -1,0 +1,6 @@
+"""Gas-phase + aqueous sulfur chemistry for the JAM aerosol harness (#496).
+
+Provides the prescribed-oxidant fields and the sulfur-oxidation terms that
+supply gas-phase H₂SO₄/SOAG to the MAM4-JAX core and in-cloud sulfate to the
+cloud-borne population.
+"""

--- a/jcm/physics/aerosol/jam/chemistry/aqueous.py
+++ b/jcm/physics/aerosol/jam/chemistry/aqueous.py
@@ -30,6 +30,12 @@ Adaptations for jcm/MAM4:
 
 Runs in the **post-cloud** block (needs the current step's cloud water /
 fraction), alongside wet deposition.
+
+A lightweight alternative is available via ``scheme="simple"``
+(:func:`_simple_aqueous_so4`): H₂O₂-limited stoichiometric oxidation with no
+Henry's law, pH or O₃ path. CAM's ``mo_setsox`` is *not* simpler than the full
+port here (it solves a 20-iteration electroneutrality pH including NH₃/HNO₃/CO₂),
+so this reduced scheme — not a CAM port — is the simple option.
 """
 
 from __future__ import annotations
@@ -66,6 +72,7 @@ _H_SO2_0, _H_SO2_ACT = 1.23, 3020.0
 # Molar masses in g/mol (HAM works in grams).
 _MW_SO2 = GAS_SPECIES["so2"].molar_mass * 1000.0          # 64.0648
 _MW_SO4 = SPECIES["so4"].molar_mass * 1000.0             # 115.0 (jcm so4)
+_MW_AIR = c.m_air * 1000.0                               # ~28.96
 _CONV_SO2_SO4_MASS = _MW_SO4 / _MW_SO2
 
 _TINY = 1.0e-30
@@ -151,6 +158,24 @@ def _aqueous_so4(so2, so4, h2o2, o3, lwc, rho, temperature, dt):
     return dso2tot * _CONV_SO2_SO4_MASS
 
 
+def _simple_aqueous_so4(so2, h2o2, rho):
+    """H₂O₂-limited fast in-cloud oxidation — the simple scheme.
+
+    Assumes ``SO₂(aq) + H₂O₂(aq) → S(VI)`` goes to completion within the step,
+    limited by whichever of SO₂/H₂O₂ is scarcer (1:1 stoichiometry) — no
+    Henry's-law partitioning, no pH, no O₃ path. ``so2`` is a mass mixing ratio
+    [kg/kg], ``h2o2`` a number density [molec cm⁻³], ``rho`` air density
+    [kg m⁻³]. Returns the in-cloud SO₄ mass produced [kg/kg]; the term applies
+    the cloud-fraction weighting and the S-conserving SO₂ sink.
+    """
+    n_air = rho * _AVO_XTOC / _MW_AIR                       # molec/cm³
+    h2o2_molefrac = h2o2 / jnp.maximum(n_air, _TINY)
+    # SO₂ mass an equal number of moles of H₂O₂ can oxidise (1:1).
+    h2o2_as_so2 = h2o2_molefrac * (_MW_SO2 / _MW_AIR)
+    so2_oxidised = jnp.minimum(jnp.maximum(so2, 0.0), h2o2_as_so2)
+    return so2_oxidised * _CONV_SO2_SO4_MASS
+
+
 @tree_math.struct
 class AqueousSulfurParameters:
     """Tunable knob for the aqueous oxidation (differentiable)."""
@@ -163,7 +188,14 @@ class AqueousSulfurParameters:
 
 
 class AqueousSulfur(PhysicsTerm):
-    """In-cloud SO₂ + H₂O₂/O₃ oxidation → cloud-borne sulfate."""
+    """In-cloud SO₂ + H₂O₂/O₃ oxidation → cloud-borne sulfate.
+
+    ``scheme="full"`` (default) runs the complete HAM ``ham_wet_chemistry``
+    port (Henry's law + per-sub-step pH + H₂O₂ and O₃ paths). ``scheme="simple"``
+    runs the lightweight H₂O₂-limited approximation (:func:`_simple_aqueous_so4`):
+    stoichiometric SO₂+H₂O₂ with no Henry/pH/O₃ — cheaper and easier to reason
+    about, capturing the dominant in-cloud pathway.
+    """
 
     name: ClassVar[str] = "jam_aqueous_sulfur"
     category: ClassVar[str] = "aerosol_aqueous_chemistry"
@@ -177,10 +209,16 @@ class AqueousSulfur(PhysicsTerm):
         params: AqueousSulfurParameters | None = None,
         *,
         spec: ModalAerosolSpec | None = None,
+        scheme: str = "full",
     ):
-        """Hold params and the population."""
+        """Hold params, the population, and the aqueous scheme."""
         self.params = nnx.Param(params or AqueousSulfurParameters.default())
         self._spec = spec or MAM4_SPEC
+        if scheme not in ("full", "simple"):
+            raise ValueError(
+                f"Unknown aqueous scheme {scheme!r}; choose 'full' or 'simple'."
+            )
+        self._scheme = scheme
         # Modes carrying sulfate that can host cloud-borne SO4 (accum, coarse).
         self._so4_modes = tuple(
             m.short for m in self._spec.modes if "so4" in m.species
@@ -213,16 +251,21 @@ class AqueousSulfur(PhysicsTerm):
             for m in self._so4_modes
         )
 
-        dso4 = params.rate_scale * _aqueous_so4(
-            so2=jnp.maximum(so2, 0.0),
-            so4=jnp.maximum(so4_total, 0.0),
-            h2o2=jnp.maximum(ox.h2o2, 0.0),
-            o3=jnp.maximum(ox.o3, 0.0),
-            lwc=lwc_incloud,
-            rho=rho,
-            temperature=state.temperature,
-            dt=dt,
-        )
+        if self._scheme == "simple":
+            dso4 = params.rate_scale * _simple_aqueous_so4(
+                so2=so2, h2o2=jnp.maximum(ox.h2o2, 0.0), rho=rho,
+            )
+        else:
+            dso4 = params.rate_scale * _aqueous_so4(
+                so2=jnp.maximum(so2, 0.0),
+                so4=jnp.maximum(so4_total, 0.0),
+                h2o2=jnp.maximum(ox.h2o2, 0.0),
+                o3=jnp.maximum(ox.o3, 0.0),
+                lwc=lwc_incloud,
+                rho=rho,
+                temperature=state.temperature,
+                dt=dt,
+            )
         dso4 = jnp.where(active, dso4, 0.0)
 
         # Grid-mean rates: produced sulfate is in-cloud, so weight by the

--- a/jcm/physics/aerosol/jam/chemistry/aqueous.py
+++ b/jcm/physics/aerosol/jam/chemistry/aqueous.py
@@ -47,6 +47,7 @@ from jcm.physics.aerosol.jam.species import SPECIES
 from jcm.physics.aerosol.jam.tracer_layout import mass_name, number_name
 from jcm.physics.physics_term import PhysicsTerm
 from jcm.physics_interface import PhysicsTendency
+import jcm.constants as c
 
 # --- HAM constants (mo_ham_chemistry.f90) ---------------------------------
 _NITER = 5
@@ -54,10 +55,11 @@ _ZHPBASE = 2.5e-6          # background H+ [mol/l]
 _ZE1K, _ZE1H = 1.1e-2, 2300.0   # O3 Henry
 _ZE3K, _ZE3H = 1.2e-2, 2010.0   # SO2 first dissociation
 _ZQ298 = 1.0 / 298.0
-_ZRGAS = 8.2e-2           # R [l·atm/mol/K]
+# Gas constant in l·atm/mol/K (HAM ``zrgas``), from R* (1 l·atm = 101.325 J).
+_ZRGAS = c.r_universal / 101.325
 _ZLWCMIN = 1.0e-7         # in-cloud LWC threshold [kg/kg]
-_AVO_XTOC = 6.022e20      # HAM's xtoc/ctox factor (avo with unit folding)
-_AVOGADRO = 6.022e23      # molec/mol
+_AVOGADRO = c.avogadro    # molec/mol
+_AVO_XTOC = _AVOGADRO * 1.0e-3   # HAM's xtoc/ctox factor (avo·1e-3 unit fold)
 # SO2 Henry's-law (H0 [mol/l/atm], activation [K]) — HAMMOZ speclist(id_so2).
 _H_SO2_0, _H_SO2_ACT = 1.23, 3020.0
 
@@ -67,6 +69,7 @@ _MW_SO4 = SPECIES["so4"].molar_mass * 1000.0             # 115.0 (jcm so4)
 _CONV_SO2_SO4_MASS = _MW_SO4 / _MW_SO2
 
 _TINY = 1.0e-30
+_NC_MIN = 1.0      # cloud-borne number [kg⁻¹] below which a mode hosts no droplets
 
 
 def _xtoc(rho: jnp.ndarray, mw: float) -> jnp.ndarray:
@@ -182,6 +185,13 @@ class AqueousSulfur(PhysicsTerm):
         self._so4_modes = tuple(
             m.short for m in self._spec.modes if "so4" in m.species
         )
+        # Fallback "droplet" mode for sulfate produced where no cloud-borne
+        # number exists yet — HAM assigns it to the coarse mode (Seinfeld &
+        # Pandis 1998); fall back to the last sulfate mode if there is none.
+        self._droplet_mode = next(
+            (m.short for m in self._spec.modes if m.name == "coarse"),
+            self._so4_modes[-1],
+        )
 
     def __call__(self, state, diagnostics, forcing, terrain):
         params = self.params.get_value()
@@ -220,19 +230,27 @@ class AqueousSulfur(PhysicsTerm):
         so4_rate = cloud_fraction * dso4 / dt
         so2_rate = -so4_rate * (_MW_SO2 / _MW_SO4)   # S-conserving SO2 sink
 
-        # Distribute the cloud-borne sulfate over accum/coarse by their
-        # cloud-borne number fraction (HAM ms4as/ms4cs split).
+        # Distribute the cloud-borne sulfate over the sulfate modes by their
+        # cloud-borne number fraction (HAM ms4as/ms4cs split). Where a cell has
+        # no cloud-borne number yet (spin-up, or a column without cloud-borne
+        # aerosol) the fractions would all be zero and the sulfur consumed by
+        # the SO2 sink would vanish; HAM instead deposits that droplet sulfate
+        # in the coarse mode, so ``frac`` falls back to 1 there. The fractions
+        # always sum to 1, so the produced sulfate exactly matches the SO2 sink.
         nc = {
             m: jnp.maximum(
                 state.tracers.get(number_name(m, cloud_borne=True), zeros), 0.0
             )
             for m in self._so4_modes
         }
-        nc_tot = jnp.maximum(sum(nc.values()), _TINY)
+        nc_sum = sum(nc.values())
+        has_number = nc_sum > _NC_MIN
+        nc_safe = jnp.maximum(nc_sum, _TINY)
 
         tracer_tends: dict[str, jnp.ndarray] = {"g_so2": so2_rate}
         for m in self._so4_modes:
-            frac = nc[m] / nc_tot
+            fallback = 1.0 if m == self._droplet_mode else 0.0
+            frac = jnp.where(has_number, nc[m] / nc_safe, fallback)
             tracer_tends[mass_name("so4", m, cloud_borne=True)] = so4_rate * frac
 
         tendency = PhysicsTendency(

--- a/jcm/physics/aerosol/jam/chemistry/aqueous.py
+++ b/jcm/physics/aerosol/jam/chemistry/aqueous.py
@@ -21,8 +21,12 @@ Adaptations for jcm/MAM4:
   HAM's ``ms4as``/``ms4cs`` distribution. SO₂ (``g_so2``) is consumed.
 * Sulfate molar mass uses jcm's ``so4`` species value (MAM4-MOM ammonium
   bisulfate, 115 g/mol) consistently in both the pH and the produced mass.
-* H₂O₂ is a prescribed reservoir here, so its in-cloud depletion is **not**
-  written back (it would be once H₂O₂ is prognostic — flagged in #496).
+* H₂O₂ is a prescribed oxidant. It is depleted *within* the ``niter``
+  sub-stepping (so the within-step H₂O₂-limitation of SO₂ oxidation is
+  respected) and reset to the prescribed field each step — this matches
+  ECHAM-HAM's offline-oxidant behaviour: ``ham_wet_chemistry`` likewise
+  discards the depleted H₂O₂ after its loop, and only a coupled MOZ-style
+  prognostic H₂O₂ budget (out of scope) would persist it across steps.
 
 Runs in the **post-cloud** block (needs the current step's cloud water /
 fraction), alongside wet deposition.

--- a/jcm/physics/aerosol/jam/chemistry/aqueous.py
+++ b/jcm/physics/aerosol/jam/chemistry/aqueous.py
@@ -1,0 +1,241 @@
+"""``AqueousSulfur`` — in-cloud SO₂ oxidation to cloud-borne sulfate (#496).
+
+Full port of ECHAM-HAM's ``mo_ham_chemistry.f90::ham_wet_chemistry`` (Feichter
+et al. 1996 aqueous sulfur chemistry), with **no simplification** of the
+kinetics: both the H₂O₂ and the O₃ pathways are integrated over ``niter=5``
+sub-steps, and the cloud-droplet pH (H⁺) is solved each sub-step from the
+sulfate/SO₂ charge balance (the quadratic in :func:`_aqueous_so4`), so the
+pH-dependent SO₂+O₃ rate uses the evolving acidity rather than a fixed pH.
+
+Rate/Henry constants are verbatim from HAM (``zhpbase``, ``ze1k/ze1h`` for O₃
+Henry, ``ze3k/ze3h`` for the SO₂ first dissociation, the SO₂ Henry coefficient,
+``za21/za22`` for the two SO₂+O₃ channels, the SO₂+H₂O₂ rate
+``8e4·exp(-3650·(1/T−1/298))/(0.1+[H⁺])``). The in-cloud liquid water and the
+``molec cm⁻³ ↔ mass-mixing-ratio`` conversions (``xtoc``/``ctox``) follow HAM.
+
+Adaptations for jcm/MAM4:
+* Oxidants (H₂O₂, O₃) arrive from the :mod:`oxidants` diagnostic already in
+  molec cm⁻³, so HAM's mmr→concentration step is skipped.
+* Product sulfate goes to the **cloud-borne** accumulation/coarse mass
+  (``mc_so4_acc``/``mc_so4_cor``), split by their cloud-borne number fraction —
+  HAM's ``ms4as``/``ms4cs`` distribution. SO₂ (``g_so2``) is consumed.
+* Sulfate molar mass uses jcm's ``so4`` species value (MAM4-MOM ammonium
+  bisulfate, 115 g/mol) consistently in both the pH and the produced mass.
+* H₂O₂ is a prescribed reservoir here, so its in-cloud depletion is **not**
+  written back (it would be once H₂O₂ is prognostic — flagged in #496).
+
+Runs in the **post-cloud** block (needs the current step's cloud water /
+fraction), alongside wet deposition.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import jax.numpy as jnp
+import tree_math
+from flax import nnx
+
+from jcm.physics.aerosol.jam.gas_species import GAS_SPECIES
+from jcm.physics.aerosol.jam.microphysics.mam4_data import MAM4_SPEC
+from jcm.physics.aerosol.jam.population import ModalAerosolSpec
+from jcm.physics.aerosol.jam.species import SPECIES
+from jcm.physics.aerosol.jam.tracer_layout import mass_name, number_name
+from jcm.physics.physics_term import PhysicsTerm
+from jcm.physics_interface import PhysicsTendency
+
+# --- HAM constants (mo_ham_chemistry.f90) ---------------------------------
+_NITER = 5
+_ZHPBASE = 2.5e-6          # background H+ [mol/l]
+_ZE1K, _ZE1H = 1.1e-2, 2300.0   # O3 Henry
+_ZE3K, _ZE3H = 1.2e-2, 2010.0   # SO2 first dissociation
+_ZQ298 = 1.0 / 298.0
+_ZRGAS = 8.2e-2           # R [l·atm/mol/K]
+_ZLWCMIN = 1.0e-7         # in-cloud LWC threshold [kg/kg]
+_AVO_XTOC = 6.022e20      # HAM's xtoc/ctox factor (avo with unit folding)
+_AVOGADRO = 6.022e23      # molec/mol
+# SO2 Henry's-law (H0 [mol/l/atm], activation [K]) — HAMMOZ speclist(id_so2).
+_H_SO2_0, _H_SO2_ACT = 1.23, 3020.0
+
+# Molar masses in g/mol (HAM works in grams).
+_MW_SO2 = GAS_SPECIES["so2"].molar_mass * 1000.0          # 64.0648
+_MW_SO4 = SPECIES["so4"].molar_mass * 1000.0             # 115.0 (jcm so4)
+_CONV_SO2_SO4_MASS = _MW_SO4 / _MW_SO2
+
+_TINY = 1.0e-30
+
+
+def _xtoc(rho: jnp.ndarray, mw: float) -> jnp.ndarray:
+    """Mass-mixing-ratio → molec cm⁻³ factor (HAM ``xtoc``: ``ρ·6.022e20/mw``)."""
+    return rho * _AVO_XTOC / mw
+
+
+def _aqueous_so4(so2, so4, h2o2, o3, lwc, rho, temperature, dt):
+    """In-cloud SO₂ oxidised to sulfate over ``niter`` sub-steps [kg/kg].
+
+    All faithful to ``ham_wet_chemistry``. ``so2``/``so4`` are in-cloud mass
+    mixing ratios [kg/kg]; ``h2o2``/``o3`` number densities [molec cm⁻³];
+    ``lwc`` the in-cloud liquid water [kg/kg]; ``rho`` air density [kg m⁻³].
+    Returns the SO₄ mass produced (mmr); SO₂ consumed = that ·(M_SO2/M_SO4).
+    """
+    qtp1 = 1.0 / temperature - _ZQ298
+    lwcl = jnp.maximum(lwc * rho * 1.0e-6, _TINY)   # [l-water/cm^3-air]
+    lwcv = lwc * rho * 1.0e-3                        # liquid volume fraction
+    # molec/cm^3(air) -> mol/l(water): HAM ``zfac1 = 1/(zlwcl·avo)``.
+    fac1 = 1.0 / (lwcl * _AVOGADRO)
+
+    # --- SO2 + H2O2 effective rate (pH from initial sulfate) ---
+    hp0 = _ZHPBASE + so4 * 1000.0 / (jnp.maximum(lwc, _TINY) * _MW_SO4)
+    rk = 8.0e4 * jnp.exp(-3650.0 * qtp1) / (0.1 + hp0)
+    rke = rk / (lwcl * _AVOGADRO)
+    h_so2 = _H_SO2_0 * jnp.exp(_H_SO2_ACT * qtp1)
+    pfac = _ZRGAS * lwcv * temperature
+    p_so2 = h_so2 * pfac
+    f_so2 = p_so2 / (1.0 + p_so2)
+    h_h2o2 = 9.7e4 * jnp.exp(6600.0 * qtp1)
+    p_h2o2 = h_h2o2 * pfac
+    f_h2o2 = p_h2o2 / (1.0 + p_h2o2)
+    rkh2o2 = rke * f_so2 * f_h2o2
+
+    # --- O3-path constants ---
+    e1 = _ZE1K * jnp.exp(_ZE1H * qtp1)
+    e3 = _ZE3K * jnp.exp(_ZE3H * qtp1)
+    za = h_so2 * _ZRGAS * temperature * lwcv
+    a21 = 4.39e11 * jnp.exp(-4131.0 / temperature)
+    a22 = 2.56e3 * jnp.exp(-926.0 / temperature)
+    ph_o3 = e1 * _ZRGAS * temperature * lwcv
+    f_o3 = ph_o3 / (1.0 + ph_o3)
+
+    so2m = so2 * _xtoc(rho, _MW_SO2)
+    so4m = so4 * _xtoc(rho, _MW_SO4)
+    h2o2m = h2o2
+    zdt = dt / _NITER
+
+    for _ in range(_NITER):
+        # H2O2 oxidation.
+        q = rkh2o2 * h2o2m
+        so2mh = so2m * jnp.exp(-q * zdt)
+        dso2h = so2m - so2mh
+        h2o2m = jnp.maximum(h2o2m - dso2h, 0.0)
+        so4m = so4m + dso2h
+        # pH from the SO2/sulfate charge balance (quadratic in H+).
+        so2l = so2mh * fac1
+        so4l = so4m * fac1
+        zb = _ZHPBASE + so4l
+        zp = (za * e3 - zb - za * zb) / (1.0 + za)
+        zq = -za * e3 * (zb + so2l) / (1.0 + za)
+        zp = 0.5 * zp
+        hp = -zp + jnp.sqrt(jnp.maximum(zp * zp - zq, 0.0))
+        qhp = 1.0 / jnp.maximum(hp, _TINY)
+        # SO2 + O3, pH-dependent.
+        a2 = (a21 + a22 * qhp) * fac1
+        heneff = 1.0 + e3 * qhp
+        p_so2b = za * heneff
+        f_so2b = p_so2b / (1.0 + p_so2b)
+        rko3 = a2 * f_o3 * f_so2b
+        q = o3 * rko3
+        so2mo = so2mh * jnp.exp(-q * zdt)
+        so4m = so4m + (so2mh - so2mo)
+        so2m = so2mo
+
+    # ctox: molec/cm3 -> mmr is mw/(6.022e20·rho); SO2 remaining as mmr.
+    so2_rem = so2m * (_MW_SO2 / (_AVO_XTOC * rho))
+    dso2tot = jnp.clip(so2 - so2_rem, 0.0, so2)
+    return dso2tot * _CONV_SO2_SO4_MASS
+
+
+@tree_math.struct
+class AqueousSulfurParameters:
+    """Tunable knob for the aqueous oxidation (differentiable)."""
+
+    rate_scale: jnp.ndarray   # multiplies the in-cloud SO4 production
+
+    @classmethod
+    def default(cls) -> "AqueousSulfurParameters":
+        return cls(rate_scale=jnp.asarray(1.0))
+
+
+class AqueousSulfur(PhysicsTerm):
+    """In-cloud SO₂ + H₂O₂/O₃ oxidation → cloud-borne sulfate."""
+
+    name: ClassVar[str] = "jam_aqueous_sulfur"
+    category: ClassVar[str] = "aerosol_aqueous_chemistry"
+    requires: ClassVar[tuple[str, ...]] = (
+        "oxidants", "clouds", "air_density",
+    )
+    provides: ClassVar[tuple[str, ...]] = ()
+
+    def __init__(
+        self,
+        params: AqueousSulfurParameters | None = None,
+        *,
+        spec: ModalAerosolSpec | None = None,
+    ):
+        """Hold params and the population."""
+        self.params = nnx.Param(params or AqueousSulfurParameters.default())
+        self._spec = spec or MAM4_SPEC
+        # Modes carrying sulfate that can host cloud-borne SO4 (accum, coarse).
+        self._so4_modes = tuple(
+            m.short for m in self._spec.modes if "so4" in m.species
+        )
+
+    def __call__(self, state, diagnostics, forcing, terrain):
+        params = self.params.get_value()
+        zeros = jnp.zeros_like(state.temperature)
+        ox = diagnostics["oxidants"]
+        clouds = diagnostics["clouds"]
+        rho = diagnostics["air_density"]
+        dt = jnp.asarray(diagnostics["_dt_seconds"], state.temperature.dtype)
+
+        cloud_fraction = jnp.clip(clouds.cloud_fraction, 0.0, 1.0)
+        # In-cloud liquid water (grid-mean qc divided by the cloudy fraction).
+        cf_safe = jnp.maximum(cloud_fraction, 1.0e-3)
+        lwc_incloud = jnp.maximum(clouds.qc, 0.0) / cf_safe
+        active = (cloud_fraction > 0.0) & (lwc_incloud > _ZLWCMIN)
+
+        so2 = state.tracers.get("g_so2", zeros)
+        so4_total = sum(
+            state.tracers.get(mass_name("so4", m), zeros)
+            for m in self._so4_modes
+        )
+
+        dso4 = params.rate_scale * _aqueous_so4(
+            so2=jnp.maximum(so2, 0.0),
+            so4=jnp.maximum(so4_total, 0.0),
+            h2o2=jnp.maximum(ox.h2o2, 0.0),
+            o3=jnp.maximum(ox.o3, 0.0),
+            lwc=lwc_incloud,
+            rho=rho,
+            temperature=state.temperature,
+            dt=dt,
+        )
+        dso4 = jnp.where(active, dso4, 0.0)
+
+        # Grid-mean rates: produced sulfate is in-cloud, so weight by the
+        # cloudy area fraction.
+        so4_rate = cloud_fraction * dso4 / dt
+        so2_rate = -so4_rate * (_MW_SO2 / _MW_SO4)   # S-conserving SO2 sink
+
+        # Distribute the cloud-borne sulfate over accum/coarse by their
+        # cloud-borne number fraction (HAM ms4as/ms4cs split).
+        nc = {
+            m: jnp.maximum(
+                state.tracers.get(number_name(m, cloud_borne=True), zeros), 0.0
+            )
+            for m in self._so4_modes
+        }
+        nc_tot = jnp.maximum(sum(nc.values()), _TINY)
+
+        tracer_tends: dict[str, jnp.ndarray] = {"g_so2": so2_rate}
+        for m in self._so4_modes:
+            frac = nc[m] / nc_tot
+            tracer_tends[mass_name("so4", m, cloud_borne=True)] = so4_rate * frac
+
+        tendency = PhysicsTendency(
+            u_wind=jnp.zeros_like(state.u_wind),
+            v_wind=jnp.zeros_like(state.v_wind),
+            temperature=jnp.zeros_like(state.temperature),
+            specific_humidity=jnp.zeros_like(state.specific_humidity),
+            tracers=tracer_tends,
+        )
+        return tendency, diagnostics

--- a/jcm/physics/aerosol/jam/chemistry/aqueous_test.py
+++ b/jcm/physics/aerosol/jam/chemistry/aqueous_test.py
@@ -1,0 +1,127 @@
+"""Phase 3 tests: in-cloud aqueous sulfur chemistry (#496)."""
+
+import types
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from jcm.physics.aerosol.jam.chemistry.aqueous import (
+    AqueousSulfur,
+    _aqueous_so4,
+    _CONV_SO2_SO4_MASS,
+)
+from jcm.physics.aerosol.jam.chemistry.oxidants import OxidantField
+from jcm.physics.aerosol.jam.tracer_layout import mass_name, number_name
+from jcm.physics_interface import PhysicsState
+
+
+def _f(**kw):
+    base = dict(
+        so2=1.0e-10, so4=1.0e-11, h2o2=1.0e10, o3=1.0e12,
+        lwc=3.0e-4, rho=1.0, temperature=275.0, dt=1800.0,
+    )
+    base.update(kw)
+    return _aqueous_so4(**{k: jnp.asarray(v) for k, v in base.items()})
+
+
+class AqueousKernelTest(unittest.TestCase):
+    def test_finite_and_bounded_by_available_so2(self):
+        dso4 = _f()
+        self.assertTrue(np.isfinite(float(dso4)))
+        self.assertGreaterEqual(float(dso4), 0.0)
+        # SO2 consumed (= dso4 / conv) cannot exceed the SO2 present.
+        self.assertLessEqual(float(dso4) / _CONV_SO2_SO4_MASS, 1.0e-10 + 1e-20)
+
+    def test_more_h2o2_more_sulfate(self):
+        low = float(_f(h2o2=1.0e8))
+        high = float(_f(h2o2=5.0e10))
+        self.assertGreater(high, low)
+
+    def test_no_so2_no_sulfate(self):
+        self.assertAlmostEqual(float(_f(so2=0.0)), 0.0)
+
+    def test_o3_path_active_without_h2o2(self):
+        # With H2O2 ~ 0 the O3 pathway still oxidises some SO2.
+        self.assertGreater(float(_f(h2o2=0.0, o3=2.0e12)), 0.0)
+
+
+class AqueousTermTest(unittest.TestCase):
+    def _setup(self, cloud_fraction=0.6, nlev=3, ncols=2):
+        from jcm.physics.aerosol.jam import MAM4_SPEC
+
+        shape = (nlev, ncols)
+        tracers = {"g_so2": jnp.full(shape, 1.0e-10)}
+        for m in (mm.short for mm in MAM4_SPEC.modes if "so4" in mm.species):
+            tracers[mass_name("so4", m)] = jnp.full(shape, 1.0e-11)
+            tracers[mass_name("so4", m, cloud_borne=True)] = jnp.full(shape, 1.0e-12)
+            tracers[number_name(m, cloud_borne=True)] = jnp.full(shape, 1.0e7)
+        state = PhysicsState.zeros(shape).copy(
+            temperature=jnp.full(shape, 275.0), tracers=tracers,
+        )
+        ox = OxidantField(
+            oh=jnp.full(shape, 1.0e6), no3=jnp.zeros(shape),
+            o3=jnp.full(shape, 1.0e12), h2o2=jnp.full(shape, 1.0e10),
+        )
+        diagnostics = {
+            "oxidants": ox,
+            "clouds": types.SimpleNamespace(
+                cloud_fraction=jnp.full(shape, cloud_fraction),
+                qc=jnp.full(shape, 2.0e-4),
+            ),
+            "air_density": jnp.full(shape, 1.0),
+            "_dt_seconds": 1800.0,
+        }
+        return state, diagnostics
+
+    def test_produces_cloud_borne_sulfate_and_consumes_so2(self):
+        state, diagnostics = self._setup()
+        tend, _ = AqueousSulfur()(state, diagnostics, None, None)
+        self.assertIn(mass_name("so4", "acc", cloud_borne=True), tend.tracers)
+        self.assertGreater(
+            float(tend.tracers[mass_name("so4", "acc", cloud_borne=True)][0, 0]),
+            0.0,
+        )
+        self.assertLess(float(tend.tracers["g_so2"][0, 0]), 0.0)
+
+    def test_sulfur_conserved(self):
+        from jcm.physics.aerosol.jam import MAM4_SPEC
+        from jcm.physics.aerosol.jam.chemistry.aqueous import _MW_SO2, _MW_SO4
+
+        state, diagnostics = self._setup()
+        tend, _ = AqueousSulfur()(state, diagnostics, None, None)
+        s_rate = np.asarray(tend.tracers["g_so2"]) / _MW_SO2
+        for m in (mm.short for mm in MAM4_SPEC.modes if "so4" in mm.species):
+            key = mass_name("so4", m, cloud_borne=True)
+            s_rate = s_rate + np.asarray(tend.tracers[key]) / _MW_SO4
+        self.assertTrue(np.all(np.abs(s_rate) < 1.0e-18))
+
+    def test_no_clouds_no_production(self):
+        state, diagnostics = self._setup(cloud_fraction=0.0)
+        tend, _ = AqueousSulfur()(state, diagnostics, None, None)
+        self.assertAlmostEqual(
+            float(tend.tracers[mass_name("so4", "acc", cloud_borne=True)][0, 0]),
+            0.0,
+        )
+
+    def test_grad_through_rate_scale_finite(self):
+        from jcm.physics.aerosol.jam.chemistry.aqueous import (
+            AqueousSulfurParameters,
+        )
+
+        state, diagnostics = self._setup()
+
+        def loss(scale):
+            term = AqueousSulfur(
+                params=AqueousSulfurParameters(rate_scale=scale)
+            )
+            tend, _ = term(state, diagnostics, None, None)
+            return sum(jnp.sum(v ** 2) for v in tend.tracers.values())
+
+        g = jax.grad(loss)(jnp.asarray(1.0))
+        self.assertTrue(np.isfinite(float(g)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jcm/physics/aerosol/jam/chemistry/aqueous_test.py
+++ b/jcm/physics/aerosol/jam/chemistry/aqueous_test.py
@@ -143,5 +143,63 @@ class AqueousTermTest(unittest.TestCase):
         self.assertTrue(np.isfinite(float(g)))
 
 
+class SimpleAqueousSchemeTest(unittest.TestCase):
+    def _setup(self, h2o2=1.0e10, so2=1.0e-10, nlev=3, ncols=2):
+        from jcm.physics.aerosol.jam import MAM4_SPEC
+
+        shape = (nlev, ncols)
+        tracers = {"g_so2": jnp.full(shape, so2)}
+        for m in (mm.short for mm in MAM4_SPEC.modes if "so4" in mm.species):
+            tracers[mass_name("so4", m)] = jnp.full(shape, 1.0e-11)
+            tracers[mass_name("so4", m, cloud_borne=True)] = jnp.full(shape, 1.0e-12)
+            tracers[number_name(m, cloud_borne=True)] = jnp.full(shape, 1.0e7)
+        state = PhysicsState.zeros(shape).copy(
+            temperature=jnp.full(shape, 275.0), tracers=tracers,
+        )
+        ox = OxidantField(
+            oh=jnp.zeros(shape), no3=jnp.zeros(shape),
+            o3=jnp.full(shape, 1.0e12), h2o2=jnp.full(shape, h2o2),
+        )
+        diagnostics = {
+            "oxidants": ox,
+            "clouds": types.SimpleNamespace(
+                cloud_fraction=jnp.full(shape, 0.6), qc=jnp.full(shape, 2.0e-4),
+            ),
+            "air_density": jnp.full(shape, 1.0),
+            "_dt_seconds": 1800.0,
+        }
+        return state, diagnostics
+
+    def test_invalid_scheme_raises(self):
+        with self.assertRaises(ValueError):
+            AqueousSulfur(scheme="bogus")
+
+    def test_simple_produces_sulfate_and_conserves_sulfur(self):
+        from jcm.physics.aerosol.jam import MAM4_SPEC
+        from jcm.physics.aerosol.jam.chemistry.aqueous import _MW_SO2, _MW_SO4
+
+        state, diagnostics = self._setup()
+        tend, _ = AqueousSulfur(scheme="simple")(state, diagnostics, None, None)
+        self.assertGreater(
+            float(tend.tracers[mass_name("so4", "acc", cloud_borne=True)][0, 0]),
+            0.0,
+        )
+        s_rate = np.asarray(tend.tracers["g_so2"]) / _MW_SO2
+        for m in (mm.short for mm in MAM4_SPEC.modes if "so4" in mm.species):
+            s_rate = s_rate + np.asarray(
+                tend.tracers[mass_name("so4", m, cloud_borne=True)]
+            ) / _MW_SO4
+        self.assertTrue(np.all(np.abs(s_rate) < 1.0e-18))
+
+    def test_simple_is_h2o2_limited(self):
+        # Scarce H2O2 caps the sulfate produced below the abundant-H2O2 case.
+        lo, _ = AqueousSulfur(scheme="simple")(*self._setup(h2o2=1.0e7)[:2], None, None)
+        hi, _ = AqueousSulfur(scheme="simple")(*self._setup(h2o2=1.0e11)[:2], None, None)
+        key = mass_name("so4", "acc", cloud_borne=True)
+        self.assertLess(
+            float(lo.tracers[key][0, 0]), float(hi.tracers[key][0, 0])
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/jcm/physics/aerosol/jam/chemistry/aqueous_test.py
+++ b/jcm/physics/aerosol/jam/chemistry/aqueous_test.py
@@ -48,7 +48,7 @@ class AqueousKernelTest(unittest.TestCase):
 
 
 class AqueousTermTest(unittest.TestCase):
-    def _setup(self, cloud_fraction=0.6, nlev=3, ncols=2):
+    def _setup(self, cloud_fraction=0.6, nc=1.0e7, nlev=3, ncols=2):
         from jcm.physics.aerosol.jam import MAM4_SPEC
 
         shape = (nlev, ncols)
@@ -56,7 +56,7 @@ class AqueousTermTest(unittest.TestCase):
         for m in (mm.short for mm in MAM4_SPEC.modes if "so4" in mm.species):
             tracers[mass_name("so4", m)] = jnp.full(shape, 1.0e-11)
             tracers[mass_name("so4", m, cloud_borne=True)] = jnp.full(shape, 1.0e-12)
-            tracers[number_name(m, cloud_borne=True)] = jnp.full(shape, 1.0e7)
+            tracers[number_name(m, cloud_borne=True)] = jnp.full(shape, nc)
         state = PhysicsState.zeros(shape).copy(
             temperature=jnp.full(shape, 275.0), tracers=tracers,
         )
@@ -91,6 +91,26 @@ class AqueousTermTest(unittest.TestCase):
 
         state, diagnostics = self._setup()
         tend, _ = AqueousSulfur()(state, diagnostics, None, None)
+        s_rate = np.asarray(tend.tracers["g_so2"]) / _MW_SO2
+        for m in (mm.short for mm in MAM4_SPEC.modes if "so4" in mm.species):
+            key = mass_name("so4", m, cloud_borne=True)
+            s_rate = s_rate + np.asarray(tend.tracers[key]) / _MW_SO4
+        self.assertTrue(np.all(np.abs(s_rate) < 1.0e-18))
+
+    def test_sulfur_conserved_without_cloud_borne_number(self):
+        # Spin-up case: no cloud-borne number anywhere. Sulfate must still be
+        # produced (in the coarse "droplet" mode) and match the SO2 sink — the
+        # SO2 sink must not vanish into nothing.
+        from jcm.physics.aerosol.jam import MAM4_SPEC
+        from jcm.physics.aerosol.jam.chemistry.aqueous import _MW_SO2, _MW_SO4
+
+        state, diagnostics = self._setup(nc=0.0)
+        tend, _ = AqueousSulfur()(state, diagnostics, None, None)
+        # All produced sulfate lands in the coarse mode.
+        self.assertGreater(
+            float(tend.tracers[mass_name("so4", "cor", cloud_borne=True)][0, 0]),
+            0.0,
+        )
         s_rate = np.asarray(tend.tracers["g_so2"]) / _MW_SO2
         for m in (mm.short for mm in MAM4_SPEC.modes if "so4" in mm.species):
             key = mass_name("so4", m, cloud_borne=True)

--- a/jcm/physics/aerosol/jam/chemistry/oxidants.py
+++ b/jcm/physics/aerosol/jam/chemistry/oxidants.py
@@ -1,0 +1,155 @@
+"""``PrescribedOxidants`` — interim oxidant fields for the JAM sulfur chemistry.
+
+The gas-phase (DMS+OH/NO₃, SO₂+OH) and aqueous (SO₂+H₂O₂/O₃) sulfur oxidation
+need OH, NO₃, O₃ and H₂O₂. A full implementation reads a monthly oxidant
+climatology; **as an interim** (issue #496) these are *derived from fields jcm
+already carries* so the chain runs and is testable without new input data:
+
+* **O₃** — reused from ``diagnostics["chemistry"].ozone_vmr`` (the
+  ``SimpleChemistry`` ozone field; mole-fraction = ``ozone_vmr·1e-6``, matching
+  RRTMGP's convention). Falls back to a fixed tropospheric value.
+* **OH** — daytime photochemical proxy ``∝ cos(zenith)·[O₃]`` (O(¹D)+H₂O source
+  scales with O₃ photolysis), reusing ``diagnostics["radiation"].cos_zenith``.
+* **H₂O₂** — a reservoir species (multi-day lifetime); a boundary-layer-weighted
+  prescribed profile (not the instantaneous cos-zenith).
+* **NO₃** — nighttime oxidant ``∝ (1−cos zenith)·[O₃]``.
+
+Chemistry + radiation run **after** the JAM block in ``echam_physics``, so both
+are read from the **previous step's carry** with a fallback (the pattern ARG
+uses for ``vertical_diffusion``); on the first step the fallbacks apply.
+
+All scales are differentiable :class:`OxidantParameters` so the interim fields
+can be calibrated and later swapped for a real climatology. Output number
+densities are in **molec cm⁻³** (the unit gas-kinetic rate constants expect).
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import jax.numpy as jnp
+import tree_math
+from flax import nnx
+
+import jcm.constants as c
+from jcm.physics.physics_term import PhysicsTerm
+from jcm.physics_interface import PhysicsTendency
+
+# Reference mole fractions for the proxy scalings.
+_O3_REF = 4.0e-8        # 40 ppbv — typical tropospheric O₃
+_P_REF = 1.0e5          # Pa — surface pressure scale for BL weighting
+
+
+@tree_math.struct
+class OxidantField:
+    """Prescribed oxidant number densities [molec cm⁻³], ``(nlev, ncols)``."""
+
+    oh: jnp.ndarray      # hydroxyl radical
+    no3: jnp.ndarray     # nitrate radical (night)
+    o3: jnp.ndarray      # ozone
+    h2o2: jnp.ndarray    # hydrogen peroxide
+
+
+@tree_math.struct
+class OxidantParameters:
+    """Tunable scales for the interim oxidant proxies (differentiable)."""
+
+    oh_ref: jnp.ndarray        # peak daytime OH [molec cm⁻³]
+    h2o2_ref_vmr: jnp.ndarray  # surface H₂O₂ mole fraction
+    no3_ref_vmr: jnp.ndarray   # nighttime NO₃ mole fraction
+    o3_fallback_vmr: jnp.ndarray   # O₃ mole fraction when chemistry absent
+    cos_zenith_fallback: jnp.ndarray  # cos(SZA) when radiation absent
+
+    @classmethod
+    def default(cls) -> "OxidantParameters":
+        return cls(
+            oh_ref=jnp.asarray(2.5e6),
+            h2o2_ref_vmr=jnp.asarray(5.0e-10),   # 0.5 ppbv
+            no3_ref_vmr=jnp.asarray(1.0e-12),    # 1 pptv
+            o3_fallback_vmr=jnp.asarray(4.0e-8),  # 40 ppbv
+            cos_zenith_fallback=jnp.asarray(0.25),
+        )
+
+
+def air_number_density(temperature: jnp.ndarray,
+                       pressure: jnp.ndarray) -> jnp.ndarray:
+    """Air number density [molec cm⁻³] from the ideal gas law ``n = P/(k_B T)``."""
+    return pressure / (c.ak * temperature) * 1.0e-6
+
+
+def oxidant_field(
+    temperature: jnp.ndarray,
+    pressure: jnp.ndarray,
+    o3_vmr_ppmv: jnp.ndarray,
+    cos_zenith: jnp.ndarray,
+    params: OxidantParameters,
+) -> OxidantField:
+    """Build the interim oxidant number densities (see module docstring).
+
+    Args:
+        temperature: ``(nlev, ncols)`` [K].
+        pressure: ``(nlev, ncols)`` [Pa].
+        o3_vmr_ppmv: ozone, in the ``SimpleChemistry`` ppmv-style unit
+            (mole fraction = ``·1e-6``); ``(nlev, ncols)``.
+        cos_zenith: cosine solar zenith angle, broadcast to ``(nlev, ncols)``.
+        params: tunable scales.
+
+    """
+    n_air = air_number_density(temperature, pressure)
+    o3_molefrac = jnp.maximum(o3_vmr_ppmv * 1.0e-6, 0.0)
+    n_o3 = o3_molefrac * n_air
+    cosz = jnp.clip(cos_zenith, 0.0, 1.0)
+    o3_ratio = jnp.clip(o3_molefrac / _O3_REF, 0.0, 5.0)
+    p_weight = jnp.clip(pressure / _P_REF, 0.0, 1.0)
+
+    # OH: daytime photochemical proxy ∝ cos(zenith)·[O₃ relative to typical].
+    oh = params.oh_ref * cosz * o3_ratio
+
+    # H₂O₂: reservoir; boundary-layer-weighted prescribed mole fraction.
+    n_h2o2 = params.h2o2_ref_vmr * p_weight * n_air
+
+    # NO₃: nighttime, O₃-scaled.
+    n_no3 = params.no3_ref_vmr * (1.0 - cosz) * o3_ratio * n_air
+
+    return OxidantField(
+        oh=jnp.maximum(oh, 0.0),
+        no3=jnp.maximum(n_no3, 0.0),
+        o3=jnp.maximum(n_o3, 0.0),
+        h2o2=jnp.maximum(n_h2o2, 0.0),
+    )
+
+
+class PrescribedOxidants(PhysicsTerm):
+    """Write the interim ``oxidants`` diagnostic for the sulfur chemistry."""
+
+    name: ClassVar[str] = "jam_prescribed_oxidants"
+    category: ClassVar[str] = "aerosol_oxidants"
+    requires: ClassVar[tuple[str, ...]] = ("pressure_full",)
+    provides: ClassVar[tuple[str, ...]] = ("oxidants",)
+
+    def __init__(self, params: OxidantParameters | None = None):
+        """Hold the (differentiable) oxidant scales."""
+        self.params = nnx.Param(params or OxidantParameters.default())
+
+    def __call__(self, state, diagnostics, forcing, terrain):
+        params = self.params.get_value()
+        temperature = state.temperature
+        pressure = diagnostics["pressure_full"]
+
+        # O₃ and solar geometry are produced *after* the aerosol block, so read
+        # them from the previous-step carry; fall back on step 1 / the probe.
+        chemistry = diagnostics.get("chemistry")
+        o3_vmr = (
+            chemistry.ozone_vmr if chemistry is not None
+            else jnp.full_like(temperature, params.o3_fallback_vmr * 1.0e6)
+        )
+        radiation = diagnostics.get("radiation")
+        cosz = (
+            jnp.broadcast_to(radiation.cos_zenith, temperature.shape)
+            if radiation is not None
+            else jnp.full_like(temperature, params.cos_zenith_fallback)
+        )
+
+        field = oxidant_field(temperature, pressure, o3_vmr, cosz, params)
+        tendency = PhysicsTendency.zeros(temperature.shape)
+        return tendency, {**diagnostics, "oxidants": field}

--- a/jcm/physics/aerosol/jam/chemistry/oxidants_test.py
+++ b/jcm/physics/aerosol/jam/chemistry/oxidants_test.py
@@ -1,0 +1,104 @@
+"""Phase 1 tests: interim prescribed oxidant fields (#496)."""
+
+import types
+import unittest
+
+import jax.numpy as jnp
+import numpy as np
+
+from jcm.physics.aerosol.jam.chemistry.oxidants import (
+    OxidantParameters,
+    PrescribedOxidants,
+    air_number_density,
+    oxidant_field,
+)
+from jcm.physics_interface import PhysicsState
+
+
+class AirNumberDensityTest(unittest.TestCase):
+    def test_surface_value(self):
+        n = air_number_density(jnp.asarray(288.0), jnp.asarray(1.0e5))
+        # ~2.5e19 molec/cm^3 at the surface.
+        self.assertAlmostEqual(float(n) / 1.0e19, 2.5, delta=0.2)
+
+    def test_decreases_with_pressure(self):
+        n_sfc = air_number_density(jnp.asarray(250.0), jnp.asarray(1.0e5))
+        n_top = air_number_density(jnp.asarray(250.0), jnp.asarray(1.0e4))
+        self.assertGreater(float(n_sfc), float(n_top))
+
+
+class OxidantFieldTest(unittest.TestCase):
+    def _inputs(self, cosz):
+        shape = (3, 2)
+        t = jnp.full(shape, 280.0)
+        p = jnp.full(shape, 9.0e4)
+        o3 = jnp.full(shape, 0.04)  # ppmv-style (40 ppbv)
+        return t, p, o3, jnp.full(shape, cosz)
+
+    def test_fields_finite_and_nonnegative(self):
+        t, p, o3, cz = self._inputs(0.5)
+        f = oxidant_field(t, p, o3, cz, OxidantParameters.default())
+        for arr in (f.oh, f.no3, f.o3, f.h2o2):
+            a = np.asarray(arr)
+            self.assertTrue(np.all(np.isfinite(a)))
+            self.assertTrue(np.all(a >= 0.0))
+
+    def test_oh_is_daytime(self):
+        params = OxidantParameters.default()
+        day = oxidant_field(*self._inputs(1.0), params)
+        night = oxidant_field(*self._inputs(0.0), params)
+        self.assertGreater(float(day.oh.mean()), float(night.oh.mean()))
+        self.assertAlmostEqual(float(night.oh.mean()), 0.0)
+
+    def test_no3_is_nighttime(self):
+        params = OxidantParameters.default()
+        day = oxidant_field(*self._inputs(1.0), params)
+        night = oxidant_field(*self._inputs(0.0), params)
+        self.assertGreater(float(night.no3.mean()), float(day.no3.mean()))
+
+    def test_oh_magnitude_reasonable(self):
+        # Daytime OH should be O(1e6) molec/cm^3, not orders off.
+        f = oxidant_field(*self._inputs(1.0), OxidantParameters.default())
+        self.assertTrue(1.0e5 < float(f.oh.mean()) < 1.0e7)
+
+
+class PrescribedOxidantsTermTest(unittest.TestCase):
+    def _state(self, nlev=3, ncols=2):
+        state = PhysicsState.zeros((nlev, ncols)).copy(
+            temperature=jnp.full((nlev, ncols), 280.0),
+        )
+        return state
+
+    def test_with_carried_chemistry_and_radiation(self):
+        state = self._state()
+        diagnostics = {
+            "pressure_full": jnp.full((3, 2), 9.0e4),
+            "chemistry": types.SimpleNamespace(
+                ozone_vmr=jnp.full((3, 2), 0.05)
+            ),
+            "radiation": types.SimpleNamespace(
+                cos_zenith=jnp.full((2,), 0.8)
+            ),
+        }
+        _, diags = PrescribedOxidants()(state, diagnostics, None, None)
+        ox = diags["oxidants"]
+        self.assertEqual(ox.oh.shape, (3, 2))
+        for arr in (ox.oh, ox.no3, ox.o3, ox.h2o2):
+            self.assertTrue(np.all(np.isfinite(np.asarray(arr))))
+        self.assertGreater(float(ox.oh.mean()), 0.0)
+
+    def test_fallback_when_carry_absent(self):
+        state = self._state()
+        diagnostics = {"pressure_full": jnp.full((3, 2), 9.0e4)}
+        _, diags = PrescribedOxidants()(state, diagnostics, None, None)
+        ox = diags["oxidants"]
+        for arr in (ox.oh, ox.no3, ox.o3, ox.h2o2):
+            a = np.asarray(arr)
+            self.assertTrue(np.all(np.isfinite(a)))
+            self.assertTrue(np.all(a >= 0.0))
+        # Fallback O3 is finite and positive.
+        self.assertGreater(float(ox.o3.mean()), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jcm/physics/aerosol/jam/chemistry/sulfur_gas.py
+++ b/jcm/physics/aerosol/jam/chemistry/sulfur_gas.py
@@ -1,0 +1,182 @@
+"""``SulfurGasChemistry`` — gas-phase DMS/SO₂ oxidation feeding MAM4 (#496).
+
+Port of ECHAM-HAM's ``mo_ham_chemistry.f90::ham_gas_chemistry`` (the
+prescribed-oxidant HAM sulfur scheme), with one adaptation for the MAM4-JAX
+coupling: where HAM converts SO₂+OH (and the DMS "MSA" branch) **directly** to
+particulate SO₄, here those route to **gas-phase H₂SO₄** (``g_h2so4``) so the
+MAM4 core does the gas→particle step (condensation + nucleation).
+
+Reactions (rate constants verbatim from HAM, cm³ molec⁻¹ s⁻¹):
+
+* DMS + OH (abstraction)  ``k1 = 9.6e-12·exp(-234/T)``
+* DMS + OH (addition)     ``k2 = 1.7e-42·exp(7810/T)·[O₂] / (1 + 5.5e-31·exp(7460/T)·[O₂])``
+  → branch ``f_so2 = (k1 + 0.75·k2)/(k1+k2)`` to SO₂; the rest to H₂SO₄ (MSA-as-sulfate).
+* DMS + NO₃               ``k3 = 1.9e-13·exp(520/T)`` → SO₂  (night)
+* SO₂ + OH + M            Troe ``k0=4.0e-31·(T/300)^-3.3``, ``k∞=2.0e-12``, ``Fc=0.45`` → H₂SO₄
+
+Day/night is handled continuously through the oxidant fields themselves
+(:mod:`oxidants` gives OH ∝ cos(zenith), NO₃ ∝ 1−cos(zenith)). Each precursor is
+integrated over the physics step with a stable exponential decay. Sulfur is
+conserved atom-for-atom (DMS→SO₂→H₂SO₄ each carry one S).
+
+SOAG: jcm has no VOC precursor yet, so SOA gas is produced at a small
+boundary-layer-weighted prescribed rate (tunable, interim) so the core sees a
+nonzero condensable organic; replace with a real VOC+OH source later.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import ClassVar
+
+import jax.numpy as jnp
+import tree_math
+from flax import nnx
+
+from jcm.physics.aerosol.jam.chemistry.oxidants import air_number_density
+from jcm.physics.aerosol.jam.gas_species import GAS_SPECIES, SULFUR_GASES
+from jcm.physics.aerosol.jam.tracer_layout import gas_name, gas_tracer_specs
+from jcm.physics.physics_term import PhysicsTerm, TracerSpec
+from jcm.physics_interface import PhysicsTendency
+
+# Molar-mass conversion factors (mass mixing ratio), from the gas table.
+_M_DMS = GAS_SPECIES["dms"].molar_mass
+_M_SO2 = GAS_SPECIES["so2"].molar_mass
+_M_H2SO4 = GAS_SPECIES["h2so4"].molar_mass
+_CONV_DMS_SO2 = _M_SO2 / _M_DMS
+_CONV_DMS_H2SO4 = _M_H2SO4 / _M_DMS
+_CONV_SO2_H2SO4 = _M_H2SO4 / _M_SO2
+
+_TINY = 1.0e-30
+_P_REF = 1.0e5   # Pa — BL weighting for the interim SOAG source
+
+
+# log of the addition-channel prefactor (1.7e-42 underflows float32, so it is
+# folded into the exponent below to keep the intermediate in range).
+_LN_K2_PREFAC = math.log(1.7e-42)
+
+
+def _k_dms_oh(t: jnp.ndarray, n_air: jnp.ndarray):
+    """DMS+OH abstraction (k1) and addition (k2) rates [cm³ molec⁻¹ s⁻¹]."""
+    o2 = 0.21 * n_air
+    k1 = 9.6e-12 * jnp.exp(-234.0 / t)
+    numerator = jnp.exp(7810.0 / t + _LN_K2_PREFAC) * o2
+    k2 = numerator / (1.0 + 5.5e-31 * jnp.exp(7460.0 / t) * o2)
+    return k1, k2
+
+
+def _k_so2_oh(t: jnp.ndarray, n_air: jnp.ndarray) -> jnp.ndarray:
+    """SO₂+OH+M termolecular (Troe) rate [cm³ molec⁻¹ s⁻¹]."""
+    k0 = 4.0e-31 * (t / 300.0) ** (-3.3)
+    k_inf = 2.0e-12
+    fc = 0.45
+    hil = jnp.maximum(k0 * n_air / k_inf, _TINY)
+    expo = 1.0 / (1.0 + jnp.log10(hil) ** 2)
+    return k0 * n_air / (1.0 + hil) * fc ** expo
+
+
+def _k_dms_no3(t: jnp.ndarray) -> jnp.ndarray:
+    """DMS+NO₃ rate [cm³ molec⁻¹ s⁻¹]."""
+    return 1.9e-13 * jnp.exp(520.0 / t)
+
+
+@tree_math.struct
+class SulfurGasParameters:
+    """Tunable knobs for the gas-phase sulfur chemistry (differentiable)."""
+
+    soag_production: jnp.ndarray   # interim SOAG source [kg/kg/s] at the surface
+
+    @classmethod
+    def default(cls) -> "SulfurGasParameters":
+        return cls(soag_production=jnp.asarray(2.0e-15))
+
+
+def sulfur_gas_tendencies(
+    dms: jnp.ndarray,
+    so2: jnp.ndarray,
+    temperature: jnp.ndarray,
+    pressure: jnp.ndarray,
+    oh: jnp.ndarray,
+    no3: jnp.ndarray,
+    dt: jnp.ndarray,
+    soag_production: jnp.ndarray,
+) -> dict[str, jnp.ndarray]:
+    """Per-tracer gas-phase tendencies [kg/kg/s] for the sulfur chain.
+
+    ``dms``/``so2`` are mass mixing ratios [kg/kg]; ``oh``/``no3`` number
+    densities [molec cm⁻³]. Returns tendencies keyed by gas tracer name.
+    """
+    n_air = air_number_density(temperature, pressure)
+    k1, k2 = _k_dms_oh(temperature, n_air)
+    k_oh = (k1 + k2) * oh            # DMS+OH first-order loss [1/s]
+    k_no3 = _k_dms_no3(temperature) * no3
+    k_dms = k_oh + k_no3
+    f_so2 = (k1 + 0.75 * k2) / jnp.maximum(k1 + k2, _TINY)  # OH→SO2 branch
+
+    # DMS loss (exponential over dt), split by channel.
+    dms_lost = dms * (1.0 - jnp.exp(-k_dms * dt))
+    frac_oh = k_oh / jnp.maximum(k_dms, _TINY)
+    dms_lost_oh = dms_lost * frac_oh
+    dms_lost_no3 = dms_lost - dms_lost_oh
+
+    so2_from_dms = (dms_lost_oh * f_so2 + dms_lost_no3) * _CONV_DMS_SO2
+    h2so4_from_dms = dms_lost_oh * (1.0 - f_so2) * _CONV_DMS_H2SO4
+
+    # SO2 + OH → H2SO4 (acts on SO2 plus the fresh DMS-derived SO2).
+    k_so2 = _k_so2_oh(temperature, n_air) * oh
+    so2_avail = so2 + so2_from_dms
+    so2_lost = so2_avail * (1.0 - jnp.exp(-k_so2 * dt))
+    h2so4_from_so2 = so2_lost * _CONV_SO2_H2SO4
+
+    # Interim SOAG source: boundary-layer-weighted prescribed production.
+    soag_src = soag_production * jnp.clip(pressure / _P_REF, 0.0, 1.0)
+
+    return {
+        gas_name("dms"): -dms_lost / dt,
+        gas_name("so2"): (so2_from_dms - so2_lost) / dt,
+        gas_name("h2so4"): (h2so4_from_dms + h2so4_from_so2) / dt,
+        gas_name("soag"): soag_src,
+    }
+
+
+class SulfurGasChemistry(PhysicsTerm):
+    """Gas-phase DMS/SO₂ oxidation → SO₂/H₂SO₄/SOAG, fed to the MAM4 core."""
+
+    name: ClassVar[str] = "jam_sulfur_gas_chemistry"
+    category: ClassVar[str] = "aerosol_gas_chemistry"
+    requires: ClassVar[tuple[str, ...]] = ("oxidants", "pressure_full")
+    provides: ClassVar[tuple[str, ...]] = ()
+
+    def __init__(self, params: SulfurGasParameters | None = None):
+        """Hold the (differentiable) chemistry knobs."""
+        self.params = nnx.Param(params or SulfurGasParameters.default())
+
+    def required_tracers(self) -> tuple[TracerSpec, ...]:  # type: ignore[override]
+        """Declare the four prognostic gas-phase precursor tracers."""
+        return gas_tracer_specs(SULFUR_GASES)
+
+    def __call__(self, state, diagnostics, forcing, terrain):
+        params = self.params.get_value()
+        zeros = jnp.zeros_like(state.temperature)
+        ox = diagnostics["oxidants"]
+        dt = jnp.asarray(diagnostics["_dt_seconds"], state.temperature.dtype)
+
+        tends = sulfur_gas_tendencies(
+            dms=state.tracers.get(gas_name("dms"), zeros),
+            so2=state.tracers.get(gas_name("so2"), zeros),
+            temperature=state.temperature,
+            pressure=diagnostics["pressure_full"],
+            oh=ox.oh,
+            no3=ox.no3,
+            dt=dt,
+            soag_production=params.soag_production,
+        )
+
+        tendency = PhysicsTendency(
+            u_wind=jnp.zeros_like(state.u_wind),
+            v_wind=jnp.zeros_like(state.v_wind),
+            temperature=jnp.zeros_like(state.temperature),
+            specific_humidity=jnp.zeros_like(state.specific_humidity),
+            tracers=tends,
+        )
+        return tendency, diagnostics

--- a/jcm/physics/aerosol/jam/chemistry/sulfur_gas.py
+++ b/jcm/physics/aerosol/jam/chemistry/sulfur_gas.py
@@ -50,34 +50,56 @@ _CONV_SO2_H2SO4 = _M_H2SO4 / _M_SO2
 _TINY = 1.0e-30
 _P_REF = 1.0e5   # Pa — BL weighting for the interim SOAG source
 
+# --- Gas-phase oxidation rate-constant coefficients -----------------------
+# These are *empirical* Arrhenius / Troe parameters from the laboratory
+# kinetics literature (JPL/DeMore & IUPAC/Atkinson evaluations), reproduced
+# verbatim from ECHAM-HAM (``mo_ham_chemistry.f90``). They are measured
+# reaction coefficients — **not** physical constants — so they cannot be
+# derived from :mod:`jcm.constants`; they are the fixed published values.
+# Arrhenius form k = A·exp(−Ea/RT), written here as A·exp(±C/T) with C = Ea/R.
 
-# log of the addition-channel prefactor (1.7e-42 underflows float32, so it is
-# folded into the exponent below to keep the intermediate in range).
-_LN_K2_PREFAC = math.log(1.7e-42)
+# DMS + OH (Atkinson). Two channels:
+#   H-abstraction:  k1 = 9.6e-12·exp(−234/T)
+#   OH-addition:    k2 = 1.7e-42·exp(7810/T)·[O₂] / (1 + 5.5e-31·exp(7460/T)·[O₂])
+_DMS_OH_ABS_A, _DMS_OH_ABS_C = 9.6e-12, 234.0
+_DMS_OH_ADD_A, _DMS_OH_ADD_C = 1.7e-42, 7810.0
+_DMS_OH_ADD_DEN_A, _DMS_OH_ADD_DEN_C = 5.5e-31, 7460.0
+# 1.7e-42 underflows float32, so its log is folded into the exponent below.
+_LN_DMS_OH_ADD_A = math.log(_DMS_OH_ADD_A)
+_O2_FRAC = 0.21   # molar fraction of O₂ in air
+
+# SO₂ + OH + M → HSO₃ (→ H₂SO₄), Troe termolecular (JPL):
+#   k0 = k0_300·(T/300)^−n (low-P limit), k_inf (high-P limit), Fc broadening.
+_SO2_OH_K0_300, _SO2_OH_K0_N = 4.0e-31, 3.3
+_SO2_OH_KINF = 2.0e-12
+_SO2_OH_FC = 0.45   # Troe broadening factor (measured, not a tuning knob)
+
+# DMS + NO₃ → HNO₃ + products (night), Atkinson:  k3 = 1.9e-13·exp(520/T)
+_DMS_NO3_A, _DMS_NO3_C = 1.9e-13, 520.0
 
 
 def _k_dms_oh(t: jnp.ndarray, n_air: jnp.ndarray):
     """DMS+OH abstraction (k1) and addition (k2) rates [cm³ molec⁻¹ s⁻¹]."""
-    o2 = 0.21 * n_air
-    k1 = 9.6e-12 * jnp.exp(-234.0 / t)
-    numerator = jnp.exp(7810.0 / t + _LN_K2_PREFAC) * o2
-    k2 = numerator / (1.0 + 5.5e-31 * jnp.exp(7460.0 / t) * o2)
+    o2 = _O2_FRAC * n_air
+    k1 = _DMS_OH_ABS_A * jnp.exp(-_DMS_OH_ABS_C / t)
+    numerator = jnp.exp(_DMS_OH_ADD_C / t + _LN_DMS_OH_ADD_A) * o2
+    k2 = numerator / (
+        1.0 + _DMS_OH_ADD_DEN_A * jnp.exp(_DMS_OH_ADD_DEN_C / t) * o2
+    )
     return k1, k2
 
 
 def _k_so2_oh(t: jnp.ndarray, n_air: jnp.ndarray) -> jnp.ndarray:
     """SO₂+OH+M termolecular (Troe) rate [cm³ molec⁻¹ s⁻¹]."""
-    k0 = 4.0e-31 * (t / 300.0) ** (-3.3)
-    k_inf = 2.0e-12
-    fc = 0.45
-    hil = jnp.maximum(k0 * n_air / k_inf, _TINY)
+    k0 = _SO2_OH_K0_300 * (t / 300.0) ** (-_SO2_OH_K0_N)
+    hil = jnp.maximum(k0 * n_air / _SO2_OH_KINF, _TINY)
     expo = 1.0 / (1.0 + jnp.log10(hil) ** 2)
-    return k0 * n_air / (1.0 + hil) * fc ** expo
+    return k0 * n_air / (1.0 + hil) * _SO2_OH_FC ** expo
 
 
 def _k_dms_no3(t: jnp.ndarray) -> jnp.ndarray:
     """DMS+NO₃ rate [cm³ molec⁻¹ s⁻¹]."""
-    return 1.9e-13 * jnp.exp(520.0 / t)
+    return _DMS_NO3_A * jnp.exp(_DMS_NO3_C / t)
 
 
 @tree_math.struct

--- a/jcm/physics/aerosol/jam/chemistry/sulfur_gas_test.py
+++ b/jcm/physics/aerosol/jam/chemistry/sulfur_gas_test.py
@@ -1,0 +1,141 @@
+"""Phase 2 tests: gas-phase sulfur chemistry (DMS/SO2 -> SO2/H2SO4) (#496)."""
+
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from jcm.physics.aerosol.jam.chemistry.oxidants import OxidantField
+from jcm.physics.aerosol.jam.chemistry.sulfur_gas import (
+    SulfurGasChemistry,
+    _k_dms_no3,
+    _k_dms_oh,
+    _k_so2_oh,
+    sulfur_gas_tendencies,
+)
+from jcm.physics.aerosol.jam.gas_species import GAS_SPECIES
+from jcm.physics.aerosol.jam.tracer_layout import gas_name
+from jcm.physics_interface import PhysicsState
+
+_M = {sp: GAS_SPECIES[sp].molar_mass for sp in ("dms", "so2", "h2so4")}
+
+
+class RateConstantTest(unittest.TestCase):
+    def test_rates_positive_and_finite(self):
+        t = jnp.asarray(280.0)
+        n_air = jnp.asarray(2.3e19)
+        k1, k2 = _k_dms_oh(t, n_air)
+        for k in (k1, k2, _k_so2_oh(t, n_air), _k_dms_no3(t)):
+            self.assertTrue(np.isfinite(float(k)))
+            self.assertGreater(float(k), 0.0)
+
+    def test_dms_oh_abstraction_matches_ham(self):
+        # k1 = 9.6e-12 * exp(-234/T)
+        t = 280.0
+        k1, _ = _k_dms_oh(jnp.asarray(t), jnp.asarray(2.3e19))
+        self.assertAlmostEqual(float(k1), 9.6e-12 * np.exp(-234.0 / t), places=18)
+
+
+class SulfurGasTendencyTest(unittest.TestCase):
+    def _call(self, oh, no3, dms=1.0e-10, so2=1.0e-10):
+        shape = (2,)
+        return sulfur_gas_tendencies(
+            dms=jnp.full(shape, dms),
+            so2=jnp.full(shape, so2),
+            temperature=jnp.full(shape, 280.0),
+            pressure=jnp.full(shape, 9.0e4),
+            oh=jnp.full(shape, oh),
+            no3=jnp.full(shape, no3),
+            dt=jnp.asarray(1800.0),
+            soag_production=jnp.asarray(2.0e-15),
+        )
+
+    def test_finite(self):
+        t = self._call(oh=2.0e6, no3=0.0)
+        for v in t.values():
+            self.assertTrue(np.all(np.isfinite(np.asarray(v))))
+
+    def test_sulfur_moles_conserved(self):
+        # DMS, SO2, H2SO4 each carry one S — molar S rate must sum to ~0
+        # (relative to the component magnitudes; float32-appropriate tolerance).
+        t = self._call(oh=2.0e6, no3=5.0e7)
+        components = [
+            np.asarray(t[gas_name(sp)]) / _M[sp] for sp in ("dms", "so2", "h2so4")
+        ]
+        s_rate = sum(components)
+        scale = sum(np.abs(c) for c in components)
+        self.assertTrue(
+            np.all(np.abs(s_rate) <= 1.0e-5 * np.maximum(scale, 1.0e-30))
+        )
+
+    def test_daytime_makes_h2so4_and_consumes_dms(self):
+        t = self._call(oh=3.0e6, no3=0.0)
+        self.assertLess(float(t[gas_name("dms")][0]), 0.0)      # DMS lost
+        self.assertGreater(float(t[gas_name("h2so4")][0]), 0.0)  # H2SO4 made
+
+    def test_nighttime_no3_makes_so2_not_h2so4(self):
+        t = self._call(oh=0.0, no3=5.0e7)
+        self.assertLess(float(t[gas_name("dms")][0]), 0.0)        # DMS lost via NO3
+        self.assertGreater(float(t[gas_name("so2")][0]), 0.0)     # -> SO2
+        self.assertAlmostEqual(float(t[gas_name("h2so4")][0]), 0.0)  # no OH -> no H2SO4
+
+    def test_soag_produced(self):
+        t = self._call(oh=1.0e6, no3=0.0)
+        self.assertGreater(float(t[gas_name("soag")][0]), 0.0)
+
+
+class SulfurGasTermTest(unittest.TestCase):
+    def _setup(self, nlev=3, ncols=2):
+        shape = (nlev, ncols)
+        tracers = {
+            gas_name("dms"): jnp.full(shape, 1.0e-10),
+            gas_name("so2"): jnp.full(shape, 1.0e-10),
+            gas_name("h2so4"): jnp.zeros(shape),
+            gas_name("soag"): jnp.zeros(shape),
+        }
+        state = PhysicsState.zeros(shape).copy(
+            temperature=jnp.full(shape, 280.0), tracers=tracers,
+        )
+        ox = OxidantField(
+            oh=jnp.full(shape, 2.0e6), no3=jnp.full(shape, 1.0e7),
+            o3=jnp.full(shape, 1.0e12), h2o2=jnp.full(shape, 1.0e10),
+        )
+        diagnostics = {
+            "oxidants": ox,
+            "pressure_full": jnp.full(shape, 9.0e4),
+            "_dt_seconds": 1800.0,
+        }
+        return state, diagnostics
+
+    def test_term_declares_gas_tracers(self):
+        names = {s.name for s in SulfurGasChemistry().required_tracers()}
+        self.assertEqual(names, {"g_dms", "g_so2", "g_h2so4", "g_soag"})
+
+    def test_term_produces_finite_tendencies(self):
+        state, diagnostics = self._setup()
+        tend, _ = SulfurGasChemistry()(state, diagnostics, None, None)
+        self.assertIn(gas_name("h2so4"), tend.tracers)
+        for v in tend.tracers.values():
+            self.assertTrue(np.all(np.isfinite(np.asarray(v))))
+
+    def test_grad_through_soag_param_finite(self):
+        from jcm.physics.aerosol.jam.chemistry.sulfur_gas import (
+            SulfurGasParameters,
+        )
+
+        state, diagnostics = self._setup()
+
+        def loss(prod):
+            term = SulfurGasChemistry(
+                params=SulfurGasParameters(soag_production=prod)
+            )
+            tend, _ = term(state, diagnostics, None, None)
+            return sum(jnp.sum(v ** 2) for v in tend.tracers.values())
+
+        g = jax.grad(loss)(jnp.asarray(2.0e-15))
+        self.assertTrue(np.isfinite(float(g)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jcm/physics/aerosol/jam/emissions/dms.py
+++ b/jcm/physics/aerosol/jam/emissions/dms.py
@@ -3,10 +3,10 @@
 Port of the Nightingale (2000) branch of HAMMOZ
 ``mo_hammoz_emi_ocean::dms_emissions``: a sea–air transfer (piston) velocity
 from the 10 m wind and the DMS Schmidt number (Andreae fit), times a
-prescribed seawater DMS concentration. The DMS gas oxidises to SO2 and then
-sulfate; since this configuration carries no gas-phase sulfur tracer, the
-emitted sulfur is added directly as primary sulfate to the Aitken/accumulation
-modes (an interim — full DMS→SO2→SO4 gas chemistry is #496).
+prescribed seawater DMS concentration. The DMS gas is emitted into the
+prognostic ``g_dms`` tracer (lowest layer) and oxidised to SO₂ → H₂SO₄ by the
+:mod:`..chemistry.sulfur_gas` term (#496), which then feeds the MAM4 core —
+replacing the earlier interim that added DMS straight to primary sulfate.
 
 The seawater DMS field is read from ``forcing.dms_seawater`` (a prescribed
 climatology, e.g. AeroCom ``conc_aerocom_DMS_sea.nc``); it falls back to zero
@@ -23,9 +23,9 @@ import jax.numpy as jnp
 import tree_math
 from flax import nnx
 
-from jcm.physics.aerosol.jam.emissions.distributors import distribute_surface_flux
 from jcm.physics.aerosol.jam.microphysics.mam4_data import MAM4_SPEC
 from jcm.physics.aerosol.jam.population import ModalAerosolSpec
+from jcm.physics.aerosol.jam.tracer_layout import gas_name
 from jcm.physics.physics_term import PhysicsTendency, PhysicsTerm
 
 _CMH_TO_MS = 0.01 / 3600.0   # cm/h → m/s
@@ -51,12 +51,11 @@ def piston_velocity(u10: jnp.ndarray, schmidt: jnp.ndarray) -> jnp.ndarray:
 class DmsParameters:
     """Calibratable knobs for DMS sea–air emission."""
 
-    flux_scale: jnp.ndarray      # folds seawater-conc units → emitted SO4 mass
-    aitken_fraction: jnp.ndarray  # split of emitted sulfate into the Aitken mode
+    flux_scale: jnp.ndarray   # folds seawater-conc units → emitted DMS mass flux
 
     @classmethod
     def default(cls) -> "DmsParameters":
-        return cls(flux_scale=jnp.asarray(1.0), aitken_fraction=jnp.asarray(0.5))
+        return cls(flux_scale=jnp.asarray(1.0))
 
 
 class DmsEmissions(PhysicsTerm):
@@ -106,13 +105,12 @@ class DmsEmissions(PhysicsTerm):
         seafrac = jnp.where(land > 0.5, 0.0, 1.0 - land)
 
         vp = piston_velocity(u10, dms_schmidt_number(sst - 273.15))
-        flux_s = p.flux_scale * vp * dms_sea * seafrac        # kg-S/m²/s scale
+        flux_dms = p.flux_scale * vp * dms_sea * seafrac    # kg-DMS/m²/s
 
-        fluxes = [
-            ("so4", "ait", flux_s * p.aitken_fraction),
-            ("so4", "acc", flux_s * (1.0 - p.aitken_fraction)),
-        ]
-        tracer_tends = distribute_surface_flux(self._spec, fluxes, air_density, dz)
+        # Surface flux → lowest-layer mixing-ratio tendency [kg/kg/s].
+        dms_rate = flux_dms / (air_density[-1] * dz[-1])
+        g_dms = jnp.zeros_like(state.temperature).at[-1].set(dms_rate)
+        tracer_tends = {gas_name("dms"): g_dms}
 
         tendency = PhysicsTendency(
             u_wind=jnp.zeros_like(state.u_wind),

--- a/jcm/physics/aerosol/jam/emissions/dms_test.py
+++ b/jcm/physics/aerosol/jam/emissions/dms_test.py
@@ -7,13 +7,13 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from jcm.physics.aerosol.jam import mass_name
 from jcm.physics.aerosol.jam.emissions.dms import (
     DmsEmissions,
     DmsParameters,
     dms_schmidt_number,
     piston_velocity,
 )
+from jcm.physics.aerosol.jam.tracer_layout import gas_name
 
 
 class DmsFunctionTest(unittest.TestCase):
@@ -52,29 +52,25 @@ def _inputs(nlev=3, ncols=2, wind=8.0, dms=1.0e-6):
 
 
 class DmsTermTest(unittest.TestCase):
-    def test_emits_sulfate_with_seawater_field(self):
+    def test_emits_gas_dms_with_seawater_field(self):
         term = DmsEmissions()
         tend, _ = term(*_inputs(dms=2.0e-6))
-        key = mass_name("so4", "acc")
-        self.assertGreater(float(tend.tracers[key][-1, 0]), 0.0)
+        # Emission enters the lowest layer of the gas-phase DMS tracer.
+        self.assertGreater(float(tend.tracers[gas_name("dms")][-1, 0]), 0.0)
+        self.assertAlmostEqual(float(tend.tracers[gas_name("dms")][0, 0]), 0.0)
 
     def test_zero_without_seawater_field(self):
         term = DmsEmissions()
         tend, _ = term(*_inputs(dms=0.0))
-        key = mass_name("so4", "acc")
-        self.assertAlmostEqual(float(tend.tracers[key][-1, 0]), 0.0)
+        self.assertAlmostEqual(float(tend.tracers[gas_name("dms")][-1, 0]), 0.0)
 
     def test_grad_through_flux_scale(self):
         state, diagnostics, forcing, terrain = _inputs()
 
         def loss(scale):
-            term = DmsEmissions(
-                params=DmsParameters(
-                    flux_scale=scale, aitken_fraction=jnp.asarray(0.5)
-                )
-            )
+            term = DmsEmissions(params=DmsParameters(flux_scale=scale))
             tend, _ = term(state, diagnostics, forcing, terrain)
-            return jnp.sum(tend.tracers[mass_name("so4", "acc")])
+            return jnp.sum(tend.tracers[gas_name("dms")])
 
         g = jax.grad(loss)(jnp.asarray(1.0))
         self.assertTrue(np.isfinite(float(g)))

--- a/jcm/physics/aerosol/jam/gas_species.py
+++ b/jcm/physics/aerosol/jam/gas_species.py
@@ -1,0 +1,45 @@
+"""Gas-phase aerosol-precursor species for the JAM sulfur cycle (#496).
+
+Molar masses [kg/mol] for the prognostic gas tracers the gas-phase chemistry
+carries: DMS, SO₂, sulfuric-acid vapour, and a single lumped SOA gas. Values
+match the MAM4-JAX gas table (``mam4_jax.data.MW_GAS`` / ``ADV_MASS``) so the
+adapter's hand-off is unit-consistent.
+
+Only :data:`MAM4_GAS` (``h2so4``, ``soag``) is passed into the MAM4-JAX core —
+its condensation/nucleation consume those two. ``dms``/``so2`` are jcm-side
+precursors (their oxidation chemistry is jcm's; MAM4 ignores SO₂/DMS).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class GasSpecies:
+    """A prognostic gas-phase precursor (pure data, compose-time only)."""
+
+    name: str
+    molar_mass: float   # kg/mol
+    long_name: str
+
+
+# token -> GasSpecies. Molar masses are the standard compound values, matching
+# MAM4-JAX (H₂SO₄ 98.0784, SOA-gas 150.0, SO₂ 64.0648, DMS 62.1324 g/mol).
+GAS_SPECIES: dict[str, GasSpecies] = {
+    "dms": GasSpecies("dms", molar_mass=0.0621324,
+                      long_name="dimethyl-sulfide"),
+    "so2": GasSpecies("so2", molar_mass=0.0640648,
+                      long_name="sulfur-dioxide"),
+    "h2so4": GasSpecies("h2so4", molar_mass=0.0980784,
+                        long_name="sulfuric-acid-vapour"),
+    "soag": GasSpecies("soag", molar_mass=0.150,
+                       long_name="soa-gas"),
+}
+
+#: All prognostic gas tracers carried by the sulfur cycle, in chain order.
+SULFUR_GASES: tuple[str, ...] = ("dms", "so2", "h2so4", "soag")
+
+#: The subset fed into the MAM4-JAX core's ``q`` gas slots (amicphys consumes
+#: these); the others stay jcm-side.
+MAM4_GAS: tuple[str, ...] = ("h2so4", "soag")

--- a/jcm/physics/aerosol/jam/gas_species.py
+++ b/jcm/physics/aerosol/jam/gas_species.py
@@ -33,8 +33,11 @@ GAS_SPECIES: dict[str, GasSpecies] = {
                       long_name="sulfur-dioxide"),
     "h2so4": GasSpecies("h2so4", molar_mass=0.0980784,
                         long_name="sulfuric-acid-vapour"),
+    # SOAG = the lumped semi-volatile organic *gas* that condenses to form
+    # secondary organic aerosol (SOA); it is the gas-phase SOA precursor, hence
+    # not itself an aerosol despite the MAM4 "SOAG" name.
     "soag": GasSpecies("soag", molar_mass=0.150,
-                       long_name="soa-gas"),
+                       long_name="secondary-organic-aerosol precursor gas"),
 }
 
 #: All prognostic gas tracers carried by the sulfur cycle, in chain order.

--- a/jcm/physics/aerosol/jam/gas_species_test.py
+++ b/jcm/physics/aerosol/jam/gas_species_test.py
@@ -1,0 +1,47 @@
+"""Phase 0 tests: gas-phase precursor species table + g_* tracer layout (#496)."""
+
+import unittest
+
+from jcm.physics.aerosol.jam.gas_species import (
+    GAS_SPECIES,
+    MAM4_GAS,
+    SULFUR_GASES,
+)
+from jcm.physics.aerosol.jam.tracer_layout import gas_name, gas_tracer_specs
+
+
+class GasSpeciesTest(unittest.TestCase):
+    def test_gas_name(self):
+        self.assertEqual(gas_name("so2"), "g_so2")
+        self.assertEqual(gas_name("h2so4"), "g_h2so4")
+
+    def test_tracer_specs_cover_the_chain(self):
+        specs = gas_tracer_specs(SULFUR_GASES)
+        self.assertEqual(
+            {s.name for s in specs},
+            {"g_dms", "g_so2", "g_h2so4", "g_soag"},
+        )
+        self.assertTrue(all(s.units == "kg/kg" for s in specs))
+
+    def test_mam4_gas_is_the_consumed_subset(self):
+        self.assertEqual(MAM4_GAS, ("h2so4", "soag"))
+        self.assertTrue(set(MAM4_GAS).issubset(GAS_SPECIES))
+        self.assertTrue(set(SULFUR_GASES).issubset(GAS_SPECIES))
+
+    def test_molar_masses_match_mam4_constants(self):
+        # MAM4-JAX MW_GAS / ADV_MASS values (g/mol) — the adapter hand-off
+        # must be unit-consistent with the core.
+        expected = {
+            "h2so4": 98.0784,
+            "soag": 150.0,
+            "so2": 64.0648,
+            "dms": 62.1324,
+        }
+        for sp, mw in expected.items():
+            self.assertAlmostEqual(
+                GAS_SPECIES[sp].molar_mass * 1000.0, mw, places=3
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jcm/physics/aerosol/jam/jam_terms.py
+++ b/jcm/physics/aerosol/jam/jam_terms.py
@@ -95,6 +95,7 @@ def jam_aerosol_physics(
     oxidants: OxidantParameters | None = None,
     sulfur_gas: SulfurGasParameters | None = None,
     aqueous: AqueousSulfurParameters | None = None,
+    aqueous_scheme: str = "full",
     activation: ArgParameters | None = None,
     sedimentation: SedParameters | None = None,
     drydep: DryDepParameters | None = None,
@@ -110,6 +111,8 @@ def jam_aerosol_physics(
             emission schemes (Gong sea salt, Nightingale DMS, Tegen dust).
         oxidants/sulfur_gas/aqueous: optional ``Parameters`` for the
             prescribed-oxidant + gas-phase + aqueous sulfur chemistry (#496).
+        aqueous_scheme: ``"full"`` (default, HAM ``ham_wet_chemistry`` port) or
+            ``"simple"`` (H2O2-limited stoichiometric oxidation).
         activation/sedimentation/drydep/wetdep: optional per-process
             ``Parameters`` overrides (each ``None`` resolves to its default).
 
@@ -140,7 +143,7 @@ def jam_aerosol_physics(
         SlinnDryDeposition(params=drydep, spec=spec),
         # In-cloud aqueous SO2 oxidation → cloud-borne sulfate; runs in the
         # post-cloud block (needs current clouds), just before wet scavenging.
-        AqueousSulfur(params=aqueous, spec=spec),
+        AqueousSulfur(params=aqueous, spec=spec, scheme=aqueous_scheme),
         WetScavenging(params=wetdep, spec=spec),
     ]
     terms = [*pre_core, core, *optics_terms, *post_core]

--- a/jcm/physics/aerosol/jam/jam_terms.py
+++ b/jcm/physics/aerosol/jam/jam_terms.py
@@ -15,6 +15,18 @@ from jcm.physics.aerosol.jam.activation.arg_term import (
     ArgActivation,
     ArgParameters,
 )
+from jcm.physics.aerosol.jam.chemistry.aqueous import (
+    AqueousSulfur,
+    AqueousSulfurParameters,
+)
+from jcm.physics.aerosol.jam.chemistry.oxidants import (
+    OxidantParameters,
+    PrescribedOxidants,
+)
+from jcm.physics.aerosol.jam.chemistry.sulfur_gas import (
+    SulfurGasChemistry,
+    SulfurGasParameters,
+)
 from jcm.physics.aerosol.jam.drydep.drydep_term import (
     DryDepParameters,
     SlinnDryDeposition,
@@ -80,6 +92,9 @@ def jam_aerosol_physics(
     seasalt: SeaSaltParameters | None = None,
     dms: DmsParameters | None = None,
     dust: DustParameters | None = None,
+    oxidants: OxidantParameters | None = None,
+    sulfur_gas: SulfurGasParameters | None = None,
+    aqueous: AqueousSulfurParameters | None = None,
     activation: ArgParameters | None = None,
     sedimentation: SedParameters | None = None,
     drydep: DryDepParameters | None = None,
@@ -93,31 +108,40 @@ def jam_aerosol_physics(
         arg_variant: ``"arg2000"`` (default) or ``"ghosh2025"`` activation.
         seasalt/dms/dust: optional ``Parameters`` overrides for the natural
             emission schemes (Gong sea salt, Nightingale DMS, Tegen dust).
+        oxidants/sulfur_gas/aqueous: optional ``Parameters`` for the
+            prescribed-oxidant + gas-phase + aqueous sulfur chemistry (#496).
         activation/sedimentation/drydep/wetdep: optional per-process
             ``Parameters`` overrides (each ``None`` resolves to its default).
 
     Returns:
-        ``[SeaSaltEmissions, DmsEmissions, DustEmissions, <core>,
-        ArgActivation, StokesSedimentation, SlinnDryDeposition,
-        WetScavenging]``.
+        The ordered term list: natural emissions, prescribed oxidants and
+        gas-phase sulfur chemistry, the microphysics core (optionally followed
+        by online optics), activation, sedimentation, dry deposition, in-cloud
+        aqueous sulfur chemistry, and wet deposition.
 
     """
     core = _resolve_microphysics(microphysics)
     spec = core.spec
-    terms = [
+    pre_core = [
         SeaSaltEmissions(params=seasalt, spec=spec),
         DmsEmissions(params=dms, spec=spec),
         DustEmissions(params=dust, spec=spec),
-        core,
+        # Sulfur chemistry: oxidants → gas-phase DMS/SO2 oxidation, producing
+        # the H2SO4/SOAG gas the core condenses + nucleates this same step.
+        PrescribedOxidants(params=oxidants),
+        SulfurGasChemistry(params=sulfur_gas),
+    ]
+    # Online aerosol direct radiative effect (#495): placed right after the core
+    # (needs ``_jam_state``); overwrites the MACv2-SP ``aerosol`` optics.
+    optics_terms = [JamOpticsTerm(spec=spec)] if optics else []
+    post_core = [
         ArgActivation(params=activation, spec=spec, variant=arg_variant),
         StokesSedimentation(params=sedimentation, spec=spec),
         SlinnDryDeposition(params=drydep, spec=spec),
+        # In-cloud aqueous SO2 oxidation → cloud-borne sulfate; runs in the
+        # post-cloud block (needs current clouds), just before wet scavenging.
+        AqueousSulfur(params=aqueous, spec=spec),
         WetScavenging(params=wetdep, spec=spec),
     ]
-    if optics:
-        # Online aerosol direct radiative effect (#495): overwrites the
-        # MACv2-SP optics in the ``aerosol`` diagnostic. Placed after the core
-        # (needs ``_jam_state``); reads the MACv2-SP ``aerosol`` struct that
-        # ``echam_physics`` provides upstream.
-        terms.insert(4, JamOpticsTerm(spec=spec))
+    terms = [*pre_core, core, *optics_terms, *post_core]
     return terms

--- a/jcm/physics/aerosol/jam/jam_terms_test.py
+++ b/jcm/physics/aerosol/jam/jam_terms_test.py
@@ -22,11 +22,14 @@ class JamFactoryTest(unittest.TestCase):
         self.assertEqual(
             cats[3:],
             [
+                "aerosol_oxidants",
+                "aerosol_gas_chemistry",
                 "aerosol_microphysics",
                 "aerosol_optics",
                 "aerosol_activation",
                 "aerosol_sedimentation",
                 "aerosol_drydep",
+                "aerosol_aqueous_chemistry",
                 "aerosol_wetdep",
             ],
         )

--- a/jcm/physics/aerosol/jam/microphysics/mam4_jax.py
+++ b/jcm/physics/aerosol/jam/microphysics/mam4_jax.py
@@ -50,13 +50,22 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
+from jcm.physics.aerosol.jam.gas_species import MAM4_GAS
 from jcm.physics.aerosol.jam.jam_state import JamAerosolState
 from jcm.physics.aerosol.jam.microphysics.base import ModalMicrophysicsTerm
 from jcm.physics.aerosol.jam.microphysics.mam4_data import MAM4_SPEC
 from jcm.physics.aerosol.jam.population import ModalAerosolSpec
-from jcm.physics.aerosol.jam.tracer_layout import mass_name, number_name
+from jcm.physics.aerosol.jam.tracer_layout import (
+    gas_name,
+    mass_name,
+    number_name,
+)
 from jcm.physics.convection.saturation import saturation_specific_humidity
 from jcm.physics_interface import PhysicsTendency
+
+# amicphys ``name_gas`` order (igas): 0 = SOA gas, 1 = H₂SO₄. ``data.LMAP_GAS``
+# maps each to its pcnst slot, so jcm's gas tokens resolve to q indices.
+_GAS_IGAS: dict[str, int] = {"soag": 0, "h2so4": 1}
 
 # jcm aerosol species token -> MAM4 ``SPECNAME_AMODE`` type index. This is the
 # physical correspondence between jcm's canonical tokens and MAM4's species
@@ -152,6 +161,11 @@ class Mam4JaxMicrophysics(ModalMicrophysicsTerm):
                 sp_list.append((midx, props.density, props.hygroscopicity))
             mode_species.append(sp_list)
 
+        # Gas tracers fed to the core: g_h2so4/g_soag -> their pcnst slots.
+        self._gas_pack = tuple(
+            (gas_name(g), int(data.LMAP_GAS[_GAS_IGAS[g]])) for g in MAM4_GAS
+        )
+
         self._q_pack = tuple(q_pack)
         self._qqcw_pack = tuple(qqcw_pack)
         self._num_pcnst = tuple(num_pcnst)
@@ -203,6 +217,10 @@ class Mam4JaxMicrophysics(ModalMicrophysicsTerm):
         q = jnp.zeros(shape + (self._pcnst,), jnp.float64)
         q = q.at[..., 0].set(jnp.asarray(state.specific_humidity, jnp.float64))
         for name, idx in self._q_pack:
+            q = q.at[..., idx].set(fetch(name))
+        # Gas-phase H₂SO₄/SOAG from the sulfur chemistry → MAM4 gas slots; the
+        # core condenses/nucleates them (other gas slots stay zero).
+        for name, idx in self._gas_pack:
             q = q.at[..., idx].set(fetch(name))
         qqcw = jnp.zeros(shape + (self._pcnst,), jnp.float64)
         for name, idx in self._qqcw_pack:
@@ -282,6 +300,12 @@ class Mam4JaxMicrophysics(ModalMicrophysicsTerm):
         for name, idx in self._qqcw_pack:
             tracer_tends[name] = (
                 (qqcw_new[..., idx] - qqcw[..., idx]) / dt
+            ).astype(out_dtype)
+        # Gas consumed by condensation/nucleation → sink on the gas tracers
+        # (the matching aerosol gain flows through the aerosol-slot readback).
+        for name, idx in self._gas_pack:
+            tracer_tends[name] = (
+                (q_new[..., idx] - q[..., idx]) / dt
             ).astype(out_dtype)
 
         jam_state = self._jam_state(

--- a/jcm/physics/aerosol/jam/microphysics/mam4_jax.py
+++ b/jcm/physics/aerosol/jam/microphysics/mam4_jax.py
@@ -161,10 +161,12 @@ class Mam4JaxMicrophysics(ModalMicrophysicsTerm):
                 sp_list.append((midx, props.density, props.hygroscopicity))
             mode_species.append(sp_list)
 
-        # Gas tracers fed to the core: g_h2so4/g_soag -> their pcnst slots.
-        self._gas_pack = tuple(
-            (gas_name(g), int(data.LMAP_GAS[_GAS_IGAS[g]])) for g in MAM4_GAS
-        )
+        # Gas tracers (H2SO4/SOAG) resolve their pcnst slot from a *different*
+        # MAM4 index table (LMAP_GAS) than the aerosol tracers, but once mapped
+        # they are packed into ``q`` and read back as tendencies exactly like
+        # any other tracer — so they just join ``q_pack``.
+        for g in MAM4_GAS:
+            q_pack.append((gas_name(g), int(data.LMAP_GAS[_GAS_IGAS[g]])))
 
         self._q_pack = tuple(q_pack)
         self._qqcw_pack = tuple(qqcw_pack)
@@ -217,10 +219,6 @@ class Mam4JaxMicrophysics(ModalMicrophysicsTerm):
         q = jnp.zeros(shape + (self._pcnst,), jnp.float64)
         q = q.at[..., 0].set(jnp.asarray(state.specific_humidity, jnp.float64))
         for name, idx in self._q_pack:
-            q = q.at[..., idx].set(fetch(name))
-        # Gas-phase H₂SO₄/SOAG from the sulfur chemistry → MAM4 gas slots; the
-        # core condenses/nucleates them (other gas slots stay zero).
-        for name, idx in self._gas_pack:
             q = q.at[..., idx].set(fetch(name))
         qqcw = jnp.zeros(shape + (self._pcnst,), jnp.float64)
         for name, idx in self._qqcw_pack:
@@ -300,12 +298,6 @@ class Mam4JaxMicrophysics(ModalMicrophysicsTerm):
         for name, idx in self._qqcw_pack:
             tracer_tends[name] = (
                 (qqcw_new[..., idx] - qqcw[..., idx]) / dt
-            ).astype(out_dtype)
-        # Gas consumed by condensation/nucleation → sink on the gas tracers
-        # (the matching aerosol gain flows through the aerosol-slot readback).
-        for name, idx in self._gas_pack:
-            tracer_tends[name] = (
-                (q_new[..., idx] - q[..., idx]) / dt
             ).astype(out_dtype)
 
         jam_state = self._jam_state(

--- a/jcm/physics/aerosol/jam/microphysics/mam4_jax_test.py
+++ b/jcm/physics/aerosol/jam/microphysics/mam4_jax_test.py
@@ -39,6 +39,9 @@ def _column_state(nlev=4, ncols=2):
             tracers[mass_name(sp, mode.short, cloud_borne=True)] = jnp.full(
                 (nlev, ncols), 1.0e-12
             )
+    # Gas-phase precursors fed to the core.
+    tracers["g_h2so4"] = jnp.full((nlev, ncols), 1.0e-12)
+    tracers["g_soag"] = jnp.full((nlev, ncols), 1.0e-12)
     state = PhysicsState.zeros((nlev, ncols)).copy(
         temperature=jnp.full((nlev, ncols), 280.0),
         specific_humidity=jnp.full((nlev, ncols), 5.0e-3),
@@ -65,6 +68,16 @@ class Mam4JaxAdapterTest(unittest.TestCase):
         terms = jam_aerosol_physics(microphysics="mam4_jax")
         core = next(t for t in terms if t.category == "aerosol_microphysics")
         self.assertEqual(core.name, "jam_mam4_jax_microphysics")
+
+    def test_gas_pack_maps_h2so4_and_soag(self):
+        from jcm.physics.aerosol.jam.microphysics.mam4_jax import (
+            Mam4JaxMicrophysics,
+        )
+
+        term = Mam4JaxMicrophysics()
+        gas = dict(term._gas_pack)
+        self.assertEqual(gas["g_h2so4"], 6)
+        self.assertEqual(gas["g_soag"], 9)
 
     def test_packing_covers_every_interstitial_tracer(self):
         from jcm.physics.aerosol.jam import MAM4_SPEC, mass_name, number_name

--- a/jcm/physics/aerosol/jam/microphysics/mam4_jax_test.py
+++ b/jcm/physics/aerosol/jam/microphysics/mam4_jax_test.py
@@ -69,15 +69,15 @@ class Mam4JaxAdapterTest(unittest.TestCase):
         core = next(t for t in terms if t.category == "aerosol_microphysics")
         self.assertEqual(core.name, "jam_mam4_jax_microphysics")
 
-    def test_gas_pack_maps_h2so4_and_soag(self):
+    def test_gas_tracers_map_to_their_pcnst_slots(self):
         from jcm.physics.aerosol.jam.microphysics.mam4_jax import (
             Mam4JaxMicrophysics,
         )
 
-        term = Mam4JaxMicrophysics()
-        gas = dict(term._gas_pack)
-        self.assertEqual(gas["g_h2so4"], 6)
-        self.assertEqual(gas["g_soag"], 9)
+        # Gases share the single q_pack with the aerosol tracers.
+        packed = dict(Mam4JaxMicrophysics()._q_pack)
+        self.assertEqual(packed["g_h2so4"], 6)
+        self.assertEqual(packed["g_soag"], 9)
 
     def test_packing_covers_every_interstitial_tracer(self):
         from jcm.physics.aerosol.jam import MAM4_SPEC, mass_name, number_name
@@ -87,16 +87,16 @@ class Mam4JaxAdapterTest(unittest.TestCase):
 
         term = Mam4JaxMicrophysics()
         packed = {name for name, _ in term._q_pack}
-        expected = set()
+        expected = {"g_h2so4", "g_soag"}
         for mode in MAM4_SPEC.modes:
             expected.add(number_name(mode.short))
             for sp in mode.species:
                 expected.add(mass_name(sp, mode.short))
         self.assertEqual(packed, expected)
-        # pcnst indices are unique and inside the aerosol band [10, 34].
+        # pcnst indices are unique and inside the aerosol/gas band [6, 34].
         idxs = [idx for _, idx in term._q_pack]
         self.assertEqual(len(idxs), len(set(idxs)))
-        self.assertTrue(all(10 <= i <= 34 for i in idxs))
+        self.assertTrue(all(6 <= i <= 34 for i in idxs))
 
     def test_forward_finite_and_physical(self):
         from jcm.physics.aerosol.jam import MAM4_SPEC, mass_name

--- a/jcm/physics/aerosol/jam/tracer_layout.py
+++ b/jcm/physics/aerosol/jam/tracer_layout.py
@@ -26,6 +26,20 @@ from jcm.physics.aerosol.jam.population import ModalAerosolSpec
 from jcm.physics.physics_term import TracerSpec
 
 
+def gas_name(species: str) -> str:
+    """Tracer key for a gas-phase precursor mixing ratio (e.g. ``g_so2``)."""
+    return f"g_{species}"
+
+
+def gas_tracer_specs(species: tuple[str, ...]) -> tuple[TracerSpec, ...]:
+    """TracerSpecs for the given gas-phase precursor tokens.
+
+    Gas precursors are ordinary mass mixing ratios [kg/kg] (transported and
+    nondimensionalised like aerosol mass), one per token.
+    """
+    return tuple(TracerSpec(gas_name(s), units="kg/kg") for s in species)
+
+
 def mass_name(species: str, mode_short: str, *, cloud_borne: bool = False) -> str:
     """Tracer key for a (species, mode) mass mixing ratio."""
     prefix = "mc" if cloud_borne else "m"

--- a/jcm/physics/echam/echam_terms.py
+++ b/jcm/physics/echam/echam_terms.py
@@ -193,11 +193,15 @@ def echam_physics(
         jam_terms = jam_aerosol_physics(
             microphysics=jam_microphysics, arg_variant=jam_arg_variant,
         )
+        # Aqueous chemistry + wet deposition need the current step's clouds, so
+        # they run after the cloud microphysics term; the rest of the JAM chain
+        # is the pre-cloud aerosol block.
+        _post_cloud = ("aerosol_wetdep", "aerosol_aqueous_chemistry")
         jam_post_cloud_terms = [
-            t for t in jam_terms if t.category == "aerosol_wetdep"
+            t for t in jam_terms if t.category in _post_cloud
         ]
         jam_pre_cloud_terms = [
-            t for t in jam_terms if t.category != "aerosol_wetdep"
+            t for t in jam_terms if t.category not in _post_cloud
         ]
         aerosol_terms = [Macv2SpAerosol(params=aerosol_p), *jam_pre_cloud_terms]
     else:

--- a/jcm/physics/echam/echam_terms.py
+++ b/jcm/physics/echam/echam_terms.py
@@ -72,6 +72,7 @@ def echam_physics(
     aerosol_module: str = "macv2sp",
     jam_microphysics: str = "placeholder",
     jam_arg_variant: str = "arg2000",
+    jam_aqueous_scheme: str = "full",
 ):
     """Create a ``ComposablePhysics`` with the standard ECHAM term ordering.
 
@@ -115,6 +116,8 @@ def echam_physics(
         jam_microphysics: JAM core when ``aerosol_module="jam"`` —
             ``"placeholder"`` (κ-Köhler equilibrium) today; MAM4-JAX is #490.
         jam_arg_variant: ``"arg2000"`` (default) or ``"ghosh2025"`` activation.
+        jam_aqueous_scheme: ``"full"`` (default, HAM port) or ``"simple"``
+            (H2O2-limited) in-cloud aqueous sulfur chemistry.
 
     Returns:
         A ``ComposablePhysics`` instance with all ECHAM terms in the
@@ -192,6 +195,7 @@ def echam_physics(
         from jcm.physics.aerosol.jam.jam_terms import jam_aerosol_physics
         jam_terms = jam_aerosol_physics(
             microphysics=jam_microphysics, arg_variant=jam_arg_variant,
+            aqueous_scheme=jam_aqueous_scheme,
         )
         # Aqueous chemistry + wet deposition need the current step's clouds, so
         # they run after the cloud microphysics term; the rest of the JAM chain


### PR DESCRIPTION
## Summary
Closes the gas-phase coupling for the MAM4-JAX core (#496, builds on #510). Implements a **prescribed-oxidant sulfur cycle** — gas-phase *and* aqueous — so the core's condensation/nucleation are driven by jcm's sulfur chemistry instead of zeroed gas slots.

The loop now closes end-to-end:
**DMS emission → DMS+OH/NO₃ → SO₂ → SO₂+OH → H₂SO₄(gas) → MAM4 condensation + nucleation**, plus **in-cloud SO₂ + H₂O₂/O₃ → cloud-borne SO₄**.

All kinetics are ported **verbatim from ECHAM-HAM** (per maintainer instruction) with **no simplification** of the aqueous chemistry.

## What's added (7 phases)
- **Gas tracers** `g_dms/g_so2/g_h2so4/g_soag` + `GasSpecies` table (`gas_species.py`, `tracer_layout.py`). Only `g_h2so4`/`g_soag` cross into MAM4's `q` slots — the gases `amicphys` consumes.
- **`PrescribedOxidants`** (`chemistry/oxidants.py`) — OH/NO₃/O₃/H₂O₂ number densities derived from fields jcm already carries: O₃ from `chemistry.ozone_vmr` and solar geometry from `radiation.cos_zenith` (both read from the previous-step carry, since chemistry/radiation run after the JAM block). OH is a daytime `cos(zenith)·[O₃]` proxy, NO₃ nighttime, H₂O₂ a BL-weighted reservoir. All scales are differentiable for later calibration / swap to a real climatology.
- **`SulfurGasChemistry`** (`chemistry/sulfur_gas.py`) — port of `mo_ham_chemistry.f90::ham_gas_chemistry`: DMS+OH abstraction+addition with the `f_so2=(k1+0.75k2)/(k1+k2)` branch, DMS+NO₃, SO₂+OH+M Troe. Rate constants verbatim. **Adapted for MAM4**: SO₂+OH and the DMS "MSA" branch route to gas-phase H₂SO₄ (not directly to aerosol SO₄), so the core owns the gas→particle step.
- **`AqueousSulfur`** (`chemistry/aqueous.py`) — **full** port of `ham_wet_chemistry` (Feichter et al. 1996): both SO₂+H₂O₂ and the pH-dependent SO₂+O₃ pathways over `niter=5` sub-steps, with the cloud-droplet H⁺ solved each sub-step from the sulfate/SO₂ charge balance (no fixed-pH). Produces cloud-borne SO₄ (`mc_so4_*`), split by cloud-borne number fraction (HAM `ms4as`/`ms4cs`). Runs post-cloud (current cloud water).
- **`DmsEmissions`** rerouted to emit `g_dms` (removes the interim direct-SO₄ shortcut).
- **MAM4 adapter** packs `g_h2so4`/`g_soag` into `q[...,6/9]` and reads the post-step change back as a gas sink (mapping from `data.LMAP_GAS`).
- **Factory + ordering**: `jam_aerosol_physics` composes oxidants + gas chemistry pre-core and aqueous chemistry post-cloud; `echam_physics` routes `aerosol_aqueous_chemistry` after the cloud term.

Sulfur is **conserved atom-for-atom** through the whole chain (verified by tests); everything is differentiable.

## Test plan
- [x] ~40 new unit tests across the 6 phases: rate constants vs HAM, sulfur conservation (gas + aqueous), day/night oxidant behaviour, H₂O₂-limited vs O₃ pathways, gradient finiteness, adapter gas-pack mapping.
- [x] Full repo fast suite green: **1075 passed, 13 skipped** (no regression from the DMS reroute / factory / echam-ordering changes).
- [x] T21 aquaplanet end-to-end (MAM4 core + full chemistry): finite & physical, ~4 GB, clean under `-W error::FutureWarning`; gas slots confirmed live.

## Follow-ups (documented in code)
- H₂O₂ is a prescribed oxidant, depleted within the niter sub-stepping (within-step limitation respected) and reset each step — this matches ECHAM-HAM offline-oxidant mode (`ham_wet_chemistry` likewise discards the depleted H₂O₂). A prognostic H₂O₂ budget is intentionally out of scope, not a gap.
- Interim oxidants are derived from existing fields; swapping in a real monthly oxidant climatology is a later sub-task.
- SOAG is an interim BL-weighted source pending a VOC precursor.
- Anthropogenic SO₂ emissions remain #498.

🤖 Generated with [Claude Code](https://claude.com/claude-code)