### PR TITLE
feat(aerosol): heterogeneous ice nucleation on dust/BC (#494)

### DIFF
--- a/jcm/physics/aerosol/jam/ice_nucleation/__init__.py
+++ b/jcm/physics/aerosol/jam/ice_nucleation/__init__.py
@@ -1,0 +1,8 @@
+"""Heterogeneous ice nucleation (dust/BC) for the JAM harness (#494).
+
+Immersion + deposition freezing on the prognostic dust and black-carbon
+populations, via a switchable parameterization (``"niemand"`` singular
+active-site, or ``"lohmann_diehl"`` ECHAM-HAM number-based). The
+:class:`IceNucleation` term writes an ``ice_nuclei`` diagnostic [m⁻³] that the
+2-moment cloud scheme reads to set the heterogeneous ice-crystal number.
+"""

--- a/jcm/physics/aerosol/jam/ice_nucleation/ice_nucleation_test.py
+++ b/jcm/physics/aerosol/jam/ice_nucleation/ice_nucleation_test.py
@@ -47,52 +47,79 @@ class InPopulationsTest(unittest.TestCase):
             0.75, rtol=1e-5,
         )
 
+    def test_cloud_borne_dust_counts_as_soluble(self):
+        # Cloud-borne (mc_) dust is in droplets → immersion-active (soluble),
+        # and does not add to the insoluble pool.
+        base = {}
+        cb = {}
+        for m in MAM4_SPEC.modes:
+            if "du" in m.species:
+                base[mass_name("du", m.short)] = jnp.full(_SHAPE, 1.0e-10)
+                cb[mass_name("du", m.short)] = jnp.full(_SHAPE, 1.0e-10)
+                cb[mass_name("du", m.short, cloud_borne=True)] = jnp.full(_SHAPE, 5.0e-11)
+        rho = jnp.full(_SHAPE, 1.0)
+        p0 = in_populations(MAM4_SPEC, base, rho, jnp.asarray(0.9))
+        p1 = in_populations(MAM4_SPEC, cb, rho, jnp.asarray(0.9))
+        self.assertGreater(
+            float(p1["du_number_sol"][0, 0]), float(p0["du_number_sol"][0, 0])
+        )
+        np.testing.assert_allclose(
+            float(p1["du_number_insol"][0, 0]),
+            float(p0["du_number_insol"][0, 0]), rtol=1e-5,
+        )
+
 
 class NiemandTest(unittest.TestCase):
     def test_immersion_rises_as_temperature_drops(self):
         params = IceNucleationParameters.default()
         pops = _pops()
-        warm = niemand_inp(pops, jnp.full(_SHAPE, 268.0), jnp.full(_SHAPE, 1.0), params)
-        cold = niemand_inp(pops, jnp.full(_SHAPE, 250.0), jnp.full(_SHAPE, 1.0), params)
+        warm, _ = niemand_inp(pops, jnp.full(_SHAPE, 268.0), jnp.full(_SHAPE, 1.0), params)
+        cold, _ = niemand_inp(pops, jnp.full(_SHAPE, 250.0), jnp.full(_SHAPE, 1.0), params)
         self.assertGreater(float(cold[0, 0]), float(warm[0, 0]))
 
     def test_capped_by_available_number(self):
         pops = _pops(du=1.0e-9)
-        inp = niemand_inp(pops, jnp.full(_SHAPE, 240.0), jnp.full(_SHAPE, 1.0),
-                          IceNucleationParameters.default())
+        imm, dep = niemand_inp(pops, jnp.full(_SHAPE, 240.0), jnp.full(_SHAPE, 1.2),
+                               IceNucleationParameters.default())
         total = pops["du_number_sol"] + pops["bc_number_sol"] + \
             pops["du_number_insol"] + pops["bc_number_insol"]
-        self.assertTrue(np.all(np.asarray(inp) <= np.asarray(total) + 1e-6))
+        self.assertTrue(np.all(np.asarray(imm + dep) <= np.asarray(total) + 1e-6))
 
     def test_deposition_rises_with_ice_supersaturation(self):
         params = IceNucleationParameters.default()
         pops = _pops()
-        sub = niemand_inp(pops, jnp.full(_SHAPE, 245.0), jnp.full(_SHAPE, 1.0), params)
-        sup = niemand_inp(pops, jnp.full(_SHAPE, 245.0), jnp.full(_SHAPE, 1.3), params)
+        _, sub = niemand_inp(pops, jnp.full(_SHAPE, 245.0), jnp.full(_SHAPE, 1.0), params)
+        _, sup = niemand_inp(pops, jnp.full(_SHAPE, 245.0), jnp.full(_SHAPE, 1.3), params)
         self.assertGreater(float(sup[0, 0]), float(sub[0, 0]))
 
 
 class LohmannDiehlTest(unittest.TestCase):
