### PR TITLE
feat(convection): surface applied convective heating & moistening diagnostics

### DIFF
--- a/jcm/physics/convection/tiedtke_nordeng/tiedtke_nordeng.py
+++ b/jcm/physics/convection/tiedtke_nordeng/tiedtke_nordeng.py
@@ -181,6 +181,16 @@ class ConvectionData:
     precip_conv: jnp.ndarray         # Convective precipitation [kg/m²/s] (ncols,)
     qc_conv: jnp.ndarray             # Convective cloud water [kg/kg] (nlev, ncols)
     qi_conv: jnp.ndarray             # Convective cloud ice [kg/kg] (nlev, ncols)
+    # Convective heating / moistening rates actually applied to the column
+    # (post-cap; see the ``_DTDT_MAX`` limiter in ``TiedtkeConvection``). These
+    # are the genuine per-level convective tendencies — the thing that balances
+    # radiative cooling in an RCE column — exposed as first-class diagnostics so
+    # they ride the saved trajectory exactly like ``RadiationData``'s
+    # ``sw_heating_rate`` / ``lw_heating_rate``, rather than being recoverable
+    # only by re-running the term. ``heating_rate`` mirrors the radiation naming
+    # convention ([K/s]); ``moistening_rate`` is its specific-humidity analog.
+    heating_rate: jnp.ndarray        # Convective heating rate [K/s] (nlev, ncols)
+    moistening_rate: jnp.ndarray     # Convective moistening rate [kg/kg/s] (nlev, ncols)
 
     @classmethod
     def zeros(cls, nodal_shape, nlev):
@@ -194,6 +204,8 @@ class ConvectionData:
             precip_conv=jnp.zeros(nodal_shape),
             qc_conv=jnp.zeros((nlev,) + nodal_shape),
             qi_conv=jnp.zeros((nlev,) + nodal_shape),
+            heating_rate=jnp.zeros((nlev,) + nodal_shape),
+            moistening_rate=jnp.zeros((nlev,) + nodal_shape),
         )
 
 
@@ -1093,7 +1105,11 @@ class TiedtkeConvection(PhysicsTerm):
         # Mass-flux / cloud-base/top / CAPE diagnostics aren't populated
         # by the wrapper today (the scheme returns the per-column state
         # but we don't reduce or surface it yet) — they stay as zeros
