### PR TITLE
fix(thermo): shared saturation module; ice-saturation fixes; NaN-gradient guards

### DIFF
--- a/jcm/physics/clouds/echam_1m.py
+++ b/jcm/physics/clouds/echam_1m.py
@@ -214,9 +214,16 @@ def cloud_droplet_radius(
     # Volume of single droplet
     volume_per_droplet = cloud_water_density / (droplet_density + config.epsilon) / c.rhow  # m³
     
-    # Volume mean radius
-    radius = (3.0 * volume_per_droplet / (4.0 * jnp.pi)) ** (1.0 / 3.0)
-    
+    # Volume mean radius. Double-where guard: the cube root has an infinite
+    # derivative at 0 and the clip below has zero slope there, so without a
+    # safe base the backward pass multiplies 0 × ∞ = NaN at cloud-free
+    # points. Forward values are unchanged (0**(1/3) was 0, then clipped).
+    has_water = volume_per_droplet > 0.0
+    volume_safe = jnp.where(has_water, volume_per_droplet, 1.0)
+    radius = jnp.where(
+        has_water, (3.0 * volume_safe / (4.0 * jnp.pi)) ** (1.0 / 3.0), 0.0,
+    )
+
     # Apply limits
     radius = jnp.clip(radius, config.ceffmin * 1e-6, config.ceffmax * 1e-6)
     
@@ -489,13 +496,23 @@ def snow_accretion(
         temp_factor = jnp.exp(-0.03 * jnp.abs(t_celsius + 15.0))
         efficiency = efficiency * temp_factor
     
-    # Snow fall velocity
+    # Snow fall velocity. Double-where guard on the fractional power:
+    # ``snow_gm3**b`` (b < 1) has an infinite derivative at 0, and although
+    # the *rate* below is proportional to snow**(1+b) (mathematically slope
+    # 0 at snow = 0), autodiff evaluates the product rule as 0 × ∞ = NaN.
+    # A safe base of 1.0 where snow is absent leaves forward values
+    # unchanged (rate is where-masked to 0 there).
     snow_gm3 = snow * air_density * 1000.0  # g/m³
-    vt_snow = config.vt_snow_a * snow_gm3**config.vt_snow_b
-    
+    snow_present = snow_gm3 > 0.0
+    vt_snow = config.vt_snow_a * jnp.where(snow_present, snow_gm3, 1.0)**config.vt_snow_b
+
     # Accretion rate
-    accretion_rate = efficiency * target * snow * vt_snow / (air_density**0.5)
-    
+    accretion_rate = jnp.where(
+        snow_present,
+        efficiency * target * snow * vt_snow / (air_density**0.5),
+        0.0,
+    )
+
     return accretion_rate
 
 
@@ -576,19 +593,24 @@ def evaporation_sublimation(
     # Subsaturation
     subsaturation = jnp.maximum(0.0, (qs - specific_humidity) / qs)
     
-    # Rain evaporation
+    # Rain evaporation. Double-where guard: sqrt has an infinite derivative
+    # at 0, so the base must be replaced by a safe value (1.0) in the
+    # where-masked region or the masked branch's 0 cotangent × ∞ derivative
+    # produces NaN gradients. Forward values are unchanged.
     rain_gm3 = rain * air_density * 1000.0
+    rain_gm3_safe = jnp.where(rain > config.epsilon, rain_gm3, 1.0)
     rain_evap = jnp.where(
         rain > config.epsilon,
-        config.cevaprain * subsaturation * rain_gm3**0.5 / air_density,
+        config.cevaprain * subsaturation * rain_gm3_safe**0.5 / air_density,
         0.0
     )
-    
-    # Snow sublimation
-    snow_gm3 = snow * air_density * 1000.0  
+
+    # Snow sublimation (same double-where guard as rain evaporation).
+    snow_gm3 = snow * air_density * 1000.0
+    snow_gm3_safe = jnp.where(snow > config.epsilon, snow_gm3, 1.0)
     snow_sublim = jnp.where(
         snow > config.epsilon,
-        config.cevapsnow * subsaturation * snow_gm3**0.5 / air_density,
+        config.cevapsnow * subsaturation * snow_gm3_safe**0.5 / air_density,
         0.0
     )
     
@@ -777,12 +799,19 @@ def cloud_microphysics(
     )
     
     # 6. Sedimentation (using simple approach for now)
-    # Calculate terminal velocities
+    # Calculate terminal velocities. Double-where guard on the fractional
+    # powers (see snow_accretion): ``x**b`` with b < 1 has an infinite
+    # derivative at x = 0 and the ``rain * vt_rain`` products below would
+    # backpropagate 0 × ∞ = NaN at precipitation-free points. Safe base 1.0
+    # where the hydrometeor is absent; the sedimentation rates are
+    # where-masked to 0 there, so forward values are unchanged.
     rain_gm3 = rain_water * air_density * 1000.0
-    vt_rain = config.vt_rain_a * rain_gm3**config.vt_rain_b * 1e-3  # m/s
-    
+    rain_present = rain_gm3 > 0.0
+    vt_rain = config.vt_rain_a * jnp.where(rain_present, rain_gm3, 1.0)**config.vt_rain_b * 1e-3  # m/s
+
     snow_gm3 = snow * air_density * 1000.0
-    vt_snow = config.vt_snow_a * snow_gm3**config.vt_snow_b * 1e-3  # m/s
+    snow_present = snow_gm3 > 0.0
+    vt_snow = config.vt_snow_a * jnp.where(snow_present, snow_gm3, 1.0)**config.vt_snow_b * 1e-3  # m/s
     
     # Ice sedimentation: ECHAM mo_cloud.f90 lines 472-491 uses
     # ``zxifall = cvtfall * (rho*xi)^0.16`` (Heymsfield-Donner content-
@@ -805,8 +834,16 @@ def cloud_microphysics(
     zal1_ice = vt_ice * dt / jnp.maximum(layer_thickness, config.epsilon)
     ice_sedi = cloud_ice * (1.0 - jnp.exp(-zal1_ice)) / jnp.maximum(dt, 1e-6)
 
-    rain_sedi = rain_water * vt_rain / (layer_thickness + config.epsilon)
-    snow_sedi = snow * vt_snow / (layer_thickness + config.epsilon)
+    rain_sedi = jnp.where(
+        rain_present,
+        rain_water * vt_rain / (layer_thickness + config.epsilon),
+        0.0,
+    )
+    snow_sedi = jnp.where(
+        snow_present,
+        snow * vt_snow / (layer_thickness + config.epsilon),
+        0.0,
+    )
     
     # Update tendencies
     dqidt = dqidt - ice_sedi
@@ -1119,22 +1156,27 @@ def cloud_microphysics_column_sweep(
         zclcpre_safe = jnp.maximum(zclcpre, config.epsilon)
         zqrho_sqrt = jnp.sqrt(jnp.maximum(rho / 1.3, config.epsilon))
         zqrho_sqrt_inv = jnp.sqrt(jnp.maximum(1.3 / jnp.maximum(rho, config.epsilon), 0.0))
-        zxrp1 = jnp.where(
-            (zrfl > config.epsilon) & (zclcpre > config.epsilon),
-            jnp.power(
-                jnp.maximum(zrfl / zclcpre_safe / (12.45 * zqrho_sqrt), 0.0),
-                8.0 / 9.0,
-            ),
-            0.0,
+        rain_present = (zrfl > config.epsilon) & (zclcpre > config.epsilon)
+        snow_present = (zsfl > config.epsilon) & (zclcpre > config.epsilon)
+        # Double-where guard on the fractional powers: ``x**(8/9)`` (and
+        # ``x**(1/1.16)``) has an infinite derivative at x == 0, and masking
+        # only the *output* with ``where`` still yields NaN in reverse mode
+        # (the masked branch's 0 cotangent multiplies the ∞ derivative).
+        # Substituting a safe base of 1.0 where the flux is absent keeps the
+        # forward values bit-identical (the outer ``where`` already returned
+        # 0 there) while making d(precip)/d(params) finite.
+        zxrp1_base = jnp.where(
+            rain_present,
+            jnp.maximum(zrfl / zclcpre_safe / (12.45 * zqrho_sqrt), 0.0),
+            1.0,
         )
-        zxsp1 = jnp.where(
-            (zsfl > config.epsilon) & (zclcpre > config.epsilon),
-            jnp.power(
-                jnp.maximum(zsfl / zclcpre_safe / config.cvtfall, 0.0),
-                1.0 / 1.16,
-            ),
-            0.0,
+        zxrp1 = jnp.where(rain_present, jnp.power(zxrp1_base, 8.0 / 9.0), 0.0)
+        zxsp1_base = jnp.where(
+            snow_present,
+            jnp.maximum(zsfl / zclcpre_safe / config.cvtfall, 0.0),
+            1.0,
         )
+        zxsp1 = jnp.where(snow_present, jnp.power(zxsp1_base, 1.0 / 1.16), 0.0)
 
         # In-cloud values for the cascade. ECHAM works on ``zxlb`` /
         # ``zxib`` which are in-cloud mixing ratios (qc/cf, qi/cf).
@@ -1231,8 +1273,16 @@ def cloud_microphysics_column_sweep(
         # here, which inverted the density dependence (suppressing
         # rain-evap in low-density layers and amplifying it in dense
         # layers — the opposite of physical).
+        # Same double-where guard as zxrp1 above: ``x**0.61`` at x == 0 has
+        # an infinite derivative, and ``zevp`` is where-masked to 0 below
+        # when no rain is present — the safe base of 1.0 in that masked
+        # region leaves every forward value unchanged but keeps the
+        # backward pass finite.
+        zrfl_in_cf_base = jnp.where(
+            rain_present, jnp.maximum(zrfl_in_cf, 0.0), 1.0,
+        )
         zzepr_rate = (
-            870.0 * zsusatw * jnp.power(jnp.maximum(zrfl_in_cf, 0.0), 0.61)
+            870.0 * zsusatw * jnp.power(zrfl_in_cf_base, 0.61)
             * zqrho_sqrt_inv / jnp.sqrt(1.3) / zthermo
         )
         zevp_unbounded = -zzepr_rate * dt * zclcpre
@@ -1241,9 +1291,7 @@ def cloud_microphysics_column_sweep(
         zevp = jnp.minimum(zevp_unbounded, zevp_max_subsat)
         zevp = jnp.maximum(zevp, 0.0)
         zevp = jnp.minimum(zevp, zevp_max_rain)
-        zevp = jnp.where(
-            (zrfl > config.epsilon) & (zclcpre > config.epsilon), zevp, 0.0,
-        )
+        zevp = jnp.where(rain_present, zevp, 0.0)
         dq_evap = zevp                                                # kg/kg over dt
         dTdt_evap = -zlvdcp * (dq_evap / dt)                          # K/s
         rain_evap_flux = zevp * mref / dt                             # kg/m²/s

--- a/jcm/physics/clouds/echam_1m_test.py
+++ b/jcm/physics/clouds/echam_1m_test.py
@@ -969,4 +969,96 @@ class TestColumnSweepMicrophysics:
             f"surface precip {float(surface_precip):.3e} kg/m²/s"
         )
 
-    print("All tests passed!")
+
+class TestColumnSweepParameterGradients:
+    """Regression tests for NaN parameter gradients through the sweep.
+
+    ``x**frac`` at a zero base (the Marshall-Palmer ``zxrp1`` / ``zxsp1``
+    concentrations and the Rotstayn rain-evap rate) has an infinite
+    derivative, and where-masking the output alone produced
+    ``d(precip)/d(params) = NaN`` even though finite differences gave a
+    perfectly good ~1e-6. These tests fail on the unguarded code and pin
+    the double-where fix.
+    """
+
+    @staticmethod
+    def _precipitating_column(nlev=20):
+        """Warm near-saturated column with a liquid cloud aloft.
+
+        Same construction as
+        ``TestColumnSweepMicrophysics.test_warm_cloud_makes_surface_rain``:
+        q at 95 % saturation so rain reaches the surface.
+        """
+        from jcm.physics.clouds.sundqvist import saturation_specific_humidity
+        T = jnp.linspace(280.0, 295.0, nlev)
+        p = jnp.linspace(20000.0, 100000.0, nlev)
+        qsw = jax.vmap(saturation_specific_humidity)(p, T)
+        q = 0.95 * qsw
+        qc = jnp.zeros(nlev).at[5].set(2e-3)
+        qi = jnp.zeros(nlev)
+        cf = jnp.where(qc > 0, 0.7, 0.0)
+        rho = p / (287.0 * T)
+        dz = jnp.full(nlev, 500.0)
+        ndrop = jnp.full(nlev, 1e8)
+        return T, q, p, qc, qi, cf, rho, dz, ndrop
+
+    @staticmethod
+    def _mixed_column(nlev=20):
+        """Mixed-phase column (ice cloud aloft, liquid cloud below) so the
+        snow path — and with it ``cvtfall`` — is exercised.
+        """
+        from jcm.physics.clouds.sundqvist import saturation_specific_humidity
+        T = jnp.linspace(230.0, 295.0, nlev)
+        p = jnp.linspace(20000.0, 100000.0, nlev)
+        qsw = jax.vmap(saturation_specific_humidity)(p, T)
+        q = 0.95 * qsw
+        qc = jnp.zeros(nlev).at[8].set(2e-3)
+        qi = jnp.zeros(nlev).at[4].set(5e-4)
+        cf = jnp.where((qc + qi) > 0, 0.7, 0.0)
+        rho = p / (287.0 * T)
+        dz = jnp.full(nlev, 500.0)
+        ndrop = jnp.full(nlev, 1e8)
+        return T, q, p, qc, qi, cf, rho, dz, ndrop
+
+    @staticmethod
+    def _total_precip(ccraut, cvtfall, column):
+        T, q, p, qc, qi, cf, rho, dz, ndrop = column
+        cfg = MicrophysicsParameters.default(ccraut=ccraut, cvtfall=cvtfall)
+        _, state = cloud_microphysics_column_sweep(
+            T, q, p, qc, qi, cf, rho, dz, ndrop, dt=1800.0, config=cfg,
+        )
+        return state.precip_rain + state.precip_snow
+
+    def test_param_gradients_finite_and_match_fd(self):
+        ccraut0, cvtfall0 = 15.0, 3.29
+        column = self._precipitating_column()
+        d_ccraut, d_cvtfall = jax.grad(self._total_precip, argnums=(0, 1))(
+            ccraut0, cvtfall0, column,
+        )
+        # The essential regression: finite (the unguarded powers gave NaN).
+        assert jnp.isfinite(d_ccraut), f"d(precip)/d(ccraut) = {d_ccraut}"
+        assert jnp.isfinite(d_cvtfall), f"d(precip)/d(cvtfall) = {d_cvtfall}"
+        # More autoconversion → more rain: strictly positive here.
+        assert float(d_ccraut) > 0.0
+
+        # Cross-check the autoconversion gradient against central finite
+        # differences (well-conditioned: FD/AD agree to ~0.03 % here).
+        h = ccraut0 * 1e-3
+        fd = (
+            float(self._total_precip(ccraut0 + h, cvtfall0, column))
+            - float(self._total_precip(ccraut0 - h, cvtfall0, column))
+        ) / (2.0 * h)
+        assert jnp.isclose(d_ccraut, fd, rtol=0.05), (
+            f"AD {float(d_ccraut)} vs FD {fd}"
+        )
+
+    def test_cvtfall_gradient_finite_with_snow_active(self):
+        # cvtfall only enters through the falling-snow concentration zxsp1;
+        # a mixed-phase column makes its gradient nonzero (and previously
+        # NaN via the unguarded x**(1/1.16)).
+        column = self._mixed_column()
+        d_cvtfall = jax.grad(self._total_precip, argnums=1)(
+            15.0, 3.29, column,
+        )
+        assert jnp.isfinite(d_cvtfall), f"d(precip)/d(cvtfall) = {d_cvtfall}"
+        assert float(d_cvtfall) != 0.0

--- a/jcm/physics/clouds/lohmann_2m.py
+++ b/jcm/physics/clouds/lohmann_2m.py
@@ -1380,8 +1380,20 @@ def het_mxphase_freezing(
     # -------------------------------------------------------------------------
     # 2. Freezing rates (contact and immersion freezing)
     # -------------------------------------------------------------------------
-    # Compute mean volume radius of cloud droplets
-    droplet_radius = (0.75 * cloud_liquid * air_density / (pi * c.rhow * droplet_number)) ** (1.0 / 3.0)
+    # Compute mean volume radius of cloud droplets. Double-where guard on
+    # the cube root: it has an infinite derivative at cloud_liquid == 0 and
+    # the freezing rates below vanish there (and are additionally
+    # where-masked on freezing_condition), so without a safe base the
+    # backward pass multiplies 0 × ∞ = NaN at liquid-free points. Forward
+    # values are unchanged (radius was 0 there, and every consumer scales
+    # by cloud_liquid).
+    has_liquid = cloud_liquid > 0.0
+    droplet_radius_base = jnp.where(
+        has_liquid,
+        0.75 * cloud_liquid * air_density / (pi * c.rhow * droplet_number),
+        1.0,
+    )
+    droplet_radius = jnp.where(has_liquid, droplet_radius_base ** (1.0 / 3.0), 0.0)
 
     # Contact freezing by dust and soot
     contact_freezing_dust = jnp.minimum(1.0, jnp.maximum(0.0, -(0.1014 * (temperature - c.tmelt) + 0.3277)))

--- a/jcm/physics/clouds/lohmann_2m.py
+++ b/jcm/physics/clouds/lohmann_2m.py
@@ -45,6 +45,7 @@ from typing import NamedTuple, Tuple
 from math import pi
 
 import jcm.constants as c
+from jcm.physics import thermodynamics
 
 from .lohmann_2m_params import (
     CloudParams2M,
@@ -521,7 +522,13 @@ def sublimation_snow_and_ice_evaporation_rain(
     # ------------------------------------------------------------------
     ll_snow = jnp.logical_and(snow_flux > cqtmin, precip_mask)
 
-    zclambs_s = zcons3 * (snow_flux / jnp.maximum(zclcpre, eps)) ** (0.25 / 1.16)
+    # Double-where guard: the fractional power has an infinite derivative at
+    # a zero base, and ``snow_sublim`` is where-masked below — masking the
+    # output alone still yields NaN gradients (0 cotangent × ∞ derivative).
+    # A safe base of 1.0 where ll_snow is False keeps forward values
+    # unchanged while keeping the backward pass finite.
+    zclambs_s_base = jnp.where(ll_snow, snow_flux / jnp.maximum(zclcpre, eps), 1.0)
+    zclambs_s = zcons3 * zclambs_s_base ** (0.25 / 1.16)
     zcfac4c_s = 0.78 * zclambs_s**2 + 232.19 * (inv_air_density**0.25) * (zclambs_s**2.625)
     ztmp2_s = zcfac4c_s * zcoeff * dp_over_g
 
@@ -537,7 +544,10 @@ def sublimation_snow_and_ice_evaporation_rain(
     # ------------------------------------------------------------------
     ll_ice = jnp.logical_and(ice_flux > cqtmin, falling_ice_mask)
 
-    zclambs_i = zcons3 * (ice_flux / jnp.maximum(zclcfi, eps)) ** (0.25 / 1.16)
+    # Same double-where guard as snow sublimation above (ice_sublim and
+    # zsubin are where-masked on ll_ice).
+    zclambs_i_base = jnp.where(ll_ice, ice_flux / jnp.maximum(zclcfi, eps), 1.0)
+    zclambs_i = zcons3 * zclambs_i_base ** (0.25 / 1.16)
     zcfac4c_i = 0.78 * zclambs_i**2 + 232.19 * (inv_air_density**0.25) * (zclambs_i**2.625)
     ztmp2_i = zcfac4c_i * zcoeff * dp_over_g
 
@@ -563,11 +573,14 @@ def sublimation_snow_and_ice_evaporation_rain(
     # ------------------------------------------------------------------
     ll_rain = jnp.logical_and(rain_flux > cqtmin, precip_mask)
 
+    # Same double-where guard as snow sublimation above (rain_evap is
+    # where-masked on ll_rain).
+    zrain_pow_base = jnp.where(ll_rain, rain_flux / jnp.maximum(zclcpre, eps), 1.0)
     ztmp2_r = (
         870.0
         * subsat_wrt_water_evap
         * dp_over_g
-        * (rain_flux / jnp.maximum(zclcpre, eps)) ** 0.61
+        * zrain_pow_base ** 0.61
         / (jnp.sqrt(jnp.maximum(air_density, eps)) * jnp.maximum(thermo_term_water, eps))
     )
 
@@ -1876,8 +1889,16 @@ def precip_formation_cold(
         ),
     )
 
-    # droplet mean radius proxy (zdw)
-    zdw = (6.0 * pirho_rcp * air_density * in_cloud_liquid / jnp.maximum(droplet_number, eps)) ** (1.0 / 3.0)
+    # droplet mean radius proxy (zdw). Double-where guard: the cube root has
+    # an infinite derivative when in_cloud_liquid == 0, and everything
+    # downstream of zdw (zcsacl) is where-masked on ll2 — safe base 1.0 in
+    # the masked region keeps forward values unchanged and gradients finite.
+    zdw_base = jnp.where(
+        ll2,
+        6.0 * pirho_rcp * air_density * in_cloud_liquid / jnp.maximum(droplet_number, eps),
+        1.0,
+    )
+    zdw = zdw_base ** (1.0 / 3.0)
     zdw = jnp.maximum(zdw, 1.0e-6)
 
     zudrop = 1.19e4 * 2500.0 * zdw**2 * (1.3 * inverse_air_density_rcp) ** 0.35
@@ -1918,8 +1939,10 @@ def precip_formation_cold(
     zcsacl = jnp.clip(zcsacl, 0.01, 1.0)
     zcsacl = jnp.where(ll2, zcsacl, 0.0)
 
-    # lambda_snow proxy and collection coefficient
-    zlamsm = cons4 * zxsp ** 0.8125
+    # lambda_snow proxy and collection coefficient. Double-where guard on
+    # the fractional power (zxsp can be 0 where ll2 is False; ztmp2 is
+    # where-masked, so the safe base only changes the masked region).
+    zlamsm = cons4 * jnp.where(ll2, zxsp, 1.0) ** 0.8125
     ztmp2 = pi * cn0s * 3.078 * zlamsm * (inverse_air_density ** 0.5)
     ztmp2 = jnp.where(ll2, ztmp2, 0.0)
 
@@ -1952,7 +1975,9 @@ def precip_formation_cold(
     ll1b = jnp.logical_and(cloud_mask, in_cloud_ice > cqtmin)
     ll2 = jnp.logical_and(ll1b, zxsp > cqtmin)
 
-    zlamsm = cons4 * zxsp ** 0.8125
+    # Double-where guard on the fractional power (zsaci is where-masked on
+    # ll2, so the safe base only changes the masked region).
+    zlamsm = cons4 * jnp.where(ll2, zxsp, 1.0) ** 0.8125
     ztmp1 = pi * cn0s * 3.078 * zlamsm * (inverse_air_density ** 0.5)
     survival = jnp.exp(-dt * ztmp1 * zcolleffi)
     zsaci = in_cloud_ice * (1.0 - survival)
@@ -2375,7 +2400,15 @@ def update_tendencies_and_important_vars(
     # breadth_factor returns dimensionless breadth parameter (Fortran breadth_factor)
     breadth = breadth_factor(cdnc)
     # convert to effective radius (um): 1e6 * breadth * ((3/(4*pi*rhoh2o)) * pxlb * prho / pcdnc)^(1/3)
-    liq_eff_radius = 1.0e6 * breadth * ((3.0 / (4.0 * pi * c.rhow)) * cloud_liquid_in_cloud * air_density / jnp.maximum(cdnc, eps)) ** (1.0 / 3.0)
+    # Double-where guard on the cube root (infinite derivative when
+    # cloud_liquid_in_cloud == 0; the result is where-masked, so the safe
+    # base only changes the masked region).
+    liq_radius_base = jnp.where(
+        liquid_cloud_flag,
+        (3.0 / (4.0 * pi * c.rhow)) * cloud_liquid_in_cloud * air_density / jnp.maximum(cdnc, eps),
+        1.0,
+    )
+    liq_eff_radius = 1.0e6 * breadth * liq_radius_base ** (1.0 / 3.0)
     liq_eff_radius = jnp.where(liquid_cloud_flag, liq_eff_radius, 0.0)
 
     # --- 7) ice crystal effective radius [um] (preffi)
@@ -3158,16 +3191,15 @@ def cloud_microphysics_2m(
     # ------------------------------------------------------------------
     # Mixed-phase deposition and corrections
     # ------------------------------------------------------------------
-    # Saturation vapor pressures (Tetens / Magnus formula, ECHAM conventions).
-    t0_sat = jnp.array(273.15, dtype=qc.dtype)
-    es0 = jnp.array(611.21, dtype=qc.dtype)  # reference esat [Pa]
-    c1_w, c2_w = 17.502, 32.19               # water, T >= 273.15 K
-    c3_i, c4_i = 22.587, -0.7                # water T<273.15 K and pure ice
-
-    es_water_warm = es0 * jnp.exp(c1_w * (temperature - t0_sat) / (temperature - c2_w))
-    es_water_cold = es0 * jnp.exp(c3_i * (temperature - t0_sat) / (temperature - c4_i))
-    es_water = jnp.where(temperature >= t0_sat, es_water_warm, es_water_cold)
-    es_ice = es0 * jnp.exp(c3_i * (temperature - t0_sat) / (temperature - c4_i))
+    # Saturation vapour pressures from the shared ECHAM coefficients
+    # (jcm.physics.thermodynamics). ``es_water`` uses the LIQUID-WATER
+    # coefficients at ALL temperatures — the Bergeron-Findeisen variable
+    # below and the threshold vertical velocity depend on the water/ice
+    # saturation *difference* below freezing, which degenerates to zero
+    # (killing the Bergeron process) if es_water switches to the ice
+    # coefficients below 0 °C.
+    es_water = thermodynamics.saturation_vapor_pressure(temperature, phase="water")
+    es_ice = thermodynamics.saturation_vapor_pressure(temperature, phase="ice")
 
     qsat_water = c.eps * es_water / jnp.maximum(pressure - (1.0 - c.eps) * es_water, params.epsec)
     qsat_ice = c.eps * es_ice / jnp.maximum(pressure - (1.0 - c.eps) * es_ice, params.epsec)

--- a/jcm/physics/convection/saturation.py
+++ b/jcm/physics/convection/saturation.py
@@ -1,68 +1,53 @@
-"""Shared saturation thermodynamics (Tetens) for the convection schemes.
+"""Saturation thermodynamics for the convection schemes.
 
-Centralises the Tetens saturation-vapour-pressure coefficients and the
-saturation specific-humidity / mixing-ratio formulas (and the analytic
-``dqs/dT`` used by the Newton adjustment steps) that were previously duplicated
-across ``tiedtke_nordeng``, ``updraft``, ``adjustment`` and ``betts_miller``.
+Thin wrappers around :mod:`jcm.physics.thermodynamics` — the single shared
+ECHAM 6.3 saturation implementation — preserving the signatures that
+``tiedtke_nordeng`` (updraft, downdraft, cuadjtq Newton steps, CAPE) and
+``betts_miller`` call.
 
 Scheme-specific choices are parameters rather than separate copies:
 
-* ``phase`` selects the saturation surface — ``"auto"`` (water above the melting
-  point, ice below; the ECHAM/Tiedtke convention), ``"water"`` (Betts-Miller,
-  following Isca), or ``"ice"``.
+* ``phase`` selects the saturation surface — ``"auto"`` (water at/above the
+  melting point, ice below; the ECHAM/Tiedtke convention), ``"water"``
+  (Betts-Miller, following Isca), or ``"ice"``.
 * ``clip`` optionally bounds the returned specific humidity (Tiedtke clips to
   ``[0, 0.5]`` via :func:`saturation_mixing_ratio`).
 
-Physical constants (``eps``, ``tmelt``) are read by attribute access from
-:mod:`jcm.constants`, so a runtime ``set_constants`` override is honoured.
+The coefficients are ECHAM's ``mo_convect_tables`` c3/c4 pairs (water:
+``c3les = 17.269`` / ``c4les = 35.86 K``; ice: ``c3ies = 21.875`` /
+``c4ies = 7.66 K``). This module previously carried its own Tetens constants
+whose ice pair reused the *water* ``c4`` (35.86) as the ice ``A`` coefficient
+— a transcription error that made sub-freezing saturation ~3× too low at
+−20 °C and ~60× too low at −60 °C. Delegating to the shared module is what
+fixed that; the water branch changed only microscopically (17.27/237.3 →
+17.269 / (T − 35.86), equivalent to ~0.01 %).
 
 These functions are intentionally *not* ``@jit``-ed: they are always called
-inside the model's outer jit (the ``_run_from_state`` step), so they are inlined
-and fused into that compiled graph. ``phase`` is a static Python string resolved
-at trace time — each phase bakes a constant into its caller's trace, so distinct
-phases never share a compiled artifact.
+inside the model's outer jit (the ``_run_from_state`` step), so they are
+inlined and fused into that compiled graph. ``phase`` is a static Python
+string resolved at trace time.
 """
 
 import jax.numpy as jnp
 
-import jcm.constants as c
+from jcm.physics import thermodynamics
 
-# Tetens coefficients: es = ES0 * exp(A * tc / (tc + B)), with tc = T - tmelt.
-# Water is used above the melting point, ice below. The ice ``A`` (35.86) is
-# this package's historical value; what matters for the Newton steps is that the
-# saturation target and its derivative use the *same* coefficients.
-ES0 = 610.78          # Pa (saturation vapour pressure at the melting point)
-A_WATER = 17.27
-B_WATER = 237.3
-A_ICE = 35.86
-B_ICE = 265.5
-
-# Math-safety temperature clip: the Tetens denominators (tc + B) vanish near
-# 8-36 K, far below any physical temperature. A loose bound avoids NaNs without
-# masking genuine upstream bugs.
-_T_MIN = 50.0
-_T_MAX = 500.0
+# Saturation vapour pressure at the melting point [Pa] — re-exported because
+# callers/tests use it as the phase-independent anchor value es(tmelt).
+ES0 = thermodynamics.C1ES
 
 
 def saturation_vapor_pressure(temperature: jnp.ndarray,
                               phase: str = "auto") -> jnp.ndarray:
-    """Tetens saturation vapour pressure (Pa).
+    """Saturation vapour pressure (Pa).
 
     Args:
         temperature: Temperature (K).
-        phase: ``"auto"`` (water above ``tmelt``, ice below), ``"water"`` or
-            ``"ice"``.
+        phase: ``"auto"`` (water at/above ``tmelt``, ice below), ``"water"``
+            or ``"ice"``.
 
     """
-    temperature = jnp.clip(temperature, _T_MIN, _T_MAX)
-    tc = temperature - c.tmelt
-    es_water = ES0 * jnp.exp(A_WATER * tc / (tc + B_WATER))
-    if phase == "water":
-        return es_water
-    es_ice = ES0 * jnp.exp(A_ICE * tc / (tc + B_ICE))
-    if phase == "ice":
-        return es_ice
-    return jnp.where(temperature > c.tmelt, es_water, es_ice)
+    return thermodynamics.saturation_vapor_pressure(temperature, phase=phase)
 
 
 def saturation_specific_humidity(temperature: jnp.ndarray,
@@ -75,13 +60,12 @@ def saturation_specific_humidity(temperature: jnp.ndarray,
         temperature: Temperature (K).
         pressure: Pressure (Pa).
         phase: Saturation surface, see :func:`saturation_vapor_pressure`.
-        clip: Optional ``(lo, hi)`` bound on the result.
+        clip: Optional ``(lo, hi)`` bound on the result (applied on top of
+            the shared implementation's ECHAM ``MIN(..., 0.5)`` cap).
 
     """
-    es = saturation_vapor_pressure(temperature, phase=phase)
-    # Cap es below the pressure so the denominator stays positive at low p.
-    es = jnp.minimum(es, 0.99 * jnp.maximum(pressure, 1.0))
-    qs = c.eps * es / jnp.maximum(pressure - es * (1.0 - c.eps), 1.0)
+    qs = thermodynamics.saturation_specific_humidity(
+        temperature, pressure, phase=phase)
     if clip is not None:
         qs = jnp.clip(qs, clip[0], clip[1])
     return qs
@@ -107,17 +91,8 @@ def saturation_specific_humidity_and_derivative(
     """Return ``(qs, dqs/dT)`` analytically for the cuadjtq / updraft Newton steps.
 
     Computing the derivative in closed form keeps the Newton iteration
-    bit-reproducible under JIT without differentiating through a lookup table.
+    bit-reproducible under JIT without differentiating through the guard
+    logic; the derivative uses the same c3/c4 coefficients as the value.
     """
-    es = saturation_vapor_pressure(temperature, phase=phase)
-    p_safe = jnp.maximum(pressure, 1.0)
-    es_safe = jnp.minimum(es, 0.99 * p_safe)
-    denom = jnp.maximum(p_safe - es_safe * (1.0 - c.eps), 1.0)
-    qs = c.eps * es_safe / denom
-
-    tc = temperature - c.tmelt
-    des_dT_water = es * A_WATER * B_WATER / jnp.maximum((tc + B_WATER) ** 2, 1e-3)
-    des_dT_ice = es * A_ICE * B_ICE / jnp.maximum((tc + B_ICE) ** 2, 1e-3)
-    des_dT = jnp.where(temperature > c.tmelt, des_dT_water, des_dT_ice)
-    dqs_dT = c.eps * p_safe * des_dT / denom ** 2
-    return qs, dqs_dT
+    return thermodynamics.saturation_specific_humidity_and_derivative(
+        temperature, pressure, phase=phase)

--- a/jcm/physics/convection/saturation_test.py
+++ b/jcm/physics/convection/saturation_test.py
@@ -39,6 +39,17 @@ class TestSaturationVaporPressure(unittest.TestCase):
             float(sat.saturation_vapor_pressure(cold, phase="auto")),
             float(sat.saturation_vapor_pressure(cold, phase="ice")), places=6)
 
+    def test_ice_coefficients_pin(self):
+        # Regression guard for the historical broken ice coefficient
+        # (A_ICE = 35.86, the *water* c4, in place of ECHAM's c3ies =
+        # 21.875): with the correct ECHAM ice pair,
+        # es_ice(253.15 K) ≈ 102.8 Pa (reference tables: ≈ 103.2 Pa). The
+        # broken coefficient gave ≈ 33 Pa here (~3× low), so a tight
+        # window pins the fix.
+        es = sat.saturation_vapor_pressure(jnp.array(253.15), phase="ice")
+        self.assertGreater(float(es), 102.0)
+        self.assertLess(float(es), 103.0)
+
     def test_ice_below_water_below_freezing(self):
         # Below freezing, saturation over ice is below that over water.
         cold = jnp.array(c.tmelt - 20.0)

--- a/jcm/physics/convection/tiedtke_nordeng/adjustment_test.py
+++ b/jcm/physics/convection/tiedtke_nordeng/adjustment_test.py
@@ -201,8 +201,18 @@ class TestSaturationAdjustment:
         assert 0.75 < rh_final < 1.05  # Should be much closer to saturation
     
     def test_condensation_cold(self):
-        """Test condensation in cold conditions"""
-        temperature = jnp.array(250.0)  # Well below freezing
+        """Test condensation in cold conditions (ice-only regime).
+
+        The start temperature must stay in the ice-only regime *after*
+        condensational warming: the liquid/ice split ramps up from
+        ``tmelt - 23 = 250.15 K``, and with the correct ECHAM ice
+        saturation (es_ice ~3x the old broken coefficient's value at
+        these temperatures) the larger condensate load warms a parcel
+        started at 250.0 K past the ramp edge, forming a trace of
+        liquid. 240 K keeps the adjusted parcel comfortably below the
+        ramp so the ice-only assertion tests the split, not the edge.
+        """
+        temperature = jnp.array(240.0)  # Well below the liquid/ice ramp
         pressure = jnp.array(50000.0)
         
         # Create supersaturated state

--- a/jcm/physics/surface/echam/land.py
+++ b/jcm/physics/surface/echam/land.py
@@ -9,6 +9,7 @@ import jax.numpy as jnp
 from typing import Tuple
 
 import jcm.constants as c
+from jcm.physics import thermodynamics
 from .surface_types import (
     SurfaceParameters, AtmosphericForcing,
     SurfaceFluxes, SurfaceTendencies
@@ -369,9 +370,17 @@ def land_surface_physics_step(
     # Soil evaporation depends on soil moisture
     soil_beta = jnp.minimum(soil_moisture[:, 0] / 0.75, 1.0)  # Evaporation efficiency
     
-    # Simplified surface humidity
-    e_sat = 611.0 * jnp.exp(17.27 * (surface_temp - c.tmelt) /
-                           (surface_temp - c.tmelt + 237.3))
+    # Simplified surface humidity, saturated over LIQUID water at all
+    # temperatures (shared ECHAM coefficients from
+    # jcm.physics.thermodynamics). Kept over-water deliberately: the
+    # latent-heat flux below pairs the resulting evaporation with the
+    # liquid-evaporation latent heat ``alhc`` unconditionally (this
+    # simplified land tile does not model frozen-soil / snow sublimation),
+    # so switching the saturation surface to ice below freezing would make
+    # the qsat/latent-heat pair inconsistent the other way around. If
+    # sublimation over frozen land is added later, both this phase choice
+    # and the ``alhc`` factor must switch together on T < tmelt.
+    e_sat = thermodynamics.saturation_vapor_pressure(surface_temp, phase="water")
     q_sat_surface = c.eps * e_sat / atmospheric_state.pressure
     q_surface = soil_beta * q_sat_surface  # Reduced by soil dryness
     

--- a/jcm/physics/surface/echam/sea_ice.py
+++ b/jcm/physics/surface/echam/sea_ice.py
@@ -14,6 +14,7 @@ import jax.numpy as jnp
 from typing import Tuple
 
 import jcm.constants as c
+from jcm.physics import thermodynamics
 from .surface_types import (
     SurfaceParameters, AtmosphericForcing,
     SurfaceFluxes, SurfaceTendencies
@@ -155,9 +156,14 @@ def sea_ice_physics_step(
     air_density = (atmospheric_state.pressure /
                   (c.rd * atmospheric_state.temperature))
 
-    # Surface saturation humidity
-    e_sat = 611.0 * jnp.exp(17.27 * (surface_temp - c.tmelt) /
-                           (surface_temp - c.tmelt + 237.3))
+    # Surface saturation humidity — over ICE, unconditionally: this is a
+    # sea-ice tile and the latent-heat flux below uses the sublimation
+    # latent heat ``alhs``, so the saturation surface must be ice for the
+    # flux pair to be thermodynamically consistent. Shared ECHAM
+    # coefficients from jcm.physics.thermodynamics; the simplified
+    # ``eps·es/p`` conversion (vs the full ``eps·es/(p−(1−eps)·es)``) is
+    # kept — the difference is <0.5 % at these temperatures.
+    e_sat = thermodynamics.saturation_vapor_pressure(surface_temp, phase="ice")
     q_sat_surface = c.eps * e_sat / atmospheric_state.pressure
 
     # Temperature and humidity differences. Positive convention: flux UP

--- a/jcm/physics/thermodynamics.py
+++ b/jcm/physics/thermodynamics.py
@@ -1,0 +1,252 @@
+"""Shared saturation thermodynamics (ECHAM 6.3 conventions).
+
+Single source of truth for saturation vapour pressure, saturation specific
+humidity (and its analytic temperature derivative), the mixed-phase liquid
+fraction, and the grid-mean → in-cloud conversion. All coefficients follow
+ECHAM 6.3 ``mo_convect_tables`` (the Tetens/Magnus family):
+
+    es(T) = c1es · exp(c3 · (T − tmelt) / (T − c4))
+
+with ``c1es = 610.78 Pa`` and, over liquid water, ``c3les = 17.269`` /
+``c4les = 35.86 K``; over ice, ``c3ies = 21.875`` / ``c4ies = 7.66 K``.
+``tmelt`` and ``eps`` are read by attribute access from :mod:`jcm.constants`,
+so runtime ``set_constants`` overrides are honoured.
+
+This module exists to end the historical divergence of six-plus independent
+qsat implementations across the physics packages (convection, clouds,
+surface tiles, aerosol), several of which had drifted onto inconsistent —
+in one case outright broken — coefficient sets. New code must call these
+functions instead of inlining coefficients. The inline saturation forms in
+:mod:`jcm.physics.clouds.lohmann_2m` (beyond the liquid/ice pair used by the
+Bergeron-Findeisen block) are intentionally **not yet** migrated — that
+scheme has a coordinated set of pending fixes and will be moved over as one
+piece.
+
+Phase selection: ``phase="auto"`` is the *simple* switch — liquid-water
+saturation at ``T ≥ tmelt`` and ice saturation below. Schemes that need a
+gradual liquid/ice transition (mixed-phase weighting) must do the blending
+themselves via :func:`mixed_phase_weight`; ``"auto"`` deliberately does not
+attempt it.
+
+All functions are pure JAX and broadcasting-native (no Python branching on
+traced values; ``phase`` is a static Python string resolved at trace time).
+They are intentionally not ``@jit``-ed: they always run inside a caller's
+compiled graph and inline there.
+"""
+
+import jax.numpy as jnp
+
+import jcm.constants as c
+
+# ECHAM 6.3 mo_convect_tables coefficients.
+C1ES = 610.78     # Pa — saturation vapour pressure at the melting point
+C3LES = 17.269    # over liquid water
+C4LES = 35.86     # K
+C3IES = 21.875    # over ice
+C4IES = 7.66      # K
+
+# Math-safety temperature clip. The exponent denominator (T − c4) vanishes
+# near 8-36 K, far below any physical temperature; a loose [50, 500] K bound
+# keeps the math finite without masking genuine upstream bugs. Note the clip
+# also zeroes the temperature gradient outside these bounds.
+_T_MIN = 50.0
+_T_MAX = 500.0
+
+# ECHAM caps the saturation specific humidity lookup at MIN(..., 0.5): at
+# very high T / low p the denominator p − (1−eps)·es shrinks toward zero and
+# qs would blow up; 0.5 is far above any physical qs, so the cap is inactive
+# in normal conditions.
+_QS_MAX = 0.5
+
+
+def _validate_phase(phase: str) -> None:
+    if phase not in ("auto", "water", "ice"):
+        raise ValueError(
+            f"phase must be 'auto', 'water' or 'ice', got {phase!r}")
+
+
+def saturation_vapor_pressure(temperature: jnp.ndarray,
+                              phase: str = "auto") -> jnp.ndarray:
+    """Saturation vapour pressure ``es(T)`` [Pa], ECHAM 6.3 coefficients.
+
+    Parameters
+    ----------
+    temperature : jnp.ndarray
+        Temperature [K]. Clipped to [50, 500] K for math safety.
+    phase : str
+        ``"water"`` (liquid-water saturation at all temperatures),
+        ``"ice"`` (ice saturation at all temperatures), or ``"auto"``
+        (water at ``T ≥ tmelt``, ice below — the simple switch; callers
+        needing a gradual mixed-phase transition must blend the two pure
+        phases themselves, e.g. with :func:`mixed_phase_weight`).
+
+    Returns
+    -------
+    jnp.ndarray
+        Saturation vapour pressure [Pa].
+
+    """
+    _validate_phase(phase)
+    temperature = jnp.clip(temperature, _T_MIN, _T_MAX)
+    tc = temperature - c.tmelt
+    if phase == "water":
+        return C1ES * jnp.exp(C3LES * tc / (temperature - C4LES))
+    if phase == "ice":
+        return C1ES * jnp.exp(C3IES * tc / (temperature - C4IES))
+    es_water = C1ES * jnp.exp(C3LES * tc / (temperature - C4LES))
+    es_ice = C1ES * jnp.exp(C3IES * tc / (temperature - C4IES))
+    return jnp.where(temperature >= c.tmelt, es_water, es_ice)
+
+
+def saturation_specific_humidity(temperature: jnp.ndarray,
+                                 pressure: jnp.ndarray,
+                                 phase: str = "auto") -> jnp.ndarray:
+    """Saturation specific humidity ``qs(T, p)`` [kg/kg].
+
+    ``qs = eps·es / (p − (1−eps)·es)`` with the denominator guarded against
+    non-positivity and the result capped at 0.5 (ECHAM's ``MIN(..., 0.5)``
+    lookup guard — inactive at physical temperatures).
+
+    Parameters
+    ----------
+    temperature : jnp.ndarray
+        Temperature [K].
+    pressure : jnp.ndarray
+        Pressure [Pa].
+    phase : str
+        Saturation surface, see :func:`saturation_vapor_pressure`.
+
+    Returns
+    -------
+    jnp.ndarray
+        Saturation specific humidity [kg/kg], in ``(0, 0.5]``.
+
+    """
+    es = saturation_vapor_pressure(temperature, phase=phase)
+    denom = jnp.maximum(pressure - (1.0 - c.eps) * es, c.epsilon)
+    return jnp.minimum(c.eps * es / denom, _QS_MAX)
+
+
+def saturation_specific_humidity_and_derivative(
+    temperature: jnp.ndarray,
+    pressure: jnp.ndarray,
+    phase: str = "auto",
+) -> tuple[jnp.ndarray, jnp.ndarray]:
+    """Return ``(qs, dqs/dT)`` with the analytic temperature derivative.
+
+    The closed form keeps Newton saturation-adjustment steps (cuadjtq,
+    updraft ascent) bit-reproducible under JIT without differentiating
+    through the guard/cap logic. From ``es = c1es·exp(c3·(T−tmelt)/(T−c4))``:
+
+        d(es)/dT  = es · c3·(tmelt − c4) / (T − c4)²
+        d(qs)/dT  = qs · c3·(tmelt − c4)/(T − c4)² · p / (p − (1−eps)·es)
+
+    (the second factor comes from differentiating the ``qs(es)`` mapping:
+    ``dqs/des = eps·p/denom²``). The derivative uses the same c3/c4
+    coefficients as the value, per phase; where the 0.5 cap or the
+    denominator guard is active the derivative is set to 0 for consistency
+    with the capped value.
+
+    Parameters
+    ----------
+    temperature : jnp.ndarray
+        Temperature [K].
+    pressure : jnp.ndarray
+        Pressure [Pa].
+    phase : str
+        Saturation surface, see :func:`saturation_vapor_pressure`.
+
+    Returns
+    -------
+    tuple of jnp.ndarray
+        ``(qs, dqs_dT)`` in [kg/kg] and [kg/kg/K].
+
+    """
+    _validate_phase(phase)
+    es = saturation_vapor_pressure(temperature, phase=phase)
+    denom_raw = pressure - (1.0 - c.eps) * es
+    denom = jnp.maximum(denom_raw, c.epsilon)
+    qs_raw = c.eps * es / denom
+    qs = jnp.minimum(qs_raw, _QS_MAX)
+
+    # d(ln es)/dT per phase, evaluated on the same clipped temperature the
+    # vapour pressure used so the pair stays self-consistent.
+    t_safe = jnp.clip(temperature, _T_MIN, _T_MAX)
+    dlnes_water = C3LES * (c.tmelt - C4LES) / (t_safe - C4LES) ** 2
+    dlnes_ice = C3IES * (c.tmelt - C4IES) / (t_safe - C4IES) ** 2
+    if phase == "water":
+        dlnes_dT = dlnes_water
+    elif phase == "ice":
+        dlnes_dT = dlnes_ice
+    else:
+        dlnes_dT = jnp.where(t_safe >= c.tmelt, dlnes_water, dlnes_ice)
+
+    dqs_dT = qs_raw * dlnes_dT * pressure / denom
+    # Guard/cap regions: the returned qs is flat there, so report a zero
+    # slope rather than the (meaningless) uncapped one.
+    dqs_dT = jnp.where((qs_raw < _QS_MAX) & (denom_raw > c.epsilon),
+                       dqs_dT, 0.0)
+    return qs, dqs_dT
+
+
+def mixed_phase_weight(temperature: jnp.ndarray,
+                       t_min: float = 238.15,
+                       t_max: float | None = None) -> jnp.ndarray:
+    """Linear liquid fraction for mixed-phase blending.
+
+    Returns ``clip((T − t_min) / (t_max − t_min), 0, 1)`` — 1 for pure
+    liquid at/above ``t_max``, 0 for pure ice at/below ``t_min``. This is
+    the standard linear ramp used to blend water/ice saturation (and latent
+    heats) across the mixed-phase range; pair it with the pure-phase
+    ``"water"`` / ``"ice"`` saturation functions.
+
+    Parameters
+    ----------
+    temperature : jnp.ndarray
+        Temperature [K].
+    t_min : float
+        Temperature at/below which the cloud is all ice [K]. Default
+        238.15 K (−35 °C, near the homogeneous-freezing threshold).
+    t_max : float, optional
+        Temperature at/above which the cloud is all liquid [K]. Defaults
+        to ``c.tmelt`` (read at call time so constant overrides apply).
+
+    Returns
+    -------
+    jnp.ndarray
+        Liquid fraction in [0, 1].
+
+    """
+    if t_max is None:
+        t_max = c.tmelt
+    return jnp.clip((temperature - t_min) / (t_max - t_min), 0.0, 1.0)
+
+
+def grid_mean_to_in_cloud(x: jnp.ndarray,
+                          cloud_fraction: jnp.ndarray,
+                          eps: float = 1e-12) -> jnp.ndarray:
+    """Convert a grid-mean quantity to its in-cloud value.
+
+    ``x / cloud_fraction`` where a cloud is present (``cf > eps``), 0
+    elsewhere. The ``maximum`` in the denominator keeps the masked-out
+    branch's gradient finite (a bare ``x / cf`` would divide by ~0 there
+    and poison reverse-mode AD even though the value is masked).
+
+    Parameters
+    ----------
+    x : jnp.ndarray
+        Grid-mean quantity (e.g. cloud water [kg/kg]).
+    cloud_fraction : jnp.ndarray
+        Cloud fraction in [0, 1].
+    eps : float
+        Presence threshold and division floor.
+
+    Returns
+    -------
+    jnp.ndarray
+        In-cloud value, 0 where ``cloud_fraction <= eps``.
+
+    """
+    return jnp.where(cloud_fraction > eps,
+                     x / jnp.maximum(cloud_fraction, eps),
+                     0.0)

--- a/jcm/physics/thermodynamics_test.py
+++ b/jcm/physics/thermodynamics_test.py
@@ -1,0 +1,205 @@
+"""Tests for the shared saturation thermodynamics module.
+
+Value pins are against standard references (Murphy & Koop 2005 for ice,
+standard meteorological tables for water) with tolerances that reflect the
+inherent accuracy of the ECHAM Tetens/Magnus fits (a few tenths of a
+percent), plus finite-difference verification of the analytic derivative
+and gradient-finiteness checks per the repo testing conventions.
+"""
+
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import jcm.constants as c
+from jcm.physics import thermodynamics as thermo
+
+
+class TestSaturationVaporPressure(unittest.TestCase):
+    """es(T) values, phase selection, and reference pins."""
+
+    def test_melting_point_anchor_both_phases(self):
+        # es(tmelt) = c1es for water, ice and auto alike.
+        for phase in ("auto", "water", "ice"):
+            es = thermo.saturation_vapor_pressure(
+                jnp.array(273.15), phase=phase)
+            self.assertAlmostEqual(float(es), 610.78, places=2)
+
+    def test_water_at_300K(self):
+        # Reference (Guide to Meteorological Instruments / Magnus fits):
+        # es_water(300 K) ≈ 3537 Pa.
+        es = thermo.saturation_vapor_pressure(jnp.array(300.0), phase="water")
+        self.assertGreater(float(es), 3530.0)
+        self.assertLess(float(es), 3570.0)
+
+    def test_ice_at_250K_murphy_koop(self):
+        # Murphy & Koop (2005): es_ice(250 K) ≈ 76.0 Pa. The ECHAM Magnus
+        # fit gives ≈ 75.6 Pa (0.6 % low) — pin within 1 %. This is the
+        # regression guard for the broken historical ice coefficient
+        # (A_ICE = 35.86), which gave ≈ 6 Pa here (~12× low).
+        es = thermo.saturation_vapor_pressure(jnp.array(250.0), phase="ice")
+        self.assertTrue(np.isclose(float(es), 76.0, rtol=0.01),
+                        msg=f"es_ice(250K) = {float(es)}")
+
+    def test_water_ice_ratio_at_250K(self):
+        # The supersaturation-over-ice ratio drives the Bergeron process;
+        # at 250 K es_water/es_ice ≈ 1.25.
+        es_w = thermo.saturation_vapor_pressure(jnp.array(250.0), phase="water")
+        es_i = thermo.saturation_vapor_pressure(jnp.array(250.0), phase="ice")
+        self.assertTrue(np.isclose(float(es_w) / float(es_i), 1.25, rtol=0.01),
+                        msg=f"ratio = {float(es_w) / float(es_i)}")
+
+    def test_auto_switches_at_tmelt(self):
+        warm, cold = jnp.array(283.15), jnp.array(263.15)
+        self.assertAlmostEqual(
+            float(thermo.saturation_vapor_pressure(warm, phase="auto")),
+            float(thermo.saturation_vapor_pressure(warm, phase="water")),
+            places=6)
+        self.assertAlmostEqual(
+            float(thermo.saturation_vapor_pressure(cold, phase="auto")),
+            float(thermo.saturation_vapor_pressure(cold, phase="ice")),
+            places=6)
+
+    def test_invalid_phase_raises(self):
+        with self.assertRaises(ValueError):
+            thermo.saturation_vapor_pressure(jnp.array(280.0), phase="mixed")
+
+    def test_extreme_temperatures_finite(self):
+        # The [50, 500] K clip keeps the math finite for garbage inputs.
+        T = jnp.array([0.0, 10.0, 50.0, 500.0, 1000.0])
+        for phase in ("auto", "water", "ice"):
+            es = thermo.saturation_vapor_pressure(T, phase=phase)
+            self.assertTrue(bool(jnp.all(jnp.isfinite(es))))
+
+
+class TestSaturationSpecificHumidity(unittest.TestCase):
+    """qs(T, p) values, guards, and the 0.5 cap."""
+
+    def test_value_at_300K_1000hPa(self):
+        qs = thermo.saturation_specific_humidity(
+            jnp.array(300.0), jnp.array(1.0e5))
+        self.assertTrue(np.isclose(float(qs), 0.0223, rtol=0.03),
+                        msg=f"qs = {float(qs)}")
+
+    def test_matches_definition(self):
+        T, p = jnp.array(295.0), jnp.array(9.0e4)
+        es = thermo.saturation_vapor_pressure(T, phase="water")
+        expected = c.eps * es / (p - (1.0 - c.eps) * es)
+        qs = thermo.saturation_specific_humidity(T, p, phase="water")
+        self.assertAlmostEqual(float(qs), float(expected), places=8)
+
+    def test_capped_at_half(self):
+        # Very hot / very low pressure would give qs >> 1; the ECHAM lookup
+        # guard caps it at 0.5.
+        qs = thermo.saturation_specific_humidity(
+            jnp.array(400.0), jnp.array(5.0e3), phase="water")
+        self.assertAlmostEqual(float(qs), 0.5, places=6)
+
+    def test_broadcasting_column_vs_block(self):
+        # Broadcasting-native per CLAUDE.md: a (kx,) column and a
+        # (kx, ncols) block must agree per column.
+        kx, ncols = 6, 4
+        T_col = jnp.linspace(230.0, 300.0, kx)
+        p_col = jnp.linspace(3.0e4, 1.0e5, kx)
+        T_blk = jnp.tile(T_col[:, None], (1, ncols))
+        p_blk = jnp.tile(p_col[:, None], (1, ncols))
+        for phase in ("auto", "water", "ice"):
+            qs_col = thermo.saturation_specific_humidity(T_col, p_col,
+                                                         phase=phase)
+            qs_blk = thermo.saturation_specific_humidity(T_blk, p_blk,
+                                                         phase=phase)
+            self.assertEqual(qs_blk.shape, (kx, ncols))
+            for j in range(ncols):
+                # Same math, but XLA may fuse the block differently than the
+                # column, so allow float32 ULP-level differences.
+                np.testing.assert_allclose(np.asarray(qs_blk[:, j]),
+                                           np.asarray(qs_col), rtol=1e-6)
+
+
+class TestDerivative(unittest.TestCase):
+    """Analytic dqs/dT against central finite differences."""
+
+    def test_derivative_matches_finite_difference(self):
+        # Verified in float64 so the FD reference is accurate to ~1e-8;
+        # temperatures straddle the auto water/ice switch at tmelt (none
+        # within h of the switch itself, where a one-sided kink is real).
+        with jax.enable_x64():
+            p = jnp.array(9.0e4, dtype=jnp.float64)
+            h = 1e-3
+            for phase in ("water", "ice", "auto"):
+                for T0 in (230.0, 250.0, 270.0, 272.5, 274.0, 285.0, 300.0):
+                    T = jnp.array(T0, dtype=jnp.float64)
+                    _, dqs = thermo.saturation_specific_humidity_and_derivative(
+                        T, p, phase=phase)
+                    qp = thermo.saturation_specific_humidity(T + h, p, phase=phase)
+                    qm = thermo.saturation_specific_humidity(T - h, p, phase=phase)
+                    fd = (float(qp) - float(qm)) / (2.0 * h)
+                    self.assertTrue(
+                        np.isclose(float(dqs), fd, rtol=1e-4),
+                        msg=f"phase={phase} T={T0}: analytic {float(dqs)} vs FD {fd}")
+
+    def test_qs_matches_plain_call(self):
+        T, p = jnp.array(265.0), jnp.array(7.0e4)
+        qs, _ = thermo.saturation_specific_humidity_and_derivative(T, p)
+        qs_plain = thermo.saturation_specific_humidity(T, p)
+        self.assertAlmostEqual(float(qs), float(qs_plain), places=10)
+
+
+class TestGradients(unittest.TestCase):
+    """All functions must be differentiable with finite gradients."""
+
+    def test_grad_finiteness(self):
+        p = jnp.array(8.0e4)
+        for phase in ("auto", "water", "ice"):
+            for T0 in (230.0, 273.15, 300.0):
+                T = jnp.array(T0)
+                g_es = jax.grad(
+                    lambda t: thermo.saturation_vapor_pressure(t, phase=phase))(T)
+                g_qs = jax.grad(
+                    lambda t: thermo.saturation_specific_humidity(
+                        t, p, phase=phase))(T)
+                g_dq = jax.grad(
+                    lambda t: thermo.saturation_specific_humidity_and_derivative(
+                        t, p, phase=phase)[1])(T)
+                for g in (g_es, g_qs, g_dq):
+                    self.assertTrue(bool(jnp.isfinite(g)),
+                                    msg=f"phase={phase} T={T0}: {g}")
+        g_w = jax.grad(thermo.mixed_phase_weight)(jnp.array(255.0))
+        self.assertTrue(bool(jnp.isfinite(g_w)))
+        g_ic = jax.grad(
+            lambda x: thermo.grid_mean_to_in_cloud(x, jnp.array(0.0)))(
+            jnp.array(1e-4))
+        self.assertTrue(bool(jnp.isfinite(g_ic)))
+
+
+class TestMixedPhaseWeight(unittest.TestCase):
+    """Linear liquid-fraction ramp."""
+
+    def test_endpoints_and_midpoint(self):
+        self.assertEqual(float(thermo.mixed_phase_weight(jnp.array(238.15))), 0.0)
+        self.assertEqual(float(thermo.mixed_phase_weight(jnp.array(220.0))), 0.0)
+        self.assertEqual(float(thermo.mixed_phase_weight(jnp.array(273.15))), 1.0)
+        self.assertEqual(float(thermo.mixed_phase_weight(jnp.array(290.0))), 1.0)
+        mid = 0.5 * (238.15 + 273.15)
+        self.assertAlmostEqual(
+            float(thermo.mixed_phase_weight(jnp.array(mid))), 0.5, places=5)
+
+    def test_custom_bounds(self):
+        w = thermo.mixed_phase_weight(jnp.array(250.0), t_min=240.0, t_max=260.0)
+        self.assertAlmostEqual(float(w), 0.5, places=6)
+
+
+class TestGridMeanToInCloud(unittest.TestCase):
+    """Grid-mean → in-cloud conversion and its masked-region behaviour."""
+
+    def test_divides_where_cloudy_zero_elsewhere(self):
+        x = jnp.array([1e-4, 1e-4, 1e-4])
+        cf = jnp.array([0.5, 1.0, 0.0])
+        out = thermo.grid_mean_to_in_cloud(x, cf)
+        np.testing.assert_allclose(np.asarray(out), [2e-4, 1e-4, 0.0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
PR 2 of the ECHAM+RRTMGP fix campaign (plan: `docs/echam_rrtmgp_fix_plan.md` on `claude/echam-rrtmgp-physics-review-zcof6u`).

## What

- **New `jcm/physics/thermodynamics.py`** — single source of truth for saturation thermodynamics, ECHAM 6.3 `mo_convect_tables` coefficients (`c1es=610.78`, water `c3les=17.269`/`c4les=35.86`, ice `c3ies=21.875`/`c4ies=7.66`): `saturation_vapor_pressure`, `saturation_specific_humidity` (+analytic `dqs/dT` for the Newton adjustment steps), `mixed_phase_weight`, `grid_mean_to_in_cloud`. Full test module (Murphy–Koop value pins, FD-checked derivative, gradient finiteness, broadcasting).
- **Review finding 1.3 (critical)** — `convection/saturation.py` had ice coefficient `A_ICE = 35.86` (the *water* c4 transcribed as the ice c3): over-ice qsat was ~3× low at −20 °C, ~60× at −60 °C. Now delegates to the shared module. Regression pin added at 253.15 K.
- **Finding 2.20** — `lohmann_2m` `es_water` used ice coefficients below 0 °C, degenerating the Bergeron–Findeisen water−ice saturation difference to ~0. Now water coefficients at all T (shared module).
- **Finding 3.1** — frozen-surface saturation: `sea_ice.py` used over-water es paired with sublimation latent heat → now ice formula. `land.py` stays over-water deliberately (its latent heat is unconditionally `alhc`); documented in-code with the pairing constraint.
- **B.0 NaN gradients** — double-where guards on every fractional-power-at-zero site in the 1M sweep (`zxrp1`, `zxsp1`, rain-evap 0.61 power), the 1M helper functions, lohmann_2m sublimation/riming/effective-radius sites, and `het_mxphase_freezing` (found by the follow-up sweep). Parameter-gradient regression tests added.

## Validation

- `JAX_PLATFORMS=cpu pytest -n 12 -m "not slow"`: **1264 passed, 17 skipped, 0 failed**; `ruff check .` passes.
- **Forward bit-identity for the double-where rewrites:** all 9 rewritten sites dumped through 8 functions on seeded physical inputs (zeros/masked branches exercised) — 72 output arrays **bitwise identical** to base `b41076a`.
- **NaN-regression tests fail without the fix:** both new parameter-gradient tests give `nan` on base (verified by running them against the base checkout); `het_mxphase_freezing` gradient likewise `nan` on base → finite here.
- **Test-pin discipline:** exactly one existing test shifted — `test_condensation_cold`. Justification (also in its docstring): with the corrected (larger) ice saturation, condensational warming pushes a 250.0 K parcel past the `tmelt−23 = 250.15 K` liquid/ice ramp edge, forming a 6.6e-7 trace of liquid; the test now starts at 240 K so it tests the ice-only split, not the ramp edge. No tolerances were loosened anywhere.
- Fractional-power sweep: all other `x**frac` sites in echam-scope physics cleared structurally (bases floored at `epsilon`/`cqtmin` or ≥ 1).
- Merges into current `dev` (06eb29f) with no conflicts.

(The `[WIP]` in the first commit's subject predates validation — kept to avoid rewriting pushed history; this description + the follow-up commit are the validation record.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)