### PR TITLE
GHG single source of truth: CO₂/N₂O from forcing, drop redundant declarations

### DIFF
--- a/jcm/forcing.py
+++ b/jcm/forcing.py
@@ -117,17 +117,24 @@ def _validate_bc_fields(ds) -> None:
 WRAP_YEAR = 0   # index by `floor(date.tyear * n_time) % n_time` — climatology mode
 BY_DATE = 1     # index by absolute time, using `time_seconds` as the lookup axis
 
-# Default scalar CO2 mixing ratio (ppmv) when no time series is supplied. 360
-# ppmv is SPEEDY's reference 1990s baseline, which the legacy `ablco2_ref`
-# constant was tuned against — keeping the default at 360 ppmv means runs that
-# do not pass a CO2 forcing reproduce SPEEDY's pre-`increase_co2` behavior.
-DEFAULT_CO2_VMR_PPMV = 360.0
+# Default scalar CO2 mixing ratio (ppmv) when no time series is supplied.
+# 420 ppmv is the value the ECHAM/RRTMGP physics was calibrated against (it was
+# previously hard-coded in ``ChemistryParameters``); SPEEDY's ``ablco2`` simply
+# scales linearly against its own reference, so this single forcing default now
+# drives every backend's CO2.
+DEFAULT_CO2_VMR_PPMV = 420.0
 
 # Default scalar CH4 mixing ratio (ppmv) when no time series is supplied.
 # 1.9 ppmv ≈ early-2020s tropospheric mean (CH4 has roughly doubled since
 # pre-industrial); previously hardcoded inside ``EchamBoundaryConditions``
 # as ``1900.0e-3`` ppmv. Issue #347.
 DEFAULT_CH4_VMR_PPMV = 1.9
+
+# Default scalar N2O mixing ratio (ppmv) when no time series is supplied.
+# 0.327 ppmv (327 ppbv) matches the value RRTMGP previously took from its
+# ``vmr_global_means.json`` fallback, so prescribing N2O from the forcing here
+# preserves the calibrated radiative effect while removing the silent fallback.
+DEFAULT_N2O_VMR_PPMV = 0.327
 
 
 # ---------------------------------------------------------------------------
@@ -206,6 +213,11 @@ class ForcingData:
     # ``EchamBoundaryConditions``; promoted to forcing in #347.
     ch4_vmr: jnp.ndarray
 
+    # N2O volume mixing ratio (ppmv). Scalar for fixed-N2O runs; TimeSeries for
+    # historical / scenario forcing. Prescribed here so RRTMGP no longer falls
+    # back silently to its ``vmr_global_means.json`` value.
+    n2o_vmr: jnp.ndarray
+
     # Aerosol temporal forcing (MACv2-SP plume weights). Today these are
     # placeholder 1-D `(nplumes,)` arrays; the multi-axis version will land
     # in the MACv2-SP fix PR (#437).
@@ -264,6 +276,7 @@ class ForcingData:
               solar=None,
               ozone_climatology=None,
               ch4_vmr=None,
+              n2o_vmr=None,
               nplumes=9):
         # Land + SST temperatures default to ~15 °C — a sensible global
         # mean surface temperature — so that ``ForcingData.zeros(...)``
@@ -280,6 +293,7 @@ class ForcingData:
             sea_surface_temperature=sea_surface_temperature if sea_surface_temperature is not None else jnp.full(nodal_shape, T_default),
             co2_vmr=co2_vmr if co2_vmr is not None else jnp.array(DEFAULT_CO2_VMR_PPMV),
             ch4_vmr=ch4_vmr if ch4_vmr is not None else jnp.array(DEFAULT_CH4_VMR_PPMV),
+            n2o_vmr=n2o_vmr if n2o_vmr is not None else jnp.array(DEFAULT_N2O_VMR_PPMV),
             aerosol_year_weight=aerosol_year_weight if aerosol_year_weight is not None else jnp.ones(nplumes),
             aerosol_ann_cycle=aerosol_ann_cycle if aerosol_ann_cycle is not None else jnp.ones(nplumes),
             solar=solar if solar is not None else SolarGeometry.zero(),
@@ -298,6 +312,7 @@ class ForcingData:
              solar=None,
              ozone_climatology=None,
              ch4_vmr=None,
