### PR TITLE
fix(radiation): RRTMGP quick wins — insolation, surface BC, pressure halo, gas-optics water, Twomey

### DIFF
--- a/jcm/physics/aerosol/macv2_sp.py
+++ b/jcm/physics/aerosol/macv2_sp.py
@@ -97,11 +97,14 @@ def get_simple_aerosol(
     # Calculate total column AOD
     aod_total = jnp.sum(aod_profile, axis=0)
 
-    # Calculate Twomey effect using proper CDNC relationship
-    cdnc_factor = (
-        get_CDNC(aod_anthropogenic)
-        / get_CDNC(jnp.zeros_like(aod_anthropogenic))
-    )
+    # Twomey effect: Stevens et al. (2017) relative droplet-number
+    # enhancement (see get_dNovrN). The previous
+    # ``get_CDNC(aod)/get_CDNC(0)`` divided by ``get_CDNC(0) = 1`` and so
+    # used an ABSOLUTE AEROCOM CDNC (~137 at AOD 0.43) as this
+    # dimensionless multiplier, overstating the indirect effects by ~100×.
+    # ``get_CDNC`` remains in use where an absolute CDNC is wanted (the
+    # ``Nccn`` activation floor below).
+    cdnc_factor = get_dNovrN(aod_anthropogenic, aod_background)
 
     # CCN concentration [cm^-3] for the SPA-style activation floor used by
     # the two-moment microphysics. Both anthropogenic and background plume
@@ -437,6 +440,27 @@ def get_CDNC(AOD, A=60, B=20):
     AEROCOM P1 original: A=60, B=20
     """
     return 1 + A * jnp.log(B * AOD + 1)
+
+
+def get_dNovrN(aod_anthropogenic, aod_background):
+    """Stevens et al. (2017) relative CDNC enhancement (Twomey factor).
+
+    ``sp_aop_dNovrN`` from mo_simple_plumes.f90:
+
+        dNovrN = ln(1000·(caod_sp + caod_bg) + 1) / ln(1000·caod_bg + 1)
+
+    with ``caod_sp`` the anthropogenic plume AOD at 550 nm and ``caod_bg``
+    the natural background AOD (the background plume contribution plus the
+    0.02 fine-mode constant, exactly the Fortran's caod_bg accumulation).
+    Dimensionless, 1.0 with no anthropogenic aerosol, and typically
+    1.0–1.6 (≈2 at the East-Asia plume maximum) — it multiplies a baseline
+    droplet number, unlike the ABSOLUTE AEROCOM CDNC from
+    :func:`get_CDNC`.
+    """
+    return (
+        jnp.log(1000.0 * (aod_anthropogenic + aod_background) + 1.0)
+        / jnp.log(1000.0 * aod_background + 1.0)
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/jcm/physics/aerosol/macv2_sp_test.py
+++ b/jcm/physics/aerosol/macv2_sp_test.py
@@ -15,6 +15,7 @@ from jcm.physics.aerosol.macv2_sp import (
     get_background_vertical_profile,
     get_optical_properties,
     get_CDNC,
+    get_dNovrN,
 )
 from jcm.physics.aerosol.macv2_sp_params import AerosolParameters
 
@@ -379,6 +380,33 @@ class TestCDNC:
         assert jnp.all(jnp.isfinite(cdnc1))
         assert jnp.all(jnp.isfinite(cdnc2))
         assert jnp.all(jnp.isfinite(cdnc3))
+
+    def test_dnovrn_stevens2017_magnitude(self):
+        """Twomey factor is the Stevens et al. (2017) RELATIVE enhancement.
+
+        Regression pin for the ~100× Twomey bug: the old
+        ``get_CDNC(aod)/get_CDNC(0)`` divided by 1 and returned an absolute
+        AEROCOM CDNC (≈137 at AOD 0.43) as the dimensionless multiplier.
+        The Stevens formula gives ≈2.0 at that plume maximum (background
+        0.02) and stays within [1, ~3] for any physical AOD.
+        """
+        # No anthropogenic aerosol → exactly no enhancement.
+        assert float(get_dNovrN(jnp.array(0.0), jnp.array(0.02))) == (
+            pytest.approx(1.0)
+        )
+        # East-Asia plume maximum from the review: AOD 0.43 over the 0.02
+        # fine-mode background → ln(451)/ln(21) ≈ 2.01 (old code: 137).
+        factor = float(get_dNovrN(jnp.array(0.43), jnp.array(0.02)))
+        assert factor == pytest.approx(2.01, abs=0.05)
+        # Monotone in anthropogenic AOD and bounded for physical values.
+        aods = jnp.array([0.0, 0.05, 0.1, 0.2, 0.43, 1.0])
+        factors = get_dNovrN(aods, jnp.array(0.02))
+        assert jnp.all(jnp.diff(factors) > 0)
+        assert float(factors[-1]) < 3.0
+        # A larger natural background damps the relative enhancement.
+        assert float(get_dNovrN(jnp.array(0.2), jnp.array(0.1))) < float(
+            get_dNovrN(jnp.array(0.2), jnp.array(0.02))
+        )
 
 
 class TestJAXCompatibility:

--- a/jcm/physics/radiation/rrtmgp.py
+++ b/jcm/physics/radiation/rrtmgp.py
@@ -144,30 +144,39 @@ def _to_3d_with_filled_halo(
     return arr_3d
 
 
-def _to_3d_with_extrapolated_halo(
-    arr_1d: jnp.ndarray, nlev: int, halo: int = 1
+def _to_3d_pressure_halo(
+    pressure_1d: jnp.ndarray,
+    dp_bottom: jnp.ndarray,
+    dp_top: jnp.ndarray,
+    nlev: int,
+    halo: int = 1,
 ) -> jnp.ndarray:
-    """Convert 1D profile to 3D (1,1,nz+2*halo) with linearly extrapolated halos.
+    """Halo-pad the pressure profile so boundary-layer Δp comes out EXACT.
 
-    Required for PRESSURE: jax-rrtmgp computes layer thickness with the
-    centered difference ``dp[k] = 0.5·(p[k+1] − p[k−1])``, so an edge-FILLED
-    halo (``p[halo] == p[interior]``) halves the effective Δp of the top and
-    bottom layers — exactly 2× the heating rate there. Linear extrapolation
-    (``2·p[0] − p[1]``) preserves the local grid spacing, matching how the
-    library itself extrapolates temperature into its halo.
+    jax-rrtmgp computes layer thickness with the centered difference
+    ``dp[k] = 0.5·|p[k+1] − p[k−1]|``, so the halo values fully determine
+    the Δp the heating rate sees in the top and bottom layers. Rather than
+    approximating them (edge fill halves the Δp of a uniform grid; linear
+    extrapolation ``2p[0] − p[1]`` is exact only for uniform spacing and
+    on the hybrid L47 grid is ~75 % too thick at the surface and goes
+    NEGATIVE at the log-spaced top), set the halo so the centered
+    difference reproduces the model's TRUE half-level layer thickness:
+
+        0.5·|p[k∓1] − halo| = Δp_true  →  halo = p[1] + 2·Δp_bottom
+                                          halo = p[-2] − 2·Δp_top
+
+    with ``Δp_bottom`` / ``Δp_top`` taken from ``pressure_interfaces``
+    (``pressure_1d`` is surface→TOA here, so index 0 is the surface).
+    The tiny positive floor on the top halo only binds if the top layer
+    is thicker than half the distance to the level below — genuinely
+    pathological — and keeps downstream log-pressure interpolation finite.
     """
     nzh = nlev + 2 * halo
-    arr_3d = jnp.zeros((1, 1, nzh), dtype=arr_1d.dtype)
-    arr_3d = arr_3d.at[0, 0, halo : halo + nlev].set(arr_1d)
-    # Floor the extrapolation at a small positive value: on a strongly
-    # stretched grid 2·p_top − p_below can go negative, and downstream
-    # log-pressure interpolation must stay finite. The floor only binds in
-    # that pathological case (where the halo Δp is wrong either way).
-    arr_3d = arr_3d.at[0, 0, 0].set(
-        jnp.maximum(2.0 * arr_1d[0] - arr_1d[1], 1e-3 * arr_1d[0])
-    )
+    arr_3d = jnp.zeros((1, 1, nzh), dtype=pressure_1d.dtype)
+    arr_3d = arr_3d.at[0, 0, halo : halo + nlev].set(pressure_1d)
+    arr_3d = arr_3d.at[0, 0, 0].set(pressure_1d[1] + 2.0 * dp_bottom)
     arr_3d = arr_3d.at[0, 0, -1].set(
-        jnp.maximum(2.0 * arr_1d[-1] - arr_1d[-2], 1e-3 * arr_1d[-1])
+        jnp.maximum(pressure_1d[-2] - 2.0 * dp_top, 1e-3 * pressure_1d[-1])
     )
     return arr_3d
 
@@ -229,6 +238,13 @@ def prepare_rrtmgp_data(
     rho = lax.cond(needs_reversal, flip, identity, rho)
     temperature_1d = lax.cond(needs_reversal, flip, identity, icon_data.temperature)
     pressure_1d = lax.cond(needs_reversal, flip, identity, icon_data.pressure)
+    # Surface-first half-level pressures, for the exact boundary-layer Δp
+    # the pressure halo must encode (see _to_3d_pressure_halo).
+    interfaces_1d = lax.cond(
+        needs_reversal, flip, identity, icon_data.pressure_interfaces,
+    )
+    dp_bottom = interfaces_1d[0] - interfaces_1d[1]
+    dp_top = interfaces_1d[-2] - interfaces_1d[-1]
     cwp_1d = lax.cond(needs_reversal, flip, identity, icon_data.cloud_water_path)
     cip_1d = lax.cond(needs_reversal, flip, identity, icon_data.cloud_ice_path)
 
@@ -276,10 +292,12 @@ def prepare_rrtmgp_data(
         "cloud_r_eff_ice": to3d_fill(cloud_r_eff_ice),
         "temperature": to3d_nan(temperature_1d),
         "sfc_temperature": jnp.reshape(surface_temperature, (1, 1)),
-        # Pressure halo must be extrapolated, not edge-filled — see
-        # _to_3d_with_extrapolated_halo (edge fill → 2× heating in the
-        # boundary layers).
-        "p_ref_xxc": _to_3d_with_extrapolated_halo(pressure_1d, nlev, halo),
+        # Pressure halo encodes the model's exact half-level boundary-layer
+        # thicknesses — see _to_3d_pressure_halo (edge fill / linear
+        # extrapolation both misstate boundary Δp on the hybrid grid).
+        "p_ref_xxc": _to_3d_pressure_halo(
+            pressure_1d, dp_bottom, dp_top, nlev, halo,
+        ),
         "sg_map": sg_map,
         "use_scan": True,
     }

--- a/jcm/physics/radiation/rrtmgp.py
+++ b/jcm/physics/radiation/rrtmgp.py
@@ -1,8 +1,8 @@
 """RRTMGP-based radiation scheme for ECHAM physics.
 
 This module integrates jax-rrtmgp with ICON's radiation interface, handling:
-- Location-specific solar geometry via jax_solar (OrbitalTime, radiation_flux,
-  get_solar_sin_altitude)
+- Location-specific solar geometry via jax_solar (OrbitalTime,
+  direct_solar_irradiance, get_solar_sin_altitude)
 - ICON vertical ordering (TOA->surface) vs RRTMGP (surface->TOA) conversion
 - Halo management (temperature NaN-padded for RRTMGP fill; others edge-filled)
 - Stretched grid mapping for non-uniform vertical coordinates
@@ -23,7 +23,7 @@ import jax
 import jax.numpy as jnp
 from jax import lax
 
-from jax_solar import OrbitalTime, radiation_flux, get_solar_sin_altitude
+from jax_solar import OrbitalTime, direct_solar_irradiance, get_solar_sin_altitude
 from jcm.physics.clouds.cloud_data import radiation_cloud_fields
 from jcm.physics.radiation.radiation_types import (
     RadiationParameters,
@@ -144,6 +144,34 @@ def _to_3d_with_filled_halo(
     return arr_3d
 
 
+def _to_3d_with_extrapolated_halo(
+    arr_1d: jnp.ndarray, nlev: int, halo: int = 1
+) -> jnp.ndarray:
+    """Convert 1D profile to 3D (1,1,nz+2*halo) with linearly extrapolated halos.
+
+    Required for PRESSURE: jax-rrtmgp computes layer thickness with the
+    centered difference ``dp[k] = 0.5·(p[k+1] − p[k−1])``, so an edge-FILLED
+    halo (``p[halo] == p[interior]``) halves the effective Δp of the top and
+    bottom layers — exactly 2× the heating rate there. Linear extrapolation
+    (``2·p[0] − p[1]``) preserves the local grid spacing, matching how the
+    library itself extrapolates temperature into its halo.
+    """
+    nzh = nlev + 2 * halo
+    arr_3d = jnp.zeros((1, 1, nzh), dtype=arr_1d.dtype)
+    arr_3d = arr_3d.at[0, 0, halo : halo + nlev].set(arr_1d)
+    # Floor the extrapolation at a small positive value: on a strongly
+    # stretched grid 2·p_top − p_below can go negative, and downstream
+    # log-pressure interpolation must stay finite. The floor only binds in
+    # that pathological case (where the halo Δp is wrong either way).
+    arr_3d = arr_3d.at[0, 0, 0].set(
+        jnp.maximum(2.0 * arr_1d[0] - arr_1d[1], 1e-3 * arr_1d[0])
+    )
+    arr_3d = arr_3d.at[0, 0, -1].set(
+        jnp.maximum(2.0 * arr_1d[-1] - arr_1d[-2], 1e-3 * arr_1d[-1])
+    )
+    return arr_3d
+
+
 def _to_4d_per_gpoint(
     per_gpt_2d: jnp.ndarray, nlev: int, halo: int = 1,
 ) -> jnp.ndarray:
@@ -248,7 +276,10 @@ def prepare_rrtmgp_data(
         "cloud_r_eff_ice": to3d_fill(cloud_r_eff_ice),
         "temperature": to3d_nan(temperature_1d),
         "sfc_temperature": jnp.reshape(surface_temperature, (1, 1)),
-        "p_ref_xxc": to3d_fill(pressure_1d),
+        # Pressure halo must be extrapolated, not edge-filled — see
+        # _to_3d_with_extrapolated_halo (edge fill → 2× heating in the
+        # boundary layers).
+        "p_ref_xxc": _to_3d_with_extrapolated_halo(pressure_1d, nlev, halo),
         "sg_map": sg_map,
         "use_scan": True,
     }
@@ -449,7 +480,16 @@ def radiation_scheme_rrtmgp(
         orbital_phase=solar.orbital_phase,
         synodic_phase=solar.synodic_phase,
     )
-    toa_flux = radiation_flux(orbital_time, longitude, latitude, parameters.solar_constant)
+    # ``irrad`` must be the NORMAL-INCIDENCE (distance-corrected) solar
+    # irradiance: jax-rrtmgp applies the cosine factor itself in the
+    # direct-beam boundary condition (flux_down_direct_bc = irrad · µ0).
+    # ``jax_solar.radiation_flux`` already includes ·µ0 (it returns flux on
+    # a horizontal surface), so passing it here multiplied the cosine in
+    # TWICE — TOA insolation ∝ µ0², a ~110 W/m² global-mean SW deficit
+    # (hemispheric mean S0/6 instead of S0/4).
+    direct_irradiance = direct_solar_irradiance(
+        solar.orbital_phase, parameters.solar_constant
+    )
     sin_altitude = get_solar_sin_altitude(orbital_time, longitude, latitude)
     cos_zenith = sin_altitude  # cos(zenith) = sin(altitude)
 
@@ -556,7 +596,16 @@ def radiation_scheme_rrtmgp(
     # arrays inside the g-point loop, so set them to zero. The clear-
     # sky branch (no per-gpoint args, just q_liq=0/q_ice=0) gives the
     # all-clear fluxes used for CRE.
+    #
+    # q_t must drop the condensate along with q_c: the library derives the
+    # water-vapour VMR as (q_t − q_c)/(1 − q_t), so zeroing q_c while q_t
+    # keeps ``vapor + in-cloud condensate`` makes gas optics absorb on the
+    # condensate as if it were vapour — in every g-point (the cloud is
+    # already represented by the per-gpoint McICA paths) and, worse, in the
+    # clear-sky CRE call. Vapour-only q_t leaves the condensate's radiative
+    # effect entirely to the cloud-optics paths.
     zero_3d = jnp.zeros_like(rrtmgp_input["q_liq"])
+    rrtmgp_input["q_t"] = rrtmgp_input["q_t"] - rrtmgp_input["q_c"]
     rrtmgp_input["q_liq"] = zero_3d
     rrtmgp_input["q_ice"] = zero_3d
     rrtmgp_input["q_c"] = zero_3d
@@ -620,11 +669,25 @@ def radiation_scheme_rrtmgp(
             "asymmetry_factor": _to_4d_per_band(aerosol_data.asy_lw_per_band),
         }
 
+    # Night columns are handled by the zenith clip (µ0 = 0 zeroes the direct
+    # beam); the irradiance itself is strictly positive by construction.
     zenith_angle = jnp.arccos(jnp.clip(cos_zenith, 0.0, 1.0))
-    irrad_val = jnp.maximum(toa_flux, 0.0)
+    irrad_val = direct_irradiance
+
+    # Per-column surface boundary condition (jax-rrtmgp >= 0.2.1 hook —
+    # previously the hardcoded AtmosphericStateCfg scalars 0.07/0.98 were
+    # used for every column, severing the ice-albedo feedback and leaving
+    # the column solve inconsistent with the surface scheme's absorbed
+    # SW·(1−albedo_tile)). The library takes one BROADBAND SW albedo, so
+    # blend the surface scheme's vis/nir pair with the ~0.46/0.54 split of
+    # the TOA solar spectrum about 0.7 µm. A true per-band albedo (and the
+    # direct/diffuse distinction ECHAM makes) needs a g-point→band albedo
+    # map in the library — deferred to the cloud/surface optics overhaul.
+    sfc_alb_broadband = 0.46 * surface_albedo_vis + 0.54 * surface_albedo_nir
 
     rrtmgp_output = rrtmgp_instance.compute_heating_rate(
         zenith=zenith_angle, irrad=irrad_val,
+        sfc_alb=sfc_alb_broadband, sfc_emis=surface_emissivity,
         cloud_path_liq_lw_per_gpt=cpl_lw_4d,
         cloud_path_ice_lw_per_gpt=cpi_lw_4d,
         cloud_path_liq_sw_per_gpt=cpl_sw_4d,
@@ -643,6 +706,7 @@ def radiation_scheme_rrtmgp(
     if compute_cre:
         rrtmgp_output_clear = rrtmgp_instance.compute_heating_rate(
             zenith=zenith_angle, irrad=irrad_val,
+            sfc_alb=sfc_alb_broadband, sfc_emis=surface_emissivity,
             vmr_fields=vmr_fields or None,
             aerosol_optics_sw=aerosol_optics_sw,
             aerosol_optics_lw=aerosol_optics_lw,

--- a/jcm/physics/radiation/rrtmgp_test.py
+++ b/jcm/physics/radiation/rrtmgp_test.py
@@ -380,21 +380,36 @@ class TestRRTMGPRadiationQuickWins:
             f"(the mu0^2 bug gives ~{expected * mu0:.1f})"
         )
 
-    def test_pressure_halo_linearly_extrapolated(self):
-        from jcm.physics.radiation.rrtmgp import _to_3d_with_extrapolated_halo
-        p = jnp.array([1000.0, 800.0, 650.0])
-        out = _to_3d_with_extrapolated_halo(p, 3, 1)[0, 0]
-        # Halo values continue the local spacing, so the library's centered
-        # difference 0.5*(p[k+1]-p[k-1]) recovers the one-sided Δp at both
-        # boundaries instead of half of it.
-        assert float(out[0]) == pytest.approx(1200.0)
-        assert float(out[-1]) == pytest.approx(500.0)
-        assert float(0.5 * (out[2] - out[0])) == pytest.approx(
-            float(p[1] - p[0])
+    def test_pressure_halo_encodes_true_boundary_thickness(self):
+        from jcm.physics.echam.echam_levels import get_echam_levels
+        from jcm.physics.radiation.rrtmgp import _to_3d_pressure_halo
+
+        # The production hybrid L47 grid — the case that broke both naive
+        # halo constructions: edge fill halves a uniform-grid boundary Δp,
+        # and linear extrapolation (2p[0]−p[1]) is +75 % at the surface and
+        # NEGATIVE at the log-spaced top.
+        vertical = get_echam_levels(47)
+        ph = jnp.asarray(vertical.a_boundaries) + jnp.asarray(
+            vertical.b_boundaries
+        ) * 101325.0
+        pf = 0.5 * (ph[:-1] + ph[1:])
+        # Surface-first, as prepare_rrtmgp_data hands it to the halo helper.
+        pf_sf, ph_sf = pf[::-1], ph[::-1]
+        dp_bottom = ph_sf[0] - ph_sf[1]
+        dp_top = ph_sf[-2] - ph_sf[-1]
+
+        out = _to_3d_pressure_halo(pf_sf, dp_bottom, dp_top, 47, 1)[0, 0]
+        # The library's centered difference 0.5*(p[k-1]-p[k+1]) must
+        # reproduce the model's TRUE half-level layer thickness at both
+        # boundaries (surface ≈ 780 Pa, top ≈ 1.99 Pa on this grid).
+        assert float(0.5 * (out[0] - out[2])) == pytest.approx(
+            float(dp_bottom), rel=1e-5
         )
-        assert float(0.5 * (out[4] - out[2])) == pytest.approx(
-            float(p[2] - p[1])
+        assert float(0.5 * (out[-3] - out[-1])) == pytest.approx(
+            float(dp_top), rel=1e-5
         )
+        # And the top halo stays strictly positive (log-pressure safety).
+        assert float(out[-1]) > 0.0
 
     def test_surface_albedo_reaches_sw_solver(self):
         dark = self._cloud_free(_make_inputs(nlev=10))

--- a/jcm/physics/radiation/rrtmgp_test.py
+++ b/jcm/physics/radiation/rrtmgp_test.py
@@ -330,3 +330,140 @@ class TestRRTMGPThinCloudInflation:
         assert jnp.isfinite(diag.toa_lw_up)
         # The thin cloud is still radiatively active (not silently dropped).
         assert float(diag.toa_sw_up) > float(diag.toa_sw_up_clear) - 1e-3
+
+
+class TestRRTMGPRadiationQuickWins:
+    """Regression pins for the radiation-glue fixes (fix-plan PR 3).
+
+    Each test fails on the pre-fix code:
+      - TOA insolation was ∝ µ0² (radiation_flux, already ×µ0, passed as
+        the normal-incidence ``irrad`` which the library multiplies by µ0
+        again) — pinned by ``test_toa_insolation_is_single_cosine`` at a
+        µ0 ≈ 0.5 point where the bug halves the insolation.
+      - The pressure halo was edge-filled, halving the boundary layers'
+        centered-difference Δp (2× heating) — pinned on the halo helper.
+      - The hardcoded ``sfc_alb=0.07`` / ``sfc_emis=0.98`` ignored the
+        surface scheme — pinned by asserting the per-column values shape
+        the SW/LW fluxes.
+      - Condensate rode into gas optics as vapour via ``q_t`` while
+        ``q_c`` was zeroed — pinned by comparing the clear-sky (CRE)
+        fluxes of a cloudy and a cloud-free column.
+    """
+
+    @staticmethod
+    def _cloud_free(inputs):
+        nlev = inputs["temperature"].shape[0]
+        inputs["cloud_water"] = jnp.zeros((nlev,))
+        inputs["cloud_ice"] = jnp.zeros((nlev,))
+        inputs["cloud_fraction"] = jnp.zeros((nlev,))
+        return inputs
+
+    def test_toa_insolation_is_single_cosine(self):
+        from jax_solar import direct_solar_irradiance
+        inputs = self._cloud_free(_make_inputs(nlev=10))
+        # June solstice, local noon at lon 0: subsolar latitude +23.4°, so
+        # -36.6° puts the sun 60° from zenith → µ0 ≈ 0.5, where the old
+        # µ0² insolation is HALF the correct value.
+        inputs["latitude"] = -36.6
+        _, diag = radiation_scheme_rrtmgp(**inputs)
+
+        mu0 = float(jnp.reshape(diag.cos_zenith, (-1,))[0])
+        assert 0.3 < mu0 < 0.7, f"geometry sanity: mu0={mu0}"
+        irrad = float(direct_solar_irradiance(
+            inputs["solar"].orbital_phase,
+            inputs["parameters"].solar_constant,
+        ))
+        expected = irrad * mu0
+        actual = float(diag.toa_sw_down)
+        assert abs(actual - expected) / expected < 0.02, (
+            f"TOA SW down {actual:.1f} vs irrad*mu0 {expected:.1f} "
+            f"(the mu0^2 bug gives ~{expected * mu0:.1f})"
+        )
+
+    def test_pressure_halo_linearly_extrapolated(self):
+        from jcm.physics.radiation.rrtmgp import _to_3d_with_extrapolated_halo
+        p = jnp.array([1000.0, 800.0, 650.0])
+        out = _to_3d_with_extrapolated_halo(p, 3, 1)[0, 0]
+        # Halo values continue the local spacing, so the library's centered
+        # difference 0.5*(p[k+1]-p[k-1]) recovers the one-sided Δp at both
+        # boundaries instead of half of it.
+        assert float(out[0]) == pytest.approx(1200.0)
+        assert float(out[-1]) == pytest.approx(500.0)
+        assert float(0.5 * (out[2] - out[0])) == pytest.approx(
+            float(p[1] - p[0])
+        )
+        assert float(0.5 * (out[4] - out[2])) == pytest.approx(
+            float(p[2] - p[1])
+        )
+
+    def test_surface_albedo_reaches_sw_solver(self):
+        dark = self._cloud_free(_make_inputs(nlev=10))
+        bright = self._cloud_free(_make_inputs(nlev=10))
+        bright["surface_albedo_vis"] = jnp.array(0.7)
+        bright["surface_albedo_nir"] = jnp.array(0.7)
+
+        _, diag_dark = radiation_scheme_rrtmgp(**dark)
+        _, diag_bright = radiation_scheme_rrtmgp(**bright)
+
+        # Reflected SW at the surface matches the prescribed albedo (vis ==
+        # nir here, so the broadband blend is exact).
+        ratio = float(diag_bright.surface_sw_up) / float(
+            diag_bright.surface_sw_down
+        )
+        assert ratio == pytest.approx(0.7, abs=0.02)
+        # And the extra reflection reaches the TOA budget (ice-albedo
+        # feedback pathway). Hardcoded 0.07 gave identical fluxes for both.
+        assert float(diag_bright.toa_sw_up) > 2.0 * float(diag_dark.toa_sw_up)
+
+    def test_surface_emissivity_reaches_lw_solver(self):
+        grey_sfc = self._cloud_free(_make_inputs(nlev=10))
+        black_sfc = self._cloud_free(_make_inputs(nlev=10))
+        grey_sfc["surface_emissivity"] = jnp.array(0.5)
+        black_sfc["surface_emissivity"] = jnp.array(1.0)
+
+        _, diag_grey = radiation_scheme_rrtmgp(**grey_sfc)
+        _, diag_black = radiation_scheme_rrtmgp(**black_sfc)
+
+        # Upwelling surface LW = eps*B(T_s) + (1-eps)*LW_down. Pin the full
+        # linear relation for both emissivities (the hardcoded-0.98 code
+        # gave the same upwelling flux regardless of the passed value; the
+        # margin between the two runs is only ~22 W/m² because this humid
+        # 300 K atmosphere has LW_down close to sigma*T^4).
+        sigma_t4 = 5.670374e-8 * 300.0**4
+        for eps_val, diag in ((0.5, diag_grey), (1.0, diag_black)):
+            expected = (
+                eps_val * sigma_t4
+                + (1.0 - eps_val) * float(diag.surface_lw_down)
+            )
+            assert float(diag.surface_lw_up) == pytest.approx(
+                expected, rel=0.01
+            ), f"eps={eps_val}"
+        assert float(diag_black.surface_lw_up) > float(
+            diag_grey.surface_lw_up
+        )
+
+    def test_clear_sky_cre_sees_vapor_only(self):
+        cloudy = _make_inputs(nlev=10)
+        nlev = cloudy["temperature"].shape[0]
+        cloudy["cloud_water"] = jnp.zeros((nlev,)).at[3:6].set(2e-3)
+        cloudy["cloud_ice"] = jnp.zeros((nlev,)).at[2:4].set(5e-4)
+        cloudy["cloud_fraction"] = jnp.zeros((nlev,)).at[2:6].set(0.5)
+        cloudy["compute_cre"] = True
+
+        clear = self._cloud_free(_make_inputs(nlev=10))
+        clear["compute_cre"] = True
+
+        _, diag_cloudy = radiation_scheme_rrtmgp(**cloudy)
+        _, diag_clear = radiation_scheme_rrtmgp(**clear)
+
+        # The clear-sky (CRE) branch must see the SAME atmosphere for both
+        # columns: vapour only. Before the q_t fix the cloudy column's
+        # condensate was counted as extra water vapour in gas optics, so
+        # its "clear-sky" OLR was biased low relative to the truly clear
+        # column.
+        assert float(diag_cloudy.toa_lw_up_clear) == pytest.approx(
+            float(diag_clear.toa_lw_up_clear), rel=1e-4
+        )
+        assert float(diag_cloudy.toa_sw_up_clear) == pytest.approx(
+            float(diag_clear.toa_sw_up_clear), rel=1e-4
+        )

--- a/jcm/rce.py
+++ b/jcm/rce.py
@@ -45,8 +45,7 @@ Example::
     # RRTMGP is the default radiation; convective_rh defaults to
     # relative_humidity − 0.1 so Betts-Miller actually precipitates (see
     # ``rce_column`` on why rhbm must sit below the environmental RH).
-    scm = rce_column(sst=300.0, relative_humidity=0.7, solar_constant=728.4,
-                     co2_ppmv=0.0)
+    scm = rce_column(sst=300.0, relative_humidity=0.7, co2_ppmv=0.0)
     ic  = rce_initial_state(scm.vertical, sst=300.0, relative_humidity=0.7)
     preds = run_rce(scm, ic, n_days=100)
     t_equilibrium = preds.relaxed_states["temperature"][-1]   # (nlev,) profile
@@ -311,7 +310,7 @@ def rce_column(
     relative_humidity: float = 0.7,
     convective_rh: float | None = None,
     co2_ppmv: float = 348.0,
-    solar_constant: float = 728.4,
+    solar_constant: float = 543.2,
     lat_deg: float = 42.55,
     nlev: int = 47,
     vertical=None,
@@ -358,6 +357,14 @@ def rce_column(
         co2_ppmv: CO₂ volume mixing ratio [ppmv] on ``forcing.co2_vmr``.
         solar_constant: Solar constant [W/m²] for the *default* radiation term;
             tune to hit the target TOA SW. Ignored if ``radiation`` is given.
+            The default 543.2 delivers the RCEMIP target ``toa_sw_down``
+            ≈ 409.6 W/m² at this configuration's fixed sun (µ0 = 0.7427 at
+            ``lat_deg=42.55`` / ``day_of_year_fraction=0.22``, orbital
+            distance factor 1.0153): 543.2 × 1.0153 × 0.7427 ≈ 409.6. The
+            previous default (728.4) was calibrated against the µ0²
+            insolation bug in the RRTMGP glue (fixed alongside this change)
+            and would now deliver ~549 W/m² — enough to shut Betts-Miller
+            deep convection off entirely in the default column.
         lat_deg: Column latitude [deg] (fixes the zenith angle with ``solar``).
         nlev: Number of levels for ``get_echam_levels`` (47 or 40) when
             ``vertical`` is not given.

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ myst-parser  # Markdown source for design/* docs
 
 # Radiation scheme
 jax-solar  # Requires Python 3.11+
-jax-rrtmgp>=0.2.0  # 0.2.0+ has the gas-optics gather + shared-table fixes the single-vmap RRTMGP path needs
+jax-rrtmgp>=0.2.1  # 0.2.1+ has the per-call sfc_alb/sfc_emis overrides the per-column surface coupling needs (0.2.0: gas-optics gather + shared-table fixes)


### PR DESCRIPTION
PR 3 of the ECHAM+RRTMGP fix campaign (plan: `docs/echam_rrtmgp_fix_plan.md` on `claude/echam-rrtmgp-physics-review-zcof6u`). Five leading-order radiation fixes, biggest W/m² per line of diff (+275/−15):

| Fix | Review ref | Effect of the bug |
|---|---|---|
| Normal-incidence `irrad` (library applies µ0 itself) | 0.3 / PR-1.5 | TOA insolation ∝ µ0² → ~110 W/m² global-mean SW deficit |
| Per-column surface albedo + emissivity reach the solver | 0.4 / PR-1.6 | hardcoded 0.07/0.98 → no ice-albedo feedback, surface/atmosphere energy inconsistency |
| Pressure halo encodes exact half-level boundary Δp | 2.34 / PR-2.39 | edge fill and linear extrapolation both misstate boundary-layer Δp (up to 2×); halo now built from `pressure_interfaces` so the library's centered difference reproduces the true thickness exactly (780 Pa surface / 1.99 Pa top on L47) |
| `q_t` drops condensate along with `q_c` | 2.35 / PR-2.40 | gas optics absorbed on condensate as vapour, incl. in the clear-sky CRE call |
| Stevens et al. (2017) `dNovrN` Twomey factor | 1.1 / PR-1.4 | `get_CDNC(aod)/get_CDNC(0)` ≡ absolute CDNC ≈ 137 used as a multiplier (~100× indirect effect) |

**Depends on** climate-analytics-lab/jax-rrtmgp#14 (per-call `sfc_alb`/`sfc_emis` overrides) — `requirements.txt` bumped to `jax-rrtmgp>=0.2.1`, so CI here needs that release (or an editable install of the PR branch). Everything else is self-contained.

**Ride-along:** `rce_column`'s default `solar_constant` recalibrated 728.4 → 543.2. The old value was tuned to the RCEMIP ~409.6 W/m² `toa_sw_down` *under the µ0² bug*; unchanged it now delivers ~549 W/m² and shuts Betts-Miller deep convection off. 543.2 restores the RCEMIP target under correct optics (543.2 × 1.0153 × 0.7427 ≈ 409.6); full calibration documented in the docstring.

**Deferred** (own PR): the effective-radius overhaul (PR-2.36) — Martin-1994 liquid rₑ(LWC/Nd), Sun–Rikus ice rₑ(IWC,T), the degenerate `cip/max(1,cwp+cip)` argument, `land_fraction` plumbing. It entangles with per-band surface optics and is not a quick win.

## Validation

- `ruff check .` clean; fast suite **1245 passed, 17 skipped, 0 failed**; `rce_test.py` incl. slow tests **17 passed**.
- **Five new regression tests, each verified to fail on unfixed base** (`b41076a`) and pass here: single-cosine TOA pin at µ0 ≈ 0.5 (bug gives half), halo-extrapolation pin, albedo/emissivity-reach-solver pins (`LW↑ = ε·σT⁴ + (1−ε)·LW↓` to 1%), clear-sky-CRE cloud-independence pin, `dNovrN` magnitude pin (≈2.0 at AOD 0.43, old code 137).
- **50-day RCE A/B** (RRTMGP + Betts-Miller column, fixed SST 300 K, `jcm/rce.py` harness):
  - baseline dev: `toa_sw_down` 408.0, precip 1.30 mm/day, rms dT/dt 0.022 K/day
  - PR3 @ matched insolation (exact-Δp halo, post-Codex-review): troposphere within **0.23 K** of baseline, precip identical (1.30 mm/day), rms dT/dt 0.021 — same climate at the same forcing
  - the structural change is the boundary-artifact removal: top-layer SW/LW rates drop from ±0.5 K/day (computed on a halved Δp) to ±0.15 K/day on the true 1.99 Pa layer thickness; the top level equilibrates ~2.6 K warmer, no longer balancing fictitious cooling
  - PR3 @ unchanged 728.4: 549 W/m² insolation, convection silenced — demonstrating why the RCE default had to be recalibrated with the optics fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
