### PR TITLE
fix(clouds): 2M stratiform cloud via grid-mean Sundqvist condensation + sequential convection→cloud coupling

### DIFF
--- a/jcm/physics/clouds/lohmann_2m.py
+++ b/jcm/physics/clouds/lohmann_2m.py
@@ -58,9 +58,10 @@ from .lohmann_2m_params import (
     fact_coll_eff, fact_tke
 )
 
-from .cloud_utils import (eff_ice_crystal_radius, minimum_CDNC,
-                          consistency_number_to_mass, gridbox_frac_falling_hydrometeor, threshold_vert_vel, 
-                          breadth_factor
+from .cloud_utils import (
+    eff_ice_crystal_radius, minimum_CDNC,
+    consistency_number_to_mass, gridbox_frac_falling_hydrometeor,
+    threshold_vert_vel, breadth_factor
 )
 
 # @tree_math.struct
@@ -3101,8 +3102,17 @@ def cloud_microphysics_2m(
     cdnc = qnc * air_density
     icnc = qni * air_density
 
-    # Minimum CDNC from the max-radius floor (uses pxwat = qc).
+    # Minimum cloud-droplet number — the SAME ECHAM ``minimum_CDNC`` the warm
+    # microphysics uses below (the dynamic max-radius floor or the fixed
+    # ``cdnc_min_fixed``, selected by ``ldyn_cdnc_min``; calibratable via the
+    # ``cdnc_min_*`` parameters). The KK2000 autoconversion rate scales as
+    # ``Nc^-1.79``, so without a floor a clean column (Nc -> 0; e.g. when the
+    # MACv2-SP aerosol AOD is ~0) autoconverts essentially all cloud water to
+    # rain instantly, leaving ~no cloud (LWP ~0.2 g/m2 vs the 1M scheme's ~20).
+    # Flooring the droplet number by that same minimum keeps a realistic
+    # cloud-water reservoir.
     cdnc_min = minimum_CDNC(qc)
+    cdnc = jnp.maximum(cdnc, cdnc_min)
 
     # pauloc==1 and pclcstar==cloud_fraction are conservative first-pass
     # approximations — refine in later 5b steps.
@@ -3673,6 +3683,25 @@ class Lohmann2MMicrophysics(PhysicsTerm):
         air_density = diagnostics["air_density"]
         layer_thickness = diagnostics["layer_thickness"]
 
+        # Post-convection thermodynamic state (sequential convection->cloud
+        # coupling): convection has already advanced ``thermo_run`` with its
+        # heating/moistening and forwarded its detrained condensate into
+        # ``clouds.qc/qi``. Doing the saturation balance + clear-sky evaporation
+        # on this post-convection (T, q) — instead of the step-start state — is
+        # what makes the in-step moist-energy balance consistent and the
+        # clear-sky evaporation stable (see
+        # ``.claude/coupled_cloud_operator_design.md``). Tendencies are returned
+        # relative to this state; the host's additive sum with convection's
+        # tendency telescopes back to the correct final state. Falls back to the
+        # step-start state if no upstream term seeded ``thermo_run``.
+        thermo_run = diagnostics.get("thermo_run")
+        if thermo_run is None:
+            temperature_in = state.temperature
+            specific_humidity_in = state.specific_humidity
+        else:
+            temperature_in = thermo_run["temperature"]
+            specific_humidity_in = thermo_run["specific_humidity"]
+
         clouds = diagnostics["clouds"]
         qc_interim = clouds.qc
         qi_interim = clouds.qi
@@ -3723,20 +3752,42 @@ class Lohmann2MMicrophysics(PhysicsTerm):
             in_axes=(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, None, None),
             out_axes=(0, 0, 0),
         )(
-            state.temperature, state.specific_humidity, pressure_full,
+            temperature_in, specific_humidity_in, pressure_full,
             qc_interim, qi_interim, qnc, qni, qr, qs,
             cloud_fraction, air_density, layer_thickness, tke,
             activated_cdnc, ice_nuclei, ice_nuclei_deposition, dt, params_2m,
         )
 
+        # Grid-mean Sundqvist condensation / evaporation — the implicit
+        # saturation adjustment the 1M column-sweep performs but the 2M
+        # microphysics lacked. Without it the 2M scheme forms almost no
+        # stratiform cloud in saturated cells (an A/B spin-up gave a
+        # radiatively-active LWP ~50x smaller than 1M) and the condensate it
+        # does carry — convective detrainment advected into sub-saturated
+        # cells — accumulates unbounded. This step condenses vapour -> qc/qi
+        # where the post-convection grid box is supersaturated (forming
+        # radiatively-active cloud) and evaporates qc/qi where it is
+        # sub-saturated, capped at the available cloud water, via the
+        # warming-feedback-damped Newton step (so it is stable, unlike the
+        # clear-cell-evaporation bolt-on). ``condensation_evaporation`` is
+        # broadcasting-native, so it runs directly on the (nlev, ncols) state.
+        from .sundqvist import (
+            condensation_evaporation as _sundqvist_cond_evap,
+            CloudParameters as _SundqvistCloudParams,
+        )
+        dtedt_strat, dqdt_strat, dqcdt_strat, dqidt_strat = _sundqvist_cond_evap(
+            temperature_in, specific_humidity_in, qc_interim, qi_interim,
+            cloud_fraction, pressure_full, dt, _SundqvistCloudParams.default(),
+        )
+
         tendency = PhysicsTendency(
             u_wind=jnp.zeros_like(state.u_wind),
             v_wind=jnp.zeros_like(state.v_wind),
-            temperature=tend_all.dtedt.T,
-            specific_humidity=tend_all.dqdt.T,
+            temperature=tend_all.dtedt.T + dtedt_strat,
+            specific_humidity=tend_all.dqdt.T + dqdt_strat,
             tracers={
-                "qc": tend_all.dqcdt.T,
-                "qi": tend_all.dqidt.T,
+                "qc": tend_all.dqcdt.T + dqcdt_strat,
+                "qi": tend_all.dqidt.T + dqidt_strat,
                 "qnc": tend_all.dqncdt.T,
                 "qni": tend_all.dqnidt.T,
                 "qr": tend_all.dqrdt.T,

--- a/jcm/physics/clouds/lohmann_2m_params.py
+++ b/jcm/physics/clouds/lohmann_2m_params.py
@@ -214,7 +214,7 @@ class CloudParams2M: #(NamedTuple):
         fact_PK: float = 8.253e-3,
         pow_PK: float = 2.475,
         ldyn_cdnc_min: bool = False,
-        cdnc_min_fixed: float = 10.0,
+        cdnc_min_fixed: float = 40.0,  # [cm^-3] ECHAM warm-microphysics floor; KK2000 autoconv (rate ∝ Nc^-1.79) runs away below this in clean air
         nic_cirrus: int = 2,
         # resolution-dependent placeholders (ICON defaults)
         crs: float = 0.975,

--- a/jcm/physics/convection/tiedtke_nordeng/tiedtke_nordeng.py
+++ b/jcm/physics/convection/tiedtke_nordeng/tiedtke_nordeng.py
@@ -1018,6 +1018,7 @@ from jcm.forcing import ForcingData  # noqa: E402
 from jcm.physics.physics_term import PhysicsTerm, TracerSpec  # noqa: E402
 from jcm.physics_interface import PhysicsState, PhysicsTendency  # noqa: E402
 from jcm.terrain import TerrainData  # noqa: E402
+from jcm.physics.diagnostics.moist_air_state import advance_thermo_run  # noqa: E402
 
 
 class TiedtkeConvection(PhysicsTerm):
@@ -1177,6 +1178,19 @@ class TiedtkeConvection(PhysicsTerm):
                 diagnostics["clouds"].qi + tendency.tracers["qi"] * dt,
                 0.0,
             ),
+        )
+
+        # Advance the running thermodynamic state so the downstream cloud
+        # microphysics sees the post-convection (T, q) — convective detrainment
+        # already updated ``clouds.qc/qi`` above; this completes the
+        # post-convection state the cloud scheme's saturation balance needs
+        # (sequential convection->cloud coupling, see
+        # ``jcm.physics.diagnostics.moist_air_state.advance_thermo_run``).
+        diagnostics = advance_thermo_run(
+            diagnostics,
+            dt,
+            d_temperature=tendency.temperature,
+            d_specific_humidity=tendency.specific_humidity,
         )
 
         return tendency, {

--- a/jcm/physics/diagnostics/moist_air_state.py
+++ b/jcm/physics/diagnostics/moist_air_state.py
@@ -54,7 +54,61 @@ MOIST_AIR_FIELDS: tuple[str, ...] = (
     "layer_thickness",
     "surface_pressure",
     "relative_humidity",
+    "thermo_run",
 )
+
+
+def advance_thermo_run(
+    diagnostics: dict,
+    dt,
+    d_temperature=None,
+    d_specific_humidity=None,
+) -> dict:
+    """Advance the running ``thermo_run`` state by a term's tendency.
+
+    ``thermo_run`` is a *running thermodynamic view* (temperature, specific
+    humidity) carried through the per-step diagnostics so a term that runs after
+    another can see the upstream term's effect. A term that changes T and/or q
+    before the cloud microphysics (currently only Tiedtke convection; the
+    pattern generalises to any opt-in pre-cloud term) calls this with its own
+    tendency, so the 2M cloud scheme's saturation balance condenses against the
+    post-convection state — the sequential convection->cloud coupling in
+    ``.claude/coupled_cloud_operator_design.md``. ``d_temperature`` /
+    ``d_specific_humidity`` are tendencies (per second) in the same layout as
+    ``thermo_run`` (the term's ``PhysicsState`` shape).
+
+    Tendency ownership — *nothing is zeroed here or by the caller.* This is an
+    operator-split model: every term returns its full tendency, the driver sums
+    all of them, and the dycore applies that single sum to the *step-start*
+    state exactly once. ``thermo_run`` is a parallel diagnostic view, NOT the
+    prognostic state, so the same tendency legitimately plays two roles — it is
+    returned for the op-split sum *and* passed here to advance ``thermo_run`` for
+    downstream terms. Zeroing it in either place would drop that term's
+    contribution from the final state. Because each term's tendency is computed
+    against the running ``thermo_run`` and the sum is applied once, additive
+    accumulation is algebraically identical to applying the terms sequentially
+    (T_final = T0 + dt*(conv_dT + cloud_dT(post-conv)) either way).
+
+    Returns a new diagnostics dict with ``thermo_run`` advanced; a no-op
+    (returns the input unchanged) if ``thermo_run`` is absent, so callers stay
+    backward-safe.
+    """
+    tr = diagnostics.get("thermo_run")
+    if tr is None:
+        return diagnostics
+    temperature = tr["temperature"]
+    specific_humidity = tr["specific_humidity"]
+    if d_temperature is not None:
+        temperature = temperature + d_temperature * dt
+    if d_specific_humidity is not None:
+        specific_humidity = specific_humidity + d_specific_humidity * dt
+    return {
+        **diagnostics,
+        "thermo_run": {
+            "temperature": temperature,
+            "specific_humidity": specific_humidity,
+        },
+    }
 
 
 class MoistAirColumnState(PhysicsTerm):
@@ -163,6 +217,20 @@ class MoistAirColumnState(PhysicsTerm):
         e = q_clip * pressure_full / (0.622 + 0.378 * q_clip)
         relative_humidity = e / jnp.maximum(es, 1e-3)
 
+        # Running thermodynamic state for sequential convection->cloud coupling.
+        # Seeded to the step-start (T, q); terms that change T/q before the cloud
+        # microphysics (radiation, convection) advance it by their tendency*dt so
+        # the cloud scheme sees the post-(radiation+convection) state — emulating
+        # ECHAM's sequential radiation->convection->cloud ordering inside our
+        # additive-splitting framework. Summing the sequentially-computed
+        # tendencies and applying to the step-start state telescopes to the same
+        # result as true sequential operator splitting. See
+        # ``.claude/coupled_cloud_operator_design.md``.
+        thermo_run = {
+            "temperature": state.temperature,
+            "specific_humidity": state.specific_humidity,
+        }
+
         zero_tendencies = PhysicsTendency.zeros(state.temperature.shape)
         return zero_tendencies, {
             **diagnostics,
@@ -174,4 +242,5 @@ class MoistAirColumnState(PhysicsTerm):
             "layer_thickness": layer_thickness,
             "surface_pressure": surface_pressure,
             "relative_humidity": relative_humidity,
+            "thermo_run": thermo_run,
         }


### PR DESCRIPTION
## Summary

Gives the 2-moment (Lohmann) cloud scheme **radiatively-active stratiform cloud**, which it previously lacked, by adding the grid-mean implicit-Newton Sundqvist condensation/evaporation the 1M column-sweep already uses, fed by a **sequential convection→cloud coupling** so the cloud step condenses against the post-convective (moistened/cooled) column.

This is the remaining un-PR'd half of the moist-stability/CRE work; the init fixes landed on #536 and the RRTMGP in-cloud cap on #538. Validated together in stable 10-day moist T63L47 runs (rh=0.5) across all four configs (grey/rrtmgp × 1m/2m).

## Commits

1. **`feat(clouds): sequential convection→cloud coupling via thermo_run`** — a running thermodynamic state threaded through the per-step diagnostics: `moist_air_state` seeds `thermo_run = {temperature, specific_humidity}`, the Tiedtke term advances it by its own tendency, and the 2M scheme reads it (falling back to the step-start state when unseeded, preserving additive-splitting behaviour). Makes the convection→cloud handoff sequential (operator splitting), as in ECHAM. (Formerly the `wip` commit; the coupling is functional and validated — label dropped.)
2. **`fix(clouds): 2M grid-mean Sundqvist condensation + disable harmful clear-cell evap`** — condenses vapour→qc/qi where the post-convection grid box is supersaturated and evaporates qc/qi where sub-saturated, via the warming-feedback-damped Newton step. Without it the 2M formed almost no stratiform cloud (LWP ~50× smaller than 1M) and detrained condensate accumulated unbounded or was destroyed by the clear-cell-evaporation bolt-on (Part A, now disabled by default behind `JCM_CLEAR_SKY_EVAP`).
3. **`fix(clouds): ECHAM cdnc_min floor on 2M warm-microphysics droplet number`** — robustness floor on the droplet number.

## Validation

- `lohmann_2m_test.py` + `sundqvist_test.py`: 71 passed. `tiedtke_nordeng/`: 116 passed.
- 10-day moist T63L47 spin-ups stable across all four configs: grey+2M decorrelation 99%→20%, CRE_SW ≈ +12.5 (was +0/exploding); rrtmgp+2M stable with active CRE.

## Note for review

The disabled Part A clear-cell-evaporation code remains in `lohmann_2m.py` gated behind `JCM_CLEAR_SKY_EVAP` (off) as a documented A/B investigation knob — happy to strip it entirely if you'd prefer it gone rather than gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)