+             n2o_vmr=None,
              nplumes=9):
         return cls(
             alb0=alb0 if alb0 is not None else jnp.ones((nodal_shape)),
@@ -308,6 +323,7 @@ class ForcingData:
             sea_surface_temperature=sea_surface_temperature if sea_surface_temperature is not None else jnp.ones((nodal_shape)),
             co2_vmr=co2_vmr if co2_vmr is not None else jnp.array(DEFAULT_CO2_VMR_PPMV),
             ch4_vmr=ch4_vmr if ch4_vmr is not None else jnp.array(DEFAULT_CH4_VMR_PPMV),
+            n2o_vmr=n2o_vmr if n2o_vmr is not None else jnp.array(DEFAULT_N2O_VMR_PPMV),
             aerosol_year_weight=aerosol_year_weight if aerosol_year_weight is not None else jnp.ones(nplumes),
             aerosol_ann_cycle=aerosol_ann_cycle if aerosol_ann_cycle is not None else jnp.ones(nplumes),
             solar=solar if solar is not None else SolarGeometry.zero(),
@@ -459,6 +475,7 @@ class ForcingData:
              solar=None,
              ozone_climatology=None,
              ch4_vmr=None,
+             n2o_vmr=None,
              nudging_target=_UNSET,
              dms_seawater=None,
              dust_source=None,
@@ -477,6 +494,7 @@ class ForcingData:
             sea_surface_temperature=sea_surface_temperature if sea_surface_temperature is not None else self.sea_surface_temperature,
             co2_vmr=co2_vmr if co2_vmr is not None else self.co2_vmr,
             ch4_vmr=ch4_vmr if ch4_vmr is not None else self.ch4_vmr,
+            n2o_vmr=n2o_vmr if n2o_vmr is not None else self.n2o_vmr,
             aerosol_year_weight=aerosol_year_weight if aerosol_year_weight is not None else self.aerosol_year_weight,
             aerosol_ann_cycle=aerosol_ann_cycle if aerosol_ann_cycle is not None else self.aerosol_ann_cycle,
             solar=solar if solar is not None else self.solar,

--- a/jcm/forcing.py
+++ b/jcm/forcing.py
@@ -450,21 +450,29 @@ class ForcingData:
         # Prescribed SSTs
         sea_surface_temperature = _ts(ds["sst"])
 
-        # Optional CO2: if the netCDF includes it, treat as a scalar (per-time)
-        # series; otherwise keep the default scalar from `ForcingData.zeros`.
-        co2_vmr = None
-        if "co2" in ds.data_vars:
-            co2_arr = jnp.asarray(ds["co2"])
-            if co2_arr.ndim == 0:
-                co2_vmr = co2_arr
-            else:
-                co2_vmr = make_time_series(co2_arr, time_seconds, align_mode=resolved_align_mode)
+        # Optional well-mixed GHG scalars (CO2/CH4/N2O): if the netCDF includes
+        # one, treat it as a scalar (per-time) series; otherwise keep the default
+        # from `ForcingData.zeros`. Radiation reads CO2 and N2O straight from the
+        # forcing (and CH4 via the chemistry seed), so reading every prescribed
+        # gas here — not just CO2 — is what lets a scenario file actually drive
+        # them rather than silently fall back to the default.
+        def _optional_ghg(name):
+            if name not in ds.data_vars:
+                return None
+            arr = jnp.asarray(ds[name])
+            if arr.ndim == 0:
+                return arr
+            return make_time_series(arr, time_seconds, align_mode=resolved_align_mode)
+
+        co2_vmr = _optional_ghg("co2")
+        ch4_vmr = _optional_ghg("ch4")
+        n2o_vmr = _optional_ghg("n2o")
 
         return cls.zeros(
             nodal_shape=alb0.shape,
             alb0=alb0, sice_am=sice_am, snowc_am=snowc_am, stl_am=stl_am,
             soilw_am=soilw_am, sea_surface_temperature=sea_surface_temperature,
-            co2_vmr=co2_vmr,
+            co2_vmr=co2_vmr, ch4_vmr=ch4_vmr, n2o_vmr=n2o_vmr,
         )
 
     def copy(self,alb0=None,

--- a/jcm/forcing_test.py
+++ b/jcm/forcing_test.py
@@ -442,6 +442,39 @@ class TestForcingDataFromFile(unittest.TestCase):
 class TestForcingDataFromFileValidation(unittest.TestCase):
     """Tests for ForcingData.from_file validation logic using mock files."""
 
+    def test_from_dataset_reads_prescribed_ghgs(self):
+        """CO2/CH4/N2O present in a forcing file must be read, not defaulted.
+
+        Regression for the silent fallback flagged on the GHG single-source PR:
+        ``from_dataset`` previously special-cased only CO2, so N2O (and CH4) in a
+        scenario file were ignored and radiation used the constant default.
+        """
+        import pandas as pd
+        import xarray as xr
+
+        valid_shape = (96, 48)  # T31
+        n_times = 12
+        times = pd.date_range("1990-01-01", periods=n_times, freq="MS")
+        ds = xr.Dataset(
+            data_vars={
+                'stl': (['lon', 'lat', 'time'], np.full((*valid_shape, n_times), 280.0)),
+                'icec': (['lon', 'lat', 'time'], np.zeros((*valid_shape, n_times))),
+                'sst': (['lon', 'lat', 'time'], np.full((*valid_shape, n_times), 290.0)),
+                'alb': (['lon', 'lat'], np.full(valid_shape, 0.1)),
+                'soilw_am': (['lon', 'lat', 'time'], np.zeros((*valid_shape, n_times))),
+                'snowc': (['lon', 'lat', 'time'], np.zeros((*valid_shape, n_times))),
+                # Scalars distinct from every default (CO2 420, CH4 1.9, N2O 0.327).
+                'co2': 700.0,
+                'ch4': 2.5,
+                'n2o': 0.5,
+            },
+            coords={'time': times},
+        )
+        forcing = ForcingData.from_dataset(ds, validate=False)
+        self.assertAlmostEqual(float(forcing.co2_vmr), 700.0)
+        self.assertAlmostEqual(float(forcing.ch4_vmr), 2.5)
+        self.assertAlmostEqual(float(forcing.n2o_vmr), 0.5)
+
     def test_from_file_validates_nodal_shape(self):
         """from_file should reject invalid nodal shapes when coords is None."""
         import xarray as xr

--- a/jcm/physics/chemistry/simple_chemistry.py
+++ b/jcm/physics/chemistry/simple_chemistry.py
@@ -23,15 +23,15 @@ class ChemistryParameters:
     ozone_tropopause_height: float # Height of ozone maximum (m)
     ozone_stratosphere_coeff: float # Stratospheric ozone coefficient
     
-    # Methane parameters  
+    # Methane parameters
     methane_surface_vmr: float     # Surface methane VMR (ppbv)
     methane_lifetime: float        # Methane lifetime (s)
     methane_oh_scaling: float      # OH scaling factor
-    
-    # CO2 parameters
-    co2_vmr: float                 # CO2 volume mixing ratio (ppmv)
-    co2_growth_rate: float         # CO2 growth rate (ppmv/year)
-    
+
+    # NB: there is deliberately no CO2 parameter here. CO2 is a prescribed
+    # forcing (``forcing.co2_vmr``), read straight from there by radiation; the
+    # chemistry scheme never redeclares it.
+
     @classmethod
     def default(cls) -> 'ChemistryParameters':
         """Return default chemistry parameters"""
@@ -43,8 +43,6 @@ class ChemistryParameters:
             methane_surface_vmr=jnp.array(1900.0),     # 1.9 ppmv
             methane_lifetime=jnp.array(9.0 * 365.25 * 24 * 3600), # 9 years
             methane_oh_scaling=jnp.array(1.0),
-            co2_vmr=jnp.array(420.0),                   # 420 ppmv
-            co2_growth_rate=jnp.array(2.5)             # 2.5 ppmv/year
         )
 
 
@@ -54,8 +52,7 @@ class ChemistryState(NamedTuple):
     # Gas concentrations (volume mixing ratios)
     ozone_vmr: jnp.ndarray          # Ozone VMR (ppbv)
     methane_vmr: jnp.ndarray        # Methane VMR (ppbv)
-    co2_vmr: jnp.ndarray           # CO2 VMR (ppmv)
-    
+
     # Production/loss rates
     ozone_production: jnp.ndarray   # Ozone production rate (ppbv/s)
     ozone_loss: jnp.ndarray        # Ozone loss rate (ppbv/s)
@@ -68,25 +65,24 @@ class ChemistryTendencies(NamedTuple):
     # Trace gas tendencies (mixing ratio per second)
     ozone_tend: jnp.ndarray         # Ozone tendency (ppbv/s)
     methane_tend: jnp.ndarray       # Methane tendency (ppbv/s)
-    co2_tend: jnp.ndarray          # CO2 tendency (ppmv/s)
 
 
 @tree_math.struct
 class ChemistryData:
     """Diagnostic sub-struct for the chemistry diagnostic-dict slot.
 
-    Seeded by ``EchamBoundaryConditions`` (which fills CO2/CH4/O3 VMRs
-    from forcing) and consumed by the radiation terms; the
+    Seeded by ``EchamBoundaryConditions`` (which fills the CH4/O3 VMRs, CH4
+    from ``forcing.ch4_vmr``) and consumed by the radiation terms; the
     ``SimpleChemistry`` term also writes its production/loss diagnostics
-    here. Lives next to the chemistry scheme so a future replacement
-    chemistry term can extend or replace this struct without reaching
-    into the ECHAM tree.
+    here. CO2 is NOT carried here — it is a prescribed forcing read directly
+    from ``forcing.co2_vmr`` by radiation. Lives next to the chemistry scheme so
+    a future replacement chemistry term can extend or replace this struct
+    without reaching into the ECHAM tree.
     """
 
     # Gas concentrations (volume mixing ratios)
     ozone_vmr: jnp.ndarray           # Ozone VMR [ppbv] (nlev, ncols)
     methane_vmr: jnp.ndarray         # Methane VMR [ppbv] (nlev, ncols)
-    co2_vmr: jnp.ndarray            # CO2 VMR [ppmv] (nlev, ncols)
 
     # Production/loss rates
     ozone_production: jnp.ndarray    # Ozone production rate [ppbv/s] (nlev, ncols)
@@ -113,7 +109,6 @@ class ChemistryData:
         return cls(
             ozone_vmr=jnp.zeros(column_shape),
             methane_vmr=jnp.zeros(column_shape),
-            co2_vmr=jnp.zeros(column_shape),
             ozone_production=jnp.zeros(column_shape),
             ozone_loss=jnp.zeros(column_shape),
             methane_loss=jnp.zeros(column_shape),
@@ -125,7 +120,6 @@ class ChemistryData:
         new_data = {
             'ozone_vmr': self.ozone_vmr,
             'methane_vmr': self.methane_vmr,
-            'co2_vmr': self.co2_vmr,
             'ozone_production': self.ozone_production,
             'ozone_loss': self.ozone_loss,
             'methane_loss': self.methane_loss,
@@ -288,23 +282,17 @@ def simple_chemistry(
         pressure, temperature, current_methane, dt, config
     )
     methane_tendency = -methane_loss
-    
-    # CO2 is fixed (no tendency)
-    co2_tendency = jnp.zeros_like(current_ozone)
-    co2_vmr = jnp.ones_like(current_ozone) * config.co2_vmr
-    
+
     # Create tendencies
     tendencies = ChemistryTendencies(
         ozone_tend=ozone_tendency,
         methane_tend=methane_tendency,
-        co2_tend=co2_tendency
     )
-    
+
     # Create state
     state = ChemistryState(
         ozone_vmr=current_ozone,
         methane_vmr=current_methane,
-        co2_vmr=co2_vmr,
         ozone_production=jnp.maximum(ozone_tendency, 0.0),
         ozone_loss=jnp.maximum(-ozone_tendency, 0.0),
         methane_loss=methane_loss
@@ -345,14 +333,10 @@ def initialize_chemistry_tracers(
     # Higher concentration at surface, decreasing with height
     height = compute_height_from_pressure(pressure, surface_pressure, temperature)
     methane_vmr = config.methane_surface_vmr * jnp.exp(-height / 8000.0)  # 8 km scale height
-    
-    # Initialize CO2 as constant
-    co2_vmr = jnp.ones((nlev, ncols)) * config.co2_vmr
 
     return ChemistryState(
         ozone_vmr=ozone_vmr,
         methane_vmr=methane_vmr,
-        co2_vmr=co2_vmr,
         ozone_production=jnp.zeros((nlev, ncols)),
         ozone_loss=jnp.zeros((nlev, ncols)),
         methane_loss=jnp.zeros((nlev, ncols))
@@ -426,7 +410,6 @@ class SimpleChemistry(PhysicsTerm):
         chemistry = chemistry.copy(
             ozone_vmr=new_state.ozone_vmr,
             methane_vmr=new_state.methane_vmr,
-            co2_vmr=new_state.co2_vmr,
             ozone_production=new_state.ozone_production,
             ozone_loss=new_state.ozone_loss,
             methane_loss=new_state.methane_loss,

--- a/jcm/physics/chemistry/simple_chemistry_test.py
+++ b/jcm/physics/chemistry/simple_chemistry_test.py
@@ -23,17 +23,15 @@ class TestChemistryParameters(TestCase):
         """Test default parameter creation"""
         config = ChemistryParameters.default()
         
-        # Check that all parameters are positive
+        # Check that all parameters are positive (CO2 is a prescribed forcing,
+        # not a chemistry parameter — see ForcingData.co2_vmr).
         self.assertGreater(config.ozone_scale_height, 0)
         self.assertGreater(config.ozone_max_vmr, 0)
         self.assertGreater(config.methane_surface_vmr, 0)
-        self.assertGreater(config.co2_vmr, 0)
-        
+
         # Check reasonable values
         self.assertGreater(config.ozone_max_vmr, 1000.0)  # > 1 ppmv
         self.assertLess(config.ozone_max_vmr, 20000.0)    # < 20 ppmv
-        self.assertGreater(config.co2_vmr, 300.0)         # > 300 ppmv
-        self.assertLess(config.co2_vmr, 1000.0)           # < 1000 ppmv
 
 
 class TestOzoneDistribution(TestCase):
@@ -132,10 +130,7 @@ class TestFullChemistry(TestCase):
         
         # Check that methane tendency is negative (loss)
         self.assertTrue(jnp.all(tendencies.methane_tend <= 0))
-        
-        # Check that CO2 is constant
-        self.assertTrue(jnp.all(tendencies.co2_tend == 0))
-        
+
     def test_chemistry_initialization(self):
         """Test chemistry tracer initialization"""
         config = ChemistryParameters.default()
@@ -150,18 +145,16 @@ class TestFullChemistry(TestCase):
             pressure, surface_pressure, temperature, config
         )
         
-        # Check output shapes
+        # Check output shapes (CO2 is not a chemistry field — it is a
+        # prescribed forcing).
         self.assertEqual(state.ozone_vmr.shape, (nlev, ncols))
         self.assertEqual(state.methane_vmr.shape, (nlev, ncols))
-        self.assertEqual(state.co2_vmr.shape, (nlev, ncols))
-        
+
         # Check all values are positive and finite
         self.assertTrue(jnp.all(state.ozone_vmr > 0))
         self.assertTrue(jnp.all(state.methane_vmr > 0))
-        self.assertTrue(jnp.all(state.co2_vmr > 0))
         self.assertTrue(jnp.all(jnp.isfinite(state.ozone_vmr)))
         self.assertTrue(jnp.all(jnp.isfinite(state.methane_vmr)))
-        self.assertTrue(jnp.all(jnp.isfinite(state.co2_vmr)))
         
         # Check that methane decreases with height
         self.assertGreater(state.methane_vmr[0, 0], state.methane_vmr[-1, 0])

--- a/jcm/physics/echam/chemistry_integration_test.py
+++ b/jcm/physics/echam/chemistry_integration_test.py
@@ -73,15 +73,12 @@ class TestChemistryIntegration(TestCase):
         # Check that methane is initialized
         self.assertTrue(jnp.all(physics_data["chemistry"].methane_vmr > 0))
         self.assertTrue(jnp.all(physics_data["chemistry"].methane_vmr < 5000))  # Less than 5 ppmv
-        
-        # Check that CO2 is initialized
-        self.assertTrue(jnp.all(physics_data["chemistry"].co2_vmr > 300))
-        self.assertTrue(jnp.all(physics_data["chemistry"].co2_vmr < 1000))  # Between 300-1000 ppmv
-        
+
+        # CO2 is a prescribed forcing (forcing.co2_vmr), not a chemistry field.
+
         # Check shapes - chemistry data should have valid array shapes
         self.assertTrue(physics_data["chemistry"].ozone_vmr.shape != ())
         self.assertTrue(physics_data["chemistry"].methane_vmr.shape != ())
-        self.assertTrue(physics_data["chemistry"].co2_vmr.shape != ())
     
     def test_chemistry_evolution(self):
         """Test that chemistry tracers evolve over time"""

--- a/jcm/physics/forcing/echam_boundary_conditions.py
+++ b/jcm/physics/forcing/echam_boundary_conditions.py
@@ -166,9 +166,11 @@ class EchamBoundaryConditions(PhysicsTerm):
         surface_temperature = surface_temperature.reshape(ncols)
         roughness_length = roughness_length.reshape(ncols)
 
-        # CO2 and CH4 both come from ``ForcingData`` (#347). Defaults are
-        # 360 ppmv (CO2) and 1.9 ppmv (CH4) — the legacy hardcoded values.
-        co2_vmr_value = forcing.co2_vmr
+        # CH4 comes from ``ForcingData`` (#347) and seeds the chemistry
+        # diagnostic (where the methane-loss scheme evolves it). CO2 is *not*
+        # seeded here: it is a prescribed forcing read straight from
+        # ``forcing.co2_vmr`` by radiation, so the chemistry diagnostic never
+        # carries it.
         ch4_vmr_value = forcing.ch4_vmr
 
         # O3: prefer the realistic CMIP6/ECHAM-style climatology carried
@@ -204,8 +206,6 @@ class EchamBoundaryConditions(PhysicsTerm):
                 methane_surface_vmr=defaults.methane_surface_vmr,
                 methane_lifetime=defaults.methane_lifetime,
                 methane_oh_scaling=defaults.methane_oh_scaling,
-                co2_vmr=defaults.co2_vmr,
-                co2_growth_rate=defaults.co2_growth_rate,
             )
             ozone_vmr_ppmv = fixed_ozone_distribution(
                 pressure=diagnostics["pressure_full"],
@@ -234,7 +234,6 @@ class EchamBoundaryConditions(PhysicsTerm):
             "chemistry", ChemistryData.zeros((ncols,), nlev),
         )
         chemistry = chemistry_zero.copy(
-            co2_vmr=jnp.ones_like(chemistry_zero.co2_vmr) * co2_vmr_value,
             methane_vmr=jnp.ones_like(chemistry_zero.methane_vmr)
             * ch4_vmr_value,
             ozone_vmr=ozone_vmr_ppmv,

--- a/jcm/physics/radiation/grey_two_stream/radiation_scheme.py
+++ b/jcm/physics/radiation/grey_two_stream/radiation_scheme.py
@@ -692,9 +692,10 @@ class GreyTwoStreamRadiation(PhysicsTerm):
         )
 
         chemistry = diagnostics["chemistry"]
-        # Convert ppmv → VMR. CO2 is well-mixed; pass as scalar.
+        # Convert ppmv → mole fraction. Ozone is a chemistry field; CO2 is a
+        # prescribed forcing read straight from ForcingData (well-mixed scalar).
         ozone_vmr = chemistry.ozone_vmr * 1e-6
-        co2_vmr = jnp.mean(chemistry.co2_vmr) * 1e-6
+        co2_vmr = forcing.co2_vmr * 1e-6
 
         # Surface temperature still lives in the legacy "surface" key
         # (until the EchamSurface migration); the radiation surface

--- a/jcm/physics/radiation/grey_two_stream/radiation_scheme_test.py
+++ b/jcm/physics/radiation/grey_two_stream/radiation_scheme_test.py
@@ -340,7 +340,6 @@ def test_radiation_scheme_custom_parameters():
         n_lw_bands=4,
         lw_band_limits=((10, 250), (250, 350), (350, 500), (500, 2500)),  # 4 LW bands
         sw_band_limits=((4000, 10000), (10000, 14500), (14500, 50000)),   # 3 SW bands
-        co2_vmr=500e-6         # Higher CO2
     )
     
     # Create aerosol data for custom parameters
@@ -364,7 +363,8 @@ def test_radiation_scheme_custom_parameters():
         surface_albedo_nir=jnp.array([0.2]),
         surface_albedo_vis=jnp.array([0.2]),
         surface_emissivity=jnp.array([0.95]),
-        surface_temperature=jnp.array([288.0])
+        surface_temperature=jnp.array([288.0]),
+        co2_vmr=500e-6,         # Higher CO2 (passed to the scheme, not parameters)
     )
 
     # The grey scheme hardcodes 2 SW / 3 LW bands internally regardless of

--- a/jcm/physics/radiation/nn_emulator_scheme.py
+++ b/jcm/physics/radiation/nn_emulator_scheme.py
@@ -294,7 +294,8 @@ class NNEmulatorRadiation(PhysicsTerm):
 
         chemistry = diagnostics["chemistry"]
         ozone_vmr = chemistry.ozone_vmr * 1e-6
-        co2_vmr = jnp.mean(chemistry.co2_vmr) * 1e-6
+        # CO2 is a prescribed forcing read straight from ForcingData.
+        co2_vmr = forcing.co2_vmr * 1e-6
 
         surface_temperature_col = (
             diagnostics["surface"].surface_temperature.reshape(ncols)

--- a/jcm/physics/radiation/radiation_types.py
+++ b/jcm/physics/radiation/radiation_types.py
@@ -41,10 +41,10 @@ class RadiationParameters:
     lw_band_limits: tuple    # LW bands
     sw_band_limits: tuple    # SW bands
 
-    # Gas concentrations (volume mixing ratios)
-    co2_vmr: float           # CO2 volume mixing ratio
-    ch4_vmr: float           # CH4 volume mixing ratio
-    n2o_vmr: float           # N2O volume mixing ratio
+    # NB: greenhouse-gas concentrations (CO2/CH4/N2O) are NOT stored here.
+    # CO2 and N2O come from ``ForcingData`` and CH4/O3 from the chemistry
+    # diagnostic — see the gas-sourcing note in ``rrtmgp.py``. Radiation never
+    # redeclares a GHG concentration.
 
     # Numerical parameters
     min_cos_zenith: float    # Minimum cosine solar zenith angle (~88 deg)
@@ -73,7 +73,6 @@ class RadiationParameters:
                  n_sw_bands=N_SW_BANDS, n_lw_bands=N_LW_BANDS,
                  lw_band_limits=LW_BAND_LIMITS,
                  sw_band_limits=SW_BAND_LIMITS,
-                 co2_vmr=400e-6, ch4_vmr=1.8e-6, n2o_vmr=0.32e-6,
                  min_cos_zenith=0.035, flux_epsilon=1e-6,
                  cld_tau_min=1e-6, cld_frac_min=1e-3,
                  cloud_overlap=2, cloud_decorrelation_km=2.0,
@@ -87,9 +86,6 @@ class RadiationParameters:
             n_lw_bands=jnp.asarray(n_lw_bands),
             lw_band_limits=jnp.asarray(lw_band_limits),
             sw_band_limits=jnp.asarray(sw_band_limits),
-            co2_vmr=jnp.array(co2_vmr),
-            ch4_vmr=jnp.array(ch4_vmr),
-            n2o_vmr=jnp.array(n2o_vmr),
             min_cos_zenith=jnp.array(min_cos_zenith),
             flux_epsilon=jnp.array(flux_epsilon),
             cld_tau_min=jnp.array(cld_tau_min),

--- a/jcm/physics/radiation/rrtmgp.py
+++ b/jcm/physics/radiation/rrtmgp.py
@@ -398,6 +398,7 @@ def radiation_scheme_rrtmgp(
     ozone_vmr: Optional[jnp.ndarray] = None,
     co2_vmr: Optional[jnp.ndarray] = None,
     ch4_vmr: Optional[jnp.ndarray] = None,
+    n2o_vmr: Optional[jnp.ndarray] = None,
 ) -> Tuple[RadiationTendencies, RadiationData]:
     """RRTMGP radiation scheme — canonical McICA partial-cloud treatment.
 
@@ -556,6 +557,12 @@ def radiation_scheme_rrtmgp(
     if ch4_vmr is not None:
         vmr_fields["ch4"] = _to_3d_with_filled_halo(
             jnp.broadcast_to(ch4_vmr, (nlev,)), nlev, halo,
+        )
+    if n2o_vmr is not None:
+        # Prescribed from ``forcing.n2o_vmr``; overrides RRTMGP's
+        # ``vmr_global_means.json`` fallback for N2O.
+        vmr_fields["n2o"] = _to_3d_with_filled_halo(
+            jnp.broadcast_to(n2o_vmr, (nlev,)), nlev, halo,
         )
 
     # Per-SW-band aerosol optics (Stevens 2017 wavelength scaling, jax-
@@ -803,10 +810,17 @@ class RRTMGPRadiation(PhysicsTerm):
             state, diagnostics,
         )
 
+        # Greenhouse-gas sourcing (all converted ppmv -> mole fraction here):
+        #   O3, CH4  <- the chemistry diagnostic (O3 analytic/climatology; CH4
+        #               forcing-seeded then evolved by the methane-loss scheme)
+        #   CO2, N2O <- prescribed forcings read straight from ForcingData
+        # Radiation never reads a GHG concentration from its own parameters, and
+        # never lets a value be silently redeclared.
         chemistry = diagnostics["chemistry"]
         ozone_vmr = chemistry.ozone_vmr * 1e-6     # (nlev, ncols)
-        co2_vmr = chemistry.co2_vmr * 1e-6         # (nlev, ncols)
         ch4_vmr = chemistry.methane_vmr * 1e-6     # (nlev, ncols)
+        co2_vmr = forcing.co2_vmr * 1e-6           # scalar
+        n2o_vmr = forcing.n2o_vmr * 1e-6           # scalar
 
         surface_temperature_col = (
             diagnostics["surface"].surface_temperature.reshape(ncols)
@@ -878,6 +892,7 @@ class RRTMGPRadiation(PhysicsTerm):
             ozone_vmr=lev_to_col(ozone_vmr),
             co2_vmr=lev_to_col(jnp.broadcast_to(co2_vmr, (nlev, ncols))),
             ch4_vmr=lev_to_col(jnp.broadcast_to(ch4_vmr, (nlev, ncols))),
+            n2o_vmr=lev_to_col(jnp.broadcast_to(n2o_vmr, (nlev, ncols))),
         )
 
         # We tried a day/night split here (solve the dark ~half LW-only, skip
@@ -894,7 +909,7 @@ class RRTMGPRadiation(PhysicsTerm):
                 None, 0, 0,
                 None, 0,
                 0, None, None, None,  # col_index, model_step, base_seed, cre
-                0, 0, 0,              # ozone_vmr, co2_vmr, ch4_vmr
+                0, 0, 0, 0,          # ozone_vmr, co2_vmr, ch4_vmr, n2o_vmr
             ),
             out_axes=(0, 0),
         )(
@@ -907,7 +922,7 @@ class RRTMGPRadiation(PhysicsTerm):
             solar, cols["latitudes"], cols["longitudes"],
             params, cols["aerosol"], cols["column_indices"],
             model_step, base_seed, compute_cre,
-            cols["ozone_vmr"], cols["co2_vmr"], cols["ch4_vmr"],
+            cols["ozone_vmr"], cols["co2_vmr"], cols["ch4_vmr"], cols["n2o_vmr"],
         )
 
         # Per-gpoint flux profiles are summed over g-points inside the


### PR DESCRIPTION
## Summary

Establishes a **single source of truth per prescribed greenhouse gas** and stops the radiation terms from reading GHG concentrations out of their own parameters. Fixes a silent-ignore bug where `forcing.co2_vmr` was discarded in the ECHAM path.

## The bug

In `echam_physics`, the term order is `EchamBoundaryConditions … SimpleChemistry … radiation`. `EchamBoundaryConditions` seeds `chemistry.co2_vmr` from `forcing.co2_vmr`, but `SimpleChemistry` then **overwrites** it with its hardcoded `ChemistryParameters.co2_vmr` (420 ppmv) before radiation reads it. So **every CO₂ forcing — historical, scenario, 2×CO₂ sensitivity — was silently discarded**; the model always used 420 ppmv.

```
Full echam:  forcing.co2_vmr = 1000  →  radiation saw 420   ❌  (before)
```

Two related redundancies: `RadiationParameters.{co2,ch4,n2o}_vmr` were never read by any term (dead config — setting them did nothing), and N₂O fell back silently to `vmr_global_means.json`.

## Resolution — one source of truth per gas

| gas | source | notes |
|---|---|---|
| **CO₂** | `forcing.co2_vmr` | prescribed scalar; read straight by radiation |
| **N₂O** | `forcing.n2o_vmr` (**new**) | was a silent file fallback |
| **CH₄** | `chemistry.methane_vmr` | forcing-seeded, methane-loss evolved |
| **O₃** | `chemistry.ozone_vmr` | genuine chemistry field |

The sourcing is documented at each read site.

## Changes
- **`forcing.py`**: add `ForcingData.n2o_vmr` (default **0.327 ppmv** = RRTMGP's prior global-means value, so behaviour is preserved); `DEFAULT_CO2_VMR_PPMV` **360 → 420** (the calibrated value, now the single forcing default for every backend).
- **`RadiationParameters`**: delete the dead `co2_vmr`/`ch4_vmr`/`n2o_vmr` fields.
- **`SimpleChemistry` / `ChemistryData` / `ChemistryParameters`**: drop CO₂ entirely (it's a prescribed forcing, never a chemistry quantity).
- **`EchamBoundaryConditions`**: stop seeding `chemistry.co2_vmr`.
- **rrtmgp / grey / nn terms**: read CO₂ from forcing; RRTMGP also reads N₂O from forcing and passes it as a `vmr_field` (overriding the global-means fallback).

## Verification
- CO₂ and N₂O forcing now **move OLR** (the knobs are live): grey OLR co2=0→149.2, co2=2000→134.8; RRTMGP OLR n2o=0→180.2, n2o=2.0→176.2.
- The chemistry diagnostic no longer carries CO₂.
- forcing / chemistry / chemistry-integration / SPEEDY-forcing / RRTMGP / nn / grey radiation / model tests pass (**183 passed**, 1 skipped).

## Blast radius for reviewers ⚠️
- **CO₂ default 360 → 420.** ECHAM was *already effectively* 420 (the bug), so its radiation is unchanged for default runs. **SPEEDY's** default CO₂ shifts 360 → 420 (it reads the same forcing field); the SPEEDY co2/forcing tests pass, but this changes SPEEDY's default-run radiation — flagging in case a baseline needs regenerating.
- **N₂O** is now prescribed from forcing at the same value RRTMGP used from the file, so RRTMGP is unchanged at the default; setting `forcing.n2o_vmr` now actually does something.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh7V9oyDQtFpHao5cogjzf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh7V9oyDQtFpHao5cogjzf)_