### PR TITLE
config(diffusion): default tracer_positivity to auto (on iff aerosols advected)

### DIFF
--- a/jcm/config/diffusion/default.yaml
+++ b/jcm/config/diffusion/default.yaml
@@ -12,9 +12,21 @@
 kind: auto
 scale: 1.0
 
-# Optional dycore-side mass-conserving positivity filter on the gridpoint
-# tracers (applied as the spectral core projects to the physics state). Off by
-# default; turn on for prescribed-aerosol-emissions runs, whose sharp sources
-# otherwise ring negative and NaN the microphysics (see issue #521). Opt-in
-# because grid-point dycores don't need it and it slightly alters tracer output.
-tracer_positivity: false
+# Dycore-side mass-conserving positivity filter on the gridpoint tracers
+# (applied as the spectral core projects to the physics state). Prescribed/
+# prognostic aerosol emissions have sharp near-zero sources that ring negative
+# (Gibbs) and NaN the microphysics — most acutely the MAM4 core, where a
+# negative aerosol mass makes wateruptake return a negative wet density and coag
+# NaNs (see issue #521). The filter clips that at the source, mass-conservingly.
+#
+#   ``auto`` (default) — on when the physics advects prognostic aerosol tracers
+#     (``physics.aerosol_module == "jam"``), off otherwise. This keeps
+#     non-aerosol runs bit-identical (the filter differs from the plain
+#     ``verify_state`` clip only where a tracer actually rings negative), while
+#     aerosol-emission runs get the fix without having to remember the flag.
+#   ``true`` / ``false`` — force on/off regardless of the physics.
+#
+# The filter is cheap (a clip + one column-mass rescale per tracer) and a
+# bit-exact no-op wherever tracers are already non-negative, so ``auto`` costs
+# nothing on runs that don't ring.
+tracer_positivity: auto

--- a/jcm/runners.py
+++ b/jcm/runners.py
@@ -641,16 +641,32 @@ def inject_jw_profile(model: Model, rh: float = 0.6) -> None:
 def build_tracer_filter(cfg: DictConfig):
     """Build the optional dycore-side gridpoint tracer filter.
 
-    Enabled via ``cfg.diffusion.tracer_positivity`` (default off). The only
-    filter currently is mass-conserving positivity, which a spectral core
-    applies as it projects to the physics gridpoint state so the sharp-source
-    tracer fields of prescribed aerosol emissions stay non-negative at the
+    Controlled by ``cfg.diffusion.tracer_positivity``. The only filter currently
+    is mass-conserving positivity, which a spectral core applies as it projects
+    to the physics gridpoint state so the sharp-source tracer fields of
+    prognostic/prescribed aerosol emissions stay non-negative at the
     dynamics→physics boundary (Gibbs ringing otherwise NaNs the microphysics;
-    see issue #521). Returns ``None`` when disabled — a no-op on the dycore.
+    see issue #521).
+
+    Resolution of the config value:
+
+    * ``true`` / ``false`` — force the filter on/off.
+    * ``"auto"`` (or unset) — enable it only when the physics advects prognostic
+      aerosol tracers (``physics.aerosol_module == "jam"``). This defaults the
+      fix on for exactly the runs that need it while leaving non-aerosol runs
+      bit-identical (the filter differs from the plain ``verify_state`` clip only
+      where a tracer rings negative).
+
+    Returns ``None`` when disabled — a no-op on the dycore.
     """
     diffusion = cfg.get("diffusion", None)
-    enabled = (False if diffusion is None
-               else bool(diffusion.get("tracer_positivity", False)))
+    tp = None if diffusion is None else diffusion.get("tracer_positivity", "auto")
+    if isinstance(tp, bool):
+        enabled = tp
+    else:  # "auto" / null → on iff prognostic aerosols are advected
+        physics = cfg.get("physics", None)
+        aerosol_module = None if physics is None else physics.get("aerosol_module", None)
+        enabled = (aerosol_module == "jam")
     if not enabled:
         return None
     from jcm.filters import MassConservingPositivity

