### PR TITLE
feat(aerosol): prescribed CEDS/biomass emissions — pipeline, wiring & CAM-faithful path (#498)

### DIFF
--- a/docs/design/jam.md
+++ b/docs/design/jam.md
@@ -169,6 +169,22 @@ from jcm.data.emissions import prepare_emissions, cesm_cmip_anthro
 ds = prepare_emissions(cesm_cmip_anthro(source_dir), coords, time_index=month)
 ```
 
+### From the CLI
+
+The `echam-jam` physics preset enables JAM with both emission terms (inert until
+fed). Point `forcing.emissions_file` at a model-grid file — it auto-routes by
+content (`emis_*` bulk vs `aero_emis_*` pre-speciated), and a wrong-grid file
+raises rather than silently zeroing:
+
+```
+python -m jcm.main physics=echam-jam grid=echam_t42_l8_sigma \
+    forcing.emissions_file=/path/to/emissions_on_model_grid.nc
+```
+
+`echam-jam` is *factory-built* (`physics.builder: echam_physics`) rather than a
+flat term list, because the JAM chain's ordering (split around the cloud term) is
+encoded by `echam_physics()` — `build_physics` delegates to it.
+
 See `.claude/aerosol_emissions_plan.md` for the full design, the data-source
 investigation (the raw 0.5° gridded CEDS is ESGF-only; a self-hosted compressed
 mirror is a tracked follow-up), and the CESM adapter's documented approximations.

--- a/docs/design/jam.md
+++ b/docs/design/jam.md
@@ -56,7 +56,9 @@ ARG variant) is a compose-time Python decision with no traced branching.
    core's population, so the harness works with any dycore (no modal
    representation is assumed on the dynamics side). DMS reads a prescribed
    seawater field and dust a prescribed source field from `ForcingData`
-   (zero fallback). Prescribed anthropogenic (CEDS) emissions are #498.
+   (zero fallback). Prescribed anthropogenic + biomass emissions
+   (`AnthropogenicEmissions`, #498) read bulk per-super-sector fluxes from
+   `ForcingData` — see "Prescribed anthropogenic & biomass emissions" below.
 2. microphysics core (`PlaceholderMicrophysics`) — writes `_jam_state`.
 3. `ArgActivation` — Abdul-Razzak & Ghan (2000); writes `activated_cdnc`
    (the same key the 2M SPA floor produces, so ARG and SPA are
@@ -101,11 +103,113 @@ to the MACv2-SP SPA floor wherever the online source is ≈0 (e.g. before the
 prognostic JAM tracers spin up from a zero-seeded initial state), so the
 default JAM+2M run always activates droplets.
 
+## Prescribed anthropogenic & biomass emissions (#498)
+
+Beyond the online natural sources, JAM can read **prescribed** SO₂/BC/OC
+emissions (`AnthropogenicEmissions`, opt-in via
+`echam_physics(aerosol_module="jam", jam_anthropogenic=True)`). These cover both
+CEDS anthropogenic activity and open biomass burning, organised into four
+**super-sectors** distinguished by *injection type and source size* (HAMMOZ's
+basis), not economic activity:
+
+| Super-sector | Injection (default) | Source |
+|---|---|---|
+| `surface_combustion` | surface (~0 m, σ 30 m) | CEDS TRA/RCO/AGR/WST/SLV |
+| `elevated_industrial` | ~50 m | CEDS ENE/IND |
+| `shipping` | marine surface | CEDS SHP |
+| `biomass_burning` | deep FIRE (~1 km, σ 1.5 km) | open burning (GFED/BB4CMIP7) |
+
+Each super-sector's bulk flux is speciated following HAMMOZ — SO₂ → a primary-SO₄
+fraction (default 2.5 %, into Aitken+accum sulfate) plus the `g_so2` gas
+remainder; BC/OC → the MAM4 primary-carbon mode (OC×1.4 = POA) — and distributed
+over a **smooth Gaussian vertical profile** (`injection.py`) so the injection
+height is differentiable (a hard level pick has no gradient). The injection
+height/thickness and primary-SO₄ fraction are per-super-sector differentiable
+`EmissionParameters`, defaulting to the HAMMOZ values, so they can be calibrated
+by gradient through the model.
+
+### Emissions-file contract
+
+The model is driven by a user-supplied file on (or already interpolated to) the
+model horizontal grid, carrying **bulk per-super-sector surface mass fluxes** —
+the model does the speciation and injection. Requirements:
+
+- **Variables:** `emis_<super_sector>_<species>` for the super-sectors above and
+  `species ∈ {so2, bc, oc}`. Any missing variable is treated as zero, so a file
+  need only carry the channels it has.
+- **Units:** kg m⁻² s⁻¹ surface flux. `so2` as SO₂ mass (not S); `bc`/`oc` as
+  carbon mass — **OC, not OM** (the OM:OC = 1.4 is applied in-model). The
+  primary-SO₄ fraction is *not* pre-applied — supply the full SO₂.
+- **Dims/time:** `(lon, lat, time)`; `time` may be a 12-month climatology
+  (wrap-year) or a multi-year monthly axis (by-date), matching the other forcing
+  fields.
+
+Load it onto `ForcingData` via:
+
+```python
+import xarray as xr
+from jcm.forcing import read_anthropogenic_emissions
+emis = read_anthropogenic_emissions(xr.open_dataset(emissions_file))
+forcing = forcing.copy(anthropogenic_emissions=emis)
+```
+
+### Preparing a file from a source product
+
+`jcm.data.emissions` regrids an arbitrary source onto the model grid and writes
+contract variables. The regridder (`regrid.py`) is light and **first-order
+conservative** (area-weighted nearest-cell binning), handling both regular
+lat/lon and unstructured `ncol` sources (e.g. CESM ne30). `prepare.py` maps
+source variables → contract variables via `Channel` records; shipped adapters
+`cesm_cmip_anthro(dir)` and `cesm_bb4cmip7(dir)` consume the CESM CMIP7 CEDS /
+biomass-burning files. `downloader.fetch` resolves a local path or arbitrary URL
+(host-agnostic — no ESGF coupling).
+
+```python
+from jcm.data.emissions import prepare_emissions, cesm_cmip_anthro
+ds = prepare_emissions(cesm_cmip_anthro(source_dir), coords, time_index=month)
+```
+
+See `.claude/aerosol_emissions_plan.md` for the full design, the data-source
+investigation (the raw 0.5° gridded CEDS is ESGF-only; a self-hosted compressed
+mirror is a tracked follow-up), and the CESM adapter's documented approximations.
+
+### Two emission paths: differentiable bulk vs CAM6-faithful pre-speciated
+
+The above is the **bulk / differentiable** path (`jam_anthropogenic=True`). There
+is a second, complementary path — `PreSpeciatedEmissions`
+(`jam_prescribed_speciated=True`) — that mirrors how **CAM6 actually applies
+emissions**: it reads **already-speciated per-tracer** fields and injects them
+directly, with no in-model speciation or injection parameters (CAM bakes the
+mode/sector split and vertical placement into the files offline;
+`mo_srf_emissions` for surface fields, `mo_extfrc` for altitude-resolved ones).
+
+| | bulk (`AnthropogenicEmissions`) | pre-speciated (`PreSpeciatedEmissions`) |
+|---|---|---|
+| Forcing | `emis_<sector>_<species>` bulk SO₂/BC/OC | `aero_emis_<tracer>` (`m_so4_acc`, `n_pcm`, `g_so2`, …) |
+| Speciation | **in-model**, differentiable (SO₄ frac, modes, OM:OC) | pre-baked in the file |
+| Injection | smooth Gaussian, differentiable height | surface (bottom layer) or 3-D volume per level |
+| Use | calibration of injection/speciation params | bit-faithful reproduction of CESM emissions |
+
+Both are independent flags (enable either, both, or neither) and both remain
+differentiable **w.r.t. the emission `ForcingData` fields themselves** — so even
+the pre-speciated path supports `∂(aerosol mmr)/∂(emission)` gradients, just not
+w.r.t. an injection-height knob it doesn't have.
+
+`prepare.cesm_mam4_speciated(dir)` + `prepare_speciated_emissions(...)` build the
+pre-speciated file from the CESM MAM4 files (a1→accum, a2→Aitken, a4→primary
+carbon; `SO2`→gas; `num_*`→number; the energy-sector `*_ene_vertical` 3-D
+`mo_extfrc` field column-integrated — ≤ ~400 m sits within the lowest model
+layer(s) at GCM resolution). This reproduces CESM's global budget, including the
+**2.5 % primary-sulfate split recovered to 3 decimals** — the validation
+counterpart to the differentiable path.
+
 ## Status and caveats
 
-- **Source magnitudes** (emissions) are order-of-magnitude defaults, not
-  inventory-calibrated. Prescribed CEDS emissions with HAMMOZ-grounded,
-  differentiable per-sector characteristics are tracked in #498.
+- **Natural source magnitudes** are order-of-magnitude defaults, not
+  inventory-calibrated. Prescribed CEDS/biomass emissions with HAMMOZ-grounded,
+  differentiable per-super-sector characteristics are now available (#498; see
+  above) and supersede the placeholders where a contract-conforming emissions
+  file is supplied.
 - **Wet scavenging** currently reconstructs the per-level precip-formation
   rate from column precip; exposing the true per-level formation/evaporation
   rates from the cloud schemes and adding re-evaporation re-injection is

--- a/jcm/config/forcing/default.yaml
+++ b/jcm/config/forcing/default.yaml
@@ -6,3 +6,11 @@ kind: default
 # ``forcing/from_file.yaml`` for the format. Null → use the analytical
 # fallback in ``EchamBoundaryConditions``.
 ozone_file: null
+
+# Optional prescribed aerosol emissions netCDF, already on the model grid
+# (regrid a source product with ``jcm.data.emissions.prepare`` first). Auto-
+# routes by content: ``emis_<sector>_<species>`` variables → the bulk /
+# differentiable path; ``aero_emis_<tracer>`` → the CAM6-faithful pre-speciated
+# path. Requires a JAM physics package with the emission term(s) enabled (e.g.
+# ``physics=echam-jam``). Null → no prescribed emissions.
+emissions_file: null

--- a/jcm/config/forcing/from_file.yaml
+++ b/jcm/config/forcing/from_file.yaml
@@ -11,3 +11,10 @@ file: ???
 # Fortuin-Kelder surrogate. Must already be on the model's horizontal
 # grid; preprocess the file if not.
 ozone_file: null
+
+# Optional prescribed aerosol emissions netCDF, already on the model grid
+# (regrid with ``jcm.data.emissions.prepare`` first). Auto-routes by content:
+# ``emis_<sector>_<species>`` → bulk/differentiable path; ``aero_emis_<tracer>``
+# → CAM6-faithful pre-speciated path. Needs a JAM physics package with the
+# emission term(s) (e.g. ``physics=echam-jam``). Null → no prescribed emissions.
+emissions_file: null

--- a/jcm/config/physics/echam-jam.yaml
+++ b/jcm/config/physics/echam-jam.yaml
@@ -14,19 +14,20 @@
 #
 # Both emission terms are enabled but **inert until a matching file is given**,
 # so a plain ``physics=echam-jam`` run is the zero-emission JAM baseline.
+#
+# Defaults use the real MAM4-JAX core, which is an optional GPL extra:
+#     pip install jcm[mam4]
+# Without it, override the core: ``physics.jam_microphysics=placeholder``.
 
 builder: echam_physics
 
 aerosol_module: jam
 cloud_scheme: 2m            # ARG activated_cdnc feeds the 2-moment scheme
-radiation_scheme: grey      # set radiation_scheme=rrtmgp for RRTMGP
-jam_microphysics: placeholder
-jam_arg_variant: arg2000    # or ghosh2025
+radiation_scheme: rrtmgp    # set radiation_scheme=grey for the cheap grey scheme
+jam_microphysics: mam4_jax  # the MAM4-JAX core (#490); "placeholder" for κ-Köhler
+jam_arg_variant: ghosh2025  # or arg2000
 jam_aqueous_scheme: full
 
 # Prescribed-emission terms (driven by forcing.emissions_file):
 jam_anthropogenic: true        # bulk SO2/BC/OC → in-model speciation + injection
 jam_prescribed_speciated: true # already-speciated per-tracer fields (CAM-faithful)
-
-# Consumed by Model (not the factory); null = auto-detect from device HBM.
-radiation_chunk_size: null

--- a/jcm/config/physics/echam-jam.yaml
+++ b/jcm/config/physics/echam-jam.yaml
@@ -1,0 +1,32 @@
+# ECHAM physics with the JAM prognostic aerosol module.
+#
+# Unlike the term-list presets (``echam.yaml`` etc.), this is **factory-built**:
+# ``physics.builder`` tells ``runners.build_physics`` to call
+# ``echam_physics(**these_kwargs)``, which encodes the JAM aerosol chain's
+# validated ordering (the chain is split around the cloud term, so a flat term
+# list can't express it). Only scalar flags below are forwarded; per-scheme
+# ``Parameters`` keep their ``.default()``.
+#
+# End-to-end usage (supply emissions on the model grid; auto-routes by content):
+#
+#     python -m jcm.main physics=echam-jam grid=echam_t42_l8_sigma \
+#         forcing.emissions_file=/path/to/emissions_on_model_grid.nc
+#
+# Both emission terms are enabled but **inert until a matching file is given**,
+# so a plain ``physics=echam-jam`` run is the zero-emission JAM baseline.
+
+builder: echam_physics
+
+aerosol_module: jam
+cloud_scheme: 2m            # ARG activated_cdnc feeds the 2-moment scheme
+radiation_scheme: grey      # set radiation_scheme=rrtmgp for RRTMGP
+jam_microphysics: placeholder
+jam_arg_variant: arg2000    # or ghosh2025
+jam_aqueous_scheme: full
+
+# Prescribed-emission terms (driven by forcing.emissions_file):
+jam_anthropogenic: true        # bulk SO2/BC/OC → in-model speciation + injection
+jam_prescribed_speciated: true # already-speciated per-tracer fields (CAM-faithful)
+
+# Consumed by Model (not the factory); null = auto-detect from device HBM.
+radiation_chunk_size: null

--- a/jcm/data/emissions/__init__.py
+++ b/jcm/data/emissions/__init__.py
@@ -1,0 +1,39 @@
+"""Emissions data pipeline: regrid an arbitrary source onto the model grid.
+
+Public API:
+
+* :func:`jcm.data.emissions.regrid.build_regridder` / ``model_grid`` — a light,
+  first-order conservative remap from any ``(lon, lat, area)`` source (regular or
+  unstructured) onto the model's spectral Gaussian grid.
+* :func:`jcm.data.emissions.prepare.prepare_emissions` + :class:`Channel` /
+  ``cesm_cmip_anthro`` — map source variables to the emissions-file contract and
+  regrid them.
+* :func:`jcm.data.emissions.downloader.fetch` — host-agnostic resolve-to-local.
+
+The produced dataset is loaded onto ``ForcingData`` via
+:func:`jcm.forcing.read_anthropogenic_emissions`. See
+``.claude/aerosol_emissions_plan.md`` for the runtime emissions-file contract.
+"""
+
+from jcm.data.emissions.prepare import (
+    Channel,
+    SpeciatedChannel,
+    cesm_bb4cmip7,
+    cesm_cmip_anthro,
+    cesm_mam4_speciated,
+    prepare_emissions,
+    prepare_speciated_emissions,
+)
+from jcm.data.emissions.regrid import build_regridder, model_grid
+
+__all__ = [
+    "build_regridder",
+    "model_grid",
+    "prepare_emissions",
+    "Channel",
+    "cesm_cmip_anthro",
+    "cesm_bb4cmip7",
+    "prepare_speciated_emissions",
+    "SpeciatedChannel",
+    "cesm_mam4_speciated",
+]

--- a/jcm/data/emissions/downloader.py
+++ b/jcm/data/emissions/downloader.py
@@ -1,0 +1,58 @@
+"""Host-agnostic fetch for emission source files.
+
+Deliberately *not* coupled to ESGF or any single provider: prescribed-emission
+files are large and live in many places (a local path on an HPC scratch disk, an
+HTTP(S) URL, an object-store bucket, a future self-hosted mirror — see the
+follow-up issue on hosting a compressed 0.5° CEDS mirror). This helper resolves
+any of those to a local path, with optional sha256 verification and on-disk
+caching, so the rest of the pipeline only ever sees a file path.
+
+It is a thin wrapper over :mod:`pooch` (already a dependency via xarray's I/O
+extra) plus a trivial local-path passthrough.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+
+
+def fetch(source: str, *, known_hash: str | None = None,
+          cache_dir: str | None = None) -> str:
+    """Resolve ``source`` to a local file path.
+
+    Args:
+        source: a local filesystem path **or** an ``http(s)://`` / ``ftp://`` /
+            ``doi:`` URL understood by pooch.
+        known_hash: optional ``"sha256:…"`` (or bare hex) to verify the file;
+            ``None`` skips verification (and, for a remote file, accepts whatever
+            is downloaded — fine for trusted sources, but pass a hash for
+            reproducibility).
+        cache_dir: directory for downloaded files; defaults to pooch's OS cache
+            under ``jcm_emissions`` (override with ``$JCM_EMISSIONS_CACHE``).
+
+    Returns:
+        Absolute path to the local file.
+
+    """
+    # Local files are returned as-is (after an existence check) so callers can
+    # point straight at e.g. the on-disk CESM CEDS files.
+    if os.path.exists(source):
+        return os.path.abspath(source)
+
+    import pooch
+
+    cache_dir = cache_dir or os.environ.get(
+        "JCM_EMISSIONS_CACHE",
+        os.path.join(pooch.os_cache("jcm_emissions")),
+    )
+    return pooch.retrieve(url=source, known_hash=known_hash, path=cache_dir)
+
+
+def stage(source: str, dest: str, *, known_hash: str | None = None) -> str:
+    """Fetch ``source`` and copy it to ``dest`` (e.g. into a run directory)."""
+    local = fetch(source, known_hash=known_hash)
+    os.makedirs(os.path.dirname(os.path.abspath(dest)), exist_ok=True)
+    if os.path.abspath(local) != os.path.abspath(dest):
+        shutil.copyfile(local, dest)
+    return os.path.abspath(dest)

--- a/jcm/data/emissions/downloader_test.py
+++ b/jcm/data/emissions/downloader_test.py
@@ -1,0 +1,44 @@
+"""Tests for the host-agnostic emissions downloader (#498)."""
+
+import os
+import tempfile
+import unittest
+
+from jcm.data.emissions.downloader import fetch, stage
+
+
+class DownloaderTest(unittest.TestCase):
+    def test_local_path_returned_as_abspath(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "emis.nc")
+            with open(p, "w") as fh:
+                fh.write("x")
+            # A local file resolves to itself (absolute), no download.
+            self.assertEqual(fetch(p), os.path.abspath(p))
+
+    def test_local_relative_path_resolved(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "rel.nc")
+            with open(p, "w") as fh:
+                fh.write("x")
+            cwd = os.getcwd()
+            try:
+                os.chdir(d)
+                self.assertEqual(fetch("rel.nc"), os.path.abspath(p))
+            finally:
+                os.chdir(cwd)
+
+    def test_stage_copies_to_dest(self):
+        with tempfile.TemporaryDirectory() as d:
+            src = os.path.join(d, "src.nc")
+            with open(src, "w") as fh:
+                fh.write("payload")
+            dest = os.path.join(d, "sub", "dest.nc")
+            out = stage(src, dest)
+            self.assertEqual(out, os.path.abspath(dest))
+            with open(out) as fh:
+                self.assertEqual(fh.read(), "payload")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jcm/data/emissions/emissions_pipeline_test.py
+++ b/jcm/data/emissions/emissions_pipeline_test.py
@@ -1,0 +1,219 @@
+"""Phase D: prescribed anthropogenic emissions wired through ForcingData.
+
+Fast tests cover the emissions-file contract round-trip (``read_anthropogenic_
+emissions`` → ``ForcingData`` → ``select(date)`` slicing). A slow test runs the
+full JAM stack on a T21 aquaplanet and checks the prescribed emission actually
+raises the relevant aerosol burden vs an emission-free control.
+"""
+
+import unittest
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import xarray as xr
+
+from jcm.forcing import (
+    ForcingData,
+    read_anthropogenic_emissions,
+    read_prescribed_aerosol_emissions,
+)
+
+_NLON, _NLAT = 64, 32  # T21 nodal shape
+_NLEV = 20
+
+
+def _synthetic_emissions_ds(nmonths: int = 12, so2=2.0e-11, bc=1.0e-11, oc=3.0e-11):
+    """Build a minimal contract-conformant emissions Dataset on the T21 grid."""
+    shape = (_NLON, _NLAT, nmonths)
+    coords = {
+        "lon": np.linspace(0, 360, _NLON, endpoint=False),
+        "lat": np.linspace(-87, 87, _NLAT),
+        "time": np.arange(nmonths),
+    }
+    data = {
+        "emis_surface_combustion_so2": (("lon", "lat", "time"), np.full(shape, so2)),
+        "emis_surface_combustion_bc": (("lon", "lat", "time"), np.full(shape, bc)),
+        "emis_surface_combustion_oc": (("lon", "lat", "time"), np.full(shape, oc)),
+    }
+    return xr.Dataset(data, coords=coords)
+
+
+class ContractRoundTripTest(unittest.TestCase):
+    def _date(self):
+        from jcm.date import DateData
+        import jax_datetime as jdt
+        return DateData.set_date(
+            model_time=jdt.Datetime.from_pydatetime(jdt.to_datetime("2001-07-02")),
+            calendar="gregorian",
+        )
+
+    def test_returns_none_without_emis_vars(self):
+        # A dataset with no emis_* variable yields None (so .copy is a no-op).
+        ds = xr.Dataset({"sst": (("lon", "lat"), np.zeros((4, 4)))})
+        self.assertIsNone(read_anthropogenic_emissions(ds))
+
+    def test_reads_all_channels(self):
+        emis = read_anthropogenic_emissions(_synthetic_emissions_ds())
+        self.assertEqual(
+            set(emis),
+            {"emis_surface_combustion_so2", "emis_surface_combustion_bc",
+             "emis_surface_combustion_oc"},
+        )
+
+    def test_select_slices_channels_to_grid(self):
+        # After select(date), each per-channel TimeSeries collapses to the bare
+        # (lon, lat) grid the term consumes (ravels to ncols = lon*lat).
+        emis = read_anthropogenic_emissions(_synthetic_emissions_ds())
+        forcing = ForcingData.zeros((_NLON, _NLAT)).copy(
+            anthropogenic_emissions=emis)
+        sliced = forcing.select(self._date(), calendar="gregorian")
+        bc = sliced.anthropogenic_emissions["emis_surface_combustion_bc"]
+        self.assertEqual(bc.shape, (_NLON, _NLAT))
+        self.assertEqual(jnp.ravel(bc).size, _NLON * _NLAT)
+        self.assertTrue(np.allclose(np.asarray(bc), 1.0e-11))
+
+    def test_static_field_passthrough(self):
+        # A time-less emissions field is carried as a bare array, still sliced
+        # to a no-op by select.
+        ds = _synthetic_emissions_ds().isel(time=0)  # drop time dim
+        emis = read_anthropogenic_emissions(ds)
+        bc = emis["emis_surface_combustion_bc"]
+        self.assertEqual(bc.shape, (_NLON, _NLAT))
+
+
+def _synthetic_speciated_ds(nmonths=12):
+    """Build a pre-speciated (aero_emis_*) Dataset: a 2-D and a 3-D channel."""
+    coords = {
+        "lon": np.linspace(0, 360, _NLON, endpoint=False),
+        "lat": np.linspace(-87, 87, _NLAT),
+        "lev": np.arange(_NLEV),
+        "time": np.arange(nmonths),
+    }
+    surf = np.full((_NLON, _NLAT, nmonths), 2.0e-11)
+    vol = np.full((_NLEV, _NLON, _NLAT, nmonths), 1.0e-13)
+    return xr.Dataset(
+        {
+            "aero_emis_m_bc_pcm": (("lon", "lat", "time"), surf),
+            "aero_emis_m_so4_acc": (("lev", "lon", "lat", "time"), vol),
+        },
+        coords=coords,
+    )
+
+
+class PreSpeciatedContractTest(unittest.TestCase):
+    def _date(self):
+        from jcm.date import DateData
+        import jax_datetime as jdt
+        return DateData.set_date(
+            model_time=jdt.Datetime.from_pydatetime(jdt.to_datetime("2001-07-02")),
+            calendar="gregorian")
+
+    def test_returns_none_without_vars(self):
+        ds = xr.Dataset({"emis_surface_combustion_so2":
+                         (("lon", "lat"), np.zeros((4, 4)))})
+        self.assertIsNone(read_prescribed_aerosol_emissions(ds))
+
+    def test_keys_strip_prefix(self):
+        emis = read_prescribed_aerosol_emissions(_synthetic_speciated_ds())
+        self.assertEqual(set(emis), {"m_bc_pcm", "m_so4_acc"})
+
+    def test_select_slices_surface_and_volume(self):
+        emis = read_prescribed_aerosol_emissions(_synthetic_speciated_ds())
+        forcing = ForcingData.zeros((_NLON, _NLAT)).copy(
+            prescribed_aerosol_emissions=emis)
+        sliced = forcing.select(self._date(), calendar="gregorian")
+        got = sliced.prescribed_aerosol_emissions
+        # 2-D surface channel → (lon, lat); 3-D volume channel → (lev, lon, lat).
+        self.assertEqual(got["m_bc_pcm"].shape, (_NLON, _NLAT))
+        self.assertEqual(got["m_so4_acc"].shape, (_NLEV, _NLON, _NLAT))
+
+
+@pytest.mark.slow
+class EmissionsRaiseBurdenTest(unittest.TestCase):
+    """End-to-end: a prescribed BC/OC source raises the primary-carbon burden."""
+
+    def _run(self, with_emissions: bool):
+        from jcm.model import Model
+        from jcm.physics.echam.echam_terms import echam_physics
+        from jcm.terrain import TerrainData
+        from jcm.utils import get_coords
+
+        sigma_boundaries = np.linspace(0, 1, 21)
+        coords = get_coords(sigma_boundaries, spectral_truncation=21)
+        terrain = TerrainData.aquaplanet(coords)
+        model = Model(
+            coords=coords, time_step=30, terrain=terrain,
+            physics=echam_physics(aerosol_module="jam", cloud_scheme="2m",
+                                  jam_anthropogenic=True),
+        )
+        from jcm.forcing import default_forcing
+        forcing = default_forcing(coords.horizontal)
+        if with_emissions:
+            # A strong, uniform anthropogenic source so the signal is
+            # unambiguous over the few-step run.
+            emis = read_anthropogenic_emissions(
+                _synthetic_emissions_ds(bc=5.0e-9, oc=5.0e-9, so2=5.0e-9))
+            forcing = forcing.copy(anthropogenic_emissions=emis)
+        preds = model.run(forcing=forcing, save_interval=0.0625, total_time=0.0625)
+        return preds
+
+    def test_bc_burden_increases_with_emissions(self):
+        from jcm.physics.aerosol.jam import mass_name
+
+        on = self._run(with_emissions=True).dynamics.tracers
+        off = self._run(with_emissions=False).dynamics.tracers
+        bc = mass_name("bc", "pcm")  # primary-carbon BC: the anthropogenic sink
+
+        burden_on = float(np.sum(np.asarray(on[bc])))
+        burden_off = float(np.sum(np.asarray(off[bc])))
+        self.assertTrue(np.all(np.isfinite(np.asarray(on[bc]))))
+        # The prescribed BC source must raise the primary-carbon BC burden.
+        self.assertGreater(burden_on, burden_off)
+
+
+@pytest.mark.slow
+class PreSpeciatedRaisesBurdenTest(unittest.TestCase):
+    """End-to-end: the CAM-faithful pre-speciated path injects into MAM4 tracers."""
+
+    def _run(self, with_emissions: bool):
+        from jcm.model import Model
+        from jcm.physics.echam.echam_terms import echam_physics
+        from jcm.terrain import TerrainData
+        from jcm.utils import get_coords
+        from jcm.forcing import default_forcing
+
+        sigma_boundaries = np.linspace(0, 1, 21)
+        coords = get_coords(sigma_boundaries, spectral_truncation=21)
+        model = Model(
+            coords=coords, time_step=30, terrain=TerrainData.aquaplanet(coords),
+            physics=echam_physics(aerosol_module="jam", cloud_scheme="2m",
+                                  jam_prescribed_speciated=True),
+        )
+        forcing = default_forcing(coords.horizontal)
+        if with_emissions:
+            # A uniform, already-speciated accumulation-sulfate source.
+            shape = (_NLON, _NLAT, 12)
+            ds = xr.Dataset(
+                {"aero_emis_m_so4_acc": (("lon", "lat", "time"),
+                                         np.full(shape, 5.0e-9))},
+                coords={"lon": np.linspace(0, 360, _NLON, endpoint=False),
+                        "lat": np.linspace(-87, 87, _NLAT),
+                        "time": np.arange(12)})
+            forcing = forcing.copy(
+                prescribed_aerosol_emissions=read_prescribed_aerosol_emissions(ds))
+        return model.run(forcing=forcing, save_interval=0.0625, total_time=0.0625)
+
+    def test_so4_burden_increases(self):
+        from jcm.physics.aerosol.jam import mass_name
+
+        on = self._run(with_emissions=True).dynamics.tracers
+        off = self._run(with_emissions=False).dynamics.tracers
+        so4 = mass_name("so4", "acc")
+        self.assertTrue(np.all(np.isfinite(np.asarray(on[so4]))))
+        self.assertGreater(float(np.sum(np.asarray(on[so4]))),
+                           float(np.sum(np.asarray(off[so4]))))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jcm/data/emissions/prepare.py
+++ b/jcm/data/emissions/prepare.py
@@ -1,0 +1,349 @@
+"""Turn a source-grid emission file into a model-grid emissions-file.
+
+Bridges an arbitrary emission product to the runtime **emissions-file contract**
+(``emis_<sector>_<species>`` bulk surface mass fluxes [kg/m²/s] on the model
+grid; see ``.claude/aerosol_emissions_plan.md``). The work is:
+
+1. read the requested source variables (each typically in its own file),
+2. convert units to kg/m²/s,
+3. conservatively regrid onto the model grid (:mod:`.regrid`), and
+4. assemble an :class:`xarray.Dataset` of contract variables ready to write and
+   load via :func:`jcm.forcing.read_anthropogenic_emissions`.
+
+The source→contract correspondence is data, not code: a list of :class:`Channel`
+records. Two concrete mappings are shipped — :func:`cesm_cmip_anthro` and
+:func:`cesm_bb4cmip7`, for the CESM CMIP7 CEDS / biomass-burning files in
+``inputdata/atm/cam/chem/emis/cmip7`` — but any product can be described the same
+way (this is what keeps the pipeline grid- and product-agnostic).
+
+**Note on the CESM CMIP adapter's approximations** (documented because they are
+load-bearing, per the issue): the CESM *bulk surface* files (``SO2-em-anthro``,
+``bc_a4-em-anthro``, ``pom_a4-em-anthro``) are summed over all 8 CEDS activity
+sectors, so they carry **no per-super-sector split** — this adapter assigns them
+all to ``surface_combustion``. Recovering the elevated/shipping injection split
+(and the full, pre-primary-split SO₂) needs the raw CEDS *sectored* product
+rather than the MAM4-speciated CESM files — that is exactly the work deferred to
+the self-hosted-mirror follow-up issue. The differentiable per-super-sector
+injection still applies at runtime to whatever channels a richer source
+populates.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import xarray as xr
+
+import jcm.constants as _const
+from jcm.data.emissions.regrid import build_regridder, model_grid
+from jcm.physics.aerosol.jam.emissions.sectors import OM_OC_RATIO
+
+_AVOGADRO = _const.physical_constants.avogadro  # molec / mol
+
+
+def molec_flux_to_mass_flux(molar_mass_g_per_mol: float) -> float:
+    """Factor converting ``molecules cm⁻² s⁻¹`` → ``kg m⁻² s⁻¹``.
+
+    ``(MW/N_A) g/molec · 1e-3 kg/g · 1e4 cm²/m² = MW·10/N_A``.
+    """
+    return molar_mass_g_per_mol * 10.0 / _AVOGADRO
+
+
+@dataclass(frozen=True)
+class Channel:
+    """One source variable mapped onto a contract variable.
+
+    Attributes:
+        contract_var: target name, ``emis_<sector>_<species>``.
+        source: path/URL of the source file (resolved via the downloader).
+        var: variable name within that file (CESM emission files use ``emiss``).
+        scale: extra multiplicative factor applied *after* unit conversion — e.g.
+            ``1/OM_OC`` to express an organic-matter source as the OC the term
+            re-inflates by OM:OC (so net POA mass is preserved).
+        molar_mass: g/mol for the molec→mass conversion; ``None`` reads the
+            source variable's ``molecular_weight`` attribute. Set to ``0``/falsy
+            via ``mass_units=True`` to skip conversion for already-mass sources.
+        mass_units: if ``True`` the source is already a mass flux (kg/m²/s) and
+            only ``scale`` is applied.
+
+    """
+
+    contract_var: str
+    source: str
+    var: str = "emiss"
+    scale: float = 1.0
+    molar_mass: float | None = None
+    mass_units: bool = False
+
+
+#: CESM CMIP7 CEDS bulk-surface anthropogenic adapter (see module docstring).
+#: ``{species}`` files live under e.g.
+#: ``…/emis/cmip7/<grid>/CEDS-CMIP-2025-04-18_20251030/<species>-em-anthro_…nc``.
+#: ``oc`` is scaled by ``1/OM_OC`` because the CESM ``pom_a4`` field is organic
+#: *matter*; the term re-applies OM:OC, so net emitted POA equals ``pom_a4``.
+def cesm_cmip_anthro(directory: str, *, suffix: str =
+                     "_input4MIPs_emissions_CMIP_CEDS-CMIP-2025-04-18_gn_"
+                     "175001-202312_c20251030.nc") -> tuple[Channel, ...]:
+    """Build the CESM CMIP7 CEDS channel list for a given grid directory."""
+    import os
+
+    def path(stem):
+        return os.path.join(directory, stem + suffix)
+
+    return (
+        Channel("emis_surface_combustion_so2", path("SO2-em-anthro"), molar_mass=64.0),
+        Channel("emis_surface_combustion_bc", path("bc_a4-em-anthro"), molar_mass=12.0),
+        Channel("emis_surface_combustion_oc", path("pom_a4-em-anthro"),
+                molar_mass=12.0, scale=1.0 / OM_OC_RATIO),
+    )
+
+
+def cesm_bb4cmip7(directory: str, *, suffix: str =
+                  "_smoothed_input4MIPs_emissions_CMIP_DRES-CMIP-BB4CMIP7-2-0_"
+                  "gn_175001-202112_c20251102.nc") -> tuple[Channel, ...]:
+    """CESM CMIP7 open-biomass-burning (DRES/van Marle BB4CMIP7) channel list.
+
+    Same bulk-surface MAM4 layout as :func:`cesm_cmip_anthro`, mapped onto the
+    ``biomass_burning`` super-sector so it picks up the deep FIRE injection
+    profile. ``oc`` is scaled by ``1/OM_OC`` (the ``pom_a4`` field is organic
+    *matter*; the term re-applies OM:OC).
+    """
+    import os
+
+    def path(stem):
+        return os.path.join(directory, stem + suffix)
+
+    return (
+        Channel("emis_biomass_burning_so2", path("SO2"), molar_mass=64.0),
+        Channel("emis_biomass_burning_bc", path("bc_a4"), molar_mass=12.0),
+        Channel("emis_biomass_burning_oc", path("pom_a4"),
+                molar_mass=12.0, scale=1.0 / OM_OC_RATIO),
+    )
+
+
+def prepare_emissions(
+    channels: tuple[Channel, ...],
+    coords,
+    *,
+    time_index=None,
+    lon_name: str = "lon",
+    lat_name: str = "lat",
+    area_name: str = "area",
+    known_hash: str | None = None,
+) -> xr.Dataset:
+    """Assemble a model-grid emissions Dataset from source ``channels``.
+
+    Args:
+        channels: source→contract mapping (e.g. ``cesm_cmip_anthro(dir)``).
+        coords: the model ``CoordinateSystem`` to regrid onto.
+        time_index: optional ``isel(time=…)`` selector (int, slice or list) to
+            subset the (often multi-century) source time axis before regridding.
+        lon_name, lat_name, area_name: source coordinate/area variable names.
+        known_hash: optional sha256 forwarded to the downloader for remote files.
+
+    Returns:
+        Dataset with dims ``(time, lon, lat)`` (lon/lat the model grid in
+        degrees), one ``emis_<sector>_<species>`` variable per channel, in
+        kg/m²/s. Missing contract channels are simply absent (the term treats
+        them as zero).
+
+    """
+    from jcm.data.emissions.downloader import fetch
+
+    dst_lon, dst_lat, _ = model_grid(coords)
+    nlon, nlat = coords.horizontal.nodal_shape
+
+    out = xr.Dataset()
+    time_coord = None
+    regridder_cache: dict[tuple, object] = {}
+
+    for ch in channels:
+        ds = xr.open_dataset(fetch(ch.source, known_hash=known_hash),
+                             decode_times=False)
+        da = ds[ch.var]
+        if time_index is not None and "time" in da.dims:
+            da = da.isel(time=time_index)
+
+        # Conservative regridder, reused across channels that share a source
+        # grid (keyed by a cheap grid signature so the operator is built once).
+        slon = ds[lon_name].values
+        slat = ds[lat_name].values
+        gkey = (slon.shape, float(slon[0]), float(slat[0]), float(slat[-1]))
+        regridder = regridder_cache.get(gkey)
+        if regridder is None:
+            regridder = build_regridder(slon, slat, ds[area_name].values,
+                                        dst_lon, dst_lat)
+            regridder_cache[gkey] = regridder
+
+        values = np.asarray(da.values, dtype=np.float64)  # (..., n_source)
+        if not ch.mass_units:
+            mw = ch.molar_mass
+            if mw is None:
+                mw = float(da.attrs["molecular_weight"])
+            values = values * molec_flux_to_mass_flux(mw)
+        values = values * ch.scale
+
+        gridded = regridder(values)  # (..., nlon, nlat)
+        dims = (["time", "lon", "lat"] if da.ndim > 1 else ["lon", "lat"])
+        out[ch.contract_var] = (dims, gridded)
+
+        if "time" in da.dims and time_coord is None:
+            time_coord = ds["time"].isel(
+                time=time_index) if time_index is not None else ds["time"]
+
+    out = out.assign_coords(
+        lon=("lon", np.rad2deg(dst_lon)),
+        lat=("lat", np.rad2deg(dst_lat)),
+    )
+    if time_coord is not None:
+        out = out.assign_coords(time=("time", np.atleast_1d(time_coord.values)))
+        for k, v in time_coord.attrs.items():
+            out["time"].attrs[k] = v
+    out.attrs["title"] = (
+        "jax-gcm prescribed anthropogenic emissions (bulk per-super-sector "
+        "surface flux, kg/m2/s) — see .claude/aerosol_emissions_plan.md"
+    )
+    for v in out.data_vars:
+        out[v].attrs["units"] = "kg m-2 s-1"
+    return out
+
+
+@dataclass(frozen=True)
+class SpeciatedChannel:
+    """One already-speciated source file mapped onto a JAM tracer.
+
+    Attributes:
+        tracer: target JAM tracer key (e.g. ``m_so4_acc``, ``n_acc``, ``g_so2``)
+            — the ``aero_emis_<tracer>`` variable this contributes to. Several
+            channels may target the same tracer (they are summed).
+        source: path/URL of the source file.
+        var: variable name within the file (CESM emission files use ``emiss``).
+        elevated: if ``True`` the file is a 3-D ``molecules cm⁻³ s⁻¹`` volume
+            source with an ``altitude`` dimension (CAM ``mo_extfrc`` style); it is
+            column-integrated over altitude to a surface flux. At GCM vertical
+            resolution the CEDS elevated layer (≤ ~400 m) sits within the lowest
+            model layer(s), so this is near-exact; the
+            :class:`PreSpeciatedEmissions` 3-D path remains for genuinely
+            high-resolution elevated injection.
+
+    Number emissions need no special casing: CESM encodes them so the same
+    ``molecular_weight``-based molec→mass conversion yields ``#/m²/s`` directly.
+
+    """
+
+    tracer: str
+    source: str
+    var: str = "emiss"
+    elevated: bool = False
+
+
+def cesm_mam4_speciated(directory: str, *, suffix: str =
+                        "-em-anthro_input4MIPs_emissions_CMIP_CEDS-CMIP-2025-"
+                        "04-18_gn_175001-202312_c20251030.nc"
+                        ) -> tuple[SpeciatedChannel, ...]:
+    """CESM CMIP7 CEDS *already-speciated* MAM4 anthropogenic channel list.
+
+    Maps the CESM modal/sector files directly onto JAM MAM4 tracers (a1→accum,
+    a2→Aitken, a4→primary-carbon; ``SO2``→gas; ``num_*``→number), summing the
+    sector-split sulfate files (and the elevated energy-sector ``ene_vertical``)
+    into their mode. This reproduces CAM6's prescribed emissions on the model
+    grid — the validation counterpart to the differentiable bulk path.
+    """
+    import os
+
+    def p(stem):
+        return os.path.join(directory, stem + suffix)
+
+    return (
+        # Accumulation-mode sulfate: surface (ag+ship+slv) + elevated energy.
+        SpeciatedChannel("m_so4_acc", p("so4_a1_ag_ship_slv")),
+        SpeciatedChannel("m_so4_acc", p("so4_a1_ene_vertical"), elevated=True),
+        SpeciatedChannel("n_acc", p("num_so4_a1_ag")),
+        SpeciatedChannel("n_acc", p("num_so4_a1_ship_slv")),
+        SpeciatedChannel("n_acc", p("num_so4_a1_ene_vertical"), elevated=True),
+        # Aitken-mode sulfate (residential + transport).
+        SpeciatedChannel("m_so4_ait", p("so4_a2_res_trs")),
+        SpeciatedChannel("n_ait", p("num_so4_a2_res_trs")),
+        # Primary-carbon mode: BC + POA (+ their number).
+        SpeciatedChannel("m_bc_pcm", p("bc_a4")),
+        SpeciatedChannel("m_poa_pcm", p("pom_a4")),
+        SpeciatedChannel("n_pcm", p("num_bc_a4")),
+        SpeciatedChannel("n_pcm", p("num_pom_a4")),
+        # SO2 gas (already net of the 2.5 % primary-sulfate diversion).
+        SpeciatedChannel("g_so2", p("SO2")),
+    )
+
+
+def prepare_speciated_emissions(
+    channels: tuple[SpeciatedChannel, ...],
+    coords,
+    *,
+    time_index=None,
+    lon_name: str = "lon",
+    lat_name: str = "lat",
+    area_name: str = "area",
+    known_hash: str | None = None,
+) -> xr.Dataset:
+    """Assemble a model-grid *pre-speciated* emissions Dataset (``aero_emis_*``).
+
+    Sister of :func:`prepare_emissions` for the CAM6-faithful path: per-tracer
+    surface fluxes (kg/m²/s for mass, #/m²/s for number) on the model grid, ready
+    for :func:`jcm.forcing.read_prescribed_aerosol_emissions`. Channels targeting
+    the same tracer are summed; ``elevated`` channels are column-integrated over
+    their altitude axis first.
+    """
+    from jcm.data.emissions.downloader import fetch
+
+    dst_lon, dst_lat, _ = model_grid(coords)
+    nlon, nlat = coords.horizontal.nodal_shape
+
+    fields: dict[str, np.ndarray] = {}
+    time_coord = None
+    regridder_cache: dict[tuple, object] = {}
+
+    for ch in channels:
+        ds = xr.open_dataset(fetch(ch.source, known_hash=known_hash),
+                             decode_times=False)
+        da = ds[ch.var]
+        if time_index is not None and "time" in da.dims:
+            da = da.isel(time=time_index)
+
+        values = np.asarray(da.values, dtype=np.float64)  # (..., [alt,] n_src)
+        if ch.elevated:
+            # molec/cm³/s volume source → column molec/cm²/s: Σ_alt emiss·Δz.
+            dz_cm = np.abs(np.diff(ds["altitude_int"].values)) * 1.0e5  # km→cm
+            alt_axis = da.dims.index("altitude")
+            values = np.tensordot(values, dz_cm, axes=([alt_axis], [0]))
+        # Same molec→mass(/number) conversion CAM applies; reads the file's MW.
+        values = values * molec_flux_to_mass_flux(float(da.attrs["molecular_weight"]))
+
+        slon = ds[lon_name].values
+        slat = ds[lat_name].values
+        gkey = (slon.shape, float(slon[0]), float(slat[0]), float(slat[-1]))
+        regridder = regridder_cache.get(gkey)
+        if regridder is None:
+            regridder = build_regridder(slon, slat, ds[area_name].values,
+                                        dst_lon, dst_lat)
+            regridder_cache[gkey] = regridder
+
+        gridded = regridder(values)  # (..., nlon, nlat)
+        fields[ch.tracer] = fields.get(ch.tracer, 0.0) + gridded
+
+        if "time" in da.dims and time_coord is None:
+            time_coord = (ds["time"].isel(time=time_index)
+                          if time_index is not None else ds["time"])
+
+    out = xr.Dataset()
+    for tracer, arr in fields.items():
+        dims = ["time", "lon", "lat"] if arr.ndim > 2 else ["lon", "lat"]
+        out[f"aero_emis_{tracer}"] = (dims, arr)
+    out = out.assign_coords(lon=("lon", np.rad2deg(dst_lon)),
+                            lat=("lat", np.rad2deg(dst_lat)))
+    if time_coord is not None:
+        out = out.assign_coords(time=("time", np.atleast_1d(time_coord.values)))
+    out.attrs["title"] = (
+        "jax-gcm prescribed pre-speciated aerosol emissions (per-tracer surface "
+        "flux; mass kg/m2/s, number #/m2/s) — CAM6/MAM4-faithful path"
+    )
+    return out

--- a/jcm/data/emissions/prepare_test.py
+++ b/jcm/data/emissions/prepare_test.py
@@ -36,6 +36,87 @@ class UnitConversionTest(unittest.TestCase):
         self.assertAlmostEqual(molec_flux_to_mass_flux(64.0), 64.0 * 10.0 / na)
 
 
+def _synthetic_source(path, *, elevated=False, var="emiss", mw=64.0,
+                      ncol=300, nt=3):
+    """Write a tiny unstructured (ncol) source emission file like the CESM ones."""
+    import xarray as xr
+
+    rng = np.random.default_rng(0)
+    lon = rng.uniform(0.0, 360.0, ncol)
+    lat = rng.uniform(-89.0, 89.0, ncol)
+    area = np.full(ncol, 4.0 * np.pi / ncol)  # steradians, sums to 4π
+    coords = {"lon": ("ncol", lon), "lat": ("ncol", lat),
+              "area": ("ncol", area), "time": np.arange(nt)}
+    if elevated:
+        nalt = 4
+        data = {var: (("time", "altitude", "ncol"),
+                      np.full((nt, nalt, ncol), 1.0e3))}
+        coords["altitude_int"] = ("altitude_int",
+                                  np.linspace(0.0, 0.4, nalt + 1))  # km
+    else:
+        data = {var: (("time", "ncol"), np.full((nt, ncol), 1.0e10))}
+    ds = xr.Dataset(data, coords=coords)
+    ds[var].attrs["molecular_weight"] = mw
+    ds.to_netcdf(path)
+    return path
+
+
+class PrepareSyntheticTest(unittest.TestCase):
+    """Fast coverage of the prepare pipeline on a tiny synthetic source."""
+
+    def setUp(self):
+        self.coords = get_speedy_coords(layers=8, spectral_truncation=31)
+        self.nodal = self.coords.horizontal.nodal_shape
+
+    def test_prepare_emissions_bulk(self):
+        from jcm.data.emissions.prepare import Channel, prepare_emissions
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            src = _synthetic_source(os.path.join(d, "so2.nc"), mw=64.0)
+            ds = prepare_emissions(
+                (Channel("emis_surface_combustion_so2", src, molar_mass=64.0),),
+                self.coords, time_index=0)
+        v = ds["emis_surface_combustion_so2"]
+        self.assertEqual(v.values.shape, self.nodal)
+        self.assertEqual(v.attrs["units"], "kg m-2 s-1")
+        self.assertTrue(np.all(np.isfinite(v.values)) and v.values.max() > 0)
+
+    def test_prepare_speciated_surface_and_elevated(self):
+        from jcm.data.emissions.prepare import (
+            SpeciatedChannel, prepare_speciated_emissions)
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            surf = _synthetic_source(os.path.join(d, "a2.nc"), mw=115.0)
+            elev = _synthetic_source(os.path.join(d, "ene.nc"), elevated=True,
+                                     mw=115.0)
+            ds = prepare_speciated_emissions(
+                (SpeciatedChannel("m_so4_ait", surf),
+                 SpeciatedChannel("m_so4_acc", elev, elevated=True)),
+                self.coords, time_index=0)
+        for t in ("m_so4_ait", "m_so4_acc"):
+            arr = ds[f"aero_emis_{t}"].values
+            self.assertEqual(arr.shape, self.nodal)
+            self.assertTrue(np.all(np.isfinite(arr)) and arr.max() > 0)
+
+    def test_adapter_builders_construct_channels(self):
+        from jcm.data.emissions.prepare import (
+            cesm_bb4cmip7, cesm_cmip_anthro, cesm_mam4_speciated)
+        anthro = {c.contract_var for c in cesm_cmip_anthro("/d")}
+        self.assertEqual(anthro, {"emis_surface_combustion_so2",
+                                  "emis_surface_combustion_bc",
+                                  "emis_surface_combustion_oc"})
+        self.assertEqual({c.contract_var for c in cesm_bb4cmip7("/d")},
+                         {"emis_biomass_burning_so2", "emis_biomass_burning_bc",
+                          "emis_biomass_burning_oc"})
+        spec = cesm_mam4_speciated("/d")
+        tracers = {c.tracer for c in spec}
+        self.assertEqual(tracers, {"m_so4_acc", "m_so4_ait", "m_bc_pcm",
+                                   "m_poa_pcm", "n_acc", "n_ait", "n_pcm",
+                                   "g_so2"})
+        # The energy-sector sulfate is the elevated (mo_extfrc) channel.
+        self.assertTrue(any(c.elevated for c in spec))
+
+
 @pytest.mark.slow
 @unittest.skipUnless(os.path.exists(_ANTHRO_SO2), "ne30 reference files absent")
 class PrepareFromCesmTest(unittest.TestCase):

--- a/jcm/data/emissions/prepare_test.py
+++ b/jcm/data/emissions/prepare_test.py
@@ -1,0 +1,130 @@
+"""Tests for the emissions prepare pipeline (#498).
+
+The unit-conversion check is self-contained; the end-to-end adapter checks run
+against the on-disk CESM CMIP7 ne30 files when present (skipped otherwise).
+"""
+
+import os
+import unittest
+
+import numpy as np
+import pytest
+
+import jcm.constants as _const
+from jcm.data.emissions.prepare import (
+    cesm_bb4cmip7,
+    cesm_cmip_anthro,
+    molec_flux_to_mass_flux,
+    prepare_emissions,
+)
+from jcm.physics.speedy.speedy_coords import get_speedy_coords
+
+_NE30 = ("/glade/campaign/cesm/cesmdata/cseg/inputdata/atm/cam/chem/emis/cmip7/"
+         "ne30")
+_ANTHRO_DIR = os.path.join(_NE30, "CEDS-CMIP-2025-04-18_20251030")
+_BB_DIR = os.path.join(_NE30, "DRES-CMIP-BB4CMIP7-2-0_smoothed_20251102")
+_ANTHRO_SO2 = os.path.join(
+    _ANTHRO_DIR,
+    "SO2-em-anthro_input4MIPs_emissions_CMIP_CEDS-CMIP-2025-04-18_gn_"
+    "175001-202312_c20251030.nc")
+
+
+class UnitConversionTest(unittest.TestCase):
+    def test_molec_to_mass_factor(self):
+        # molec cm-2 s-1 -> kg m-2 s-1 is MW * 10 / N_A.
+        na = _const.physical_constants.avogadro
+        self.assertAlmostEqual(molec_flux_to_mass_flux(64.0), 64.0 * 10.0 / na)
+
+
+@pytest.mark.slow
+@unittest.skipUnless(os.path.exists(_ANTHRO_SO2), "ne30 reference files absent")
+class PrepareFromCesmTest(unittest.TestCase):
+    def setUp(self):
+        self.coords = get_speedy_coords(layers=8, spectral_truncation=31)
+        self.nodal = self.coords.horizontal.nodal_shape
+        # A single recent month keeps the regrid cheap.
+        self.month = (2014 - 1750) * 12 + 6
+
+    def test_anthro_adapter_produces_contract_vars(self):
+        ds = prepare_emissions(cesm_cmip_anthro(_ANTHRO_DIR), self.coords,
+                               time_index=self.month)
+        for sp in ("so2", "bc", "oc"):
+            v = f"emis_surface_combustion_{sp}"
+            self.assertIn(v, ds.data_vars)
+            arr = ds[v].values
+            self.assertEqual(arr.shape, self.nodal)
+            self.assertTrue(np.all(np.isfinite(arr)))
+            self.assertGreater(float(arr.sum()), 0.0)
+            self.assertEqual(ds[v].attrs["units"], "kg m-2 s-1")
+
+    def test_anthro_so2_global_budget_plausible(self):
+        # Sanity-check magnitude: a mid-2010s month of global anthropogenic SO2
+        # annualises to ~100 Tg(SO2)/yr — right order, not off by 1000×.
+        ds = prepare_emissions(cesm_cmip_anthro(_ANTHRO_DIR), self.coords,
+                               time_index=self.month)
+        _, _, area = __import__(
+            "jcm.data.emissions.regrid", fromlist=["model_grid"]).model_grid(
+            self.coords)
+        r2 = self.coords.horizontal.radius ** 2
+        kg_s = float(np.sum(ds["emis_surface_combustion_so2"].values * area * r2))
+        tg_yr = kg_s * 3.1536e7 / 1e9
+        self.assertGreater(tg_yr, 40.0)
+        self.assertLess(tg_yr, 200.0)
+
+    @unittest.skipUnless(os.path.isdir(_BB_DIR), "BB4CMIP7 files absent")
+    def test_biomass_adapter_produces_contract_vars(self):
+        ds = prepare_emissions(cesm_bb4cmip7(_BB_DIR), self.coords,
+                               time_index=self.month)
+        for sp in ("so2", "bc", "oc"):
+            v = f"emis_biomass_burning_{sp}"
+            self.assertIn(v, ds.data_vars)
+            self.assertEqual(ds[v].values.shape, self.nodal)
+            self.assertTrue(np.all(np.isfinite(ds[v].values)))
+
+
+@pytest.mark.slow
+@unittest.skipUnless(os.path.exists(_ANTHRO_SO2), "ne30 reference files absent")
+class PrepareSpeciatedTest(unittest.TestCase):
+    """CAM6-faithful pre-speciated path reproduces CESM's MAM4 emissions."""
+
+    def setUp(self):
+        from jcm.data.emissions.prepare import (
+            cesm_mam4_speciated, prepare_speciated_emissions)
+        self.coords = get_speedy_coords(layers=8, spectral_truncation=31)
+        self.ds = prepare_speciated_emissions(
+            cesm_mam4_speciated(_ANTHRO_DIR), self.coords,
+            time_index=(2014 - 1750) * 12 + 6)
+
+    def _tg_per_yr(self, tracer):
+        from jcm.data.emissions.regrid import model_grid
+        _, _, area = model_grid(self.coords)
+        r2 = self.coords.horizontal.radius ** 2
+        kg_s = float(np.sum(self.ds[f"aero_emis_{tracer}"].values * area * r2))
+        return kg_s * 3.1536e7 / 1e9
+
+    def test_produces_all_mam4_tracers(self):
+        for t in ("m_so4_acc", "m_so4_ait", "m_bc_pcm", "m_poa_pcm",
+                  "n_acc", "n_ait", "n_pcm", "g_so2"):
+            v = f"aero_emis_{t}"
+            self.assertIn(v, self.ds.data_vars)
+            arr = self.ds[v].values
+            self.assertEqual(arr.shape, self.coords.horizontal.nodal_shape)
+            self.assertTrue(np.all(np.isfinite(arr)) and np.all(arr >= 0.0))
+
+    def test_recovers_hammoz_primary_so4_fraction(self):
+        # SO₄(115 g/mol, 1 S=32) primary + SO₂ gas(64, 1 S=32) should split as
+        # the HAMMOZ/MAM4 2.5 % primary sulfate — recovered from CESM's files.
+        s_so4 = (self._tg_per_yr("m_so4_acc")
+                 + self._tg_per_yr("m_so4_ait")) * 32.0 / 115.0
+        s_gas = self._tg_per_yr("g_so2") * 32.0 / 64.0
+        self.assertAlmostEqual(s_so4 / (s_so4 + s_gas), 0.025, places=3)
+
+    def test_total_sulfur_budget_plausible(self):
+        s = ((self._tg_per_yr("m_so4_acc") + self._tg_per_yr("m_so4_ait"))
+             * 32.0 / 115.0 + self._tg_per_yr("g_so2") * 32.0 / 64.0)
+        self.assertGreater(s, 20.0)   # 2014 global anthropogenic S ~50 Tg/yr
+        self.assertLess(s, 80.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jcm/data/emissions/regrid.py
+++ b/jcm/data/emissions/regrid.py
@@ -24,6 +24,15 @@ Design (kept deliberately light — no ESMF/xesmf dependency):
 The source grid is described purely by per-cell ``(lon, lat, area)`` triples, so
 structured and unstructured sources go through the same path — only the adapter
 that produces those triples differs.
+
+Note — this is intentionally *not* the same remapper as
+``jcm.data.bc.interpolate`` (``upsample_forcings_ds``): that path **bilinearly
+interpolates** smooth structured lat/lon boundary fields (SST, soil moisture, …)
+to a higher spectral resolution and is *not* mass-conserving, whereas emissions
+are **flux** fields where conserving the column-integrated source is the property
+that matters, and their sources are often unstructured (``ncol``). Different
+problems (non-conservative bilinear upsampling vs conservative,
+unstructured-capable flux remap), hence kept separate.
 """
 
 from __future__ import annotations

--- a/jcm/data/emissions/regrid.py
+++ b/jcm/data/emissions/regrid.py
@@ -1,0 +1,152 @@
+"""General, mass-conserving regridding of emission fields onto the model grid.
+
+Emissions reach jax-gcm on whatever grid their source happens to use — a regular
+0.5° lat/lon CEDS product, or an unstructured ``ncol`` mesh like the CESM ne30
+files in ``inputdata/atm/cam/chem/emis/cmip7``. This module remaps any such
+source onto the model's spectral Gaussian nodal grid **conservatively**, so the
+global emitted mass is (to first order) preserved — the property that matters for
+a flux boundary condition.
+
+Design (kept deliberately light — no ESMF/xesmf dependency):
+
+* The regridder is **first-order conservative / area-weighted**. Each source cell
+  is assigned, by nearest cell centre, to exactly one target cell; the target
+  value is the source-area-weighted mean of the cells that land in it
+  (``Σ fₛ Aₛ / Σ Aₛ``). For *coarsening* (fine source → coarse model grid, the
+  usual case here) many source cells fall in each target cell and this converges
+  to the true cell-mean flux; the area-weighting makes the column-integrated mass
+  conservative to the binning accuracy. It does **not** smooth or do higher-order
+  reconstruction, and it is not intended for *refinement* (coarse → fine), which
+  would alias.
+* It is a pure host-side (numpy/scipy) tool used offline by
+  :mod:`jcm.data.emissions.prepare`, not inside the JIT'd model.
+
+The source grid is described purely by per-cell ``(lon, lat, area)`` triples, so
+structured and unstructured sources go through the same path — only the adapter
+that produces those triples differs.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import scipy.sparse as sp
+
+
+class Regridder:
+    """A conservative source→target remap operator, reusable across fields.
+
+    Built once from the source/target geometry, then applied to any field on the
+    same source grid (e.g. every month/level of an emission time series) via
+    :meth:`__call__`. Internally a sparse ``(n_target, n_source)`` matrix whose
+    rows are the source-area weights of the cells assigned to each target cell.
+    """
+
+    def __init__(self, matrix: sp.csr_matrix, target_shape: tuple[int, int],
+                 covered_area: np.ndarray):
+        """Hold the prebuilt remap matrix, target shape, and area normaliser."""
+        self._matrix = matrix              # (n_target, n_source), data = src area
+        self._target_shape = target_shape  # (nlon, nlat)
+        # Σ source-area landing in each target cell; the normaliser that turns
+        # accumulated mass back into an (area-weighted mean) flux.
+        self._covered_area = covered_area  # (n_target,)
+
+    @property
+    def target_shape(self) -> tuple[int, int]:
+        return self._target_shape
+
+    def __call__(self, values: np.ndarray) -> np.ndarray:
+        """Regrid ``values`` shaped ``(..., n_source)`` → ``(..., nlon, nlat)``.
+
+        Leading axes (time, level, …) are preserved. Target cells that received
+        no source cell (only possible when *refining*) come back as zero.
+        """
+        values = np.asarray(values, dtype=np.float64)
+        lead = values.shape[:-1]
+        flat = values.reshape(-1, values.shape[-1])          # (K, n_source)
+        mass = flat @ self._matrix.T                          # (K, n_target)
+        with np.errstate(invalid="ignore", divide="ignore"):
+            mean = np.where(self._covered_area > 0.0,
+                            mass / self._covered_area, 0.0)
+        nlon, nlat = self._target_shape
+        return mean.reshape(*lead, nlon, nlat)
+
+
+def _nearest_lon_index(src_lon: np.ndarray, dst_lon: np.ndarray) -> np.ndarray:
+    """Nearest target longitude index under periodic (wrap-around) distance."""
+    # (n_src, nlon) circular separation in [0, π]; argmin over targets.
+    d = np.abs(src_lon[:, None] - dst_lon[None, :])
+    d = np.minimum(d, 2.0 * np.pi - d)
+    return np.argmin(d, axis=1)
+
+
+def _nearest_lat_index(src_lat: np.ndarray, dst_lat: np.ndarray) -> np.ndarray:
+    """Nearest target latitude index (latitudes are not periodic)."""
+    return np.argmin(np.abs(src_lat[:, None] - dst_lat[None, :]), axis=1)
+
+
+def build_regridder(
+    src_lon: np.ndarray,
+    src_lat: np.ndarray,
+    src_area: np.ndarray,
+    dst_lon: np.ndarray,
+    dst_lat: np.ndarray,
+    *,
+    src_in_degrees: bool = True,
+    dst_in_degrees: bool = False,
+) -> Regridder:
+    """Build a conservative regridder from source points to a target lon×lat grid.
+
+    Args:
+        src_lon, src_lat: 1-D source cell-centre coordinates, length ``n_source``
+            (e.g. the flattened lat/lon mesh, or the ``ncol`` arrays of an
+            unstructured file).
+        src_area: 1-D per-source-cell area weight (any consistent units — only
+            ratios matter), length ``n_source``.
+        dst_lon, dst_lat: 1-D target grid coordinates (the model's
+            ``horizontal.longitudes`` / ``.latitudes``), lengths ``nlon`` /
+            ``nlat``. The target is the tensor-product grid ``(nlon, nlat)``.
+        src_in_degrees, dst_in_degrees: unit flags; coordinates are converted to
+            radians internally (netCDF lon/lat are degrees; the dinosaur grid is
+            radians).
+
+    Returns:
+        A :class:`Regridder` mapping ``(..., n_source)`` arrays to
+        ``(..., nlon, nlat)``.
+
+    """
+    to_rad = np.deg2rad
+    sl = to_rad(src_lon) if src_in_degrees else np.asarray(src_lon, float)
+    sb = to_rad(src_lat) if src_in_degrees else np.asarray(src_lat, float)
+    dl = to_rad(dst_lon) if dst_in_degrees else np.asarray(dst_lon, float)
+    db = to_rad(dst_lat) if dst_in_degrees else np.asarray(dst_lat, float)
+    sl = np.mod(sl, 2.0 * np.pi)
+    dl = np.mod(dl, 2.0 * np.pi)
+
+    area = np.asarray(src_area, dtype=np.float64).ravel()
+    n_src = area.size
+    nlon, nlat = dl.size, db.size
+
+    i_lon = _nearest_lon_index(sl, dl)
+    i_lat = _nearest_lat_index(sb, db)
+    # Row-major (lon, lat) flattening — matches numpy reshape((nlon, nlat)).
+    target_idx = i_lon * nlat + i_lat
+
+    matrix = sp.coo_matrix(
+        (area, (target_idx, np.arange(n_src))),
+        shape=(nlon * nlat, n_src),
+    ).tocsr()
+    covered_area = np.asarray(matrix.sum(axis=1)).ravel()
+    return Regridder(matrix, (nlon, nlat), covered_area)
+
+
+def model_grid(coords) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Target ``(lon_rad, lat_rad, cell_solid_angle)`` for a model CoordinateSystem.
+
+    ``cell_solid_angle`` is the per-cell quadrature weight (steradians, summing to
+    4π) — handy as the target area for conservation diagnostics.
+    """
+    h = coords.horizontal
+    lon = np.asarray(h.longitudes)
+    lat = np.asarray(h.latitudes)
+    area = np.asarray(h.quadrature_weights)  # (nlon, nlat)
+    return lon, lat, area

--- a/jcm/data/emissions/regrid_test.py
+++ b/jcm/data/emissions/regrid_test.py
@@ -1,0 +1,86 @@
+"""Tests for the conservative emissions regridder (#498)."""
+
+import os
+import unittest
+
+import numpy as np
+
+from jcm.data.emissions.regrid import build_regridder, model_grid
+from jcm.physics.speedy.speedy_coords import get_speedy_coords
+
+# The CESM CEDS ne30 reference files, used for an end-to-end conservation check
+# when present (skipped otherwise so the suite stays self-contained).
+_NE30_DIR = (
+    "/glade/campaign/cesm/cesmdata/cseg/inputdata/atm/cam/chem/emis/cmip7/"
+    "ne30/CEDS-CMIP-2025-04-18_20251030"
+)
+_NE30_BC = os.path.join(
+    _NE30_DIR,
+    "bc_a4-em-anthro_input4MIPs_emissions_CMIP_CEDS-CMIP-2025-04-18_gn_"
+    "175001-202312_c20251030.nc",
+)
+
+
+def _regular_latlon(nlon: int, nlat: int):
+    """Cell centres + (relative) areas for a regular lat/lon grid [deg]."""
+    lon = (np.arange(nlon) + 0.5) * (360.0 / nlon)
+    lat = -90.0 + (np.arange(nlat) + 0.5) * (180.0 / nlat)
+    LON, LAT = np.meshgrid(lon, lat, indexing="ij")
+    area = np.cos(np.deg2rad(LAT))            # ∝ cos(lat) dlon dlat (dlon,dlat const)
+    return LON.ravel(), LAT.ravel(), area.ravel()
+
+
+class RegridConservationTest(unittest.TestCase):
+    def setUp(self):
+        # A fine (1°) source coarsened onto the T31 model grid — the regime the
+        # first-order conservative scheme is designed for.
+        self.coords = get_speedy_coords(layers=8, spectral_truncation=31)
+        self.dlon, self.dlat, self.darea = model_grid(self.coords)
+        self.slon, self.slat, self.sarea = _regular_latlon(360, 180)
+        self.R = build_regridder(self.slon, self.slat, self.sarea,
+                                 self.dlon, self.dlat)
+
+    def test_target_shape(self):
+        out = self.R(np.ones(self.slon.size))
+        self.assertEqual(out.shape, self.coords.horizontal.nodal_shape)
+
+    def test_constant_field_preserved(self):
+        # A spatially constant flux must come back constant (area-weighted mean
+        # of a constant is that constant), everywhere the grid is covered.
+        out = self.R(np.full(self.slon.size, 3.7))
+        np.testing.assert_allclose(out, 3.7, rtol=1e-12)
+
+    def test_global_mass_conserved(self):
+        # A smooth non-constant field: global integral ∫f dΩ preserved to the
+        # first-order binning accuracy (<1%).
+        f = 1.0 + np.cos(np.deg2rad(self.slat)) ** 2 * np.sin(np.deg2rad(self.slon))
+        out = self.R(f)
+        src_int = np.sum(f * self.sarea) / np.sum(self.sarea)      # area-wt mean
+        tgt_int = np.sum(out * self.darea) / np.sum(self.darea)
+        self.assertLess(abs(tgt_int / src_int - 1.0), 1e-2)
+
+    def test_leading_axes_preserved(self):
+        # (time, level, n_source) regrids to (time, level, nlon, nlat).
+        vals = np.random.default_rng(0).random((4, 3, self.slon.size))
+        out = self.R(vals)
+        self.assertEqual(out.shape, (4, 3, *self.coords.horizontal.nodal_shape))
+
+    @unittest.skipUnless(os.path.exists(_NE30_BC), "ne30 reference file absent")
+    def test_ne30_reference_conserves(self):
+        # Regrid a real CESM CEDS field (unstructured ncol) onto T31 and check
+        # the global emitted mass is preserved to first order.
+        import xarray as xr
+
+        ds = xr.open_dataset(_NE30_BC, decode_times=False)
+        em = ds["emiss"].isel(time=-1).values
+        R = build_regridder(ds["lon"].values, ds["lat"].values,
+                            ds["area"].values, self.dlon, self.dlat)
+        out = R(em)
+        src_int = np.sum(em * ds["area"].values)
+        tgt_int = np.sum(out * self.darea)
+        self.assertLess(abs(tgt_int / src_int - 1.0), 5e-3)
+        self.assertFalse(np.isnan(out).any())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jcm/forcing.py
+++ b/jcm/forcing.py
@@ -237,6 +237,24 @@ class ForcingData:
     dms_seawater: Any = None   # seawater DMS concentration (DmsEmissions)
     dust_source: Any = None    # dust source / erodibility 0–1 (DustEmissions)
 
+    # Prescribed anthropogenic aerosol emissions (#498). A single mapping
+    # ``{emis_<sector>_<species>: array | TimeSeries}`` of **bulk** per-super-
+    # sector surface mass fluxes [kg/m²/s] on the model grid (so2 as SO₂ mass;
+    # bc/oc as carbon mass — see the emissions-file contract in
+    # ``.claude/aerosol_emissions_plan.md``). ``None`` ⇒ no anthropogenic
+    # emission. Kept as one dict-valued field rather than a field per
+    # (sector, species) so new channels need no struct change; ``select(date)``
+    # slices the per-channel ``TimeSeries`` leaves like any other forcing leaf.
+    anthropogenic_emissions: Any = None
+
+    # Prescribed *already-speciated* aerosol emissions (#498), the CAM6/MAM4-
+    # faithful counterpart to ``anthropogenic_emissions``. A mapping
+    # ``{tracer_name: array | TimeSeries}`` keyed by the tracer each field feeds
+    # (e.g. ``m_so4_acc``, ``m_bc_pcm``, ``n_pcm``, ``g_so2``); 2-D fields are
+    # surface fluxes, 3-D ``(lev, …)`` fields are per-model-level volume fluxes
+    # (see :class:`PreSpeciatedEmissions`). ``None`` ⇒ no prescribed emission.
+    prescribed_aerosol_emissions: Any = None
+
     @classmethod
     def zeros(cls,nodal_shape,
               alb0=None,sice_am=None,snowc_am=None,
@@ -443,7 +461,9 @@ class ForcingData:
              ch4_vmr=None,
              nudging_target=_UNSET,
              dms_seawater=None,
-             dust_source=None):
+             dust_source=None,
+             anthropogenic_emissions=None,
+             prescribed_aerosol_emissions=None):
         # ``nudging_target`` uses an ``_UNSET`` sentinel because ``None`` is
         # the natural value for "no nudging target wired" — falling back to
         # ``self.nudging_target`` only when the caller didn't supply the
@@ -470,6 +490,15 @@ class ForcingData:
             ),
             dms_seawater=dms_seawater if dms_seawater is not None else self.dms_seawater,
             dust_source=dust_source if dust_source is not None else self.dust_source,
+            anthropogenic_emissions=(
+                anthropogenic_emissions if anthropogenic_emissions is not None
+                else self.anthropogenic_emissions
+            ),
+            prescribed_aerosol_emissions=(
+                prescribed_aerosol_emissions
+                if prescribed_aerosol_emissions is not None
+                else self.prescribed_aerosol_emissions
+            ),
         )
 
     def isnan(self):
@@ -623,6 +652,78 @@ def _fixed_ssts(grid: HorizontalGridTypes) -> jnp.ndarray:
     lat = grid.latitudes
     sst_profile = jnp.where(jnp.abs(lat) < jnp.pi/3, 27*jnp.cos(3*lat/2)**2, 0) + 273.15
     return jnp.tile(sst_profile, (grid.nodal_shape[0], 1))
+
+def read_anthropogenic_emissions(ds, align_mode: str = "auto"):
+    """Build the ``ForcingData.anthropogenic_emissions`` mapping from a dataset.
+
+    Reads every ``emis_<sector>_<species>`` variable (the emissions-file
+    contract — see ``.claude/aerosol_emissions_plan.md``) and wraps each as a
+    ``TimeSeries`` leaf (time-varying) or a bare array (static), keyed by the
+    variable name. Returns ``None`` when the dataset carries no such variable,
+    so the result can be passed straight to ``ForcingData.copy``::
+
+        ds = xr.open_dataset(emissions_file)
+        forcing = forcing.copy(anthropogenic_emissions=read_anthropogenic_emissions(ds))
+
+    The fields must already be on the model horizontal grid: this does **no**
+    regridding (use :mod:`jcm.data.emissions.prepare` to conservatively remap a
+    source-grid file first). Monthly data uses the same wrap-year/by-date time
+    alignment as the other forcing fields, so a 12-month climatology wraps and a
+    multi-year axis aligns by date.
+    """
+    emis_names = [str(v) for v in ds.data_vars if str(v).startswith("emis_")]
+    if not emis_names:
+        return None
+    has_time = any("time" in ds[n].dims for n in emis_names)
+    time_seconds = _time_axis_seconds_from_ds(ds) if has_time else None
+    mode = _resolve_align_mode(align_mode, ds) if has_time else BY_DATE
+    out: dict[str, Any] = {}
+    for name in emis_names:
+        da = ds[name]
+        if "time" in da.dims:
+            # Lead with time so `_select_time_series` can index axis 0; keep the
+            # remaining (horizontal) axes in their file order — the term ravels
+            # them to (ncols,).
+            others = [d for d in da.dims if d != "time"]
+            arr = jnp.asarray(da.transpose("time", *others).values)
+            out[name] = make_time_series(arr, time_seconds, align_mode=mode)
+        else:
+            out[name] = jnp.asarray(da.values)
+    return out
+
+
+def read_prescribed_aerosol_emissions(ds, align_mode: str = "auto"):
+    """Build ``ForcingData.prescribed_aerosol_emissions`` from a dataset.
+
+    Reads every ``aero_emis_<tracer>`` variable (the already-speciated emissions
+    contract — see ``.claude/aerosol_emissions_plan.md``), keyed by the bare
+    tracer name (``aero_emis_m_so4_acc`` → ``m_so4_acc``), and wraps each as a
+    ``TimeSeries`` leaf (time-varying) or a bare array (static). Returns ``None``
+    when no such variable is present. Fields may be 2-D (``lon, lat`` surface) or
+    3-D (``lev, lon, lat`` volume); the non-time axes are kept in file order
+    (``lev`` before the horizontal), which :class:`PreSpeciatedEmissions`
+    reshapes to ``(nlev, ncols)``. Fields must already be on the model grid (no
+    regridding here — use :mod:`jcm.data.emissions.prepare`).
+    """
+    prefix = "aero_emis_"
+    names = [str(v) for v in ds.data_vars if str(v).startswith(prefix)]
+    if not names:
+        return None
+    has_time = any("time" in ds[n].dims for n in names)
+    time_seconds = _time_axis_seconds_from_ds(ds) if has_time else None
+    mode = _resolve_align_mode(align_mode, ds) if has_time else BY_DATE
+    out: dict[str, Any] = {}
+    for name in names:
+        da = ds[name]
+        key = name[len(prefix):]
+        if "time" in da.dims:
+            others = [d for d in da.dims if d != "time"]
+            arr = jnp.asarray(da.transpose("time", *others).values)
+            out[key] = make_time_series(arr, time_seconds, align_mode=mode)
+        else:
+            out[key] = jnp.asarray(da.values)
+    return out
+
 
 def default_forcing(
     grid: HorizontalGridTypes,

--- a/jcm/main.py
+++ b/jcm/main.py
@@ -18,6 +18,14 @@ Override individual options::
     python -m jcm.main run.total_time=30 run.save_interval=1 run.time_step=20
     python -m jcm.main physics=echam physics.radiation=rrtmgp init=jw
 
+JAM prognostic aerosol + prescribed emissions (the file must be on the model
+grid — ``jcm.data.emissions.prepare`` regrids a source product — and auto-routes
+by content: ``emis_<sector>_<species>`` bulk or ``aero_emis_<tracer>``
+pre-speciated)::
+
+    python -m jcm.main physics=echam-jam grid=echam_t42_l8_sigma \
+        forcing.emissions_file=/path/to/emissions_on_model_grid.nc
+
 Multi-run sweep::
 
     python -m jcm.main -m run.time_step=10,20,30

--- a/jcm/physics/aerosol/jam/emissions/anthropogenic.py
+++ b/jcm/physics/aerosol/jam/emissions/anthropogenic.py
@@ -1,10 +1,14 @@
-"""``AnthropogenicEmissions`` — prescribed CEDS super-sector emissions (#498).
+"""``AnthropogenicEmissions`` — prescribed primary super-sector emissions (#498).
 
-Emits prescribed anthropogenic SO₂/BC/OC surface fluxes (per super-sector, read
-from ``ForcingData``) over a **smooth, differentiable vertical profile** rather
-than HAMMOZ's discrete injection levels, so injection height is calibratable by
-gradient (:mod:`injection`). Each super-sector's flux is split following HAMMOZ
-(:mod:`sectors`):
+Emits prescribed SO₂/BC/OC surface fluxes (per super-sector, read from
+``ForcingData``) over a **smooth, differentiable vertical profile** rather than
+HAMMOZ's discrete injection levels, so injection height is calibratable by
+gradient (:mod:`injection`). The super-sectors (:mod:`sectors`) cover both CEDS
+anthropogenic activity (surface / elevated-industrial / shipping) and open
+**biomass burning** (GFED), which differs only in its deeper FIRE injection
+profile — all four run through the identical speciation + injection path and are
+independently gated by which ``emis_<sector>_<species>`` forcing channels exist.
+Each super-sector's flux is split following HAMMOZ (:mod:`sectors`):
 
 * SO₂ → a primary-SO₄ fraction (default 2.5 %, differentiable) into Aitken+accum
   modal sulfate, the remainder into the ``g_so2`` gas tracer (oxidised by the
@@ -106,8 +110,19 @@ class AnthropogenicEmissions(PhysicsTerm):
 
     @staticmethod
     def _flux(forcing, name, ncols):
-        """Per-super-sector species surface flux [kg/m²/s]; 0 if not forced."""
-        v = getattr(forcing, name, None) if forcing is not None else None
+        """Per-super-sector species surface flux [kg/m²/s]; 0 if not forced.
+
+        Reads from the ``anthropogenic_emissions`` mapping on ``ForcingData``
+        (keyed ``emis_<sector>_<species>``; see the emissions-file contract in
+        ``.claude/aerosol_emissions_plan.md``). A single dict-valued field —
+        rather than one struct field per (sector, species) — keeps the forcing
+        general: new sectors/species need no ``ForcingData`` change, and
+        ``select(date)`` slices the per-channel ``TimeSeries`` leaves
+        automatically. Absent forcing, mapping, or channel ⇒ zero, so the term
+        is inert until the matching channel is supplied.
+        """
+        emis = getattr(forcing, "anthropogenic_emissions", None) if forcing is not None else None
+        v = emis.get(name) if emis is not None else None
         if v is not None and jnp.size(v) == ncols:
             return jnp.ravel(v)
         return jnp.zeros((ncols,))

--- a/jcm/physics/aerosol/jam/emissions/anthropogenic.py
+++ b/jcm/physics/aerosol/jam/emissions/anthropogenic.py
@@ -1,0 +1,167 @@
+"""``AnthropogenicEmissions`` — prescribed CEDS super-sector emissions (#498).
+
+Emits prescribed anthropogenic SO₂/BC/OC surface fluxes (per super-sector, read
+from ``ForcingData``) over a **smooth, differentiable vertical profile** rather
+than HAMMOZ's discrete injection levels, so injection height is calibratable by
+gradient (:mod:`injection`). Each super-sector's flux is split following HAMMOZ
+(:mod:`sectors`):
+
+* SO₂ → a primary-SO₄ fraction (default 2.5 %, differentiable) into Aitken+accum
+  modal sulfate, the remainder into the ``g_so2`` gas tracer (oxidised by the
+  gas-phase sulfur chemistry, #496);
+* BC → primary-carbon-mode black carbon;
+* OC → primary-carbon-mode POA (mass scaled by OM:OC = 1.4).
+
+The injection height/thickness and the primary-SO₄ fraction are differentiable
+``EmissionParameters`` (per super-sector). With no CEDS forcing supplied the
+flux fields default to zero, so the term is inert until the data pipeline
+(Phases B–D) is wired.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import jax.numpy as jnp
+import tree_math
+from flax import nnx
+
+from jcm.physics.aerosol.jam.emissions.distributors import (
+    emit_over_profile,
+    particle_mean_mass,
+)
+from jcm.physics.aerosol.jam.emissions.injection import (
+    gaussian_injection_weights,
+)
+from jcm.physics.aerosol.jam.emissions.sectors import (
+    CARBON_MODE,
+    OM_OC_RATIO,
+    SECTOR_DEFAULTS,
+    SO2_TO_SO4_MASS,
+    SO4_AITKEN_FRACTION,
+    SO4_MODES,
+    SO4_PRIMARY_FRACTION,
+    SUPER_SECTORS,
+)
+from jcm.physics.aerosol.jam.microphysics.mam4_data import MAM4_SPEC
+from jcm.physics.aerosol.jam.population import ModalAerosolSpec
+from jcm.physics.aerosol.jam.tracer_layout import (
+    gas_name,
+    mass_name,
+    number_name,
+)
+from jcm.physics.physics_term import PhysicsTendency, PhysicsTerm
+
+
+@tree_math.struct
+class EmissionParameters:
+    """Differentiable per-super-sector emission knobs (HAMMOZ defaults).
+
+    The arrays are indexed by :data:`SUPER_SECTORS`. ``injection_height`` and
+    ``injection_thickness`` set the smooth Gaussian vertical profile (the
+    load-bearing calibratable uncertainty); ``so4_primary_fraction`` is the
+    SO₂→primary-SO₄ split.
+    """
+
+    injection_height: jnp.ndarray       # (n_sector,) [m]
+    injection_thickness: jnp.ndarray    # (n_sector,) [m]
+    so4_primary_fraction: jnp.ndarray   # (n_sector,) [-]
+    scale: jnp.ndarray                  # overall emission scale
+
+    @classmethod
+    def default(cls) -> "EmissionParameters":
+        return cls(
+            injection_height=jnp.asarray(
+                [SECTOR_DEFAULTS[s].injection_height for s in SUPER_SECTORS]
+            ),
+            injection_thickness=jnp.asarray(
+                [SECTOR_DEFAULTS[s].injection_thickness for s in SUPER_SECTORS]
+            ),
+            so4_primary_fraction=jnp.full(
+                len(SUPER_SECTORS), SO4_PRIMARY_FRACTION
+            ),
+            scale=jnp.asarray(1.0),
+        )
+
+
+class AnthropogenicEmissions(PhysicsTerm):
+    """Prescribed CEDS anthropogenic SO₂/BC/OC emission over super-sectors."""
+
+    name: ClassVar[str] = "jam_anthropogenic_emissions"
+    category: ClassVar[str] = "aerosol_emissions"
+    requires: ClassVar[tuple[str, ...]] = (
+        "air_density", "layer_thickness", "height_full",
+    )
+    provides: ClassVar[tuple[str, ...]] = ()
+
+    def __init__(
+        self,
+        params: EmissionParameters | None = None,
+        *,
+        spec: ModalAerosolSpec | None = None,
+    ):
+        """Hold the (differentiable) emission params and the population."""
+        self.params = nnx.Param(params or EmissionParameters.default())
+        self._spec = spec or MAM4_SPEC
+
+    @staticmethod
+    def _flux(forcing, name, ncols):
+        """Per-super-sector species surface flux [kg/m²/s]; 0 if not forced."""
+        v = getattr(forcing, name, None) if forcing is not None else None
+        if v is not None and jnp.size(v) == ncols:
+            return jnp.ravel(v)
+        return jnp.zeros((ncols,))
+
+    def __call__(self, state, diagnostics, forcing, terrain):
+        p = self.params.get_value()
+        rho = diagnostics["air_density"]
+        dz = diagnostics["layer_thickness"]
+        height_full = diagnostics["height_full"]
+        nlev, ncols = state.temperature.shape
+        zeros3 = jnp.zeros((nlev, ncols))
+
+        tends: dict[str, jnp.ndarray] = {}
+
+        def add_mass(name, flux2d, weights):
+            tends[name] = tends.get(name, zeros3) + emit_over_profile(
+                flux2d, weights, rho, dz
+            )
+
+        def add_aerosol(species, mode_short, flux2d, weights):
+            # Mass into (species, mode); implied number into the mode, both over
+            # the same vertical profile.
+            add_mass(mass_name(species, mode_short), flux2d, weights)
+            density = self._spec.species_props(species).density
+            m_p = particle_mean_mass(self._spec.mode(mode_short), density)
+            add_mass(number_name(mode_short), flux2d / m_p, weights)
+
+        for i, sector in enumerate(SUPER_SECTORS):
+            weights = gaussian_injection_weights(
+                height_full, dz,
+                p.injection_height[i], p.injection_thickness[i],
+            )
+            so2 = p.scale * self._flux(forcing, f"emis_{sector}_so2", ncols)
+            bc = p.scale * self._flux(forcing, f"emis_{sector}_bc", ncols)
+            oc = p.scale * self._flux(forcing, f"emis_{sector}_oc", ncols)
+
+            # SO2 → primary SO4 (Aitken/accum) + g_so2 gas (S-conserving).
+            frac = p.so4_primary_fraction[i]
+            so4_mass = frac * so2 * SO2_TO_SO4_MASS
+            ait, acc = SO4_MODES
+            add_aerosol("so4", ait, so4_mass * SO4_AITKEN_FRACTION, weights)
+            add_aerosol("so4", acc, so4_mass * (1.0 - SO4_AITKEN_FRACTION),
+                        weights)
+            add_mass(gas_name("so2"), (1.0 - frac) * so2, weights)
+
+            # Primary carbonaceous mass → primary_carbon mode.
+            add_aerosol("bc", CARBON_MODE, bc, weights)
+            add_aerosol("poa", CARBON_MODE, oc * OM_OC_RATIO, weights)
+
+        tendency = PhysicsTendency(
+            u_wind=jnp.zeros_like(state.u_wind),
+            v_wind=jnp.zeros_like(state.v_wind),
+            temperature=jnp.zeros_like(state.temperature),
+            specific_humidity=jnp.zeros_like(state.specific_humidity),
+            tracers=tends,
+        )
+        return tendency, diagnostics

--- a/jcm/physics/aerosol/jam/emissions/anthropogenic.py
+++ b/jcm/physics/aerosol/jam/emissions/anthropogenic.py
@@ -32,18 +32,14 @@ from flax import nnx
 
 from jcm.physics.aerosol.jam.emissions.distributors import (
     emit_over_profile,
-    particle_mean_mass,
 )
 from jcm.physics.aerosol.jam.emissions.injection import (
     gaussian_injection_weights,
 )
 from jcm.physics.aerosol.jam.emissions.sectors import (
-    CARBON_MODE,
     OM_OC_RATIO,
     SECTOR_DEFAULTS,
     SO2_TO_SO4_MASS,
-    SO4_AITKEN_FRACTION,
-    SO4_MODES,
     SO4_PRIMARY_FRACTION,
     SUPER_SECTORS,
 )
@@ -142,13 +138,14 @@ class AnthropogenicEmissions(PhysicsTerm):
                 flux2d, weights, rho, dz
             )
 
-        def add_aerosol(species, mode_short, flux2d, weights):
-            # Mass into (species, mode); implied number into the mode, both over
-            # the same vertical profile.
-            add_mass(mass_name(species, mode_short), flux2d, weights)
+        def add_aerosol(species, mode, flux2d, weights):
+            # Mass into (species, class); implied number from the class's
+            # ``number_factor`` (the family-agnostic mass→number conversion, so
+            # this is unchanged for a sectional bin), both over the same profile.
+            add_mass(mass_name(species, mode.short), flux2d, weights)
             density = self._spec.species_props(species).density
-            m_p = particle_mean_mass(self._spec.mode(mode_short), density)
-            add_mass(number_name(mode_short), flux2d / m_p, weights)
+            add_mass(number_name(mode.short),
+                     flux2d * mode.number_factor / density, weights)
 
         for i, sector in enumerate(SUPER_SECTORS):
             weights = gaussian_injection_weights(
@@ -159,18 +156,21 @@ class AnthropogenicEmissions(PhysicsTerm):
             bc = p.scale * self._flux(forcing, f"emis_{sector}_bc", ncols)
             oc = p.scale * self._flux(forcing, f"emis_{sector}_oc", ncols)
 
-            # SO2 → primary SO4 (Aitken/accum) + g_so2 gas (S-conserving).
+            # SO2 → primary SO4 + g_so2 gas remainder (S-conserving). The
+            # population owns which classes receive primary sulfate and in what
+            # proportion (``primary_split``) — no Aitken/accum assumption here.
             frac = p.so4_primary_fraction[i]
             so4_mass = frac * so2 * SO2_TO_SO4_MASS
-            ait, acc = SO4_MODES
-            add_aerosol("so4", ait, so4_mass * SO4_AITKEN_FRACTION, weights)
-            add_aerosol("so4", acc, so4_mass * (1.0 - SO4_AITKEN_FRACTION),
-                        weights)
+            for mode, mode_frac in self._spec.primary_split("so4"):
+                add_aerosol("so4", mode, so4_mass * mode_frac, weights)
             add_mass(gas_name("so2"), (1.0 - frac) * so2, weights)
 
-            # Primary carbonaceous mass → primary_carbon mode.
-            add_aerosol("bc", CARBON_MODE, bc, weights)
-            add_aerosol("poa", CARBON_MODE, oc * OM_OC_RATIO, weights)
+            # Primary carbonaceous mass → the population's primary-carbon
+            # class(es); OC scaled to POA by OM:OC.
+            for mode, mode_frac in self._spec.primary_split("bc"):
+                add_aerosol("bc", mode, bc * mode_frac, weights)
+            for mode, mode_frac in self._spec.primary_split("poa"):
+                add_aerosol("poa", mode, oc * OM_OC_RATIO * mode_frac, weights)
 
         tendency = PhysicsTendency(
             u_wind=jnp.zeros_like(state.u_wind),

--- a/jcm/physics/aerosol/jam/emissions/anthropogenic_test.py
+++ b/jcm/physics/aerosol/jam/emissions/anthropogenic_test.py
@@ -15,6 +15,7 @@ from jcm.physics.aerosol.jam.emissions.sectors import (
     OM_OC_RATIO,
     SO2_TO_SO4_MASS,
     SO4_PRIMARY_FRACTION,
+    SUPER_SECTORS,
 )
 from jcm.physics.aerosol.jam.gas_species import GAS_SPECIES
 from jcm.physics.aerosol.jam.species import SPECIES
@@ -37,8 +38,13 @@ def _setup(**fluxes):
             (_NLEV, _NCOLS),
         ),
     }
+    # The term reads per-channel fluxes from the ``anthropogenic_emissions``
+    # mapping on ``ForcingData`` (keyed ``emis_<sector>_<species>``); mirror
+    # that here so the test exercises the real forcing contract.
     forcing = types.SimpleNamespace(
-        **{k: jnp.full((_NCOLS,), v) for k, v in fluxes.items()}
+        anthropogenic_emissions={
+            k: jnp.full((_NCOLS,), v) for k, v in fluxes.items()
+        }
     )
     return state, diagnostics, forcing
 
@@ -121,6 +127,65 @@ class AnthropogenicEmissionsTest(unittest.TestCase):
             self.assertTrue(np.isfinite(float(gi)))
         # Injection height genuinely matters (non-zero gradient).
         self.assertGreater(abs(float(g[0])), 0.0)
+
+
+def _mass_weighted_height(tend, rho, dz, height, col=0):
+    """Column mass-weighted injection height [m] of a tracer tendency."""
+    w = np.asarray((tend * rho * dz)[:, col])
+    h = np.asarray(height[:, col])
+    return float(np.sum(w * h) / np.sum(w))
+
+
+class BiomassBurningTest(unittest.TestCase):
+    """Phase E: open biomass burning as a 4th super-sector with FIRE injection."""
+
+    def test_biomass_bc_to_primary_carbon_mass_conserving(self):
+        # Biomass BC/OC use the same speciation as anthropogenic carbon (MAM4
+        # routes both to the single primary-carbon mode), just a deeper profile.
+        state, diagnostics, forcing = _setup(
+            emis_biomass_burning_bc=_F_BC, emis_biomass_burning_oc=_F_OC)
+        tend, _ = AnthropogenicEmissions()(state, diagnostics, forcing, None)
+        rho, dz = diagnostics["air_density"], diagnostics["layer_thickness"]
+        bc = _column_integral(tend.tracers[mass_name("bc", "pcm")], rho, dz)
+        poa = _column_integral(tend.tracers[mass_name("poa", "pcm")], rho, dz)
+        np.testing.assert_allclose(bc, _F_BC, rtol=1e-5)
+        np.testing.assert_allclose(poa, _F_OC * OM_OC_RATIO, rtol=1e-5)
+
+    def test_fire_profile_is_deeper_than_surface(self):
+        # The FIRE default injects much higher than surface combustion: the
+        # mass-weighted height of the emitted BC must be substantially larger.
+        state, diagnostics, _ = _setup()
+        rho, dz = diagnostics["air_density"], diagnostics["layer_thickness"]
+        h = diagnostics["height_full"]
+
+        _, _, f_fire = _setup(emis_biomass_burning_bc=_F_BC)
+        _, _, f_surf = _setup(emis_surface_combustion_bc=_F_BC)
+        t_fire, _ = AnthropogenicEmissions()(state, diagnostics, f_fire, None)
+        t_surf, _ = AnthropogenicEmissions()(state, diagnostics, f_surf, None)
+        bc = mass_name("bc", "pcm")
+        z_fire = _mass_weighted_height(t_fire.tracers[bc], rho, dz, h)
+        z_surf = _mass_weighted_height(t_surf.tracers[bc], rho, dz, h)
+        self.assertGreater(z_fire, z_surf + 300.0)
+
+    def test_grad_through_biomass_injection_height_finite(self):
+        i = SUPER_SECTORS.index("biomass_burning")
+        state, diagnostics, forcing = _setup(emis_biomass_burning_bc=_F_BC)
+
+        def loss(height):
+            base = EmissionParameters.default()
+            p = EmissionParameters(
+                injection_height=base.injection_height.at[i].set(height),
+                injection_thickness=base.injection_thickness,
+                so4_primary_fraction=base.so4_primary_fraction,
+                scale=base.scale,
+            )
+            tend, _ = AnthropogenicEmissions(params=p)(
+                state, diagnostics, forcing, None)
+            return sum(jnp.sum(v ** 2) for v in tend.tracers.values())
+
+        g = float(jax.grad(loss)(jnp.asarray(1000.0)))
+        self.assertTrue(np.isfinite(g))
+        self.assertGreater(abs(g), 0.0)
 
 
 class FactoryWiringTest(unittest.TestCase):

--- a/jcm/physics/aerosol/jam/emissions/anthropogenic_test.py
+++ b/jcm/physics/aerosol/jam/emissions/anthropogenic_test.py
@@ -1,0 +1,141 @@
+"""Tests for prescribed CEDS anthropogenic emissions (#498, Phase A)."""
+
+import types
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from jcm.physics.aerosol.jam.emissions.anthropogenic import (
+    AnthropogenicEmissions,
+    EmissionParameters,
+)
+from jcm.physics.aerosol.jam.emissions.sectors import (
+    OM_OC_RATIO,
+    SO2_TO_SO4_MASS,
+    SO4_PRIMARY_FRACTION,
+)
+from jcm.physics.aerosol.jam.gas_species import GAS_SPECIES
+from jcm.physics.aerosol.jam.species import SPECIES
+from jcm.physics.aerosol.jam.tracer_layout import gas_name, mass_name
+from jcm.physics_interface import PhysicsState
+
+_NLEV, _NCOLS = 5, 2
+_F_SO2, _F_BC, _F_OC = 2.0e-9, 1.0e-9, 3.0e-9   # kg/m²/s
+
+
+def _setup(**fluxes):
+    state = PhysicsState.zeros((_NLEV, _NCOLS)).copy(
+        temperature=jnp.full((_NLEV, _NCOLS), 280.0),
+    )
+    diagnostics = {
+        "air_density": jnp.full((_NLEV, _NCOLS), 1.0),
+        "layer_thickness": jnp.full((_NLEV, _NCOLS), 200.0),
+        "height_full": jnp.broadcast_to(
+            jnp.asarray([4000.0, 2000.0, 1000.0, 300.0, 50.0])[:, None],
+            (_NLEV, _NCOLS),
+        ),
+    }
+    forcing = types.SimpleNamespace(
+        **{k: jnp.full((_NCOLS,), v) for k, v in fluxes.items()}
+    )
+    return state, diagnostics, forcing
+
+
+def _column_integral(tend, rho, dz):
+    """Σ ρ_k Δz_k · tend_k  → the recovered surface flux [/m²/s], (ncols,)."""
+    return np.asarray(jnp.sum(tend * rho * dz, axis=0))
+
+
+class AnthropogenicEmissionsTest(unittest.TestCase):
+    def test_zero_without_forcing(self):
+        state, diagnostics, _ = _setup()
+        tend, _ = AnthropogenicEmissions()(state, diagnostics, None, None)
+        for v in tend.tracers.values():
+            self.assertTrue(np.all(np.asarray(v) == 0.0))
+
+    def test_primary_so4_split_and_gas_remainder(self):
+        state, diagnostics, forcing = _setup(emis_surface_combustion_so2=_F_SO2)
+        tend, _ = AnthropogenicEmissions()(state, diagnostics, forcing, None)
+        rho, dz = diagnostics["air_density"], diagnostics["layer_thickness"]
+
+        so4 = (_column_integral(tend.tracers[mass_name("so4", "ait")], rho, dz)
+               + _column_integral(tend.tracers[mass_name("so4", "acc")], rho, dz))
+        gso2 = _column_integral(tend.tracers[gas_name("so2")], rho, dz)
+        # 2.5% of S → primary SO4 mass; 97.5% → SO2 gas.
+        np.testing.assert_allclose(
+            so4, SO4_PRIMARY_FRACTION * _F_SO2 * SO2_TO_SO4_MASS, rtol=1e-5
+        )
+        np.testing.assert_allclose(
+            gso2, (1.0 - SO4_PRIMARY_FRACTION) * _F_SO2, rtol=1e-5
+        )
+
+    def test_sulfur_conserved(self):
+        state, diagnostics, forcing = _setup(emis_elevated_industrial_so2=_F_SO2)
+        tend, _ = AnthropogenicEmissions()(state, diagnostics, forcing, None)
+        rho, dz = diagnostics["air_density"], diagnostics["layer_thickness"]
+        m_so2 = GAS_SPECIES["so2"].molar_mass
+        m_so4 = SPECIES["so4"].molar_mass
+        s_so4 = (
+            _column_integral(tend.tracers[mass_name("so4", "ait")], rho, dz)
+            + _column_integral(tend.tracers[mass_name("so4", "acc")], rho, dz)
+        ) / m_so4
+        s_gas = _column_integral(tend.tracers[gas_name("so2")], rho, dz) / m_so2
+        np.testing.assert_allclose(s_so4 + s_gas, _F_SO2 / m_so2, rtol=1e-5)
+
+    def test_bc_and_oc_to_primary_carbon(self):
+        state, diagnostics, forcing = _setup(
+            emis_shipping_bc=_F_BC, emis_shipping_oc=_F_OC,
+        )
+        tend, _ = AnthropogenicEmissions()(state, diagnostics, forcing, None)
+        rho, dz = diagnostics["air_density"], diagnostics["layer_thickness"]
+        bc = _column_integral(tend.tracers[mass_name("bc", "pcm")], rho, dz)
+        poa = _column_integral(tend.tracers[mass_name("poa", "pcm")], rho, dz)
+        np.testing.assert_allclose(bc, _F_BC, rtol=1e-5)
+        np.testing.assert_allclose(poa, _F_OC * OM_OC_RATIO, rtol=1e-5)  # OM:OC
+
+    def test_grad_through_injection_and_so4_params_finite(self):
+        state, diagnostics, forcing = _setup(
+            emis_surface_combustion_so2=_F_SO2,
+            emis_surface_combustion_bc=_F_BC,
+        )
+
+        def loss(height, thickness, frac):
+            base = EmissionParameters.default()
+            p = EmissionParameters(
+                injection_height=base.injection_height.at[0].set(height),
+                injection_thickness=base.injection_thickness.at[0].set(thickness),
+                so4_primary_fraction=base.so4_primary_fraction.at[0].set(frac),
+                scale=base.scale,
+            )
+            tend, _ = AnthropogenicEmissions(params=p)(
+                state, diagnostics, forcing, None
+            )
+            return sum(jnp.sum(v ** 2) for v in tend.tracers.values())
+
+        g = jax.grad(loss, argnums=(0, 1, 2))(
+            jnp.asarray(40.0), jnp.asarray(50.0), jnp.asarray(0.025)
+        )
+        for gi in g:
+            self.assertTrue(np.isfinite(float(gi)))
+        # Injection height genuinely matters (non-zero gradient).
+        self.assertGreater(abs(float(g[0])), 0.0)
+
+
+class FactoryWiringTest(unittest.TestCase):
+    def test_default_excludes_anthropogenic(self):
+        from jcm.physics.aerosol.jam import jam_aerosol_physics
+
+        names = [t.name for t in jam_aerosol_physics()]
+        self.assertNotIn("jam_anthropogenic_emissions", names)
+
+    def test_flag_includes_anthropogenic(self):
+        from jcm.physics.aerosol.jam import jam_aerosol_physics
+
+        names = [t.name for t in jam_aerosol_physics(anthropogenic=True)]
+        self.assertIn("jam_anthropogenic_emissions", names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jcm/physics/aerosol/jam/emissions/distributors.py
+++ b/jcm/physics/aerosol/jam/emissions/distributors.py
@@ -8,8 +8,6 @@ modal path is implemented here; a sectional distributor is future work (#491).
 
 from __future__ import annotations
 
-import math
-
 import jax.numpy as jnp
 
 from jcm.physics.aerosol.jam.population import AerosolMode, ModalAerosolSpec
@@ -17,18 +15,14 @@ from jcm.physics.aerosol.jam.tracer_layout import mass_name, number_name
 
 
 def particle_mean_mass(mode: AerosolMode, species_density: float) -> float:
-    """Mean single-particle mass [kg] of a log-normal mode at its ref size.
+    """Mean single-particle mass [kg] of a class at its reference size.
 
-    ``m_p = ρ_p (π/6) Dg³ exp(9/2 ln²σ)`` (mass-equivalent of the number
-    distribution's third moment).
+    ``m_p = ρ_material / number_factor`` — the inverse of the family-agnostic
+    ``mode.number_factor`` (number per unit dry-aerosol volume), so the modal
+    log-normal third-moment formula lives in one place (``AerosolMode``) and a
+    sectional class returns its own mean particle mass through the same call.
     """
-    ln_sigma = math.log(mode.geom_std_dev)
-    return (
-        species_density
-        * (math.pi / 6.0)
-        * mode.dgnum ** 3
-        * math.exp(4.5 * ln_sigma ** 2)
-    )
+    return species_density / mode.number_factor
 
 
 def emit_over_profile(

--- a/jcm/physics/aerosol/jam/emissions/distributors.py
+++ b/jcm/physics/aerosol/jam/emissions/distributors.py
@@ -31,6 +31,23 @@ def particle_mean_mass(mode: AerosolMode, species_density: float) -> float:
     )
 
 
+def emit_over_profile(
+    flux: jnp.ndarray,             # (ncols,) surface flux [X/m²/s]
+    weights: jnp.ndarray,          # (nlev, ncols) vertical weights summing to 1
+    air_density: jnp.ndarray,      # (nlev, ncols) [kg/m³]
+    layer_thickness: jnp.ndarray,  # (nlev, ncols) [m]
+) -> jnp.ndarray:
+    """Spread a surface mass/number flux over a vertical profile.
+
+    Returns a ``(nlev, ncols)`` mixing-ratio tendency [X/kg/s]. Because
+    ``weights`` sum to 1 over levels, the column-integrated emitted amount
+    equals the input flux (``Σ ρ_k Δz_k · dq_k = flux``), so it is
+    mass-conserving for any (differentiable) profile. Works for both mass
+    [kg/kg/s] and number [kg⁻¹/s] tendencies.
+    """
+    return weights * flux[jnp.newaxis, :] / (air_density * layer_thickness)
+
+
 def distribute_surface_flux(
     spec: ModalAerosolSpec,
     fluxes: list[tuple[str, str, jnp.ndarray]],

--- a/jcm/physics/aerosol/jam/emissions/dust.py
+++ b/jcm/physics/aerosol/jam/emissions/dust.py
@@ -107,9 +107,13 @@ class DustEmissions(PhysicsTerm):
         g_flux = horizontal_flux(u_star, p.u_threshold, air_density[-1], p.scale)
         flux = source * p.alpha * g_flux                       # kg/m²/s
 
+        # The population owns *which* classes receive primary dust (and their
+        # default split); the tunable ``accum_fraction`` overrides the fraction
+        # for this 2-class fine/coarse scheme. No literal mode names here.
+        (fine, _), (coarse, _) = self._spec.primary_split("du")
         fluxes = [
-            ("du", "acc", flux * p.accum_fraction),
-            ("du", "cor", flux * (1.0 - p.accum_fraction)),
+            ("du", fine.short, flux * p.accum_fraction),
+            ("du", coarse.short, flux * (1.0 - p.accum_fraction)),
         ]
         tracer_tends = distribute_surface_flux(self._spec, fluxes, air_density, dz)
 

--- a/jcm/physics/aerosol/jam/emissions/injection.py
+++ b/jcm/physics/aerosol/jam/emissions/injection.py
@@ -39,9 +39,18 @@ def gaussian_injection_weights(
     z = (height_full - injection_height) / sigma
     g = jnp.exp(-0.5 * z * z) * layer_thickness
     total = jnp.sum(g, axis=0, keepdims=True)
-    # Fall back to the lowest layer if the column has no overlap (numerically
-    # the Gaussian underflowed everywhere) so weights still sum to 1.
+    # Fallback when the Gaussian underflowed in *every* layer — i.e. the
+    # injection height sits far outside the column (above the model top or below
+    # the surface) or the width is so small no mid-layer height registers. Put
+    # all the mass in the single layer whose height is nearest the injection
+    # height, so an above-top height loads the top layer and a below-surface one
+    # the bottom layer. (Previously this always picked the lowest layer, which
+    # silently turned a calibrated high-altitude injection into a surface
+    # emission — corrupting gradient-based tuning that explores large heights.)
     safe = total > 0.0
     weights = jnp.where(safe, g / jnp.where(safe, total, 1.0), 0.0)
-    lowest = jnp.zeros_like(weights).at[-1].set(1.0)
-    return jnp.where(safe, weights, lowest)
+    nlev = height_full.shape[0]
+    nearest_idx = jnp.argmin(jnp.abs(height_full - injection_height), axis=0)
+    nearest = (jnp.arange(nlev)[:, None] == nearest_idx[None, :]).astype(
+        weights.dtype)
+    return jnp.where(safe, weights, nearest)

--- a/jcm/physics/aerosol/jam/emissions/injection.py
+++ b/jcm/physics/aerosol/jam/emissions/injection.py
@@ -1,0 +1,47 @@
+"""Smooth, differentiable vertical injection profiles for emissions (#498).
+
+HAMMOZ injects emissions at discrete levels by type (``EM_SURFACE``,
+``EM_LEVEL50M``, ``EM_VOLUME``, ``EM_FIRE`` in ``mo_hammoz_emissions.f90``). A
+hard level-index pick has **zero/undefined gradient** w.r.t. the injection
+height, which defeats the point of a differentiable GCM (injection height is a
+large, calibratable uncertainty). So here the profile is a *smooth* normalised
+Gaussian in geometric height, centred at ``injection_height`` with width
+``injection_thickness``, evaluated on the model mid-layer heights — giving
+well-defined ``d(emission)/d(height)`` and ``d(emission)/d(thickness)``. As the
+thickness → 0 it collapses to a near-surface spike (the ``EM_SURFACE`` limit).
+
+The returned per-level weights **sum to 1 over the column**, so distributing a
+surface mass flux ``F`` [kg/m²/s] as ``F·w_k/(ρ_k·Δz_k)`` conserves the
+column-integrated emitted mass exactly (``Σ ρ_k Δz_k · dq_k = F``).
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+
+_MIN_THICKNESS = 1.0   # m — floor so the Gaussian never degenerates
+
+
+def gaussian_injection_weights(
+    height_full: jnp.ndarray,        # (nlev, ncols) mid-layer height [m]
+    layer_thickness: jnp.ndarray,    # (nlev, ncols) [m]
+    injection_height: jnp.ndarray,   # scalar [m]
+    injection_thickness: jnp.ndarray,  # scalar [m]
+) -> jnp.ndarray:
+    """Per-level emission weights (sum to 1 over levels), smooth in the inputs.
+
+    The continuous Gaussian ``g(z) = exp(-½((z−h)/σ)²)`` is discretised by
+    weighting each level by its thickness, ``w_k ∝ g(z_k)·Δz_k``, then
+    normalised. Differentiable w.r.t. ``injection_height`` (``h``) and
+    ``injection_thickness`` (``σ``).
+    """
+    sigma = jnp.maximum(injection_thickness, _MIN_THICKNESS)
+    z = (height_full - injection_height) / sigma
+    g = jnp.exp(-0.5 * z * z) * layer_thickness
+    total = jnp.sum(g, axis=0, keepdims=True)
+    # Fall back to the lowest layer if the column has no overlap (numerically
+    # the Gaussian underflowed everywhere) so weights still sum to 1.
+    safe = total > 0.0
+    weights = jnp.where(safe, g / jnp.where(safe, total, 1.0), 0.0)
+    lowest = jnp.zeros_like(weights).at[-1].set(1.0)
+    return jnp.where(safe, weights, lowest)

--- a/jcm/physics/aerosol/jam/emissions/injection_test.py
+++ b/jcm/physics/aerosol/jam/emissions/injection_test.py
@@ -33,6 +33,22 @@ class InjectionProfileTest(unittest.TestCase):
         zbar_high = float(jnp.sum(high[:, 0] * _Z[:, 0]))
         self.assertGreater(zbar_high, zbar_low)
 
+    def test_underflow_above_top_loads_top_layer(self):
+        # An injection height far above the column (tiny width → Gaussian
+        # underflows everywhere) must fall back to the nearest layer = the top
+        # (level 0), not silently dump into the surface layer.
+        w = gaussian_injection_weights(_Z, _DZ, jnp.asarray(1.0e6),
+                                       jnp.asarray(1.0))
+        np.testing.assert_allclose(float(jnp.sum(w)), 1.0, rtol=1e-5)
+        self.assertEqual(int(jnp.argmax(w[:, 0])), 0)
+
+    def test_underflow_below_surface_loads_bottom_layer(self):
+        # Far below the surface → nearest layer = the bottom (level -1).
+        w = gaussian_injection_weights(_Z, _DZ, jnp.asarray(-1.0e6),
+                                       jnp.asarray(1.0))
+        np.testing.assert_allclose(float(jnp.sum(w)), 1.0, rtol=1e-5)
+        self.assertEqual(int(jnp.argmax(w[:, 0])), _Z.shape[0] - 1)
+
     def test_grad_wrt_height_and_thickness_finite_and_nonzero(self):
         def mean_height(h, t):
             w = gaussian_injection_weights(_Z, _DZ, h, t)

--- a/jcm/physics/aerosol/jam/emissions/injection_test.py
+++ b/jcm/physics/aerosol/jam/emissions/injection_test.py
@@ -1,0 +1,48 @@
+"""Tests for the smooth differentiable vertical injection profile (#498)."""
+
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from jcm.physics.aerosol.jam.emissions.injection import (
+    gaussian_injection_weights,
+)
+
+# Column: level 0 = top, level -1 = surface. Heights [m] and thicknesses [m].
+_Z = jnp.asarray([4000.0, 2000.0, 1000.0, 300.0, 50.0])[:, None]  # (nlev, 1)
+_DZ = jnp.asarray([2000.0, 1200.0, 700.0, 300.0, 100.0])[:, None]
+
+
+class InjectionProfileTest(unittest.TestCase):
+    def test_weights_sum_to_one(self):
+        for h in (0.0, 50.0, 1000.0, 3000.0):
+            w = gaussian_injection_weights(_Z, _DZ, jnp.asarray(h), jnp.asarray(50.0))
+            np.testing.assert_allclose(float(jnp.sum(w)), 1.0, rtol=1e-5)
+
+    def test_surface_injection_loads_lowest_layer(self):
+        w = gaussian_injection_weights(_Z, _DZ, jnp.asarray(50.0), jnp.asarray(40.0))
+        self.assertEqual(int(jnp.argmax(w[:, 0])), _Z.shape[0] - 1)
+
+    def test_elevated_injection_shifts_upward(self):
+        low = gaussian_injection_weights(_Z, _DZ, jnp.asarray(50.0), jnp.asarray(100.0))
+        high = gaussian_injection_weights(_Z, _DZ, jnp.asarray(2000.0), jnp.asarray(100.0))
+        # Mass-weighted mean injection height rises with injection_height.
+        zbar_low = float(jnp.sum(low[:, 0] * _Z[:, 0]))
+        zbar_high = float(jnp.sum(high[:, 0] * _Z[:, 0]))
+        self.assertGreater(zbar_high, zbar_low)
+
+    def test_grad_wrt_height_and_thickness_finite_and_nonzero(self):
+        def mean_height(h, t):
+            w = gaussian_injection_weights(_Z, _DZ, h, t)
+            return jnp.sum(w[:, 0] * _Z[:, 0])
+
+        gh = jax.grad(mean_height, argnums=0)(jnp.asarray(800.0), jnp.asarray(300.0))
+        gt = jax.grad(mean_height, argnums=1)(jnp.asarray(800.0), jnp.asarray(300.0))
+        self.assertTrue(np.isfinite(float(gh)) and abs(float(gh)) > 0.0)
+        self.assertTrue(np.isfinite(float(gt)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jcm/physics/aerosol/jam/emissions/prescribed.py
+++ b/jcm/physics/aerosol/jam/emissions/prescribed.py
@@ -1,0 +1,85 @@
+"""``PreSpeciatedEmissions`` — CAM6/MAM4-faithful prescribed modal emissions (#498).
+
+The companion to :class:`AnthropogenicEmissions`. Where that term takes *bulk*
+SO₂/BC/OC and does the speciation + smooth injection in-model (so injection
+height and the primary-SO₄ fraction are differentiable), this term mirrors how
+**CAM6 actually applies emissions**: it reads **already-speciated** per-tracer
+emission fields and injects them directly, with no in-model speciation or
+injection-profile parameters. The split into modes/species and the vertical
+placement were done offline when the emission files were built (CAM does the same
+— ``mo_srf_emissions`` for surface fields, ``mo_extfrc`` for altitude-resolved
+"external forcing" fields).
+
+This is deliberately **representation-agnostic**: each ``ForcingData`` field is
+keyed by the *tracer name it feeds* (e.g. ``m_so4_acc``, ``m_bc_pcm``, ``n_pcm``,
+``g_so2``) and simply added to that tracer's tendency — the term knows nothing
+about MAM4 specifically, so any aerosol layout works. A field is applied as:
+
+* **surface** — shape ``(ncols,)`` (a 2-D ``(lon, lat)`` field after
+  ``select``): a surface mass/number flux [X/m²/s] added to the **lowest layer**.
+* **volume** — shape ``(nlev, ncols)`` (a 3-D ``(lev, lon, lat)`` field): a
+  per-model-layer flux [X/m²/s per layer] added across levels (the ``mo_extfrc``
+  analogue for elevated emissions pre-distributed onto model levels).
+
+Both are mass-conserving (``Σ_k ρ_k Δz_k · dq_k = Σ_k flux_k``). There is no
+injection-height/SO₄ parameter here — but because the emission fields are
+differentiable ``ForcingData`` leaves entering the tracer tendencies linearly,
+``∂(aerosol mmr)/∂(emission field)`` is still well-defined and finite, so the
+emission magnitudes remain calibratable by gradient.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import jax.numpy as jnp
+from flax import nnx
+
+from jcm.physics.physics_term import PhysicsTendency, PhysicsTerm
+
+
+class PreSpeciatedEmissions(PhysicsTerm):
+    """Inject prescribed, already-speciated per-tracer emission fields directly."""
+
+    name: ClassVar[str] = "jam_prescribed_aerosol_emissions"
+    category: ClassVar[str] = "aerosol_emissions"
+    requires: ClassVar[tuple[str, ...]] = ("air_density", "layer_thickness")
+    provides: ClassVar[tuple[str, ...]] = ()
+
+    def __init__(self, *, scale: float = 1.0):
+        """Hold an overall (differentiable) emission scale."""
+        # A single multiplicative knob, handy for sensitivity runs / calibration
+        # of the whole prescribed source without per-field plumbing.
+        self.scale = nnx.Param(jnp.asarray(scale))
+
+    def __call__(self, state, diagnostics, forcing, terrain):
+        rho = diagnostics["air_density"]
+        dz = diagnostics["layer_thickness"]
+        nlev, ncols = state.temperature.shape
+        scale = self.scale.get_value()
+
+        emis = (getattr(forcing, "prescribed_aerosol_emissions", None)
+                if forcing is not None else None)
+
+        tends: dict[str, jnp.ndarray] = {}
+        if emis:
+            inv = 1.0 / (rho * dz)               # (nlev, ncols) mmr per kg/m²
+            for tracer, field in emis.items():
+                f = scale * jnp.asarray(field)
+                if jnp.size(f) == ncols:
+                    # Surface flux → lowest layer only.
+                    dq = jnp.zeros((nlev, ncols)).at[-1].set(
+                        f.ravel() * inv[-1])
+                else:
+                    # Per-layer volume flux already on model levels.
+                    dq = f.reshape(nlev, ncols) * inv
+                tends[tracer] = tends.get(tracer, jnp.zeros((nlev, ncols))) + dq
+
+        tendency = PhysicsTendency(
+            u_wind=jnp.zeros_like(state.u_wind),
+            v_wind=jnp.zeros_like(state.v_wind),
+            temperature=jnp.zeros_like(state.temperature),
+            specific_humidity=jnp.zeros_like(state.specific_humidity),
+            tracers=tends,
+        )
+        return tendency, diagnostics

--- a/jcm/physics/aerosol/jam/emissions/prescribed_test.py
+++ b/jcm/physics/aerosol/jam/emissions/prescribed_test.py
@@ -1,0 +1,113 @@
+"""Tests for the CAM6/MAM4-faithful pre-speciated emissions term (#498)."""
+
+import types
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from jcm.physics.aerosol.jam.emissions.prescribed import PreSpeciatedEmissions
+from jcm.physics.aerosol.jam.tracer_layout import mass_name, number_name
+from jcm.physics_interface import PhysicsState
+
+_NLEV, _NCOLS = 5, 3
+_RHO, _DZ = 1.1, 200.0
+
+
+def _setup(**fields):
+    state = PhysicsState.zeros((_NLEV, _NCOLS)).copy(
+        temperature=jnp.full((_NLEV, _NCOLS), 280.0))
+    diagnostics = {
+        "air_density": jnp.full((_NLEV, _NCOLS), _RHO),
+        "layer_thickness": jnp.full((_NLEV, _NCOLS), _DZ),
+    }
+    forcing = types.SimpleNamespace(prescribed_aerosol_emissions=fields or None)
+    return state, diagnostics, forcing
+
+
+def _column_integral(tend):
+    """Σ ρ Δz · tend over levels → recovered surface flux [X/m²/s], (ncols,)."""
+    return np.asarray(jnp.sum(tend * _RHO * _DZ, axis=0))
+
+
+class PreSpeciatedEmissionsTest(unittest.TestCase):
+    def test_zero_without_forcing(self):
+        state, diagnostics, forcing = _setup()
+        tend, _ = PreSpeciatedEmissions()(state, diagnostics, forcing, None)
+        self.assertEqual(tend.tracers, {})
+
+    def test_surface_field_loads_lowest_layer_mass_conserving(self):
+        flux = 2.0e-10
+        tracer = mass_name("so4", "acc")
+        state, diagnostics, forcing = _setup(
+            **{tracer: jnp.full((_NCOLS,), flux)})
+        tend, _ = PreSpeciatedEmissions()(state, diagnostics, forcing, None)
+        dq = tend.tracers[tracer]
+        # All mass enters the lowest layer; the column integral recovers flux.
+        self.assertTrue(np.all(np.asarray(dq[:-1]) == 0.0))
+        np.testing.assert_allclose(_column_integral(dq), flux, rtol=1e-6)
+
+    def test_volume_field_distributes_over_levels_mass_conserving(self):
+        # A 3-D per-layer flux is added across model levels (the elevated /
+        # mo_extfrc path); the column integral is the sum of the per-layer flux.
+        per_layer = jnp.asarray([0.0, 1e-11, 3e-11, 0.0, 0.0])[:, None]
+        field = jnp.broadcast_to(per_layer, (_NLEV, _NCOLS))
+        tracer = mass_name("so4", "acc")
+        state, diagnostics, forcing = _setup(**{tracer: field})
+        tend, _ = PreSpeciatedEmissions()(state, diagnostics, forcing, None)
+        np.testing.assert_allclose(
+            _column_integral(tend.tracers[tracer]),
+            np.asarray(jnp.sum(field, axis=0)), rtol=1e-6)
+        # Mass genuinely lands aloft, not just at the surface.
+        self.assertGreater(float(tend.tracers[tracer][1, 0]), 0.0)
+
+    def test_multiple_tracers_independent(self):
+        state, diagnostics, forcing = _setup(
+            **{mass_name("bc", "pcm"): jnp.full((_NCOLS,), 1e-10),
+               number_name("pcm"): jnp.full((_NCOLS,), 5e6)})
+        tend, _ = PreSpeciatedEmissions()(state, diagnostics, forcing, None)
+        self.assertIn(mass_name("bc", "pcm"), tend.tracers)
+        self.assertIn(number_name("pcm"), tend.tracers)
+
+    def test_scale_multiplies_emission(self):
+        tracer = mass_name("bc", "pcm")
+        state, diagnostics, forcing = _setup(
+            **{tracer: jnp.full((_NCOLS,), 1e-10)})
+        tend, _ = PreSpeciatedEmissions(scale=2.0)(
+            state, diagnostics, forcing, None)
+        np.testing.assert_allclose(_column_integral(tend.tracers[tracer]),
+                                   2.0e-10, rtol=1e-6)
+
+    def test_grad_of_mmr_wrt_emission_field_finite(self):
+        # The user-facing point: even without an injection-height parameter,
+        # ∂(aerosol mmr tendency)/∂(emission ForcingData field) is well-defined.
+        tracer = mass_name("so4", "acc")
+        state, diagnostics, _ = _setup()
+
+        def loss(flux_field):
+            forcing = types.SimpleNamespace(
+                prescribed_aerosol_emissions={tracer: flux_field})
+            tend, _ = PreSpeciatedEmissions()(state, diagnostics, forcing, None)
+            return jnp.sum(tend.tracers[tracer] ** 2)
+
+        x = jnp.full((_NCOLS,), 2.0e-10)
+        g = jax.grad(loss)(x)
+        self.assertTrue(np.all(np.isfinite(np.asarray(g))))
+        self.assertTrue(np.all(np.asarray(g) > 0.0))
+
+
+class FactoryWiringTest(unittest.TestCase):
+    def test_default_excludes_prescribed(self):
+        from jcm.physics.aerosol.jam import jam_aerosol_physics
+        names = [t.name for t in jam_aerosol_physics()]
+        self.assertNotIn("jam_prescribed_aerosol_emissions", names)
+
+    def test_flag_includes_prescribed(self):
+        from jcm.physics.aerosol.jam import jam_aerosol_physics
+        names = [t.name for t in jam_aerosol_physics(prescribed_speciated=True)]
+        self.assertIn("jam_prescribed_aerosol_emissions", names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jcm/physics/aerosol/jam/emissions/seasalt.py
+++ b/jcm/physics/aerosol/jam/emissions/seasalt.py
@@ -26,7 +26,7 @@ import tree_math
 from flax import nnx
 
 from jcm.physics.aerosol.jam.microphysics.mam4_data import MAM4_SPEC
-from jcm.physics.aerosol.jam.population import ModalAerosolSpec
+from jcm.physics.aerosol.jam.population import AerosolMode, ModalAerosolSpec
 from jcm.physics.aerosol.jam.tracer_layout import mass_name, number_name
 from jcm.physics.physics_term import PhysicsTendency, PhysicsTerm
 
@@ -36,18 +36,27 @@ _DMTA = 0.100e-6        # lower dry diameter [m]
 _DMTD = 1.000e-5        # upper dry diameter [m]
 _DMTB_GONG = 0.221e-6   # Gong small/large particle split [m]
 _PPWW = 3.41            # default wind-speed exponent
-# Dry-diameter ranges mapping bins → (aitken, accumulation, coarse) [m].
-_DBEG = (0.050e-6, 0.100e-6, 1.000e-6)
-_DEND = (0.100e-6, 1.000e-6, 1.000e-5)
 
 
-def gong_mode_factors(density: float) -> dict[str, float]:
-    """Integrate the Gong source function over each mode's size range.
+def gong_class_factors(
+    classes: tuple[AerosolMode, ...], density: float
+) -> dict[str, tuple[float, float]]:
+    """Partition the Gong (2003) source flux across a population's ``ss`` classes.
 
-    Returns ``{"mass_acc", "numb_acc", "mass_cor", "numb_cor"}`` — the
+    Returns ``{class_short: (mass_factor, number_factor)}`` — the
     wind-independent factors such that, per open-water area,
-    ``mass_flux = mass_<mode> · u10**ppww`` [kg/m²/s] and
-    ``number_flux = numb_<mode> · u10**ppww`` [#/m²/s].
+    ``mass_flux = mass_factor · u10**ppww`` [kg/m²/s] and
+    ``number_flux = number_factor · u10**ppww`` [#/m²/s].
+
+    The Gong source is evaluated on a fine dry-diameter grid, then **every bin
+    is assigned to exactly one of ``classes``** — the class whose ``[dgnum_lo,
+    dgnum_hi]`` contains it, or, for a bin in a gap/tail, the nearest class in
+    log-diameter. That makes the split representation-agnostic (modal modes or
+    sectional bins via each class's own size range) and **mass-conserving** — the
+    whole 0.1–10 µm Gong spectrum is distributed with nothing dropped. (This
+    replaces the previous hardcoded ``(accumulation, coarse)`` HAMMOZ-M7 diameter
+    bands; the accum/coarse boundary now follows the population's mode edges
+    rather than a fixed 1 µm cut.)
     """
     zdx = (math.log(_DMTD) - math.log(_DMTA)) / _NBIN
     dmt = np.exp(math.log(_DMTA) + np.arange(_NBIN) * zdx)   # dry diameter [m]
@@ -73,13 +82,17 @@ def gong_mode_factors(density: float) -> dict[str, float]:
             fi[m] = p1 * p2 * p3 * dr
 
     zav = density * (4.0 / 3.0) * math.pi * rd ** 3          # particle mass [kg]
-    acc = (dmt > _DBEG[1]) & (dmt <= _DEND[1])
-    cor = (dmt > _DBEG[2]) & (dmt <= _DEND[2])
+
+    # Assign each bin to the class containing it (log-distance 0), else nearest.
+    ld = np.log(dmt)[:, None]
+    lo = np.log(np.array([c.dgnum_lo for c in classes]))[None, :]
+    hi = np.log(np.array([c.dgnum_hi for c in classes]))[None, :]
+    dist = np.maximum(0.0, np.maximum(lo - ld, ld - hi))     # 0 if inside
+    assign = np.argmin(dist, axis=1)                         # (nbin,) class idx
     return {
-        "mass_acc": float(np.sum(fi[acc] * zav[acc])),
-        "numb_acc": float(np.sum(fi[acc])),
-        "mass_cor": float(np.sum(fi[cor] * zav[cor])),
-        "numb_cor": float(np.sum(fi[cor])),
+        c.short: (float(np.sum(fi[assign == ci] * zav[assign == ci])),
+                  float(np.sum(fi[assign == ci])))
+        for ci, c in enumerate(classes)
     }
 
 
@@ -109,11 +122,14 @@ class SeaSaltEmissions(PhysicsTerm):
         *,
         spec: ModalAerosolSpec | None = None,
     ):
-        """Precompute the Gong per-mode bin factors for sea-salt density."""
+        """Precompute the Gong per-class bin factors for sea-salt density."""
         self.params = nnx.Param(params or SeaSaltParameters.default())
         self._spec = spec or MAM4_SPEC
         density = self._spec.species_props("ss").density
-        self._fac = gong_mode_factors(density)
+        # Which classes carry sea salt — and their size ranges — come from the
+        # population, so the term names no modes and a sectional spec works
+        # unchanged.
+        self._fac = gong_class_factors(self._spec.classes_for("ss"), density)
 
     def _open_water_fraction(self, forcing, terrain, ncols):
         """Non-iced open-water fraction (1 − land)·(1 − sea-ice), land>0.5→0."""
@@ -145,12 +161,10 @@ class SeaSaltEmissions(PhysicsTerm):
         inv = 1.0 / (air_density[-1] * dz[-1])              # kg/kg per kg/m²/s
         bottom = lambda flux2d: jnp.zeros((nlev, ncols)).at[-1].set(flux2d * inv)
 
-        tracer_tends = {
-            mass_name("ss", "acc"): bottom(self._fac["mass_acc"] * wind),
-            number_name("acc"): bottom(self._fac["numb_acc"] * wind),
-            mass_name("ss", "cor"): bottom(self._fac["mass_cor"] * wind),
-            number_name("cor"): bottom(self._fac["numb_cor"] * wind),
-        }
+        tracer_tends = {}
+        for short, (mass_fac, numb_fac) in self._fac.items():
+            tracer_tends[mass_name("ss", short)] = bottom(mass_fac * wind)
+            tracer_tends[number_name(short)] = bottom(numb_fac * wind)
         tendency = PhysicsTendency(
             u_wind=jnp.zeros_like(state.u_wind),
             v_wind=jnp.zeros_like(state.v_wind),

--- a/jcm/physics/aerosol/jam/emissions/seasalt_test.py
+++ b/jcm/physics/aerosol/jam/emissions/seasalt_test.py
@@ -11,22 +11,44 @@ from jcm.physics.aerosol.jam import mass_name, number_name
 from jcm.physics.aerosol.jam.emissions.seasalt import (
     SeaSaltEmissions,
     SeaSaltParameters,
-    gong_mode_factors,
+    gong_class_factors,
 )
+from jcm.physics.aerosol.jam.microphysics.mam4_data import MAM4_SPEC
 
 
 class GongFactorTest(unittest.TestCase):
-    def test_factors_positive(self):
-        f = gong_mode_factors(1900.0)
-        for v in f.values():
-            self.assertGreater(v, 0.0)
+    def test_factors_nonneg_over_ss_classes(self):
+        classes = MAM4_SPEC.classes_for("ss")
+        f = gong_class_factors(classes, 1900.0)
+        # One (mass, number) factor per ss-carrying class; all non-negative.
+        self.assertEqual(set(f), {c.short for c in classes})
+        for mass, numb in f.values():
+            self.assertGreaterEqual(mass, 0.0)
+            self.assertGreaterEqual(numb, 0.0)
+        # Accumulation + coarse carry the emission; the Aitken mode lies below
+        # the Gong size range, so it gets ~nothing.
+        self.assertGreater(f["acc"][0], 0.0)
+        self.assertGreater(f["cor"][0], 0.0)
 
     def test_coarse_dominates_mass_accum_dominates_number(self):
-        f = gong_mode_factors(1900.0)
-        # Coarse particles carry far more mass per particle…
-        self.assertGreater(f["mass_cor"], f["mass_acc"])
-        # …while the accumulation range holds more particles (number).
-        self.assertGreater(f["numb_acc"], f["numb_cor"])
+        f = gong_class_factors(MAM4_SPEC.classes_for("ss"), 1900.0)
+        self.assertGreater(f["cor"][0], f["acc"][0])   # mass per class
+        self.assertGreater(f["acc"][1], f["cor"][1])   # number per class
+
+    def test_partition_conserves_total(self):
+        # Splitting across the real classes must conserve the total emitted mass
+        # and number vs. lumping everything into one all-spanning class.
+        from jcm.physics.aerosol.jam.population import AerosolMode
+        whole = AerosolMode(
+            name="whole", short="whole", geom_std_dev=2.0, dgnum=1e-6,
+            dgnum_lo=1e-9, dgnum_hi=1e-2, species=("ss",), soluble=True,
+            can_activate=True, sediments=True)
+        ref = gong_class_factors((whole,), 1900.0)["whole"]
+        split = gong_class_factors(MAM4_SPEC.classes_for("ss"), 1900.0)
+        tot_mass = sum(m for m, _ in split.values())
+        tot_numb = sum(n for _, n in split.values())
+        np.testing.assert_allclose(tot_mass, ref[0], rtol=1e-10)
+        np.testing.assert_allclose(tot_numb, ref[1], rtol=1e-10)
 
 
 def _inputs(nlev=3, ncols=2, wind=10.0, land=0.0, sice=0.0):

--- a/jcm/physics/aerosol/jam/emissions/sectors.py
+++ b/jcm/physics/aerosol/jam/emissions/sectors.py
@@ -25,11 +25,18 @@ from jcm.physics.aerosol.jam.gas_species import GAS_SPECIES
 from jcm.physics.aerosol.jam.species import SPECIES
 
 #: Super-sectors in a fixed order — the ``EmissionParameters`` arrays index by
-#: this, and the forcing fields are keyed ``emis_<sector>_<species>``.
+#: this, and the forcing fields are keyed ``emis_<sector>_<species>``. The first
+#: three are CEDS anthropogenic activity super-sectors; ``biomass_burning`` is
+#: open (GFED/van Marle) burning, distinguished only by its deeper FIRE injection
+#: profile (HAMMOZ ``EM_FIRE``). All four go through the same speciation +
+#: smooth-injection machinery and are independently gated by which
+#: ``emis_<sector>_<species>`` forcing channels are supplied (absent ⇒ inert), so
+#: an anthropogenic-only run simply omits the biomass channels.
 SUPER_SECTORS: tuple[str, ...] = (
     "surface_combustion",   # CEDS TRA, RCO, AGR, WST, SLV — surface
     "elevated_industrial",  # CEDS ENE, IND — ~50 m
     "shipping",             # CEDS SHP — marine surface
+    "biomass_burning",      # open burning (GFED) — deep FIRE injection profile
 )
 
 #: Aerosol-relevant CEDS species carried here (gas precursors NH3/NOx/CO are
@@ -52,6 +59,16 @@ SECTOR_DEFAULTS: dict[str, SectorDefaults] = {
                                           injection_thickness=30.0),
     "shipping": SectorDefaults(injection_height=0.0,
                                injection_thickness=30.0),
+    # Open biomass burning (HAMMOZ ``EM_FIRE``): smoke is lofted through a deep
+    # layer rather than emitted at the surface. Defaults centre the smooth
+    # Gaussian ~1 km up with a ~1.5 km width — a clearly elevated, deep profile
+    # vs the near-surface sectors. Fire injection height is a large, poorly
+    # constrained uncertainty (most fires inject within the boundary layer;
+    # pyroconvection lofts the tail far higher), so these are deliberately just
+    # defaults — ``injection_height``/``injection_thickness`` are differentiable
+    # and meant to be calibrated.
+    "biomass_burning": SectorDefaults(injection_height=1000.0,
+                                      injection_thickness=1500.0),
 }
 
 # --- HAMMOZ species-handling constants (differentiable defaults on the term) --
@@ -65,3 +82,10 @@ SO2_TO_SO4_MASS = SPECIES["so4"].molar_mass / GAS_SPECIES["so2"].molar_mass
 #: MAM4 mode shorts that receive the primary emissions.
 SO4_MODES: tuple[str, str] = ("ait", "acc")   # primary sulfate
 CARBON_MODE = "pcm"                            # primary_carbon (BC + POA)
+
+# Note on emitted size: HAMMOZ/M7 distinguishes fossil-fuel (~0.03 µm) from
+# biomass (~0.075 µm) primary-carbon size. MAM4 carries a *single*
+# primary-carbon mode (``pcm``) for both fossil and biomass BC/POA, so that
+# distinction collapses here — biomass and anthropogenic carbon differ only in
+# their injection profile, not their emitted mode. A per-super-sector emitted
+# size (count-median radius) would be future work (see #498).

--- a/jcm/physics/aerosol/jam/emissions/sectors.py
+++ b/jcm/physics/aerosol/jam/emissions/sectors.py
@@ -1,0 +1,67 @@
+"""Super-sector emission characteristics for anthropogenic CEDS emissions (#498).
+
+HAMMOZ varies emissions by **injection type** and **source size**, not economic
+activity per se. We collapse CEDS's ~8 activity sectors into **3 characteristic
+super-sectors**, each with a default injection height/thickness and a size→mode
+placement. The HAMMOZ values here are *defaults*; the load-bearing uncertainties
+(injection heights, the primary-SO₄ fraction) are exposed as differentiable
+``EmissionParameters`` on the term.
+
+Species handling (HAMMOZ ``mo_ham_m7_emissions`` / ``mo_hammoz_emissions``):
+
+* **SO₂** — a small fraction (default 2.5 %, ``zfacso2 = 0.975``) of the sulfur
+  is emitted as primary particulate **SO₄** (split ~50/50 Aitken/accum per
+  ``cmr_sk``/``cmr_sa``); the remainder enters the **``g_so2``** gas tracer and
+  is oxidised by the gas-phase sulfur chemistry (#496).
+* **BC / OC** — primary carbonaceous mass into the MAM4 **primary_carbon** mode
+  (the Aitken mode carries neither BC nor POA); OC→POA uses **OM:OC = 1.4**.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from jcm.physics.aerosol.jam.gas_species import GAS_SPECIES
+from jcm.physics.aerosol.jam.species import SPECIES
+
+#: Super-sectors in a fixed order — the ``EmissionParameters`` arrays index by
+#: this, and the forcing fields are keyed ``emis_<sector>_<species>``.
+SUPER_SECTORS: tuple[str, ...] = (
+    "surface_combustion",   # CEDS TRA, RCO, AGR, WST, SLV — surface
+    "elevated_industrial",  # CEDS ENE, IND — ~50 m
+    "shipping",             # CEDS SHP — marine surface
+)
+
+#: Aerosol-relevant CEDS species carried here (gas precursors NH3/NOx/CO are
+#: out of scope until nitrate / fuller chemistry lands).
+EMITTED_SPECIES: tuple[str, ...] = ("so2", "bc", "oc")
+
+
+@dataclass(frozen=True)
+class SectorDefaults:
+    """Default smooth-injection geometry for a super-sector [m]."""
+
+    injection_height: float     # Gaussian centre height
+    injection_thickness: float  # Gaussian width
+
+
+SECTOR_DEFAULTS: dict[str, SectorDefaults] = {
+    "surface_combustion": SectorDefaults(injection_height=0.0,
+                                         injection_thickness=30.0),
+    "elevated_industrial": SectorDefaults(injection_height=50.0,
+                                          injection_thickness=30.0),
+    "shipping": SectorDefaults(injection_height=0.0,
+                               injection_thickness=30.0),
+}
+
+# --- HAMMOZ species-handling constants (differentiable defaults on the term) --
+SO4_PRIMARY_FRACTION = 0.025     # fraction of SO2 sulfur → primary SO4 (zfacso2)
+SO4_AITKEN_FRACTION = 0.5        # primary-SO4 split into Aitken vs accum
+OM_OC_RATIO = 1.4                # OM:OC mass ratio for OC → POA
+
+#: SO₂ mass → SO₄ mass factor (one S atom each).
+SO2_TO_SO4_MASS = SPECIES["so4"].molar_mass / GAS_SPECIES["so2"].molar_mass
+
+#: MAM4 mode shorts that receive the primary emissions.
+SO4_MODES: tuple[str, str] = ("ait", "acc")   # primary sulfate
+CARBON_MODE = "pcm"                            # primary_carbon (BC + POA)

--- a/jcm/physics/aerosol/jam/emissions/sectors.py
+++ b/jcm/physics/aerosol/jam/emissions/sectors.py
@@ -73,19 +73,22 @@ SECTOR_DEFAULTS: dict[str, SectorDefaults] = {
 
 # --- HAMMOZ species-handling constants (differentiable defaults on the term) --
 SO4_PRIMARY_FRACTION = 0.025     # fraction of SO2 sulfur → primary SO4 (zfacso2)
-SO4_AITKEN_FRACTION = 0.5        # primary-SO4 split into Aitken vs accum
 OM_OC_RATIO = 1.4                # OM:OC mass ratio for OC → POA
 
 #: SO₂ mass → SO₄ mass factor (one S atom each).
 SO2_TO_SO4_MASS = SPECIES["so4"].molar_mass / GAS_SPECIES["so2"].molar_mass
 
-#: MAM4 mode shorts that receive the primary emissions.
-SO4_MODES: tuple[str, str] = ("ait", "acc")   # primary sulfate
-CARBON_MODE = "pcm"                            # primary_carbon (BC + POA)
-
+# Which population classes receive primary SO4 / BC / POA — and in what
+# proportion — is **not** decided here: it is the population's policy, owned by
+# the aerosol spec's ``primary_emission`` table and queried via
+# ``spec.primary_split(species)``. This keeps the term representation-agnostic
+# (a sectional population supplies its own bin split) and centralises the
+# assumption with the population, HAMMOZ-style. For MAM4 the split is 50/50
+# Aitken/accumulation sulfate and primary-carbon-mode BC/POA (see
+# ``mam4_data._MAM4_PRIMARY_EMISSION``).
+#
 # Note on emitted size: HAMMOZ/M7 distinguishes fossil-fuel (~0.03 µm) from
 # biomass (~0.075 µm) primary-carbon size. MAM4 carries a *single*
-# primary-carbon mode (``pcm``) for both fossil and biomass BC/POA, so that
-# distinction collapses here — biomass and anthropogenic carbon differ only in
-# their injection profile, not their emitted mode. A per-super-sector emitted
-# size (count-median radius) would be future work (see #498).
+# primary-carbon mode for both, so that distinction collapses here — biomass and
+# anthropogenic carbon differ only in their injection profile. A per-super-sector
+# emitted size (count-median radius) would be future work (see #498).

--- a/jcm/physics/aerosol/jam/jam_terms.py
+++ b/jcm/physics/aerosol/jam/jam_terms.py
@@ -31,6 +31,10 @@ from jcm.physics.aerosol.jam.drydep.drydep_term import (
     DryDepParameters,
     SlinnDryDeposition,
 )
+from jcm.physics.aerosol.jam.emissions.anthropogenic import (
+    AnthropogenicEmissions,
+    EmissionParameters,
+)
 from jcm.physics.aerosol.jam.emissions.dms import DmsEmissions, DmsParameters
 from jcm.physics.aerosol.jam.emissions.dust import DustEmissions, DustParameters
 from jcm.physics.aerosol.jam.emissions.seasalt import (
@@ -96,6 +100,8 @@ def jam_aerosol_physics(
     seasalt: SeaSaltParameters | None = None,
     dms: DmsParameters | None = None,
     dust: DustParameters | None = None,
+    anthropogenic: bool = False,
+    anthropogenic_params: EmissionParameters | None = None,
     oxidants: OxidantParameters | None = None,
     sulfur_gas: SulfurGasParameters | None = None,
     aqueous: AqueousSulfurParameters | None = None,
@@ -115,6 +121,8 @@ def jam_aerosol_physics(
         arg_variant: ``"arg2000"`` (default) or ``"ghosh2025"`` activation.
         seasalt/dms/dust: optional ``Parameters`` overrides for the natural
             emission schemes (Gong sea salt, Nightingale DMS, Tegen dust).
+        anthropogenic: include prescribed CEDS anthropogenic emissions (#498);
+            ``anthropogenic_params`` overrides the differentiable defaults.
         oxidants/sulfur_gas/aqueous: optional ``Parameters`` for the
             prescribed-oxidant + gas-phase + aqueous sulfur chemistry (#496).
         aqueous_scheme: ``"full"`` (default, HAM ``ham_wet_chemistry`` port) or
@@ -134,10 +142,19 @@ def jam_aerosol_physics(
     """
     core = _resolve_microphysics(microphysics)
     spec = core.spec
-    pre_core = [
+    emissions = [
         SeaSaltEmissions(params=seasalt, spec=spec),
         DmsEmissions(params=dms, spec=spec),
         DustEmissions(params=dust, spec=spec),
+    ]
+    if anthropogenic:
+        # Prescribed CEDS anthropogenic SO2/BC/OC (#498); inert until forcing
+        # fluxes are supplied.
+        emissions.append(
+            AnthropogenicEmissions(params=anthropogenic_params, spec=spec)
+        )
+    pre_core = [
+        *emissions,
         # Sulfur chemistry: oxidants → gas-phase DMS/SO2 oxidation, producing
         # the H2SO4/SOAG gas the core condenses + nucleates this same step.
         PrescribedOxidants(params=oxidants),

--- a/jcm/physics/aerosol/jam/jam_terms.py
+++ b/jcm/physics/aerosol/jam/jam_terms.py
@@ -35,6 +35,7 @@ from jcm.physics.aerosol.jam.emissions.anthropogenic import (
     AnthropogenicEmissions,
     EmissionParameters,
 )
+from jcm.physics.aerosol.jam.emissions.prescribed import PreSpeciatedEmissions
 from jcm.physics.aerosol.jam.emissions.dms import DmsEmissions, DmsParameters
 from jcm.physics.aerosol.jam.emissions.dust import DustEmissions, DustParameters
 from jcm.physics.aerosol.jam.emissions.seasalt import (
@@ -102,6 +103,7 @@ def jam_aerosol_physics(
     dust: DustParameters | None = None,
     anthropogenic: bool = False,
     anthropogenic_params: EmissionParameters | None = None,
+    prescribed_speciated: bool = False,
     oxidants: OxidantParameters | None = None,
     sulfur_gas: SulfurGasParameters | None = None,
     aqueous: AqueousSulfurParameters | None = None,
@@ -121,8 +123,13 @@ def jam_aerosol_physics(
         arg_variant: ``"arg2000"`` (default) or ``"ghosh2025"`` activation.
         seasalt/dms/dust: optional ``Parameters`` overrides for the natural
             emission schemes (Gong sea salt, Nightingale DMS, Tegen dust).
-        anthropogenic: include prescribed CEDS anthropogenic emissions (#498);
-            ``anthropogenic_params`` overrides the differentiable defaults.
+        anthropogenic: include prescribed CEDS anthropogenic emissions (#498),
+            the *bulk* path (in-model differentiable speciation + smooth
+            injection); ``anthropogenic_params`` overrides the defaults.
+        prescribed_speciated: include the CAM6/MAM4-faithful *already-speciated*
+            emission path (#498) — per-tracer fields injected directly, no
+            in-model speciation. Independent of ``anthropogenic``; both, either,
+            or neither may be enabled.
         oxidants/sulfur_gas/aqueous: optional ``Parameters`` for the
             prescribed-oxidant + gas-phase + aqueous sulfur chemistry (#496).
         aqueous_scheme: ``"full"`` (default, HAM ``ham_wet_chemistry`` port) or
@@ -153,6 +160,10 @@ def jam_aerosol_physics(
         emissions.append(
             AnthropogenicEmissions(params=anthropogenic_params, spec=spec)
         )
+    if prescribed_speciated:
+        # CAM6/MAM4-faithful already-speciated emissions (#498); inert until
+        # per-tracer forcing fields are supplied.
+        emissions.append(PreSpeciatedEmissions())
     pre_core = [
         *emissions,
         # Sulfur chemistry: oxidants → gas-phase DMS/SO2 oxidation, producing

--- a/jcm/physics/aerosol/jam/microphysics/mam4_data.py
+++ b/jcm/physics/aerosol/jam/microphysics/mam4_data.py
@@ -65,9 +65,26 @@ MAM4_MODES: tuple[AerosolMode, ...] = (
 _USED = tuple(sorted({s for m in MAM4_MODES for s in m.species}))
 MAM4_SPECIES = tuple(SPECIES[t] for t in _USED) + (SPECIES["h2o"],)
 
+#: Where freshly-emitted *primary* mass of each species goes in MAM4 — the
+#: population's centralised emission policy (emission terms query it via
+#: ``primary_split`` instead of hardcoding modes; see #498). Primary sulfate is
+#: split 50/50 into the Aitken and accumulation modes (HAMMOZ ``cmr_sk``/
+#: ``cmr_sa``); primary carbonaceous mass (BC, POA) goes wholly to the
+#: primary-carbon mode (MAM4 carries no BC/POA in the Aitken mode). Dust's
+#: accum/coarse split default (Tegen) lives here too, though the dust term lets
+#: a tunable parameter override the fractions. Size-mapped source schemes (Gong
+#: sea salt) instead partition over ``classes_for`` and need no entry.
+_MAM4_PRIMARY_EMISSION = {
+    "so4": (("ait", 0.5), ("acc", 0.5)),
+    "bc": (("pcm", 1.0),),
+    "poa": (("pcm", 1.0),),
+    "du": (("acc", 0.1), ("cor", 0.9)),
+}
+
 #: The MAM4 4-mode population.
 MAM4_SPEC = ModalAerosolSpec(
     modes=MAM4_MODES,
     species=MAM4_SPECIES,
     family="modal",
+    primary_emission=_MAM4_PRIMARY_EMISSION,
 )

--- a/jcm/physics/aerosol/jam/population.py
+++ b/jcm/physics/aerosol/jam/population.py
@@ -133,6 +133,17 @@ class ModalAerosolSpec:
     modes: tuple[AerosolMode, ...]
     species: tuple[AerosolSpecies, ...]
     family: str = "modal"
+    #: Population policy for where freshly-emitted **primary** mass of a species
+    #: goes: ``{species: ((mode_short, mass_fraction), ...)}`` with fractions
+    #: summing to 1. This centralises the modal (or sectional) assumption with
+    #: the population — HAMMOZ keeps the same table in its aerosol module — so
+    #: emission terms ask :meth:`primary_split` instead of hardcoding modes. A
+    #: sectional spec supplies its own bin split here. ``ss``/``du`` size-mapped
+    #: source schemes (Gong/Tegen) instead use :meth:`classes_for` + the class
+    #: size ranges, so they need no entry.
+    primary_emission: dict[str, tuple[tuple[str, float], ...]] = (
+        dataclasses.field(default_factory=dict)
+    )
 
     def __post_init__(self) -> None:
         """Validate the family tag and species references."""
@@ -176,3 +187,31 @@ class ModalAerosolSpec:
             if s.name == name:
                 return s
         raise KeyError(f"No species named {name!r}.")
+
+    def classes_for(self, species: str) -> tuple[AerosolMode, ...]:
+        """Classes (modes/bins) that may carry ``species``, in spec order.
+
+        The family-agnostic way for an emission term to discover which classes a
+        species lives in without naming modes literally — a size-resolved source
+        scheme (Gong sea salt, Tegen dust) partitions its size-distributed flux
+        across these using each class's ``dgnum_lo``/``dgnum_hi`` range.
+        """
+        return tuple(m for m in self.modes if species in m.species)
+
+    def primary_split(
+        self, species: str
+    ) -> tuple[tuple[AerosolMode, float], ...]:
+        """Default ``((class, mass_fraction), ...)`` for primary ``species``.
+
+        Resolves the population's :attr:`primary_emission` policy table to the
+        actual classes. Terms with a *tunable* split (e.g. dust's accumulation
+        fraction) take the class set from here and substitute their own
+        fractions. Raises ``KeyError`` for a species with no primary policy.
+        """
+        table = self.primary_emission.get(species)
+        if table is None:
+            raise KeyError(
+                f"No primary-emission split defined for {species!r}; add it to "
+                "the spec's ``primary_emission`` table."
+            )
+        return tuple((self.mode(short), frac) for short, frac in table)

--- a/jcm/physics/aerosol/jam/population_test.py
+++ b/jcm/physics/aerosol/jam/population_test.py
@@ -1,0 +1,60 @@
+"""Tests for the population-owned distribution API (#498)."""
+
+import math
+import unittest
+
+from jcm.physics.aerosol.jam.emissions.distributors import particle_mean_mass
+from jcm.physics.aerosol.jam.microphysics.mam4_data import MAM4_SPEC
+
+
+class ClassesForTest(unittest.TestCase):
+    def test_classes_for_returns_carrying_modes(self):
+        shorts = [m.short for m in MAM4_SPEC.classes_for("ss")]
+        # ss is carried by acc, ait and cor in MAM4 (not the primary-carbon mode).
+        self.assertEqual(set(shorts), {"acc", "ait", "cor"})
+        self.assertNotIn("pcm", shorts)
+
+    def test_classes_for_preserves_spec_order(self):
+        shorts = [m.short for m in MAM4_SPEC.classes_for("so4")]
+        spec_order = [m.short for m in MAM4_SPEC.modes if "so4" in m.species]
+        self.assertEqual(shorts, spec_order)
+
+
+class PrimarySplitTest(unittest.TestCase):
+    def test_so4_splits_aitken_accum_half(self):
+        split = MAM4_SPEC.primary_split("so4")
+        self.assertEqual({m.short for m, _ in split}, {"ait", "acc"})
+        for _, frac in split:
+            self.assertAlmostEqual(frac, 0.5)
+
+    def test_primary_carbon_to_pcm_only(self):
+        for species in ("bc", "poa"):
+            split = MAM4_SPEC.primary_split(species)
+            self.assertEqual(len(split), 1)
+            self.assertEqual(split[0][0].short, "pcm")
+            self.assertAlmostEqual(split[0][1], 1.0)
+
+    def test_fractions_sum_to_one(self):
+        for species in ("so4", "bc", "poa", "du"):
+            total = sum(frac for _, frac in MAM4_SPEC.primary_split(species))
+            self.assertAlmostEqual(total, 1.0)
+
+    def test_unknown_species_raises(self):
+        with self.assertRaises(KeyError):
+            MAM4_SPEC.primary_split("not_a_species")
+
+
+class NumberFactorTest(unittest.TestCase):
+    def test_particle_mean_mass_matches_lognormal_moment(self):
+        # particle_mean_mass now delegates to mode.number_factor; check it still
+        # equals the closed-form log-normal third-moment mean particle mass.
+        mode = MAM4_SPEC.mode("acc")
+        rho = 1770.0
+        ln_sig = math.log(mode.geom_std_dev)
+        expected = rho * (math.pi / 6.0) * mode.dgnum ** 3 * math.exp(4.5 * ln_sig ** 2)
+        self.assertAlmostEqual(particle_mean_mass(mode, rho) / expected, 1.0,
+                               places=10)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jcm/physics/echam/echam_terms.py
+++ b/jcm/physics/echam/echam_terms.py
@@ -75,6 +75,7 @@ def echam_physics(
     jam_aqueous_scheme: str = "full",
     jam_ice_scheme: str = "niemand",
     jam_anthropogenic: bool = False,
+    jam_prescribed_speciated: bool = False,
 ):
     """Create a ``ComposablePhysics`` with the standard ECHAM term ordering.
 
@@ -123,7 +124,11 @@ def echam_physics(
         jam_aqueous_scheme: ``"full"`` (default, HAM port) or ``"simple"``
             (H2O2-limited) in-cloud aqueous sulfur chemistry.
         jam_anthropogenic: include prescribed CEDS anthropogenic emissions
-            (#498); inert until CEDS forcing fluxes are supplied.
+            (#498), the bulk in-model-speciated path; inert until CEDS forcing
+            fluxes are supplied.
+        jam_prescribed_speciated: include the CAM6/MAM4-faithful already-
+            speciated emission path (#498); inert until per-tracer forcing
+            fields are supplied.
 
     Returns:
         A ``ComposablePhysics`` instance with all ECHAM terms in the
@@ -204,6 +209,7 @@ def echam_physics(
             aqueous_scheme=jam_aqueous_scheme,
             ice_scheme=jam_ice_scheme,
             anthropogenic=jam_anthropogenic,
+            prescribed_speciated=jam_prescribed_speciated,
         )
         # Aqueous chemistry + wet deposition need the current step's clouds, so
         # they run after the cloud microphysics term; the rest of the JAM chain

--- a/jcm/physics/echam/echam_terms.py
+++ b/jcm/physics/echam/echam_terms.py
@@ -74,6 +74,7 @@ def echam_physics(
     jam_arg_variant: str = "arg2000",
     jam_aqueous_scheme: str = "full",
     jam_ice_scheme: str = "niemand",
+    jam_anthropogenic: bool = False,
 ):
     """Create a ``ComposablePhysics`` with the standard ECHAM term ordering.
 
@@ -121,6 +122,8 @@ def echam_physics(
             (default) or ``"lohmann_diehl"`` (drives the 2M ICNC).
         jam_aqueous_scheme: ``"full"`` (default, HAM port) or ``"simple"``
             (H2O2-limited) in-cloud aqueous sulfur chemistry.
+        jam_anthropogenic: include prescribed CEDS anthropogenic emissions
+            (#498); inert until CEDS forcing fluxes are supplied.
 
     Returns:
         A ``ComposablePhysics`` instance with all ECHAM terms in the
@@ -200,6 +203,7 @@ def echam_physics(
             microphysics=jam_microphysics, arg_variant=jam_arg_variant,
             aqueous_scheme=jam_aqueous_scheme,
             ice_scheme=jam_ice_scheme,
+            anthropogenic=jam_anthropogenic,
         )
         # Aqueous chemistry + wet deposition need the current step's clouds, so
         # they run after the cloud microphysics term; the rest of the JAM chain

--- a/jcm/runners.py
+++ b/jcm/runners.py
@@ -201,11 +201,20 @@ def build_physics(cfg: DictConfig):
     from jcm.physics.composable_physics import ComposablePhysics
 
     physics_cfg = cfg.physics
+    # Two physics-config styles: an explicit ``terms`` list (the default), or a
+    # ``builder`` that delegates to a factory which already encodes the term
+    # ordering. The factory style is how multi-term, order-sensitive packages
+    # (notably the JAM aerosol chain, which is split around the cloud term) are
+    # configured without re-expressing that ordering as flat YAML.
+    if physics_cfg.get("builder", None) is not None:
+        return _build_physics_from_factory(physics_cfg)
+
     terms_raw = physics_cfg.get("terms", None)
     if terms_raw is None:
         raise ValueError(
-            "cfg.physics.terms is required. Each entry must declare a "
-            "_target_ pointing at a PhysicsTerm subclass."
+            "cfg.physics.terms is required (unless physics.builder is set). "
+            "Each entry must declare a _target_ pointing at a PhysicsTerm "
+            "subclass."
         )
     terms_cfg = OmegaConf.to_container(terms_raw, resolve=True) or {}
 
@@ -224,6 +233,41 @@ def build_physics(cfg: DictConfig):
         vectorize_columns=physics_cfg.get("vectorize_columns", False),
         band_config=_band_config_for_terms(terms),
     )
+
+
+#: Physics ``builder`` names → factory callables returning a ``ComposablePhysics``
+#: with its own validated term ordering (and band_config/vectorize handled
+#: internally). The factory already orders the JAM aerosol chain (incl. the
+#: pre/post-cloud split), so the preset YAML only carries scalar flags.
+def _physics_factories():
+    from jcm.physics.echam.echam_terms import echam_physics
+    return {"echam_physics": echam_physics}
+
+
+def _build_physics_from_factory(physics_cfg):
+    """Build physics by delegating to a factory named by ``physics.builder``.
+
+    Only the factory keyword args present in the YAML are forwarded (filtered
+    against the factory signature), so config-only keys consumed elsewhere
+    (``builder``, ``radiation_chunk_size``) are ignored here.
+    """
+    import inspect
+
+    from omegaconf import OmegaConf
+
+    factories = _physics_factories()
+    builder = physics_cfg.get("builder")
+    factory = factories.get(builder)
+    if factory is None:
+        raise ValueError(
+            f"Unknown physics.builder={builder!r}; expected one of "
+            f"{sorted(factories)}."
+        )
+    cfg_dict = OmegaConf.to_container(physics_cfg, resolve=True) or {}
+    accepted = set(inspect.signature(factory).parameters)
+    kwargs = {k: v for k, v in cfg_dict.items()
+              if k in accepted and v is not None}
+    return factory(**kwargs)
 
 
 def _band_config_for_terms(terms):
@@ -538,18 +582,21 @@ def build_forcing(cfg: DictConfig, coords):
     aquaplanet ``default_forcing(coords.horizontal)``. ``kind: from_file``
     loads a netCDF boundary file via ``ForcingData.from_file``.
 
-    Optionally attaches an ozone climatology if ``cfg.forcing.ozone_file``
-    is set; the file must be on the same horizontal grid as the model
-    (CMIP6-style ``(time, plev, lat, lon)`` mole/mole netCDF).
+    Optionally attaches an ozone climatology (``cfg.forcing.ozone_file``) and
+    prescribed aerosol emissions (``cfg.forcing.emissions_file``); both files
+    must already be on the model horizontal grid.
     """
     forcing_cfg = cfg.get("forcing", None)
     if forcing_cfg is None or forcing_cfg.kind == "default":
-        return _attach_ozone(None, forcing_cfg, coords)
-    if forcing_cfg.kind == "from_file":
+        forcing = None
+    elif forcing_cfg.kind == "from_file":
         from jcm.forcing import ForcingData
         forcing = ForcingData.from_file(forcing_cfg.file, coords=coords)
-        return _attach_ozone(forcing, forcing_cfg, coords)
-    raise ValueError(f"Unknown forcing.kind={forcing_cfg.kind!r}")
+    else:
+        raise ValueError(f"Unknown forcing.kind={forcing_cfg.kind!r}")
+    forcing = _attach_ozone(forcing, forcing_cfg, coords)
+    forcing = _attach_emissions(forcing, forcing_cfg, coords)
+    return forcing
 
 
 def _attach_ozone(forcing, forcing_cfg, coords):
@@ -588,6 +635,71 @@ def _attach_ozone(forcing, forcing_cfg, coords):
     if forcing is None:
         forcing = default_forcing(coords.horizontal)
     return forcing.copy(ozone_climatology=climatology)
+
+
+def _attach_emissions(forcing, forcing_cfg, coords):
+    """Attach prescribed aerosol emissions from ``cfg.forcing.emissions_file``.
+
+    No-op when unset. A single file auto-routes by content: variables named
+    ``emis_<sector>_<species>`` drive the bulk / in-model-speciated path
+    (``anthropogenic_emissions``); ``aero_emis_<tracer>`` variables drive the
+    CAM6-faithful pre-speciated path (``prescribed_aerosol_emissions``). A file
+    may carry either or both. The fields must already be on the model horizontal
+    grid — this does **not** regrid (use :mod:`jcm.data.emissions.prepare`
+    first); a grid mismatch raises rather than silently zeroing (the emission
+    terms fall back to zero on a size mismatch, which from the CLI would look
+    like the file "did nothing"). Like ozone, when ``kind: default`` supplies no
+    parent struct one is built via ``default_forcing`` so the aquaplanet SST
+    climatology is preserved.
+
+    The matching emission term must also be in the physics package (e.g.
+    ``physics=echam-jam``) for the fields to be consumed.
+    """
+    if forcing_cfg is None:
+        return forcing
+    path = forcing_cfg.get("emissions_file", None)
+    if path in (None, "", "null"):
+        return forcing
+
+    import xarray as xr
+
+    from jcm.forcing import (
+        default_forcing,
+        read_anthropogenic_emissions,
+        read_prescribed_aerosol_emissions,
+    )
+
+    ds = xr.open_dataset(path)
+    anthro = read_anthropogenic_emissions(ds)
+    speciated = read_prescribed_aerosol_emissions(ds)
+    if anthro is None and speciated is None:
+        raise ValueError(
+            f"forcing.emissions_file {path!r} has no emissions variables: "
+            "expected ``emis_<sector>_<species>`` (bulk) or "
+            "``aero_emis_<tracer>`` (pre-speciated). See the emissions-file "
+            "contract in docs/design/jam.md."
+        )
+    _validate_emissions_grid({**(anthro or {}), **(speciated or {})},
+                             coords, path)
+    if forcing is None:
+        forcing = default_forcing(coords.horizontal)
+    return forcing.copy(anthropogenic_emissions=anthro,
+                        prescribed_aerosol_emissions=speciated)
+
+
+def _validate_emissions_grid(mapping, coords, path):
+    """Raise if any emission field's horizontal shape != the model grid."""
+    from jcm.forcing import TimeSeries
+    nodal = tuple(coords.horizontal.nodal_shape)
+    for name, leaf in mapping.items():
+        arr = leaf.values if isinstance(leaf, TimeSeries) else leaf
+        spatial = tuple(arr.shape[-2:])
+        if spatial != nodal:
+            raise ValueError(
+                f"forcing.emissions_file {path!r}: field {name!r} has "
+                f"horizontal shape {spatial}, but the model grid is {nodal}. "
+                "Regrid the file with jcm.data.emissions.prepare first."
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/jcm/runners.py
+++ b/jcm/runners.py
@@ -640,11 +640,15 @@ def _attach_ozone(forcing, forcing_cfg, coords):
 def _attach_emissions(forcing, forcing_cfg, coords):
     """Attach prescribed aerosol emissions from ``cfg.forcing.emissions_file``.
 
-    No-op when unset. A single file auto-routes by content: variables named
-    ``emis_<sector>_<species>`` drive the bulk / in-model-speciated path
-    (``anthropogenic_emissions``); ``aero_emis_<tracer>`` variables drive the
-    CAM6-faithful pre-speciated path (``prescribed_aerosol_emissions``). A file
-    may carry either or both. The fields must already be on the model horizontal
+    No-op when unset. ``emissions_file`` may be a single path or a **list** of
+    paths (e.g. one file for biomass burning and one for the rest) — multiple
+    files are merged by coordinates via ``xr.open_mfdataset``, so each can carry
+    a disjoint set of channels on the same grid. The fields auto-route by
+    content: variables named ``emis_<sector>_<species>`` drive the bulk /
+    in-model-speciated path (``anthropogenic_emissions``); ``aero_emis_<tracer>``
+    variables drive the CAM6-faithful pre-speciated path
+    (``prescribed_aerosol_emissions``). A file may carry either or both. The
+    fields must already be on the model horizontal
     grid — this does **not** regrid (use :mod:`jcm.data.emissions.prepare`
     first); a grid mismatch raises rather than silently zeroing (the emission
     terms fall back to zero on a size mismatch, which from the CLI would look
@@ -662,6 +666,7 @@ def _attach_emissions(forcing, forcing_cfg, coords):
         return forcing
 
     import xarray as xr
+    from omegaconf import ListConfig
 
     from jcm.forcing import (
         default_forcing,
@@ -669,7 +674,14 @@ def _attach_emissions(forcing, forcing_cfg, coords):
         read_prescribed_aerosol_emissions,
     )
 
-    ds = xr.open_dataset(path)
+    # One path → open_dataset; several → merge by coords (disjoint channels on a
+    # shared grid, e.g. biomass-burning + anthropogenic files).
+    if isinstance(path, (list, tuple, ListConfig)):
+        paths = [str(p) for p in path]
+        ds = xr.open_mfdataset(paths, combine="by_coords") if len(paths) > 1 \
+            else xr.open_dataset(paths[0])
+    else:
+        ds = xr.open_dataset(path)
     anthro = read_anthropogenic_emissions(ds)
     speciated = read_prescribed_aerosol_emissions(ds)
     if anthro is None and speciated is None:

--- a/jcm/runners_test.py
+++ b/jcm/runners_test.py
@@ -214,6 +214,97 @@ class TestAttachOzonePreservesAquaplanetSST(unittest.TestCase):
         )
 
 
+class TestEmissionsConfig(unittest.TestCase):
+    """CLI/config plumbing for prescribed aerosol emissions (#498)."""
+
+    def _coords(self):
+        from jcm.runners import build_coords
+        return build_coords(_compose(["physics=echam", "grid=echam_t42_l8_sigma"]))
+
+    def _write(self, tmp, data_vars, nlon, nlat, lev=False):
+        import xarray as xr
+        coords = {"lon": np.linspace(0, 360, nlon, endpoint=False),
+                  "lat": np.linspace(-87, 87, nlat), "time": np.arange(12)}
+        if lev:
+            coords["lev"] = np.arange(4)
+        path = Path(tmp) / "emis.nc"
+        xr.Dataset(data_vars, coords=coords).to_netcdf(path)
+        return str(path)
+
+    def test_echam_jam_factory_includes_emission_terms(self):
+        from jcm.runners import build_physics
+        cfg = _compose(["physics=echam-jam", "grid=echam_t42_l8_sigma"])
+        names = [t.name for t in build_physics(cfg).terms]
+        self.assertIn("jam_anthropogenic_emissions", names)
+        self.assertIn("jam_prescribed_aerosol_emissions", names)
+
+    def test_unknown_builder_raises(self):
+        from jcm.runners import build_physics
+        cfg = _compose(["physics=echam-jam", "grid=echam_t42_l8_sigma"])
+        cfg.physics.builder = "not_a_factory"
+        with self.assertRaisesRegex(ValueError, "Unknown physics.builder"):
+            build_physics(cfg)
+
+    def test_bulk_file_autoroutes_to_anthropogenic(self):
+        import tempfile
+        from jcm.runners import build_forcing
+        coords = self._coords()
+        nlon, nlat = coords.horizontal.nodal_shape
+        with tempfile.TemporaryDirectory() as tmp:
+            p = self._write(tmp, {"emis_surface_combustion_bc":
+                                  (("lon", "lat", "time"),
+                                   np.full((nlon, nlat, 12), 1e-11))}, nlon, nlat)
+            cfg = _compose(["physics=echam-jam", "grid=echam_t42_l8_sigma",
+                            f"forcing.emissions_file={p}"])
+            f = build_forcing(cfg, coords)
+        self.assertIn("emis_surface_combustion_bc", f.anthropogenic_emissions)
+        self.assertIsNone(f.prescribed_aerosol_emissions)
+
+    def test_speciated_file_autoroutes_to_prescribed(self):
+        import tempfile
+        from jcm.runners import build_forcing
+        coords = self._coords()
+        nlon, nlat = coords.horizontal.nodal_shape
+        with tempfile.TemporaryDirectory() as tmp:
+            p = self._write(tmp, {"aero_emis_m_so4_acc":
+                                  (("lon", "lat", "time"),
+                                   np.full((nlon, nlat, 12), 1e-11))}, nlon, nlat)
+            cfg = _compose(["physics=echam-jam", "grid=echam_t42_l8_sigma",
+                            f"forcing.emissions_file={p}"])
+            f = build_forcing(cfg, coords)
+        self.assertIn("m_so4_acc", f.prescribed_aerosol_emissions)
+        self.assertIsNone(f.anthropogenic_emissions)
+
+    def test_grid_mismatch_raises(self):
+        import tempfile
+        from jcm.runners import build_forcing
+        coords = self._coords()
+        nlon, nlat = coords.horizontal.nodal_shape
+        with tempfile.TemporaryDirectory() as tmp:
+            # Wrong horizontal shape — must raise, not silently zero.
+            p = self._write(tmp, {"emis_surface_combustion_bc":
+                                  (("lon", "lat", "time"),
+                                   np.full((nlon + 2, nlat, 12), 1e-11))},
+                            nlon + 2, nlat)
+            cfg = _compose(["physics=echam-jam", "grid=echam_t42_l8_sigma",
+                            f"forcing.emissions_file={p}"])
+            with self.assertRaisesRegex(ValueError, "model grid"):
+                build_forcing(cfg, coords)
+
+    def test_file_without_emission_vars_raises(self):
+        import tempfile
+        from jcm.runners import build_forcing
+        coords = self._coords()
+        nlon, nlat = coords.horizontal.nodal_shape
+        with tempfile.TemporaryDirectory() as tmp:
+            p = self._write(tmp, {"sst": (("lon", "lat", "time"),
+                                          np.zeros((nlon, nlat, 12)))}, nlon, nlat)
+            cfg = _compose(["physics=echam-jam", "grid=echam_t42_l8_sigma",
+                            f"forcing.emissions_file={p}"])
+            with self.assertRaisesRegex(ValueError, "no emissions variables"):
+                build_forcing(cfg, coords)
+
+
 class TestEndToEnd(unittest.TestCase):
     """Tiny end-to-end runs at T31/L8.
 

--- a/jcm/runners_test.py
+++ b/jcm/runners_test.py
@@ -232,8 +232,15 @@ class TestEmissionsConfig(unittest.TestCase):
         return str(path)
 
     def test_echam_jam_factory_includes_emission_terms(self):
+        # Exercise the factory-build path and emission-term wiring with
+        # lightweight overrides — the preset's real defaults (mam4_jax core,
+        # rrtmgp) need the optional ``jcm[mam4]`` extra / radiation data that the
+        # base CI image doesn't carry; the wiring under test is independent of
+        # both.
         from jcm.runners import build_physics
-        cfg = _compose(["physics=echam-jam", "grid=echam_t42_l8_sigma"])
+        cfg = _compose(["physics=echam-jam", "grid=echam_t42_l8_sigma",
+                        "physics.jam_microphysics=placeholder",
+                        "physics.radiation_scheme=grey"])
         names = [t.name for t in build_physics(cfg).terms]
         self.assertIn("jam_anthropogenic_emissions", names)
         self.assertIn("jam_prescribed_aerosol_emissions", names)
@@ -274,6 +281,33 @@ class TestEmissionsConfig(unittest.TestCase):
             f = build_forcing(cfg, coords)
         self.assertIn("m_so4_acc", f.prescribed_aerosol_emissions)
         self.assertIsNone(f.anthropogenic_emissions)
+
+    def test_multiple_files_merge_disjoint_channels(self):
+        # A list of files (e.g. anthropogenic + biomass burning) is merged by
+        # coords; channels from both end up on the forcing.
+        import tempfile
+        import xarray as xr
+        from jcm.runners import build_forcing
+        coords = self._coords()
+        nlon, nlat = coords.horizontal.nodal_shape
+        with tempfile.TemporaryDirectory() as tmp:
+            base = {"lon": np.linspace(0, 360, nlon, endpoint=False),
+                    "lat": np.linspace(-87, 87, nlat), "time": np.arange(12)}
+            p1 = Path(tmp) / "anthro.nc"
+            p2 = Path(tmp) / "bb.nc"
+            xr.Dataset({"emis_surface_combustion_bc":
+                        (("lon", "lat", "time"),
+                         np.full((nlon, nlat, 12), 1e-11))},
+                       coords=base).to_netcdf(p1)
+            xr.Dataset({"emis_biomass_burning_bc":
+                        (("lon", "lat", "time"),
+                         np.full((nlon, nlat, 12), 2e-11))},
+                       coords=base).to_netcdf(p2)
+            cfg = _compose(["physics=echam-jam", "grid=echam_t42_l8_sigma",
+                            f"forcing.emissions_file=[{p1},{p2}]"])
+            f = build_forcing(cfg, coords)
+        self.assertIn("emis_surface_combustion_bc", f.anthropogenic_emissions)
+        self.assertIn("emis_biomass_burning_bc", f.anthropogenic_emissions)
 
     def test_grid_mismatch_raises(self):
         import tempfile


### PR DESCRIPTION
Implements #498: prescribed CEDS anthropogenic + open biomass-burning aerosol emissions for JAM, grid-flexible and differentiable. Builds on the merged gas-coupling (#496) and harness (#497).

## What's here

**Two complementary prescribed-emission paths** — both differentiable w.r.t. the emission `ForcingData` fields:

1. **Bulk / differentiable** (`AnthropogenicEmissions`, `jam_anthropogenic=True`) — bulk per-super-sector SO₂/BC/OC → **in-model** HAMMOZ speciation (2.5 % primary SO₄, Aitken/accum split, OM:OC=1.4) + a **smooth Gaussian vertical profile** so injection height / SO₄-fraction are *calibratable by gradient* (a hard level pick has none). Four super-sectors: surface / elevated-industrial / shipping / **biomass_burning** (deep FIRE profile).
2. **CAM6-faithful pre-speciated** (`PreSpeciatedEmissions`, `jam_prescribed_speciated=True`) — reads already-speciated per-tracer fields and injects them directly (surface → bottom layer; 3-D volume → per level), mirroring CAM's `mo_srf_emissions` / `mo_extfrc`. No in-model speciation, but still differentiable w.r.t. the emission fields. For bit-faithful reproduction of CESM emissions / validation.

**Data pipeline** (`jcm/data/emissions/`):
- `regrid.py` — light, first-order **conservative** (area-weighted) remap from any lat/lon **or** unstructured `ncol` source onto the model grid (**0.07 % global-mass error** ne30→T31).
- `prepare.py` — mapping-driven source→contract assembly: `cesm_cmip_anthro` / `cesm_bb4cmip7` (bulk) and `cesm_mam4_speciated` / `prepare_speciated_emissions` (pre-speciated) adapters for the CESM CMIP7 files.
- `downloader.py` — host-agnostic fetch (local path / arbitrary URL), **no ESGF coupling**.

**Wiring** — `ForcingData` carries emissions as dict-valued fields (`anthropogenic_emissions`, `prescribed_aerosol_emissions`) with `read_anthropogenic_emissions` / `read_prescribed_aerosol_emissions` loaders; `select(date)` slices the per-channel `TimeSeries` automatically. Opt-in via `echam_physics(jam_anthropogenic=…, jam_prescribed_speciated=…)`.

## Scope decision (data investigation)
The raw 0.5° gridded CEDS is **ESGF-only** (Zenodo carries only CSV totals; only the CESM ne30 MAM4-processed product is on disk). So the original ESGF-fetch pipeline and mirror-upload were **dropped** in favour of the general regridder + documented emissions-file contract + host-agnostic downloader, assuming the user supplies a conformant model-grid file. Self-hosting a compressed 0.5° mirror is tracked in #515.

## Validation
The pre-speciated adapter on the real ne30 files reproduces CESM's global sulfur budget (**~46.6 Tg S/yr, 2014**) and **recovers the HAMMOZ 2.5 % primary-sulfate split to 3 decimals** — a clean cross-check of the mode mapping, number encoding, and elevated-integration.

## Test plan
- [x] Injection profile, bulk speciation (S-conserving), BC/OC→primary-carbon, grad finiteness (height/thickness/SO₄-fraction).
- [x] Biomass `FIRE` profile deeper than surface; grad through biomass injection height.
- [x] Pre-speciated term: surface + 3-D mass conservation, multi-tracer, `∂(mmr)/∂(emission field)` finite.
- [x] Conservative regridder incl. a real ne30 reference (<0.5 % mass error).
- [x] Contract round-trips (both loaders + `select` slicing, 2-D & 3-D).
- [x] End-to-end T21 JAM runs for **both** paths raise the expected tracer burden.
- [x] Guarded budget tests (2.5 % recovery + global S). Full fast suite green; lint clean.
- [x] Emissions-file contract documented in `docs/design/jam.md`.

## Follow-up
- #515 — self-host a compressed 0.5° CEDS mirror (feed the bulk path without ESGF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)