-        # for back-compat with existing xarray field names.
+        # for back-compat with existing xarray field names. The heating /
+        # moistening rates, by contrast, are the *applied* (post-cap)
+        # tendencies returned above, surfaced so downstream analysis (e.g.
+        # an RCE convective-vs-radiative heating balance) reads them straight
+        # off the trajectory instead of re-running the term.
         convection = ConvectionData(
             mass_flux_up=jnp.zeros_like(pressure_full),
             mass_flux_down=jnp.zeros_like(pressure_full),
@@ -1103,6 +1119,8 @@ class TiedtkeConvection(PhysicsTerm):
             precip_conv=tendencies_all.precip_conv,
             qc_conv=tendencies_all.qc_conv.T,
             qi_conv=tendencies_all.qi_conv.T,
+            heating_rate=tendency.temperature,
+            moistening_rate=tendency.specific_humidity,
         )
 
         clouds = diagnostics["clouds"].copy(

--- a/jcm/physics/convection/tiedtke_nordeng/tiedtke_nordeng_test.py
+++ b/jcm/physics/convection/tiedtke_nordeng/tiedtke_nordeng_test.py
@@ -152,6 +152,84 @@ def test_wrapper_advances_cloud_diagnostics_for_downstream_microphysics(monkeypa
     assert jnp.allclose(diagnostics_out["convection"].qc_conv, dqc_col[:, None] * dt)
 
 
+def test_wrapper_surfaces_applied_convective_heating_and_moistening(monkeypatch):
+    """The convection diagnostic exposes the *applied* (post-cap) T/q rates.
+
+    ``heating_rate`` / ``moistening_rate`` must mirror the tendencies actually
+    handed back to the dynamics — i.e. after the ``_DTDT_MAX`` heating cap — so
+    an RCE convective-vs-radiative balance can be read straight off the saved
+    trajectory. We feed a heating profile that straddles the cap to pin the
+    diagnostic to the capped value rather than the raw scheme output.
+    """
+    nlev, ncols = 4, 2
+    dt = 60.0
+    shape = (nlev, ncols)
+
+    cap = 5.0 / 3600.0  # _DTDT_MAX, K/s
+    # Levels 0/1 exceed the cap (must clip); levels 2/3 sit below it (pass through).
+    dtedt_col = jnp.array([10.0 / 3600.0, -8.0 / 3600.0, 1.0 / 3600.0, 0.0])
+    dqdt_col = jnp.array([1.0e-7, -2.0e-7, 3.0e-7, 0.0])
+
+    def fake_convection(
+        temperature, humidity, pressure, layer_thickness, air_density,
+        u_wind, v_wind, qc, qi, dt_seconds, params, land_fraction,
+        moisture_supply,
+    ):
+        zeros = jnp.zeros_like(temperature)
+        return ConvectionTendencies(
+            dtedt=dtedt_col,
+            dqdt=dqdt_col,
+            dudt=zeros,
+            dvdt=zeros,
+            qc_conv=zeros,
+            qi_conv=zeros,
+            precip_conv=jnp.array(0.0),
+            dqc_dt=zeros,
+            dqi_dt=zeros,
+        ), None
+
+    monkeypatch.setattr(
+        convection_module, "tiedtke_nordeng_convection", fake_convection,
+    )
+
+    state = PhysicsState.zeros(
+        shape,
+        temperature=jnp.ones(shape) * 280.0,
+        specific_humidity=jnp.ones(shape) * 1.0e-3,
+        tracers={"qc": jnp.zeros(shape), "qi": jnp.zeros(shape)},
+    )
+    clouds = CloudData.zeros((ncols,), nlev).copy(
+        cloud_fraction=jnp.ones(shape) * 0.5,
+    )
+    diagnostics = {
+        "_dt_seconds": dt,
+        "pressure_full": jnp.ones(shape) * 80000.0,
+        "layer_thickness": jnp.ones(shape) * 500.0,
+        "air_density": jnp.ones(shape),
+        "clouds": clouds,
+    }
+    terrain = SimpleNamespace(fmask=jnp.zeros(ncols))
+
+    tendency, diagnostics_out = TiedtkeConvection()(
+        state, diagnostics, forcing=None, terrain=terrain,
+    )
+    convection = diagnostics_out["convection"]
+
+    # The diagnostic is exactly the tendency applied to the dynamics.
+    assert jnp.allclose(convection.heating_rate, tendency.temperature)
+    assert jnp.allclose(convection.moistening_rate, tendency.specific_humidity)
+
+    # ...which is the *capped* heating, not the raw scheme output.
+    expected_dt = jnp.broadcast_to(jnp.clip(dtedt_col, -cap, cap)[:, None], shape)
+    expected_dq = jnp.broadcast_to(dqdt_col[:, None], shape)
+    assert jnp.allclose(convection.heating_rate, expected_dt)
+    assert jnp.allclose(convection.moistening_rate, expected_dq)
+    # Guard the "post-cap" semantics: the raw (uncapped) profile would differ.
+    assert not jnp.allclose(
+        convection.heating_rate, jnp.broadcast_to(dtedt_col[:, None], shape)
+    )
+
+
 class TestMassFluxCFLCap:
     """The cloud-base mass flux must respect the layer-mass / dt CFL cap
     that ECHAM enforces in ``mo_cumastr.f90:582-583``::


### PR DESCRIPTION
## What

Expose the per-level **convective heating and moistening rates** from the Tiedtke-Nordeng scheme as first-class diagnostics on `ConvectionData`, named to match the radiation convention:

- `heating_rate` — convective heating rate `[K/s]`, shape `(nlev, ncols)` (mirrors `RadiationData`'s `sw_heating_rate` / `lw_heating_rate`)
- `moistening_rate` — convective moistening rate `[kg/kg/s]`, shape `(nlev, ncols)` (the specific-humidity analog)

These are the **applied** tendencies — i.e. the values handed back to the dynamics *after* the `_DTDT_MAX` heating cap — not the raw scheme output. They ride the saved trajectory exactly like the radiation heating rates, so an RCE convective-vs-radiative heating balance (and any other tendency-budget analysis) can be read straight off the output instead of re-running the term.

## Why

The convective tendencies that balance radiative cooling in an RCE column were previously only recoverable by re-executing the convection term against a saved state. Surfacing them as diagnostics makes the convective heating/moistening directly observable on the trajectory, alongside the existing radiation heating-rate diagnostics — and the shared `*_heating_rate` naming makes the two directly comparable.

## Details

- `ConvectionData` gains the two fields (+ zero-init in `ConvectionData.zeros`).
- The `TiedtkeConvection` wrapper populates them from the post-cap `tendency.temperature` / `tendency.specific_humidity`.
- They flow to xarray as `convection.heating_rate` / `convection.moistening_rate`. `data_to_xarray` infers dims from the `(nlev, ncols)` array shape — identical to the existing `qc_conv`/`qi_conv` fields — so **no serialization changes are required**.
- The other reserved `ConvectionData` fields (mass flux, cloud base/top, CAPE) remain zero-filled as before.

## Testing

- New unit test `test_wrapper_surfaces_applied_convective_heating_and_moistening` feeds a heating profile that straddles the `_DTDT_MAX` cap and asserts the diagnostic equals the **capped** (applied) tendency, not the raw scheme output.
- `tiedtke_nordeng_test.py` (26 passed) and `rce_integration_test.py` (10 passed) green; `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