-    def _inp(self, t=255.0, cooling=1.0e-3, du=2.0e-10, bc=1.0e-11, s_ice=1.0):
-        return lohmann_diehl_inp(
+    def _imm(self, t=255.0, cooling=1.0e-3, du=2.0e-10, bc=1.0e-11, s_ice=1.0):
+        imm, _ = lohmann_diehl_inp(
             _pops(du=du, bc=bc), jnp.full(_SHAPE, t), jnp.full(_SHAPE, s_ice),
             jnp.full(_SHAPE, cooling), jnp.asarray(1800.0),
             IceNucleationParameters.default(),
         )
+        return imm
 
     def test_dust_dominates_bc(self):
-        dusty = float(self._inp(du=2.0e-10, bc=0.0)[0, 0])
-        sooty = float(self._inp(du=0.0, bc=2.0e-10)[0, 0])
+        dusty = float(self._imm(du=2.0e-10, bc=0.0)[0, 0])
+        sooty = float(self._imm(du=0.0, bc=2.0e-10)[0, 0])
         self.assertGreater(dusty, sooty)
 
     def test_more_ascent_more_freezing(self):
         self.assertGreater(
-            float(self._inp(cooling=5.0e-3)[0, 0]),
-            float(self._inp(cooling=1.0e-4)[0, 0]),
+            float(self._imm(cooling=5.0e-3)[0, 0]),
+            float(self._imm(cooling=1.0e-4)[0, 0]),
         )
 
     def test_finite(self):
-        self.assertTrue(np.all(np.isfinite(np.asarray(self._inp()))))
+        imm, dep = lohmann_diehl_inp(
+            _pops(), jnp.full(_SHAPE, 255.0), jnp.full(_SHAPE, 1.2),
+            jnp.full(_SHAPE, 1.0e-3), jnp.asarray(1800.0),
+            IceNucleationParameters.default(),
+        )
+        self.assertTrue(np.all(np.isfinite(np.asarray(imm + dep))))
 
 
 class IceNucleationTermTest(unittest.TestCase):
@@ -123,10 +150,11 @@ class IceNucleationTermTest(unittest.TestCase):
         for scheme in ("niemand", "lohmann_diehl"):
             state, diagnostics = self._setup()
             _, diags = IceNucleation(scheme=scheme)(state, diagnostics, None, None)
-            inp = diags["ice_nuclei"]
-            self.assertEqual(inp.shape, _SHAPE)
-            self.assertTrue(np.all(np.isfinite(np.asarray(inp))))
-            self.assertGreater(float(jnp.max(inp)), 0.0)
+            for key in ("ice_nuclei", "ice_nuclei_deposition"):
+                inp = diags[key]
+                self.assertEqual(inp.shape, _SHAPE)
+                self.assertTrue(np.all(np.isfinite(np.asarray(inp))))
+            self.assertGreater(float(jnp.max(diags["ice_nuclei"])), 0.0)
 
     def test_grad_through_params_finite(self):
         state, diagnostics = self._setup()

--- a/jcm/physics/aerosol/jam/ice_nucleation/ice_nucleation_test.py
+++ b/jcm/physics/aerosol/jam/ice_nucleation/ice_nucleation_test.py
@@ -146,5 +146,26 @@ class IceNucleationTermTest(unittest.TestCase):
         self.assertTrue(np.isfinite(float(g)) and float(g) != 0.0)
 
 
+class FactoryWiringTest(unittest.TestCase):
+    def test_ice_term_present_with_default_scheme(self):
+        from jcm.physics.aerosol.jam import jam_aerosol_physics
+
+        term = next(
+            t for t in jam_aerosol_physics()
+            if t.category == "aerosol_ice_nucleation"
+        )
+        self.assertEqual(term.name, "jam_ice_nucleation")
+        self.assertEqual(term._scheme, "niemand")
+
+    def test_scheme_threads_through(self):
+        from jcm.physics.aerosol.jam import jam_aerosol_physics
+
+        term = next(
+            t for t in jam_aerosol_physics(ice_scheme="lohmann_diehl")
+            if t.category == "aerosol_ice_nucleation"
+        )
+        self.assertEqual(term._scheme, "lohmann_diehl")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/jcm/physics/aerosol/jam/ice_nucleation/ice_nucleation_test.py
+++ b/jcm/physics/aerosol/jam/ice_nucleation/ice_nucleation_test.py
@@ -1,0 +1,150 @@
+"""Tests for heterogeneous ice nucleation (dust/BC) (#494)."""
+
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from jcm.physics.aerosol.jam import MAM4_SPEC, mass_name
+from jcm.physics.aerosol.jam.ice_nucleation.in_populations import in_populations
+from jcm.physics.aerosol.jam.ice_nucleation.ice_term import IceNucleation
+from jcm.physics.aerosol.jam.ice_nucleation.lohmann_diehl import lohmann_diehl_inp
+from jcm.physics.aerosol.jam.ice_nucleation.niemand import niemand_inp
+from jcm.physics.aerosol.jam.ice_nucleation.params import IceNucleationParameters
+from jcm.physics_interface import PhysicsState
+
+_SHAPE = (4, 2)
+
+
+def _pops(du=2.0e-10, bc=1.0e-11, frac_du_soluble=0.9):
+    tracers = {}
+    for m in MAM4_SPEC.modes:
+        if "du" in m.species:
+            tracers[mass_name("du", m.short)] = jnp.full(_SHAPE, du)
+        if "bc" in m.species:
+            tracers[mass_name("bc", m.short)] = jnp.full(_SHAPE, bc)
+    rho = jnp.full(_SHAPE, 1.0)
+    return in_populations(
+        MAM4_SPEC, tracers, rho, jnp.asarray(frac_du_soluble)
+    )
+
+
+class InPopulationsTest(unittest.TestCase):
+    def test_positive_and_scales_with_mass(self):
+        lo = _pops(du=1.0e-11)
+        hi = _pops(du=1.0e-9)
+        self.assertGreater(float(hi["du_number_sol"][0, 0]),
+                           float(lo["du_number_sol"][0, 0]))
+        for v in lo.values():
+            self.assertTrue(np.all(np.asarray(v) >= 0.0))
+
+    def test_solubility_split(self):
+        p = _pops(frac_du_soluble=0.75)
+        np.testing.assert_allclose(
+            float(p["du_number_sol"][0, 0])
+            / (float(p["du_number_sol"][0, 0]) + float(p["du_number_insol"][0, 0])),
+            0.75, rtol=1e-5,
+        )
+
+
+class NiemandTest(unittest.TestCase):
+    def test_immersion_rises_as_temperature_drops(self):
+        params = IceNucleationParameters.default()
+        pops = _pops()
+        warm = niemand_inp(pops, jnp.full(_SHAPE, 268.0), jnp.full(_SHAPE, 1.0), params)
+        cold = niemand_inp(pops, jnp.full(_SHAPE, 250.0), jnp.full(_SHAPE, 1.0), params)
+        self.assertGreater(float(cold[0, 0]), float(warm[0, 0]))
+
+    def test_capped_by_available_number(self):
+        pops = _pops(du=1.0e-9)
+        inp = niemand_inp(pops, jnp.full(_SHAPE, 240.0), jnp.full(_SHAPE, 1.0),
+                          IceNucleationParameters.default())
+        total = pops["du_number_sol"] + pops["bc_number_sol"] + \
+            pops["du_number_insol"] + pops["bc_number_insol"]
+        self.assertTrue(np.all(np.asarray(inp) <= np.asarray(total) + 1e-6))
+
+    def test_deposition_rises_with_ice_supersaturation(self):
+        params = IceNucleationParameters.default()
+        pops = _pops()
+        sub = niemand_inp(pops, jnp.full(_SHAPE, 245.0), jnp.full(_SHAPE, 1.0), params)
+        sup = niemand_inp(pops, jnp.full(_SHAPE, 245.0), jnp.full(_SHAPE, 1.3), params)
+        self.assertGreater(float(sup[0, 0]), float(sub[0, 0]))
+
+
+class LohmannDiehlTest(unittest.TestCase):
+    def _inp(self, t=255.0, cooling=1.0e-3, du=2.0e-10, bc=1.0e-11, s_ice=1.0):
+        return lohmann_diehl_inp(
+            _pops(du=du, bc=bc), jnp.full(_SHAPE, t), jnp.full(_SHAPE, s_ice),
+            jnp.full(_SHAPE, cooling), jnp.asarray(1800.0),
+            IceNucleationParameters.default(),
+        )
+
+    def test_dust_dominates_bc(self):
+        dusty = float(self._inp(du=2.0e-10, bc=0.0)[0, 0])
+        sooty = float(self._inp(du=0.0, bc=2.0e-10)[0, 0])
+        self.assertGreater(dusty, sooty)
+
+    def test_more_ascent_more_freezing(self):
+        self.assertGreater(
+            float(self._inp(cooling=5.0e-3)[0, 0]),
+            float(self._inp(cooling=1.0e-4)[0, 0]),
+        )
+
+    def test_finite(self):
+        self.assertTrue(np.all(np.isfinite(np.asarray(self._inp()))))
+
+
+class IceNucleationTermTest(unittest.TestCase):
+    def _setup(self, scheme="niemand"):
+        tracers = {}
+        for m in MAM4_SPEC.modes:
+            if "du" in m.species:
+                tracers[mass_name("du", m.short)] = jnp.full(_SHAPE, 2.0e-10)
+            if "bc" in m.species:
+                tracers[mass_name("bc", m.short)] = jnp.full(_SHAPE, 1.0e-11)
+        state = PhysicsState.zeros(_SHAPE).copy(
+            temperature=jnp.full(_SHAPE, 250.0),
+            specific_humidity=jnp.full(_SHAPE, 2.0e-4),
+            tracers=tracers,
+        )
+        diagnostics = {
+            "pressure_full": jnp.full(_SHAPE, 4.0e4),
+            "air_density": jnp.full(_SHAPE, 0.6),
+            "_dt_seconds": 1800.0,
+        }
+        return state, diagnostics
+
+    def test_invalid_scheme_raises(self):
+        with self.assertRaises(ValueError):
+            IceNucleation(scheme="bogus")
+
+    def test_both_schemes_produce_finite_ice_nuclei(self):
+        for scheme in ("niemand", "lohmann_diehl"):
+            state, diagnostics = self._setup()
+            _, diags = IceNucleation(scheme=scheme)(state, diagnostics, None, None)
+            inp = diags["ice_nuclei"]
+            self.assertEqual(inp.shape, _SHAPE)
+            self.assertTrue(np.all(np.isfinite(np.asarray(inp))))
+            self.assertGreater(float(jnp.max(inp)), 0.0)
+
+    def test_grad_through_params_finite(self):
+        state, diagnostics = self._setup()
+
+        def loss(scale):
+            base = IceNucleationParameters.default()
+            p = IceNucleationParameters(
+                frac_du_soluble=base.frac_du_soluble,
+                bc_efficiency=base.bc_efficiency,
+                deposition_scale=base.deposition_scale,
+                scale=scale,
+            )
+            _, diags = IceNucleation(params=p)(state, diagnostics, None, None)
+            return jnp.sum(diags["ice_nuclei"] ** 2)
+
+        g = jax.grad(loss)(jnp.asarray(1.0))
+        self.assertTrue(np.isfinite(float(g)) and float(g) != 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jcm/physics/aerosol/jam/ice_nucleation/ice_nucleation_test.py
+++ b/jcm/physics/aerosol/jam/ice_nucleation/ice_nucleation_test.py
@@ -167,5 +167,45 @@ class FactoryWiringTest(unittest.TestCase):
         self.assertEqual(term._scheme, "lohmann_diehl")
 
 
+class IceNucleationModelTest(unittest.TestCase):
+    """End-to-end: het ice nucleation drives the 2M scheme on a T21 run."""
+
+    def _run(self, scheme):
+        import numpy as onp
+
+        from jcm.model import Model
+        from jcm.physics.echam.echam_terms import echam_physics
+        from jcm.terrain import TerrainData
+        from jcm.utils import get_coords
+
+        coords = get_coords(onp.linspace(0, 1, 21), spectral_truncation=21)
+        terrain = TerrainData.aquaplanet(coords)
+        model = Model(
+            coords=coords, time_step=30, terrain=terrain,
+            physics=echam_physics(
+                aerosol_module="jam", cloud_scheme="2m", jam_ice_scheme=scheme,
+            ),
+        )
+        return model.run(save_interval=0.0625, total_time=0.0625)
+
+    def _check(self, scheme):
+        dyn = self._run(scheme).dynamics
+        self.assertFalse(bool(jnp.any(jnp.isnan(dyn.temperature))))
+        for key in ("qi", "qni"):
+            self.assertFalse(bool(jnp.any(jnp.isnan(dyn.tracers[key]))))
+
+    def test_niemand_runs_finite(self):
+        self._check("niemand")
+
+    def test_lohmann_diehl_runs_finite(self):
+        self._check("lohmann_diehl")
+
+
+# Mark the model-level tests slow.
+import pytest  # noqa: E402
+
+IceNucleationModelTest = pytest.mark.slow(IceNucleationModelTest)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/jcm/physics/aerosol/jam/ice_nucleation/ice_term.py
+++ b/jcm/physics/aerosol/jam/ice_nucleation/ice_term.py
@@ -1,0 +1,90 @@
+"""``IceNucleation`` — heterogeneous freezing term writing ``ice_nuclei`` (#494).
+
+Computes the dust/BC IN populations from the prognostic aerosol, the ambient
+temperature and ice saturation ratio, and (for the rate-based scheme) a
+characteristic cooling rate from the TTE-TKE updraft; applies the selected
+freezing parameterization (:mod:`niemand` or :mod:`lohmann_diehl`); and writes
+the heterogeneous ice-crystal number ``ice_nuclei`` [m⁻³]. The 2-moment cloud
+scheme reads it (like ARG's ``activated_cdnc``) to set the het ICNC.
+
+Runs in the JAM pre-cloud block, before the cloud microphysics.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import jax.numpy as jnp
+from flax import nnx
+
+from jcm.constants import cpd as _CPD
+from jcm.constants import grav as _G
+from jcm.physics.aerosol.jam.ice_nucleation.in_populations import in_populations
+from jcm.physics.aerosol.jam.ice_nucleation.lohmann_diehl import (
+    lohmann_diehl_inp,
+)
+from jcm.physics.aerosol.jam.ice_nucleation.niemand import niemand_inp
+from jcm.physics.aerosol.jam.ice_nucleation.params import IceNucleationParameters
+from jcm.physics.aerosol.jam.microphysics.mam4_data import MAM4_SPEC
+from jcm.physics.aerosol.jam.population import ModalAerosolSpec
+from jcm.physics.convection.saturation import saturation_specific_humidity
+from jcm.physics.physics_term import PhysicsTerm
+from jcm.physics_interface import PhysicsTendency
+
+_W_MIN = 0.01      # m/s — floor on the characteristic updraft
+_W_DEFAULT = 0.1   # m/s — fallback updraft when TKE is unavailable (step 1)
+
+
+class IceNucleation(PhysicsTerm):
+    """Heterogeneous (immersion+deposition) freezing on dust + BC."""
+
+    name: ClassVar[str] = "jam_ice_nucleation"
+    category: ClassVar[str] = "aerosol_ice_nucleation"
+    requires: ClassVar[tuple[str, ...]] = ("pressure_full", "air_density")
+    provides: ClassVar[tuple[str, ...]] = ("ice_nuclei",)
+
+    def __init__(
+        self,
+        params: IceNucleationParameters | None = None,
+        *,
+        spec: ModalAerosolSpec | None = None,
+        scheme: str = "niemand",
+    ):
+        """Hold params, the population, and the freezing scheme."""
+        self.params = nnx.Param(params or IceNucleationParameters.default())
+        self._spec = spec or MAM4_SPEC
+        if scheme not in ("niemand", "lohmann_diehl"):
+            raise ValueError(
+                f"Unknown ice scheme {scheme!r}; choose 'niemand' or "
+                "'lohmann_diehl'."
+            )
+        self._scheme = scheme
+
+    def _cooling_rate(self, diagnostics, temperature):
+        """Characteristic cooling rate [K/s] from the TKE updraft (ascent)."""
+        vd = diagnostics.get("vertical_diffusion")
+        if vd is not None:
+            w = jnp.sqrt(jnp.maximum(2.0 / 3.0 * vd.tke, 0.0))
+        else:
+            w = jnp.full_like(temperature, _W_DEFAULT)
+        return jnp.maximum(w, _W_MIN) * _G / _CPD
+
+    def __call__(self, state, diagnostics, forcing, terrain):
+        p = self.params.get_value()
+        rho = diagnostics["air_density"]
+        pressure = diagnostics["pressure_full"]
+        t = state.temperature
+
+        pops = in_populations(self._spec, state.tracers, rho, p.frac_du_soluble)
+        qsat_ice = saturation_specific_humidity(t, pressure, phase="ice")
+        s_ice = state.specific_humidity / jnp.maximum(qsat_ice, 1.0e-30)
+
+        if self._scheme == "niemand":
+            inp = niemand_inp(pops, t, s_ice, p)
+        else:
+            dt = jnp.asarray(diagnostics["_dt_seconds"], t.dtype)
+            cooling = self._cooling_rate(diagnostics, t)
+            inp = lohmann_diehl_inp(pops, t, s_ice, cooling, dt, p)
+
+        tendency = PhysicsTendency.zeros(t.shape)
+        return tendency, {**diagnostics, "ice_nuclei": jnp.maximum(inp, 0.0)}

--- a/jcm/physics/aerosol/jam/ice_nucleation/ice_term.py
+++ b/jcm/physics/aerosol/jam/ice_nucleation/ice_term.py
@@ -41,7 +41,7 @@ class IceNucleation(PhysicsTerm):
     name: ClassVar[str] = "jam_ice_nucleation"
     category: ClassVar[str] = "aerosol_ice_nucleation"
     requires: ClassVar[tuple[str, ...]] = ("pressure_full", "air_density")
-    provides: ClassVar[tuple[str, ...]] = ("ice_nuclei",)
+    provides: ClassVar[tuple[str, ...]] = ("ice_nuclei", "ice_nuclei_deposition")
 
     def __init__(
         self,
@@ -80,11 +80,18 @@ class IceNucleation(PhysicsTerm):
         s_ice = state.specific_humidity / jnp.maximum(qsat_ice, 1.0e-30)
 
         if self._scheme == "niemand":
-            inp = niemand_inp(pops, t, s_ice, p)
+            inp_imm, inp_dep = niemand_inp(pops, t, s_ice, p)
         else:
             dt = jnp.asarray(diagnostics["_dt_seconds"], t.dtype)
             cooling = self._cooling_rate(diagnostics, t)
-            inp = lohmann_diehl_inp(pops, t, s_ice, cooling, dt, p)
+            inp_imm, inp_dep = lohmann_diehl_inp(pops, t, s_ice, cooling, dt, p)
 
+        # Immersion feeds the 2M mixed-phase het freezing; deposition feeds the
+        # cirrus nucleation hook (newly_formed_ice). Splitting them avoids
+        # double-counting where the regimes overlap.
         tendency = PhysicsTendency.zeros(t.shape)
-        return tendency, {**diagnostics, "ice_nuclei": jnp.maximum(inp, 0.0)}
+        return tendency, {
+            **diagnostics,
+            "ice_nuclei": jnp.maximum(inp_imm, 0.0),
+            "ice_nuclei_deposition": jnp.maximum(inp_dep, 0.0),
+        }

--- a/jcm/physics/aerosol/jam/ice_nucleation/in_populations.py
+++ b/jcm/physics/aerosol/jam/ice_nucleation/in_populations.py
@@ -14,10 +14,12 @@ log-normal geometry:
 * number-equiv:  ``n = (m/ρ) / v_p``,         ``v_p = (π/6)·dg³·exp(4.5 ln²σ)``
 * surface area:  ``A = (m/ρ) · 6/(dg·exp(2.5 ln²σ))``    [m²/m³ after ×ρ_air]
 
-Solubility (MAM4-MOM): BC in accum/coarse is treated as aged/coated → soluble,
-BC in primary_carbon → insoluble; dust (only in accum/coarse) is split by the
-differentiable ``frac_du_soluble`` (most aged dust is immersion-active, a small
-bare fraction is available for deposition).
+Solubility: **cloud-borne** dust/BC (``mc_*``) is already inside cloud droplets,
+so it is immersion-active (soluble) regardless of mode. For **interstitial**
+(``m_*``) aerosol: BC in accum/coarse is treated as aged/coated → soluble, BC in
+primary_carbon → insoluble; interstitial dust (only in accum/coarse) is split by
+the differentiable ``frac_du_soluble`` (most aged dust is immersion-active, a
+small bare fraction is available for deposition).
 """
 
 from __future__ import annotations
@@ -54,48 +56,51 @@ def in_populations(
     """
     zeros = jnp.zeros_like(air_density)
 
-    def species_number_area(species, mode_short):
-        mass = tracers.get(mass_name(species, mode_short), zeros)
+    def number_area(species, mode_short, *, cloud_borne):
+        mass = tracers.get(
+            mass_name(species, mode_short, cloud_borne=cloud_borne), zeros
+        )
         density = spec.species_props(species).density
         vol = jnp.maximum(mass, 0.0) / density        # m³/kg-air
         n_fac, a_fac = _geometry_factors(spec, mode_short)
-        number = vol * n_fac * air_density            # m⁻³
-        area = vol * a_fac * air_density              # m²/m³
-        return number, area
+        return vol * n_fac * air_density, vol * a_fac * air_density
 
-    # Dust lives only in the soluble (accum/coarse) modes; split by solubility.
-    du_n = zeros
-    du_a = zeros
-    for m in _SOLUBLE_MODES:
-        if "du" in spec.mode(m).species:
-            n, a = species_number_area("du", m)
-            du_n = du_n + n
-            du_a = du_a + a
+    def cloud_borne_pool(species):
+        """Cloud-borne (in-droplet) → immersion-active in any mode."""
+        n, a = zeros, zeros
+        for m in (*_SOLUBLE_MODES, *_INSOLUBLE_MODES):
+            if species in spec.mode(m).species:
+                dn, da = number_area(species, m, cloud_borne=True)
+                n, a = n + dn, a + da
+        return n, a
+
+    def interstitial(species, modes):
+        n, a = zeros, zeros
+        for m in modes:
+            if species in spec.mode(m).species:
+                dn, da = number_area(species, m, cloud_borne=False)
+                n, a = n + dn, a + da
+        return n, a
+
     fsol = jnp.clip(frac_du_soluble, 0.0, 1.0)
 
-    # BC solubility follows the mode (soluble modes vs primary carbon).
-    bc_n_sol = zeros
-    bc_a_sol = zeros
-    for m in _SOLUBLE_MODES:
-        if "bc" in spec.mode(m).species:
-            n, a = species_number_area("bc", m)
-            bc_n_sol = bc_n_sol + n
-            bc_a_sol = bc_a_sol + a
-    bc_n_insol = zeros
-    bc_a_insol = zeros
-    for m in _INSOLUBLE_MODES:
-        if "bc" in spec.mode(m).species:
-            n, a = species_number_area("bc", m)
-            bc_n_insol = bc_n_insol + n
-            bc_a_insol = bc_a_insol + a
+    # Dust: interstitial only in accum/coarse, split by frac; all cloud-borne
+    # dust is soluble (in droplets).
+    du_int_n, du_int_a = interstitial("du", _SOLUBLE_MODES)
+    du_cb_n, du_cb_a = cloud_borne_pool("du")
+    # BC: interstitial soluble (accum/coarse) vs insoluble (primary carbon);
+    # all cloud-borne BC is soluble.
+    bc_int_sol_n, bc_int_sol_a = interstitial("bc", _SOLUBLE_MODES)
+    bc_int_ins_n, bc_int_ins_a = interstitial("bc", _INSOLUBLE_MODES)
+    bc_cb_n, bc_cb_a = cloud_borne_pool("bc")
 
     return {
-        "du_number_sol": du_n * fsol,
-        "du_area_sol": du_a * fsol,
-        "du_number_insol": du_n * (1.0 - fsol),
-        "du_area_insol": du_a * (1.0 - fsol),
-        "bc_number_sol": bc_n_sol,
-        "bc_area_sol": bc_a_sol,
-        "bc_number_insol": bc_n_insol,
-        "bc_area_insol": bc_a_insol,
+        "du_number_sol": du_int_n * fsol + du_cb_n,
+        "du_area_sol": du_int_a * fsol + du_cb_a,
+        "du_number_insol": du_int_n * (1.0 - fsol),
+        "du_area_insol": du_int_a * (1.0 - fsol),
+        "bc_number_sol": bc_int_sol_n + bc_cb_n,
+        "bc_area_sol": bc_int_sol_a + bc_cb_a,
+        "bc_number_insol": bc_int_ins_n,
+        "bc_area_insol": bc_int_ins_a,
     }

--- a/jcm/physics/aerosol/jam/ice_nucleation/in_populations.py
+++ b/jcm/physics/aerosol/jam/ice_nucleation/in_populations.py
@@ -1,4 +1,4 @@
-"""Dust/BC ice-nucleating-particle populations from the modal aerosol (#494).
+"""Dust/BC ice-nucleating-particle populations from the aerosol spec (#494).
 
 The freezing schemes need, for dust and black carbon, an IN **number** [m⁻³]
 (to cap the nucleated crystals) and a **surface-area** concentration [m²/m³]
@@ -7,41 +7,34 @@ The freezing schemes need, for dust and black carbon, an IN **number** [m⁻³]
 (deposition/contact freezing, bare particles) — the analog of HAMMOZ's
 ``mo_ham_freezing.f90::get_aerofreez_nc``.
 
-``_jam_state`` only carries per-mode totals, so the per-species dust/BC mass is
-read from the ``m_du_*``/``m_bc_*`` tracers and converted with each mode's
-log-normal geometry:
+This is written against the *generic* aerosol-population interface rather than
+any particular microphysics: for each population class it reads only the
+``species`` it carries, its ``soluble`` flag, and the family-agnostic
+``number_factor`` / ``area_factor`` geometry (see
+:class:`jcm.physics.aerosol.jam.population.AerosolMode`). A sectional spec
+(#491) exposes the same per-class interface, so this code is invariant to the
+modal-vs-sectional choice. Per-species dust/BC mass comes from the
+``m_du_*``/``m_bc_*`` (interstitial) and ``mc_*`` (cloud-borne) tracers:
 
-* number-equiv:  ``n = (m/ρ) / v_p``,         ``v_p = (π/6)·dg³·exp(4.5 ln²σ)``
-* surface area:  ``A = (m/ρ) · 6/(dg·exp(2.5 ln²σ))``    [m²/m³ after ×ρ_air]
+* number-equiv:  ``n = (m/ρ) · number_factor``
+* surface area:  ``A = (m/ρ) · area_factor``        [both ×ρ_air for /m³]
 
-Solubility: **cloud-borne** dust/BC (``mc_*``) is already inside cloud droplets,
-so it is immersion-active (soluble) regardless of mode. For **interstitial**
-(``m_*``) aerosol: BC in accum/coarse is treated as aged/coated → soluble, BC in
-primary_carbon → insoluble; interstitial dust (only in accum/coarse) is split by
-the differentiable ``frac_du_soluble`` (most aged dust is immersion-active, a
-small bare fraction is available for deposition).
+Solubility comes from the spec, not hard-coded class names. **Cloud-borne**
+dust/BC (``mc_*``) is already inside cloud droplets, so it is immersion-active
+(soluble) regardless of class. **Interstitial** (``m_*``) aerosol is classed by
+the population's own ``soluble`` flag (aged/coated classes → immersion;
+hydrophobic classes such as primary carbon → deposition/contact). Interstitial
+dust in a soluble class is further split by the differentiable
+``frac_du_soluble`` (most aged dust is immersion-active, a small bare fraction
+is available for deposition).
 """
 
 from __future__ import annotations
-
-import math
 
 import jax.numpy as jnp
 
 from jcm.physics.aerosol.jam.population import ModalAerosolSpec
 from jcm.physics.aerosol.jam.tracer_layout import mass_name
-
-_SOLUBLE_MODES = ("acc", "cor")     # aged/coated → immersion
-_INSOLUBLE_MODES = ("pcm",)         # primary carbon → deposition/contact
-
-
-def _geometry_factors(spec: ModalAerosolSpec, mode_short: str):
-    """``(number_factor [1/m³], area_factor [1/m])`` for a mode's log-normal."""
-    mode = spec.mode(mode_short)
-    ln_sigma = math.log(mode.geom_std_dev)
-    v_p = (math.pi / 6.0) * mode.dgnum ** 3 * math.exp(4.5 * ln_sigma ** 2)
-    area_factor = 6.0 / (mode.dgnum * math.exp(2.5 * ln_sigma ** 2))
-    return 1.0 / v_p, area_factor
 
 
 def in_populations(
@@ -56,51 +49,51 @@ def in_populations(
     """
     zeros = jnp.zeros_like(air_density)
 
-    def number_area(species, mode_short, *, cloud_borne):
+    def number_area(species, mode, *, cloud_borne):
         mass = tracers.get(
-            mass_name(species, mode_short, cloud_borne=cloud_borne), zeros
+            mass_name(species, mode.short, cloud_borne=cloud_borne), zeros
         )
         density = spec.species_props(species).density
         vol = jnp.maximum(mass, 0.0) / density        # m³/kg-air
-        n_fac, a_fac = _geometry_factors(spec, mode_short)
-        return vol * n_fac * air_density, vol * a_fac * air_density
+        return (vol * mode.number_factor * air_density,
+                vol * mode.area_factor * air_density)
 
-    def cloud_borne_pool(species):
-        """Cloud-borne (in-droplet) → immersion-active in any mode."""
-        n, a = zeros, zeros
-        for m in (*_SOLUBLE_MODES, *_INSOLUBLE_MODES):
-            if species in spec.mode(m).species:
-                dn, da = number_area(species, m, cloud_borne=True)
-                n, a = n + dn, a + da
-        return n, a
+    def pools(species):
+        """``(soluble, insoluble, cloud_borne)`` (number, area) pairs.
 
-    def interstitial(species, modes):
-        n, a = zeros, zeros
-        for m in modes:
-            if species in spec.mode(m).species:
-                dn, da = number_area(species, m, cloud_borne=False)
-                n, a = n + dn, a + da
-        return n, a
+        Interstitial mass is sorted into the soluble / insoluble pool by each
+        class's own ``soluble`` flag; cloud-borne mass is immersion-active
+        (soluble) in any class.
+        """
+        sol = ins = cb = (zeros, zeros)
+        for mode in spec.modes:
+            if species not in mode.species:
+                continue
+            dn, da = number_area(species, mode, cloud_borne=True)
+            cb = (cb[0] + dn, cb[1] + da)
+            dn, da = number_area(species, mode, cloud_borne=False)
+            if mode.soluble:
+                sol = (sol[0] + dn, sol[1] + da)
+            else:
+                ins = (ins[0] + dn, ins[1] + da)
+        return sol, ins, cb
 
     fsol = jnp.clip(frac_du_soluble, 0.0, 1.0)
-
-    # Dust: interstitial only in accum/coarse, split by frac; all cloud-borne
-    # dust is soluble (in droplets).
-    du_int_n, du_int_a = interstitial("du", _SOLUBLE_MODES)
-    du_cb_n, du_cb_a = cloud_borne_pool("du")
-    # BC: interstitial soluble (accum/coarse) vs insoluble (primary carbon);
-    # all cloud-borne BC is soluble.
-    bc_int_sol_n, bc_int_sol_a = interstitial("bc", _SOLUBLE_MODES)
-    bc_int_ins_n, bc_int_ins_a = interstitial("bc", _INSOLUBLE_MODES)
-    bc_cb_n, bc_cb_a = cloud_borne_pool("bc")
+    (du_sol, du_ins, du_cb) = pools("du")
+    (bc_sol, bc_ins, bc_cb) = pools("bc")
 
     return {
-        "du_number_sol": du_int_n * fsol + du_cb_n,
-        "du_area_sol": du_int_a * fsol + du_cb_a,
-        "du_number_insol": du_int_n * (1.0 - fsol),
-        "du_area_insol": du_int_a * (1.0 - fsol),
-        "bc_number_sol": bc_int_sol_n + bc_cb_n,
-        "bc_area_sol": bc_int_sol_a + bc_cb_a,
-        "bc_number_insol": bc_int_ins_n,
-        "bc_area_insol": bc_int_ins_a,
+        # Dust: soluble-class interstitial dust is split by frac_du_soluble
+        # into an immersion-active and a bare (deposition) fraction; cloud-borne
+        # dust is always immersion-active; any insoluble-class dust stays bare.
+        "du_number_sol": du_sol[0] * fsol + du_cb[0],
+        "du_area_sol": du_sol[1] * fsol + du_cb[1],
+        "du_number_insol": du_sol[0] * (1.0 - fsol) + du_ins[0],
+        "du_area_insol": du_sol[1] * (1.0 - fsol) + du_ins[1],
+        # BC: soluble-class interstitial + cloud-borne is immersion-active;
+        # hydrophobic-class (e.g. primary carbon) interstitial is bare.
+        "bc_number_sol": bc_sol[0] + bc_cb[0],
+        "bc_area_sol": bc_sol[1] + bc_cb[1],
+        "bc_number_insol": bc_ins[0],
+        "bc_area_insol": bc_ins[1],
     }

--- a/jcm/physics/aerosol/jam/ice_nucleation/in_populations.py
+++ b/jcm/physics/aerosol/jam/ice_nucleation/in_populations.py
@@ -1,0 +1,101 @@
+"""Dust/BC ice-nucleating-particle populations from the modal aerosol (#494).
+
+The freezing schemes need, for dust and black carbon, an IN **number** [m⁻³]
+(to cap the nucleated crystals) and a **surface-area** concentration [m²/m³]
+(the active-site schemes scale with area), split into a **soluble** pool
+(immersion freezing, inside cloud droplets) and an **insoluble** pool
+(deposition/contact freezing, bare particles) — the analog of HAMMOZ's
+``mo_ham_freezing.f90::get_aerofreez_nc``.
+
+``_jam_state`` only carries per-mode totals, so the per-species dust/BC mass is
+read from the ``m_du_*``/``m_bc_*`` tracers and converted with each mode's
+log-normal geometry:
+
+* number-equiv:  ``n = (m/ρ) / v_p``,         ``v_p = (π/6)·dg³·exp(4.5 ln²σ)``
+* surface area:  ``A = (m/ρ) · 6/(dg·exp(2.5 ln²σ))``    [m²/m³ after ×ρ_air]
+
+Solubility (MAM4-MOM): BC in accum/coarse is treated as aged/coated → soluble,
+BC in primary_carbon → insoluble; dust (only in accum/coarse) is split by the
+differentiable ``frac_du_soluble`` (most aged dust is immersion-active, a small
+bare fraction is available for deposition).
+"""
+
+from __future__ import annotations
+
+import math
+
+import jax.numpy as jnp
+
+from jcm.physics.aerosol.jam.population import ModalAerosolSpec
+from jcm.physics.aerosol.jam.tracer_layout import mass_name
+
+_SOLUBLE_MODES = ("acc", "cor")     # aged/coated → immersion
+_INSOLUBLE_MODES = ("pcm",)         # primary carbon → deposition/contact
+
+
+def _geometry_factors(spec: ModalAerosolSpec, mode_short: str):
+    """``(number_factor [1/m³], area_factor [1/m])`` for a mode's log-normal."""
+    mode = spec.mode(mode_short)
+    ln_sigma = math.log(mode.geom_std_dev)
+    v_p = (math.pi / 6.0) * mode.dgnum ** 3 * math.exp(4.5 * ln_sigma ** 2)
+    area_factor = 6.0 / (mode.dgnum * math.exp(2.5 * ln_sigma ** 2))
+    return 1.0 / v_p, area_factor
+
+
+def in_populations(
+    spec: ModalAerosolSpec,
+    tracers: dict,
+    air_density: jnp.ndarray,        # (nlev, ncols)
+    frac_du_soluble: jnp.ndarray,    # scalar in [0, 1]
+) -> dict[str, jnp.ndarray]:
+    """Dust/BC IN number [m⁻³] and area [m²/m³], soluble + insoluble.
+
+    Returns keys ``{du,bc}_{number,area}_{sol,insol}`` each ``(nlev, ncols)``.
+    """
+    zeros = jnp.zeros_like(air_density)
+
+    def species_number_area(species, mode_short):
+        mass = tracers.get(mass_name(species, mode_short), zeros)
+        density = spec.species_props(species).density
+        vol = jnp.maximum(mass, 0.0) / density        # m³/kg-air
+        n_fac, a_fac = _geometry_factors(spec, mode_short)
+        number = vol * n_fac * air_density            # m⁻³
+        area = vol * a_fac * air_density              # m²/m³
+        return number, area
+
+    # Dust lives only in the soluble (accum/coarse) modes; split by solubility.
+    du_n = zeros
+    du_a = zeros
+    for m in _SOLUBLE_MODES:
+        if "du" in spec.mode(m).species:
+            n, a = species_number_area("du", m)
+            du_n = du_n + n
+            du_a = du_a + a
+    fsol = jnp.clip(frac_du_soluble, 0.0, 1.0)
+
+    # BC solubility follows the mode (soluble modes vs primary carbon).
+    bc_n_sol = zeros
+    bc_a_sol = zeros
+    for m in _SOLUBLE_MODES:
+        if "bc" in spec.mode(m).species:
+            n, a = species_number_area("bc", m)
+            bc_n_sol = bc_n_sol + n
+            bc_a_sol = bc_a_sol + a
+    bc_n_insol = zeros
+    bc_a_insol = zeros
+    for m in _INSOLUBLE_MODES:
+        if "bc" in spec.mode(m).species:
+            n, a = species_number_area("bc", m)
+            bc_n_insol = bc_n_insol + n
+            bc_a_insol = bc_a_insol + a
+
+    return {
+        "du_number_sol": du_n * fsol,
+        "du_area_sol": du_a * fsol,
+        "du_number_insol": du_n * (1.0 - fsol),
+        "du_area_insol": du_a * (1.0 - fsol),
+        "bc_number_sol": bc_n_sol,
+        "bc_area_sol": bc_a_sol,
+        "bc_number_insol": bc_n_insol,
+        "bc_area_insol": bc_a_insol,
+    }

--- a/jcm/physics/aerosol/jam/ice_nucleation/lohmann_diehl.py
+++ b/jcm/physics/aerosol/jam/ice_nucleation/lohmann_diehl.py
@@ -1,0 +1,70 @@
+"""Lohmann & Diehl (2006) number-based heterogeneous freezing (#494).
+
+The classic ECHAM-HAM scheme, adapted to a diagnostic frozen-number form:
+
+* **Immersion** — Lohmann & Diehl (2006), as in HAMMOZ
+  ``mo_cloud_micro_2m.f90``: the immersion freezing of soluble dust/BC scales
+  with the species coefficients ``a_du = 32.3`` (montmorillonite) ≫
+  ``a_bc = 2.91e-3``, the temperature factor ``exp(T_melt − T)``, and the
+  cooling rate (ascent). Here the frozen *fraction* of the soluble IN over the
+  step is ``1 − exp(−a·exp(T_melt−T)·|cooling|·Δt·C)``, capped by the IN number.
+  The relative dust≫BC, colder-is-more, and ascent dependences are L&D's; the
+  absolute magnitude is set by the calibration constant ``C`` and the
+  differentiable ``scale`` (the diagnostic form drops HAMMOZ's per-droplet
+  volume factor).
+* **Deposition** — Meyers et al. (1992) condensation/deposition number,
+  ``n_dep = 10³·exp(−0.639 + 0.1296·100·(S_ice−1))`` [m⁻³], active where
+  ice-supersaturated, capped by the insoluble dust/BC number.
+
+Returns the heterogeneous ice-crystal number [m⁻³].
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+
+from jcm.physics.aerosol.jam.ice_nucleation.params import IceNucleationParameters
+
+_TMELT = 273.15
+# Lohmann & Diehl (2006) immersion coefficients (HAMMOZ).
+_A_IMM_DU = 32.3        # montmorillonite
+_A_IMM_BC = 2.91e-3     # black carbon
+# Calibration bringing the diagnostic frozen fraction into a physical range
+# (absorbs HAMMOZ's per-droplet liquid-volume factor that this diagnostic form
+# drops). Chosen so dust immersion ramps from ~0 near −10 °C to near-complete by
+# ~−35 °C at typical cooling rates; tune together with the ``scale`` param.
+_LD_CALIB = 1.0e-10
+# Meyers et al. (1992) deposition number coefficients (per litre → ×1e3 = m⁻³).
+_MEYERS_A = -0.639
+_MEYERS_B = 0.1296
+
+
+def _immersion_fraction(coeff, temperature, cooling, dt, scale):
+    """Frozen fraction of an immersion-IN population (L&D dependences)."""
+    temp_factor = jnp.exp(jnp.clip(_TMELT - temperature, 0.0, 60.0))
+    rate = scale * _LD_CALIB * coeff * temp_factor * jnp.maximum(cooling, 0.0)
+    return 1.0 - jnp.exp(-jnp.clip(rate * dt, 0.0, 50.0))
+
+
+def lohmann_diehl_inp(pops, temperature, s_ice, cooling, dt,
+                      params: IceNucleationParameters):
+    """Heterogeneous INP number [m⁻³] (immersion + deposition)."""
+    t = temperature
+    cold = t < _TMELT
+
+    # --- Immersion: soluble dust + BC, L&D temperature/cooling dependence ---
+    f_du = _immersion_fraction(_A_IMM_DU, t, cooling, dt, params.scale)
+    f_bc = _immersion_fraction(_A_IMM_BC, t, cooling, dt, params.scale)
+    inp_imm = jnp.where(
+        cold, pops["du_number_sol"] * f_du + pops["bc_number_sol"] * f_bc, 0.0
+    )
+
+    # --- Deposition: Meyers (1992) on insoluble IN, ice-supersaturated ---
+    si_excess = jnp.maximum(s_ice - 1.0, 0.0)
+    n_meyers = params.deposition_scale * 1.0e3 * jnp.exp(
+        _MEYERS_A + _MEYERS_B * jnp.clip(100.0 * si_excess, 0.0, 100.0)
+    )
+    insol_number = pops["du_number_insol"] + pops["bc_number_insol"]
+    inp_dep = jnp.where(si_excess > 0.0, jnp.minimum(n_meyers, insol_number), 0.0)
+
+    return params.scale * (inp_imm + inp_dep)

--- a/jcm/physics/aerosol/jam/ice_nucleation/lohmann_diehl.py
+++ b/jcm/physics/aerosol/jam/ice_nucleation/lohmann_diehl.py
@@ -39,22 +39,27 @@ _MEYERS_A = -0.639
 _MEYERS_B = 0.1296
 
 
-def _immersion_fraction(coeff, temperature, cooling, dt, scale):
-    """Frozen fraction of an immersion-IN population (L&D dependences)."""
+def _immersion_fraction(coeff, temperature, cooling, dt):
+    """Frozen fraction of an immersion-IN population (L&D dependences).
+
+    The overall ``scale`` is applied **once** by the caller (to the resulting
+    number), not here, so it stays a linear knob consistent with the deposition
+    path and the Niemand scheme.
+    """
     temp_factor = jnp.exp(jnp.clip(_TMELT - temperature, 0.0, 60.0))
-    rate = scale * _LD_CALIB * coeff * temp_factor * jnp.maximum(cooling, 0.0)
+    rate = _LD_CALIB * coeff * temp_factor * jnp.maximum(cooling, 0.0)
     return 1.0 - jnp.exp(-jnp.clip(rate * dt, 0.0, 50.0))
 
 
 def lohmann_diehl_inp(pops, temperature, s_ice, cooling, dt,
                       params: IceNucleationParameters):
-    """Heterogeneous INP number [m⁻³] (immersion + deposition)."""
+    """Immersion and deposition INP numbers [m⁻³] as ``(immersion, deposition)``."""
     t = temperature
     cold = t < _TMELT
 
     # --- Immersion: soluble dust + BC, L&D temperature/cooling dependence ---
-    f_du = _immersion_fraction(_A_IMM_DU, t, cooling, dt, params.scale)
-    f_bc = _immersion_fraction(_A_IMM_BC, t, cooling, dt, params.scale)
+    f_du = _immersion_fraction(_A_IMM_DU, t, cooling, dt)
+    f_bc = _immersion_fraction(_A_IMM_BC, t, cooling, dt)
     inp_imm = jnp.where(
         cold, pops["du_number_sol"] * f_du + pops["bc_number_sol"] * f_bc, 0.0
     )
@@ -67,4 +72,4 @@ def lohmann_diehl_inp(pops, temperature, s_ice, cooling, dt,
     insol_number = pops["du_number_insol"] + pops["bc_number_insol"]
     inp_dep = jnp.where(si_excess > 0.0, jnp.minimum(n_meyers, insol_number), 0.0)
 
-    return params.scale * (inp_imm + inp_dep)
+    return params.scale * inp_imm, params.scale * inp_dep

--- a/jcm/physics/aerosol/jam/ice_nucleation/niemand.py
+++ b/jcm/physics/aerosol/jam/ice_nucleation/niemand.py
@@ -1,0 +1,64 @@
+"""Niemand-family singular (active-site) heterogeneous freezing (#494).
+
+Surface-area-based immersion + deposition INP, the modern "ns" approach:
+
+* **Immersion** — Niemand et al. (2012) desert-dust active-site density
+  ``ns_imm(T) = exp(−0.517·(T−273.15) + 8.934)`` [m⁻²] (valid ~237–261 K). The
+  immersion-frozen number is the active-site count capped by the available
+  particle number: ``INP = min(ns·A_sol, N_sol)``. BC contributes with a
+  reduced efficiency ``bc_efficiency``.
+* **Deposition** — a simplified, calibratable active-site density that rises
+  monotonically with ice supersaturation (Ullrich-2017-style), active on the
+  insoluble (bare) dust/BC where ``S_ice > 1`` and ``T`` is cold:
+  ``ns_dep = deposition_scale · ns_dep0 · max(S_ice−1, 0)``. Coefficients are
+  exposed for calibration rather than claiming exact published values.
+
+Both contributions are diagnostic and smooth (differentiable). Returns the
+heterogeneous ice-crystal number [m⁻³].
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+
+from jcm.physics.aerosol.jam.ice_nucleation.params import IceNucleationParameters
+
+# Niemand (2012) immersion active-site density coefficients.
+_NS_IMM_A = -0.517
+_NS_IMM_B = 8.934
+# Simplified deposition: reference active-site density [m⁻²] per unit S_ice
+# excess, gated below this temperature (cirrus/cold mixed-phase).
+_NS_DEP0 = 1.0e9
+_T_DEP_MAX = 260.0   # K — deposition only colder than this
+_T_IMM_MAX = 273.15  # K — immersion only below freezing
+
+
+def ns_imm_niemand(temperature: jnp.ndarray) -> jnp.ndarray:
+    """Niemand (2012) immersion active-site density [m⁻²]."""
+    return jnp.exp(_NS_IMM_A * (temperature - 273.15) + _NS_IMM_B)
+
+
+def niemand_inp(pops, temperature, s_ice, params: IceNucleationParameters):
+    """Heterogeneous INP number [m⁻³] (immersion + deposition)."""
+    t = temperature
+    cold = t < _T_IMM_MAX
+
+    # --- Immersion (soluble dust + BC), active-site count capped by number ---
+    ns_imm = ns_imm_niemand(t)
+    sites_du = ns_imm * pops["du_area_sol"]
+    sites_bc = params.bc_efficiency * ns_imm * pops["bc_area_sol"]
+    inp_imm_du = jnp.minimum(sites_du, pops["du_number_sol"])
+    inp_imm_bc = jnp.minimum(sites_bc, pops["bc_number_sol"])
+    inp_imm = jnp.where(cold, inp_imm_du + inp_imm_bc, 0.0)
+
+    # --- Deposition (insoluble dust + BC), ice-supersaturated and cold ---
+    si_excess = jnp.maximum(s_ice - 1.0, 0.0)
+    ns_dep = params.deposition_scale * _NS_DEP0 * si_excess
+    sites_du_dep = ns_dep * pops["du_area_insol"]
+    sites_bc_dep = params.bc_efficiency * ns_dep * pops["bc_area_insol"]
+    inp_dep_du = jnp.minimum(sites_du_dep, pops["du_number_insol"])
+    inp_dep_bc = jnp.minimum(sites_bc_dep, pops["bc_number_insol"])
+    active_dep = (si_excess > 0.0) & (t < _T_DEP_MAX)
+    inp_dep = jnp.where(active_dep, inp_dep_du + inp_dep_bc, 0.0)
+
+    return params.scale * (inp_imm + inp_dep)

--- a/jcm/physics/aerosol/jam/ice_nucleation/niemand.py
+++ b/jcm/physics/aerosol/jam/ice_nucleation/niemand.py
@@ -39,7 +39,7 @@ def ns_imm_niemand(temperature: jnp.ndarray) -> jnp.ndarray:
 
 
 def niemand_inp(pops, temperature, s_ice, params: IceNucleationParameters):
-    """Heterogeneous INP number [m⁻³] (immersion + deposition)."""
+    """Immersion and deposition INP numbers [m⁻³] as ``(immersion, deposition)``."""
     t = temperature
     cold = t < _T_IMM_MAX
 
@@ -61,4 +61,4 @@ def niemand_inp(pops, temperature, s_ice, params: IceNucleationParameters):
     active_dep = (si_excess > 0.0) & (t < _T_DEP_MAX)
     inp_dep = jnp.where(active_dep, inp_dep_du + inp_dep_bc, 0.0)
 
-    return params.scale * (inp_imm + inp_dep)
+    return params.scale * inp_imm, params.scale * inp_dep

--- a/jcm/physics/aerosol/jam/ice_nucleation/params.py
+++ b/jcm/physics/aerosol/jam/ice_nucleation/params.py
@@ -1,0 +1,30 @@
+"""Differentiable parameters for heterogeneous ice nucleation (#494)."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import tree_math
+
+
+@tree_math.struct
+class IceNucleationParameters:
+    """Calibratable knobs shared by the freezing schemes.
+
+    The load-bearing uncertainties — the dust soluble/insoluble split, the BC
+    IN efficiency, and the deposition strength — are exposed so they can be
+    tuned by gradient through the model.
+    """
+
+    frac_du_soluble: jnp.ndarray      # dust immersion(soluble) vs deposition split
+    bc_efficiency: jnp.ndarray        # BC IN efficiency relative to dust [-]
+    deposition_scale: jnp.ndarray     # deposition active-site / number scale [-]
+    scale: jnp.ndarray                # overall INP scale
+
+    @classmethod
+    def default(cls) -> "IceNucleationParameters":
+        return cls(
+            frac_du_soluble=jnp.asarray(0.9),
+            bc_efficiency=jnp.asarray(0.01),
+            deposition_scale=jnp.asarray(1.0),
+            scale=jnp.asarray(1.0),
+        )

--- a/jcm/physics/aerosol/jam/jam_terms.py
+++ b/jcm/physics/aerosol/jam/jam_terms.py
@@ -37,6 +37,10 @@ from jcm.physics.aerosol.jam.emissions.seasalt import (
     SeaSaltEmissions,
     SeaSaltParameters,
 )
+from jcm.physics.aerosol.jam.ice_nucleation.ice_term import IceNucleation
+from jcm.physics.aerosol.jam.ice_nucleation.params import (
+    IceNucleationParameters,
+)
 from jcm.physics.aerosol.jam.microphysics.base import ModalMicrophysicsTerm
 from jcm.physics.aerosol.jam.microphysics.placeholder import (
     PlaceholderMicrophysics,
@@ -96,6 +100,8 @@ def jam_aerosol_physics(
     sulfur_gas: SulfurGasParameters | None = None,
     aqueous: AqueousSulfurParameters | None = None,
     aqueous_scheme: str = "full",
+    ice_scheme: str = "niemand",
+    ice_nucleation_params: IceNucleationParameters | None = None,
     activation: ArgParameters | None = None,
     sedimentation: SedParameters | None = None,
     drydep: DryDepParameters | None = None,
@@ -113,6 +119,9 @@ def jam_aerosol_physics(
             prescribed-oxidant + gas-phase + aqueous sulfur chemistry (#496).
         aqueous_scheme: ``"full"`` (default, HAM ``ham_wet_chemistry`` port) or
             ``"simple"`` (H2O2-limited stoichiometric oxidation).
+        ice_scheme: heterogeneous freezing scheme — ``"niemand"`` (default,
+            singular/active-site) or ``"lohmann_diehl"`` (ECHAM-HAM number-based);
+            ``ice_nucleation_params`` overrides the differentiable defaults.
         activation/sedimentation/drydep/wetdep: optional per-process
             ``Parameters`` overrides (each ``None`` resolves to its default).
 
@@ -139,6 +148,11 @@ def jam_aerosol_physics(
     optics_terms = [JamOpticsTerm(spec=spec)] if optics else []
     post_core = [
         ArgActivation(params=activation, spec=spec, variant=arg_variant),
+        # Heterogeneous ice nucleation on dust/BC → ``ice_nuclei`` for the 2M
+        # cloud scheme (#494). Harmless with the 1M scheme (diagnostic unused).
+        IceNucleation(
+            params=ice_nucleation_params, spec=spec, scheme=ice_scheme,
+        ),
         StokesSedimentation(params=sedimentation, spec=spec),
         SlinnDryDeposition(params=drydep, spec=spec),
         # In-cloud aqueous SO2 oxidation → cloud-borne sulfate; runs in the

--- a/jcm/physics/aerosol/jam/jam_terms_test.py
+++ b/jcm/physics/aerosol/jam/jam_terms_test.py
@@ -27,6 +27,7 @@ class JamFactoryTest(unittest.TestCase):
                 "aerosol_microphysics",
                 "aerosol_optics",
                 "aerosol_activation",
+                "aerosol_ice_nucleation",
                 "aerosol_sedimentation",
                 "aerosol_drydep",
                 "aerosol_aqueous_chemistry",

--- a/jcm/physics/aerosol/jam/population.py
+++ b/jcm/physics/aerosol/jam/population.py
@@ -27,6 +27,7 @@ Design notes
 from __future__ import annotations
 
 import dataclasses
+import math
 
 
 @dataclasses.dataclass(frozen=True)
@@ -84,6 +85,40 @@ class AerosolMode:
     soluble: bool
     can_activate: bool
     sediments: bool
+
+    # ------------------------------------------------------------------
+    # Geometry: per-class conversions from mass to number / surface area.
+    #
+    # These are the family-agnostic interface a process harness uses to turn
+    # a per-class dry-aerosol *volume* (mass / material-density) into a
+    # number- or area-concentration without knowing whether the class is a
+    # log-normal mode or a size bin. The modal realisation below uses the
+    # log-normal moments; a sectional class (#491) exposes the same two
+    # properties from its bin geometry, so consumers (e.g. the ice-nucleation
+    # IN populations) stay invariant to the aerosol family.
+    # ------------------------------------------------------------------
+
+    @property
+    def number_factor(self) -> float:
+        """Particle number per unit dry-aerosol volume [1/m³].
+
+        ``number = (mass / ρ_material) · number_factor``. Modal: the
+        reciprocal mean single-particle volume of the log-normal,
+        ``v_p = (π/6)·dgnum³·exp(4.5·ln²σ_g)``.
+        """
+        ln_sigma = math.log(self.geom_std_dev)
+        v_p = (math.pi / 6.0) * self.dgnum ** 3 * math.exp(4.5 * ln_sigma ** 2)
+        return 1.0 / v_p
+
+    @property
+    def area_factor(self) -> float:
+        """Particle surface area per unit dry-aerosol volume [1/m].
+
+        ``area = (mass / ρ_material) · area_factor``. Modal: the surface-area
+        moment of the log-normal, ``6/(dgnum·exp(2.5·ln²σ_g))``.
+        """
+        ln_sigma = math.log(self.geom_std_dev)
+        return 6.0 / (self.dgnum * math.exp(2.5 * ln_sigma ** 2))
 
 
 @dataclasses.dataclass(frozen=True)

--- a/jcm/physics/clouds/lohmann_2m.py
+++ b/jcm/physics/clouds/lohmann_2m.py
@@ -3048,7 +3048,8 @@ def cloud_microphysics_2m(
     layer_thickness: jnp.ndarray,   # (nlev,)  m   (dz, full-level layer depths)
     tke: jnp.ndarray,               # (nlev,)  m²/s²  turbulent kinetic energy
     activated_cdnc: jnp.ndarray,    # (nlev,)  1/m³   aerosol-activated CDNC (from MACv2-SP)
-    ice_nuclei: jnp.ndarray,        # (nlev,)  1/m³   het ice nuclei (JAM #494); 0 → DeMott floor
+    ice_nuclei: jnp.ndarray,        # (nlev,)  1/m³   immersion het INP (JAM #494); 0 → DeMott floor
+    ice_nuclei_deposition: jnp.ndarray,  # (nlev,) 1/m³  deposition INP → cirrus nucleation
     dt: jnp.ndarray,                # scalar   seconds
     params: CloudParams2M,          # tunable parameters
 ) -> tuple[MicrophysicsTendencies_2M, jnp.ndarray, jnp.ndarray]:
@@ -3214,7 +3215,7 @@ def cloud_microphysics_2m(
         deposition_rate,
         zero,                 # tompkins_genti
         zero,                 # tompkins_gentl
-        zero,                 # newly_formed_ice (cirrus scheme not plumbed)
+        ice_nuclei_deposition,  # newly_formed_ice: cirrus deposition nucleation (#494)
         q_tmp,                # specific_humidity_tmp
         qsat_tmp,             # sat_spec_humidity_tmp
         air_density,
@@ -3709,20 +3710,23 @@ class Lohmann2MMicrophysics(PhysicsTerm):
             activated_cdnc = jnp.where(arg_cdnc > 1.0, arg_cdnc, spa_floor)
 
         # Online heterogeneous ice nuclei (JAM #494); 0 where absent so the
-        # core falls back to its DeMott floor.
-        ice_nuclei = diagnostics.get(
-            "ice_nuclei", jnp.zeros_like(state.temperature)
+        # core falls back to its DeMott floor. Immersion drives the mixed-phase
+        # het freezing; deposition drives the cirrus nucleation hook.
+        zeros_2d = jnp.zeros_like(state.temperature)
+        ice_nuclei = diagnostics.get("ice_nuclei", zeros_2d)
+        ice_nuclei_deposition = diagnostics.get(
+            "ice_nuclei_deposition", zeros_2d
         )
 
         tend_all, surface_rain_flux, surface_snow_flux = jax.vmap(
             cloud_microphysics_2m,
-            in_axes=(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, None, None),
+            in_axes=(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, None, None),
             out_axes=(0, 0, 0),
         )(
             state.temperature, state.specific_humidity, pressure_full,
             qc_interim, qi_interim, qnc, qni, qr, qs,
             cloud_fraction, air_density, layer_thickness, tke,
-            activated_cdnc, ice_nuclei, dt, params_2m,
+            activated_cdnc, ice_nuclei, ice_nuclei_deposition, dt, params_2m,
         )
 
         tendency = PhysicsTendency(

--- a/jcm/physics/clouds/lohmann_2m.py
+++ b/jcm/physics/clouds/lohmann_2m.py
@@ -3048,6 +3048,7 @@ def cloud_microphysics_2m(
     layer_thickness: jnp.ndarray,   # (nlev,)  m   (dz, full-level layer depths)
     tke: jnp.ndarray,               # (nlev,)  m²/s²  turbulent kinetic energy
     activated_cdnc: jnp.ndarray,    # (nlev,)  1/m³   aerosol-activated CDNC (from MACv2-SP)
+    ice_nuclei: jnp.ndarray,        # (nlev,)  1/m³   het ice nuclei (JAM #494); 0 → DeMott floor
     dt: jnp.ndarray,                # scalar   seconds
     params: CloudParams2M,          # tunable parameters
 ) -> tuple[MicrophysicsTendencies_2M, jnp.ndarray, jnp.ndarray]:
@@ -3251,17 +3252,18 @@ def cloud_microphysics_2m(
     )
 
     # ------------------------------------------------------------------
-    # Heterogeneous mixed-phase freezing via DeMott (2010) INP
+    # Heterogeneous mixed-phase freezing INP [1/m³]
     #
-    # Replaces the ECHAM6 het_mxphase_freezing call (which needs 9 modal
-    # aerosol inputs from JAM, see #436) with a simpler INP-based
-    # parameterization that only needs temperature + prescribed total
-    # aerosol number > 0.5 μm.
+    # Prefer the online JAM heterogeneous ice nucleation (immersion+deposition
+    # on prognostic dust/BC, #494) where it is active; fall back to the DeMott
+    # (2010) parameterization on a prescribed coarse-aerosol number wherever the
+    # online source is empty (≈0) — e.g. clean air or before the JAM tracers
+    # spin up. Mirrors the ``activated_cdnc``/SPA-floor pattern for droplets.
     # ------------------------------------------------------------------
     het_condition = (temperature < params.tmelt) & (temperature >= params.cthomi)
 
-    # DeMott (2010) INP concentration [1/m³] in the mixed-phase range.
-    n_inp = demott2010_inp(temperature, params.n_aer_coarse)
+    demott_floor = demott2010_inp(temperature, params.n_aer_coarse)
+    n_inp = jnp.where(ice_nuclei > 0.0, ice_nuclei, demott_floor)
 
     # Where het freezing is active and INP > current ICNC, set ICNC to
     # INP and freeze a corresponding amount of liquid → ice.
@@ -3706,15 +3708,21 @@ class Lohmann2MMicrophysics(PhysicsTerm):
         else:
             activated_cdnc = jnp.where(arg_cdnc > 1.0, arg_cdnc, spa_floor)
 
+        # Online heterogeneous ice nuclei (JAM #494); 0 where absent so the
+        # core falls back to its DeMott floor.
+        ice_nuclei = diagnostics.get(
+            "ice_nuclei", jnp.zeros_like(state.temperature)
+        )
+
         tend_all, surface_rain_flux, surface_snow_flux = jax.vmap(
             cloud_microphysics_2m,
-            in_axes=(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, None, None),
+            in_axes=(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, None, None),
             out_axes=(0, 0, 0),
         )(
             state.temperature, state.specific_humidity, pressure_full,
             qc_interim, qi_interim, qnc, qni, qr, qs,
             cloud_fraction, air_density, layer_thickness, tke,
-            activated_cdnc, dt, params_2m,
+            activated_cdnc, ice_nuclei, dt, params_2m,
         )
 
         tendency = PhysicsTendency(

--- a/jcm/physics/echam/echam_terms.py
+++ b/jcm/physics/echam/echam_terms.py
@@ -73,6 +73,7 @@ def echam_physics(
     jam_microphysics: str = "placeholder",
     jam_arg_variant: str = "arg2000",
     jam_aqueous_scheme: str = "full",
+    jam_ice_scheme: str = "niemand",
 ):
     """Create a ``ComposablePhysics`` with the standard ECHAM term ordering.
 
@@ -116,6 +117,8 @@ def echam_physics(
         jam_microphysics: JAM core when ``aerosol_module="jam"`` —
             ``"placeholder"`` (κ-Köhler equilibrium) today; MAM4-JAX is #490.
         jam_arg_variant: ``"arg2000"`` (default) or ``"ghosh2025"`` activation.
+        jam_ice_scheme: heterogeneous ice nucleation scheme — ``"niemand"``
+            (default) or ``"lohmann_diehl"`` (drives the 2M ICNC).
         jam_aqueous_scheme: ``"full"`` (default, HAM port) or ``"simple"``
             (H2O2-limited) in-cloud aqueous sulfur chemistry.
 
@@ -196,6 +199,7 @@ def echam_physics(
         jam_terms = jam_aerosol_physics(
             microphysics=jam_microphysics, arg_variant=jam_arg_variant,
             aqueous_scheme=jam_aqueous_scheme,
+            ice_scheme=jam_ice_scheme,
         )
         # Aqueous chemistry + wet deposition need the current step's clouds, so
         # they run after the cloud microphysics term; the rest of the JAM chain


### PR DESCRIPTION
## Summary
Adds **heterogeneous ice nucleation** (immersion + deposition freezing) driven by the prognostic **dust and black-carbon** populations, feeding the 2-moment cloud scheme's ice crystal number — closing the last major aerosol issue (#494).

Two **switchable** parameterizations (`ice_scheme="niemand" | "lohmann_diehl"`), both covering immersion + deposition on dust + BC, coupled to the cloud scheme via a diagnostic **`ice_nuclei`** [m⁻³] that `Lohmann2MMicrophysics` reads — mirroring the existing `ARG → activated_cdnc` droplet pattern.

## What's added (`jcm/physics/aerosol/jam/ice_nucleation/`)
- **`in_populations.py`** — dust/BC IN **number** + **surface area**, split into a **soluble** pool (immersion) and **insoluble** pool (deposition), from the `m_du_*`/`m_bc_*` tracers + modal geometry (the analog of HAMMOZ `mo_ham_freezing.f90::get_aerofreez_nc`).
- **`niemand.py`** — singular / active-site: Niemand (2012) immersion `ns_imm(T)=exp(−0.517·(T−273.15)+8.934)` × surface area, capped by particle number, BC at a reduced efficiency; a simplified calibratable deposition active-site density rising with ice supersaturation.
- **`lohmann_diehl.py`** — ECHAM-HAM number-based: Lohmann & Diehl (2006) immersion (dust≫BC coeffs `32.3`/`2.91e-3`, `exp(T_melt−T)`, cooling-rate dependent — verbatim from HAMMOZ `mo_cloud_micro_2m.f90`) + Meyers (1992) deposition. The per-droplet liquid-volume factor of the in-cloud HAMMOZ form is folded into a documented calibration constant + the `scale` param (diagnostic frozen-number form).
- **`IceNucleation` term** — computes T, ice saturation ratio, and a TKE-updraft cooling rate; dispatches the scheme; writes `ice_nuclei`. Differentiable `IceNucleationParameters` (dust soluble fraction, BC efficiency, deposition scale, overall scale).

## Coupling
`Lohmann2MMicrophysics` now reads `ice_nuclei` and uses it for the mixed-phase het INP, **falling back to its existing DeMott (2010)-on-prescribed-number floor** wherever the online source is empty (clean air / spin-up) — exactly the `activated_cdnc`/SPA-floor pattern. Selectable via `jam_aerosol_physics(ice_scheme=...)` / `echam_physics(jam_ice_scheme=...)`; default `niemand`.

> The deposition term mainly matters for cirrus (T < ~238 K), where the 2M scheme currently does homogeneous freezing; this PR drives the **mixed-phase** het path (the dust/BC immersion the issue names). Extending the cirrus path to consume deposition INP is a natural follow-up.

## Test plan
- [x] 13 unit tests: IN populations scale with mass + solubility split; both schemes — INP rises as T drops and with ice supersaturation, dust ≫ BC, more ascent → more freezing (L&D), capped by available number, gradients finite; invalid scheme raises; factory wiring + scheme threading.
- [x] T21 aquaplanet end-to-end (jam + 2M) with **both** schemes: finite & physical, `qi`/`qni` finite (~95 s / ~54 s). Slow regression test added.
- [x] Full repo fast suite green: **1092 passed, 13 skipped** (no regression from the 2M signature change). Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)