--- a/jcm/runners_test.py
+++ b/jcm/runners_test.py
@@ -21,6 +21,7 @@ from jcm.runners import (
     build_model,
     build_physics,
     build_terrain,
+    build_tracer_filter,
     configure_host_device_count,
     run,
 )
@@ -33,6 +34,34 @@ def _compose(overrides=None):
     overrides = overrides or []
     with initialize_config_dir(version_base=None, config_dir=CONFIG_DIR):
         return compose(config_name="config", overrides=overrides)
+
+
+class TestTracerPositivityResolution(unittest.TestCase):
+    """``diffusion.tracer_positivity`` resolution in build_tracer_filter.
+
+    ``auto`` (the default) turns the mass-conserving positivity filter on only
+    when the physics advects prognostic aerosol tracers (aerosol_module==jam),
+    so aerosol-emission runs get the ringing fix by default while non-aerosol
+    runs stay bit-identical; explicit true/false always wins.
+    """
+
+    def test_auto_on_for_prognostic_aerosol(self):
+        self.assertIsNotNone(build_tracer_filter(_compose(["physics=echam-jam"])))
+
+    def test_auto_off_for_diagnostic_aerosol(self):
+        # echam term-list preset uses diagnostic MACv2-SP → no advected aerosol.
+        self.assertIsNone(build_tracer_filter(_compose(["physics=echam"])))
+
+    def test_auto_off_without_aerosol(self):
+        self.assertIsNone(build_tracer_filter(_compose(["physics=held_suarez"])))
+
+    def test_explicit_false_overrides_auto(self):
+        self.assertIsNone(build_tracer_filter(
+            _compose(["physics=echam-jam", "diffusion.tracer_positivity=false"])))
+
+    def test_explicit_true_overrides_auto(self):
+        self.assertIsNotNone(build_tracer_filter(
+            _compose(["physics=echam", "diffusion.tracer_positivity=true"])))
 
 
 class TestConfigComposition(unittest.TestCase):


### PR DESCRIPTION
## Summary

The mass-conserving gridpoint positivity filter (`MassConservingPositivity`, #521) is the root fix for the aerosol-emission Gibbs-ringing NaN: spectral advection of the sharp near-zero aerosol source leaves small **negative** tracer masses, which NaN the microphysics — most acutely the MAM4 core, where a negative aerosol mass makes `wateruptake` return a **negative wet density** and coagulation NaNs (`_mam_coag_1subarea`). It was previously **opt-in** (`tracer_positivity: false`), so every aerosol-emission run had to remember the flag.

This defaults it to **`auto`**: `build_tracer_filter` now enables the filter exactly when the physics advects prognostic aerosol tracers (`physics.aerosol_module == "jam"`), and leaves it off otherwise.

## Why gate on aerosols rather than flip the global default

- **Reproducibility, not cost.** The filter is cheap (a clip + one column-mass rescale per tracer) and a **bit-exact no-op wherever tracers are already ≥ 0** (`scale = col_mass / col_mass = 1.0`). But it differs from the plain `verify_state` clip *wherever a field rings negative* — so turning it on globally would change **non-aerosol moist runs** (humidity/cloud ringing) and risk drifting pinned fingerprint tests. Gating on prognostic aerosols keeps every non-aerosol config **bit-identical**.
- Aerosol-emission runs (`echam-jam`) get the fix automatically; nothing else changes.

## Config semantics

| `diffusion.tracer_positivity` | filter |
|---|---|
| `auto` (default) | on iff `physics.aerosol_module == "jam"` |
| `true` / `false` | forced on / off |

## Tests

`TestTracerPositivityResolution` (5 cases, all green): auto-on for echam-jam, auto-off for diagnostic-aerosol (echam) and no-aerosol (held_suarez), and explicit true/false overriding auto.

Verified in-model earlier: `tracer_positivity=true` alone (no other aerosol-input floor) resolves the MAM4 sea-salt coag NaN, and the aerosol run then equilibrates stably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)