### PR TITLE
fix(aerosol): stabilize JAM deposition — implicit scavenging + sedimentation CFL cap

### DIFF
--- a/jcm/physics/aerosol/jam/drydep/drydep_term.py
+++ b/jcm/physics/aerosol/jam/drydep/drydep_term.py
@@ -83,6 +83,7 @@ class SlinnDryDeposition(PhysicsTerm):
         temperature = state.temperature
         nlev, ncols = temperature.shape
 
+        dt = diagnostics.get("_dt_seconds", 1800.0)
         u_star = self._u_star(diagnostics, ncols, params)        # (ncols,)
         t_sfc = temperature[-1]
         p_sfc = pressure[-1]
@@ -102,6 +103,13 @@ class SlinnDryDeposition(PhysicsTerm):
                 z_ref=params.z_ref, z0=params.z0,
             )
             loss_rate = v_dep / dz_sfc  # [1/s] applied to bottom layer
+            # Implicit (exponential) removal over the step, bounded to ≤100% of
+            # the layer's mass: q(t+dt) = q·exp(-loss_rate·dt). An explicit
+            # ``-loss_rate·q`` step overshoots into a sign-flipped runaway when
+            # ``loss_rate·dt > 1`` (large deposition velocity for the coarse mode
+            # over a thin surface layer) — the same instability that NaNs wet
+            # deposition. ``1 - exp(-x)`` is unconditionally stable for any x ≥ 0.
+            removed_frac = -jnp.expm1(-loss_rate * dt)   # ∈ [0, 1]
 
             names = [number_name(mode.short)] + [
                 mass_name(sp, mode.short) for sp in mode.species
@@ -109,7 +117,7 @@ class SlinnDryDeposition(PhysicsTerm):
             for nm in names:
                 q = state.tracers.get(nm, zeros)
                 tracer_tends[nm] = jnp.zeros_like(q).at[-1].set(
-                    -loss_rate * q[-1]
+                    -(removed_frac * q[-1]) / dt
                 )
 
         tendency = PhysicsTendency(

--- a/jcm/physics/aerosol/jam/sedimentation/sedi_term.py
+++ b/jcm/physics/aerosol/jam/sedimentation/sedi_term.py
@@ -44,6 +44,13 @@ def air_viscosity(temperature: jnp.ndarray) -> jnp.ndarray:
     return 1.458e-6 * temperature ** 1.5 / (temperature + 110.4)
 
 
+# Upper bound on the settling radius [m]. HAMMOZ ``mo_ham_sedimentation``
+# (lines 178–191) caps the count/mass median *diameter* at 50 µm before the
+# Stokes velocity so a runaway κ-Köhler wet-growth tail (sea salt at high RH)
+# can't drive an unphysically large fall speed. 50 µm diameter → 25 µm radius.
+_R_WET_MAX = 25.0e-6
+
+
 def stokes_velocity(
     r_wet: jnp.ndarray,
     rho_p: jnp.ndarray,
@@ -53,14 +60,17 @@ def stokes_velocity(
     """Stokes settling velocity [m/s] with Cunningham slip correction.
 
     ``v = (2 g ρ_p r² C_c) / (9 μ)``. Inputs broadcast against each other;
-    ``r_wet``/``rho_p`` may carry a leading mode axis.
+    ``r_wet``/``rho_p`` may carry a leading mode axis. The radius is capped at
+    :data:`_R_WET_MAX` (HAMMOZ 50 µm median-diameter cap) so extreme wet growth
+    can't inflate the velocity.
     """
+    r = jnp.minimum(r_wet, _R_WET_MAX)
     mu = air_viscosity(temperature)
     # Mean free path λ = (μ/p)·√(π R T / (2 M_a)).
     mfp = (mu / pressure) * jnp.sqrt(jnp.pi * _RGAS * temperature / (2.0 * _MA))
-    kn = mfp / jnp.maximum(r_wet, 1.0e-10)
+    kn = mfp / jnp.maximum(r, 1.0e-10)
     cunningham = 1.0 + kn * (1.257 + 0.4 * jnp.exp(-1.1 / jnp.maximum(kn, 1e-12)))
-    return (2.0 * _G * rho_p * r_wet ** 2 * cunningham) / (9.0 * mu)
+    return (2.0 * _G * rho_p * r ** 2 * cunningham) / (9.0 * mu)
 
 
 def sediment_column(
@@ -111,6 +121,9 @@ class StokesSedimentation(PhysicsTerm):
         dz = diagnostics["layer_thickness"]
         pressure = diagnostics["pressure_full"]
         temperature = state.temperature
+        # Model timestep for the CFL velocity cap below (injected by
+        # ComposablePhysics; default mirrors the SPEEDY fallback elsewhere).
+        dt = diagnostics.get("_dt_seconds", 1800.0)
 
         # Gather every interstitial tracer to settle and the (per-mode)
         # settling velocity that transports it, then run the donor-cell
@@ -128,6 +141,18 @@ class StokesSedimentation(PhysicsTerm):
             v = params.velocity_scale * stokes_velocity(
                 aer.r_wet[i], aer.rho[i], temperature, pressure,
             )
+            # CFL cap: an explicit donor-cell step is only stable for a Courant
+            # number ≤ 1, i.e. a particle may fall at most one layer per step.
+            # Without this, coarse-mode sea salt at high near-surface RH (large
+            # wet radius → large Stokes velocity, worst over the high-wind
+            # Southern Ocean) drives the Courant number past 1 and the explicit
+            # scheme explodes in a single step (33 orders of magnitude),
+            # poisoning the aerosol → activation → cloud → dynamics chain.
+            # Mirrors HAMMOZ ``mo_ham_sedimentation`` L228:
+            # ``zvsedi = MIN(zvsedi, pdz/time_step_len)``. With Courant ≤ 1 the
+            # donor-cell flux out of a layer cannot exceed its content, so the
+            # tracers also stay non-negative (HAMMOZ's L235 flux limiter).
+            v = jnp.minimum(v, dz / dt)
             for nm in [number_name(mode.short)] + [
                 mass_name(sp, mode.short) for sp in mode.species
             ]:

--- a/jcm/physics/aerosol/jam/sedimentation/sedi_test.py
+++ b/jcm/physics/aerosol/jam/sedimentation/sedi_test.py
@@ -36,6 +36,18 @@ class StokesVelocityTest(unittest.TestCase):
         )
         self.assertTrue(1e-5 < float(v[0]) < 1e-2)
 
+    def test_wet_radius_capped(self):
+        # HAMMOZ caps the settling diameter at 50 µm (25 µm radius), so a
+        # runaway κ-Köhler wet-growth tail can't inflate the fall speed: the
+        # velocity at 25 µm and 1 mm must be identical (both clamped to 25 µm),
+        # and strictly above a sub-cap radius.
+        t, p, rho = jnp.array([280.0]), jnp.array([9.0e4]), jnp.array([1800.0])
+        v_cap = stokes_velocity(jnp.array([25.0e-6]), rho, t, p)
+        v_huge = stokes_velocity(jnp.array([1.0e-3]), rho, t, p)
+        v_sub = stokes_velocity(jnp.array([10.0e-6]), rho, t, p)
+        np.testing.assert_allclose(float(v_huge[0]), float(v_cap[0]), rtol=1e-6)
+        self.assertGreater(float(v_cap[0]), float(v_sub[0]))
+
 
 class DonorCellTest(unittest.TestCase):
     def test_zero_velocity_no_change(self):
@@ -99,6 +111,7 @@ class SedimentationTermTest(unittest.TestCase):
             "air_density": jnp.full((nlev, ncols), 1.0),
             "layer_thickness": jnp.full((nlev, ncols), 200.0),
             "pressure_full": jnp.full((nlev, ncols), 9.0e4),
+            "_dt_seconds": 720.0,
         }
         return state, diagnostics
 
@@ -113,6 +126,27 @@ class SedimentationTermTest(unittest.TestCase):
         self.assertTrue(np.all(np.isfinite(np.asarray(tend.tracers[key]))))
         # Top layer should be losing aerosol (negative tendency).
         self.assertLessEqual(float(tend.tracers[key][0, 0]), 0.0)
+
+    def test_cfl_cap_keeps_tendency_stable_for_extreme_velocity(self):
+        # Coarse-mode sea-salt-like extreme: huge wet radius + thin layers +
+        # a long step would give a Courant number ≫ 1 and an unstable explicit
+        # donor-cell step (the natural-emission blowup). The CFL cap (v ≤ dz/dt)
+        # must keep a forward Euler step finite and non-negative.
+        state, diagnostics = self._setup(nlev=6, ncols=2)
+        dt = 1800.0
+        diagnostics = dict(diagnostics)
+        diagnostics["_dt_seconds"] = dt
+        diagnostics["layer_thickness"] = jnp.full((6, 2), 20.0)  # thin → easy CFL break
+        aer = diagnostics["_jam_state"]
+        # Inflate every mode's wet radius well past the 25 µm cap.
+        diagnostics["_jam_state"] = aer.copy(r_wet=jnp.full_like(aer.r_wet, 1.0e-4))
+
+        term = StokesSedimentation()
+        tend, _ = term(state, diagnostics, None, None)
+        for nm, dq in tend.tracers.items():
+            q_new = np.asarray(state.tracers[nm]) + np.asarray(dq) * dt
+            self.assertTrue(np.all(np.isfinite(q_new)), nm)
+            self.assertGreaterEqual(float(q_new.min()), -1e-20, nm)
 
     def test_grad_through_velocity_scale_finite(self):
         from jcm.physics.aerosol.jam.sedimentation.sedi_term import SedParameters

--- a/jcm/physics/aerosol/jam/sedimentation/sedi_test.py
+++ b/jcm/physics/aerosol/jam/sedimentation/sedi_test.py
@@ -146,7 +146,14 @@ class SedimentationTermTest(unittest.TestCase):
         for nm, dq in tend.tracers.items():
             q_new = np.asarray(state.tracers[nm]) + np.asarray(dq) * dt
             self.assertTrue(np.all(np.isfinite(q_new)), nm)
-            self.assertGreaterEqual(float(q_new.min()), -1e-20, nm)
+            # The CFL cap keeps the donor-cell step non-negative up to
+            # floating-point roundoff. Assert relative to the field scale: a
+            # real Courant>1 runaway drives q_new to O(-q); harmless f32
+            # roundoff at the CFL boundary (q(1-v·dt/dz) with v·dt/dz→1+eps) is
+            # ~1e-7·q, which an absolute -1e-20 bound spuriously rejects for the
+            # ~1e8 number tracers (n_acc → -8 in the full-suite build).
+            scale = float(np.abs(q_new).max())
+            self.assertGreaterEqual(float(q_new.min()), -1e-5 * scale, nm)
 
     def test_grad_through_velocity_scale_finite(self):
         from jcm.physics.aerosol.jam.sedimentation.sedi_term import SedParameters

--- a/jcm/physics/aerosol/jam/wetdep/wetdep_term.py
+++ b/jcm/physics/aerosol/jam/wetdep/wetdep_term.py
@@ -91,9 +91,14 @@ def below_cloud_rate(
     """Below-cloud impaction scavenging rate [1/s], size-dependent (∝ r²)."""
     rain_mmph = precip_col[jnp.newaxis, :] * 3600.0  # kg/m²/s -> mm/h
     efficiency = (r_wet / params.below_radius_ref) ** 2
-    return (
-        params.below_coeff * rain_mmph * (1.0 - cloud_fraction) * efficiency
-    )
+    # Clear-sky (below-cloud) fraction, clipped to [0, 1]. The cloud scheme can
+    # return cloud_fraction > 1 (e.g. where RH > 1), which would make this
+    # fraction — and hence the scavenging rate — NEGATIVE. A negative rate makes
+    # the implicit ``1 - exp(-rate·dt)`` removed fraction overflow to +inf,
+    # NaN-ing every aerosol tracer. Scavenging rates are non-negative by
+    # construction, so clip the clear fraction here.
+    clear_fraction = jnp.clip(1.0 - cloud_fraction, 0.0, 1.0)
+    return params.below_coeff * rain_mmph * clear_fraction * efficiency
 
 
 class WetScavenging(PhysicsTerm):
@@ -172,7 +177,10 @@ class WetScavenging(PhysicsTerm):
         # ``mo_ham_wetdep`` applies the same ``1 - exp(-Λ·Δt)`` removed fraction).
         # Emitted as a per-second tendency so the operator-split sum + dynamics
         # apply exactly ``q·(exp(-rate·dt) - 1)`` over the step.
-        removed_frac = -jnp.expm1(-jnp.stack(rate_list) * dt)   # 1 - exp(-rate·dt) ∈ [0, 1]
+        # Clamp the decay rate to ≥0 so the exponential update is always a
+        # bounded removal (a scavenging rate is non-negative by construction).
+        rate_arr = jnp.maximum(jnp.stack(rate_list), 0.0)
+        removed_frac = -jnp.expm1(-rate_arr * dt)              # 1 - exp(-rate·dt) ∈ [0, 1]
         dq_stack = -(removed_frac * jnp.stack(q_list)) / dt
         tracer_tends = {nm: dq_stack[k] for k, nm in enumerate(names)}
 

--- a/jcm/physics/aerosol/jam/wetdep/wetdep_term.py
+++ b/jcm/physics/aerosol/jam/wetdep/wetdep_term.py
@@ -123,6 +123,8 @@ class WetScavenging(PhysicsTerm):
         activated_fraction = diagnostics["activated_fraction"]
         air_density = diagnostics["air_density"]
         dz = diagnostics["layer_thickness"]
+        # Timestep for the implicit (exponential) scavenging update below.
+        dt = diagnostics.get("_dt_seconds", 1800.0)
 
         clouds = diagnostics["clouds"]
         precip_col = clouds.precip_rain + clouds.precip_snow
@@ -158,7 +160,20 @@ class WetScavenging(PhysicsTerm):
                 q_list.append(state.tracers.get(nm, zeros))
                 rate_list.append(rate)
 
-        dq_stack = -jnp.stack(rate_list) * jnp.stack(q_list)
+        # Implicit (exponential) scavenging over the step: q(t+dt) = q·exp(-rate·dt).
+        # The first-order-decay rate is unbounded — the in-cloud rate ∝ 1/qc
+        # diverges in near-clear cells and the below-cloud rate ∝ (r_wet/r_ref)²
+        # is large for the coarse mode — so an explicit ``dq = -rate·q`` step
+        # removes far more than the available mass when ``rate·dt ≫ 1`` (observed
+        # ``rate·dt ~ 1e4`` for coarse sea salt over the high-wind Southern
+        # Ocean), overshooting into a sign-flipped runaway that NaNs the model
+        # in a few steps. The analytic exponential of the decay is unconditionally
+        # stable and positivity-preserving for any ``rate ≥ 0`` (HAMMOZ
+        # ``mo_ham_wetdep`` applies the same ``1 - exp(-Λ·Δt)`` removed fraction).
+        # Emitted as a per-second tendency so the operator-split sum + dynamics
+        # apply exactly ``q·(exp(-rate·dt) - 1)`` over the step.
+        removed_frac = -jnp.expm1(-jnp.stack(rate_list) * dt)   # 1 - exp(-rate·dt) ∈ [0, 1]
+        dq_stack = -(removed_frac * jnp.stack(q_list)) / dt
         tracer_tends = {nm: dq_stack[k] for k, nm in enumerate(names)}
 
         tendency = PhysicsTendency(

--- a/jcm/physics/aerosol/jam/wetdep/wetdep_test.py
+++ b/jcm/physics/aerosol/jam/wetdep/wetdep_test.py
@@ -122,8 +122,12 @@ class WetDepTermTest(unittest.TestCase):
             q0 = np.asarray(state.tracers[nm])
             q_new = q0 + np.asarray(dq) * dt
             self.assertTrue(np.all(np.isfinite(q_new)), nm)
-            self.assertGreaterEqual(float(q_new.min()), -1e-25, nm)
-            self.assertLessEqual(float(q_new.max()), float(q0.max()) + 1e-25, nm)
+            # Bounds hold up to floating-point roundoff; assert relative to the
+            # field scale so f32 roundoff on the ~1e8 number tracers (n_acc →
+            # -8 in the full-suite build) isn't mistaken for a real overshoot.
+            scale = float(np.abs(q0).max())
+            self.assertGreaterEqual(float(q_new.min()), -1e-5 * scale, nm)
+            self.assertLessEqual(float(q_new.max()), float(q0.max()) + 1e-5 * scale, nm)
 
     def test_cloud_fraction_gt_one_stays_finite(self):
         # The cloud scheme can hand back cloud_fraction > 1 (e.g. where RH > 1).

--- a/jcm/physics/aerosol/jam/wetdep/wetdep_test.py
+++ b/jcm/physics/aerosol/jam/wetdep/wetdep_test.py
@@ -125,6 +125,27 @@ class WetDepTermTest(unittest.TestCase):
             self.assertGreaterEqual(float(q_new.min()), -1e-25, nm)
             self.assertLessEqual(float(q_new.max()), float(q0.max()) + 1e-25, nm)
 
+    def test_cloud_fraction_gt_one_stays_finite(self):
+        # The cloud scheme can hand back cloud_fraction > 1 (e.g. where RH > 1).
+        # The below-cloud clear-sky fraction (1 - cf) then goes negative, which
+        # made the scavenging rate negative and the implicit 1-exp(-rate·dt)
+        # removed fraction overflow to +inf, NaN-ing every aerosol tracer.
+        # The clear fraction (and the rate) are clamped to ≥0, so the tendency
+        # must stay finite for cf > 1. Regression guard.
+        state, diagnostics, spec, mass_name = self._setup(precip=1.0e-2)
+        diagnostics = dict(diagnostics)
+        diagnostics["clouds"] = diagnostics["clouds"].copy(
+            cloud_fraction=jnp.full_like(diagnostics["clouds"].cloud_fraction, 1.3)
+        )
+        # coarse wet radius makes the below-cloud rate large in magnitude
+        aer = diagnostics["_jam_state"]
+        diagnostics["_jam_state"] = aer.copy(r_wet=jnp.full_like(aer.r_wet, 5.0e-6))
+        term = WetScavenging()
+        tend, _ = term(state, diagnostics, None, None)
+        for nm, dq in tend.tracers.items():
+            self.assertTrue(np.all(np.isfinite(np.asarray(dq))), nm)
+            self.assertTrue(bool(jnp.all(dq <= 0.0)), nm)  # still a sink, not a source
+
     def test_no_precip_no_removal(self):
         state, diagnostics, spec, mass_name = self._setup(precip=0.0)
         term = WetScavenging()

--- a/jcm/physics/aerosol/jam/wetdep/wetdep_test.py
+++ b/jcm/physics/aerosol/jam/wetdep/wetdep_test.py
@@ -99,6 +99,32 @@ class WetDepTermTest(unittest.TestCase):
         self.assertTrue(bool(jnp.all(tend.tracers[key] <= 0.0)))
         self.assertTrue(np.all(np.isfinite(np.asarray(tend.tracers[key]))))
 
+    def test_extreme_rate_stays_bounded(self):
+        # A scavenging rate with rate·dt ≫ 1 (heavy precip + near-clear low qc +
+        # large coarse wet radius) must NOT remove more than the available mass
+        # in one step. The implicit q·exp(-rate·dt) update keeps a forward step
+        # in [0, q]; the old explicit -rate·q overshot into a sign-flipped
+        # runaway (the natural-emission blow-up). Regression guard.
+        state, diagnostics, spec, mass_name = self._setup(precip=1.0e-2)
+        dt = 1800.0
+        diagnostics = dict(diagnostics)
+        diagnostics["_dt_seconds"] = dt
+        aer = diagnostics["_jam_state"]
+        diagnostics["_jam_state"] = aer.copy(
+            r_wet=jnp.full_like(aer.r_wet, 5.0e-6)        # huge below-cloud rate
+        )
+        diagnostics["clouds"] = diagnostics["clouds"].copy(
+            qc=jnp.full_like(diagnostics["clouds"].qc, 1.0e-9)  # huge in-cloud rate
+        )
+        term = WetScavenging()
+        tend, _ = term(state, diagnostics, None, None)
+        for nm, dq in tend.tracers.items():
+            q0 = np.asarray(state.tracers[nm])
+            q_new = q0 + np.asarray(dq) * dt
+            self.assertTrue(np.all(np.isfinite(q_new)), nm)
+            self.assertGreaterEqual(float(q_new.min()), -1e-25, nm)
+            self.assertLessEqual(float(q_new.max()), float(q0.max()) + 1e-25, nm)
+
     def test_no_precip_no_removal(self):
         state, diagnostics, spec, mass_name = self._setup(precip=0.0)
         term = WetScavenging()


### PR DESCRIPTION
## Problem
Turning on JAM aerosol emissions NaN'd T63L47 within hours (incl. natural-only / sea-salt). Per-step in-process onset tracing pinned the **fast** blow-up to **wet deposition**.

`wetdep_term.py` applied an **explicit** first-order decay `dq = -rate·q` with an **unbounded rate**:
- in-cloud `∝ activated_frac·p_form/qc` → diverges as `qc → 0` (near-clear cells)
- below-cloud `∝ (r_wet/r_ref)²` → large for the coarse mode

Over the high-wind Southern Ocean `rate·dt ≈ 1e4` for coarse sea salt, so the explicit step removed ~10⁴× the available mass in one timestep and overshot into a **sign-flipped runaway** (per-term breakdown: `jam_wet_deposition` emitted an `m_ss_cor` tendency·dt of 4e26 while every other term was ~1e-8), poisoning activation → CDNC → cloud → dynamics a few steps later.

## Fix (faithful to HAMMOZ)
- **wetdep** — implicit/exponential scavenging `q(t+dt) = q·exp(-rate·dt)`; removed fraction `1-exp(-rate·dt) ∈ [0,1]` so ≤100% removed per step → unconditionally stable + positivity-preserving for any rate. Mirrors `mo_ham_wetdep`'s `1-exp(-Λ·Δt)`.
- **drydep** — same explicit `-loss_rate·q` pattern (bounded in practice, identical latent landmine) → same implicit update.
- **sedimentation** — explicit donor-cell had an unbounded settling velocity; add HAMMOZ CFL cap `v = min(v, dz/dt)` (Courant ≤ 1) and the 50 µm wet-diameter cap (`mo_ham_sedimentation` L228/L178). Separate latent bug (capping it didn't change this trajectory), kept because it *will* bite at other dt/resolution.

## Validation
- In-process onset: the step-5 explosion (−4.5e22) is gone — tracers stay ~1e-17, no NaN.
- New regression tests: wetdep extreme-rate stays in `[0, q]`; sedimentation CFL keeps an extreme-Courant step finite/non-negative; Stokes radius cap.
- Full JAM aerosol suite (182 passed, 1 skipped) + `ruff` clean.

## Scope
Addresses a real cause of the JAM aerosol NaN in #521 (the removal overshoot — distinct from that issue's spectral-ringing hypothesis). A **second, independent** instability — the 2M droplet-number `qnc` runaway under ARG's low clean-marine CDNC driving the KK2000 `N^-1.79` autoconversion toward a singularity — is **not** addressed here and is being pursued separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)