### PR TITLE
fix(aerosol): floor JAM modal number at 0 in ARG activation

### DIFF
--- a/jcm/physics/aerosol/jam/activation/arg.py
+++ b/jcm/physics/aerosol/jam/activation/arg.py
@@ -115,6 +115,17 @@ def arg_activation(
       * ``activated_fraction`` (nlev, ncols) number-weighted fraction [-]
       * ``s_max`` (nlev, ncols) maximum supersaturation [-]
     """
+    # Floor the modal number at 0: spectral advection of the aerosol-number
+    # tracers leaves small NEGATIVE number on the near-zero cold-start field
+    # (Gibbs ringing). A negative ``number_vol`` makes the number-weighted
+    # ``n_total`` negative, collapsing ``activated_fraction = n_act / n_total``
+    # to a ±huge value (and the per-cell ``activated_cdnc`` negative). The cloud
+    # masks the negative CDNC via the SPA floor and wet deposition clamps the
+    # rate, so the model stays finite — but the activated fraction handed to wet
+    # scavenging is garbage. Flooring here makes every derived quantity physical:
+    # n_act, n_total ≥ 0 ⇒ activated_fraction ∈ [0, 1], activated_cdnc ≥ 0. Same
+    # ringing root cause as the JAM-optics number floor (#543).
+    number_vol = jnp.maximum(number_vol, 0.0)
     t = temperature
     p = pressure
     es = _saturation_vapor_pressure(t)

--- a/jcm/physics/aerosol/jam/activation/arg_test.py
+++ b/jcm/physics/aerosol/jam/activation/arg_test.py
@@ -108,6 +108,18 @@ class ArgActivationCoreTest(unittest.TestCase):
         self.assertAlmostEqual(n_act, 0.0)
         self.assertAlmostEqual(frac, 0.0)
 
+    def test_negative_number_ringing_stays_bounded(self):
+        """Negative modal number (spectral Gibbs ringing on the growing
+        aerosol field) must not blow the activated fraction. Without flooring
+        the number at 0, ``n_total`` goes negative, ``activated_fraction =
+        n_act / n_total`` diverges to +/-huge, and that garbage fraction feeds
+        wet scavenging. Assert a floored, physical result instead.
+        """
+        n_act, frac, smax = self._run(n_percc=-100.0)
+        self.assertTrue(np.isfinite(n_act) and np.isfinite(frac))
+        self.assertGreaterEqual(n_act, 0.0)          # no negative droplets
+        self.assertTrue(0.0 <= frac <= 1.0)          # not +/-1e35 / -inf
+
     def test_ghosh_variant_runs_and_differs(self):
         _, arg, _ = self._run(variant="arg2000", n_percc=1500.0, w=0.2)
         _, gho, _ = self._run(variant="ghosh2025", n_percc=1500.0, w=0.2)


### PR DESCRIPTION
## Problem

Verifying the ARG droplet-activation scheme against the online sea-salt emissions (echam-jam, natural-only) surfaced a garbage \`activated_fraction\`: in-model it read **max ~1e35, mean −inf** within the first simulated hours, while \`activated_cdnc\` stayed superficially healthy (~15–30 cm⁻³).

## Root cause

Same spectral-ringing root cause as #543 (JAM optics). \`arg_activation\` forms

\`\`\`
n_act   = Σ_i can_activate · number_vol · f_act        # f_act ∈ [0,1]
n_total = Σ_i can_activate · number_vol
activated_fraction = n_act / max(n_total, _TINY)
\`\`\`

from the **raw** per-mode \`number_vol\`. Spectral advection of the aerosol-number tracers leaves small **negative** number on the near-zero cold-start field (Gibbs ringing). Where the number goes negative, \`n_total\` goes negative, the denominator collapses to \`_TINY\`, and the fraction diverges to ±1e35 / −inf; the per-cell \`activated_cdnc\` (= \`n_act\`) also goes negative there.

This is **not** just a broken diagnostic: \`activated_fraction\` is consumed by in-cloud wet scavenging (\`wetdep_term.py\`). The model only stays finite because the #540 wet-scavenging rate clamp and the SPA CDNC floor happen to mask the garbage (negative \`arg_cdnc\` falls back to the SPA floor).

## Fix

Floor \`number_vol\` at 0 at the top of \`arg_activation\` — negative modal number is unphysical. Then \`n_act, n_total ≥ 0\` ⇒ \`activated_fraction ∈ [0, 1]\` and \`activated_cdnc ≥ 0\`, consistently across every downstream use (the \`n_s\` kinetic term was already floored; this makes the activated quantities match).

## Validation

- New regression test \`test_negative_number_ringing_stays_bounded\` (drives the number negative, asserts \`n_act ≥ 0\` and \`frac ∈ [0,1]\`). Full \`arg_test.py\` green (13/13).
- In-model (echam-jam natural, sea salt): \`activated_fraction\` now ∈ [0,1] (mean ~0.3–0.5, physical for the marine constant-updraft regime), \`activated_cdnc\` ~15–30 cm⁻³, finite and stable across 60 steps.

Companion to #540 (deposition), #542 (SPA units), #543 (optics number-floor) — the JAM natural-emissions stability set. All four target \`dev\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)