### PR TITLE
2M ice-regime adjoint: physical floors on guard divisions and riming slopes

### DIFF
--- a/jcm/physics/clouds/cloud_utils.py
+++ b/jcm/physics/clouds/cloud_utils.py
@@ -111,12 +111,19 @@ def gridbox_frac_falling_hydrometeor(
     total_precip_flux = precip_flux_from_above + precip_flux_from_level
 
     # Determine where total flux is greater than the minimum threshold
-    ll1 = total_precip_flux > params.cqtmin
+    # The guard threshold is a PHYSICAL minimum flux (1e-9 kg/m2/s is well
+    # under a mm per year), not cqtmin = 1e-12: the division VJP forms
+    # -g*x/(flux*flux), and for fluxes between 1e-12 and ~1e-6 the selected
+    # branch's derivative reaches 1e12-1e24 per call. Those cotangent spikes
+    # compound through the precip-fraction carry and are one of the
+    # ice-regime adjoint amplifiers that break long-window reverse mode.
+    _min_flux = 1.0e-9
+    ll1 = total_precip_flux > _min_flux
 
     # Compute weighted average fraction
     weighted_precip_frac = (
         (precip_frac_from_level * precip_flux_from_level + updated_precip_frac_from_above * precip_flux_from_above)
-        / jnp.maximum(total_precip_flux, params.cqtmin)
+        / jnp.maximum(total_precip_flux, _min_flux)
     )
     weighted_precip_frac = jnp.clip(weighted_precip_frac, 0.0, 1.0)
 

--- a/jcm/physics/clouds/lohmann_2m/precip.py
+++ b/jcm/physics/clouds/lohmann_2m/precip.py
@@ -597,10 +597,17 @@ def precip_formation_cold(
     zusnow = 2.34 * jnp.maximum(100.0 * zdplanar, 1.0e-30) ** 0.3 * (1.3 * inverse_air_density_rcp) ** 0.35
 
     zstokes = 2.0 * c.rgrav * (zusnow - zudrop) * zudrop / zdplanar
-    zstokes = jnp.maximum(zstokes, params.cqtmin)
+    # Floors are PHYSICAL minima, not cqtmin = 1e-12: the collection-
+    # efficiency curves below take log10(zstokes) and zrey**(-1.12), whose
+    # derivatives at a 1e-12 floor reach ~1e12 inside the selected branch
+    # (real cells with small droplets land there) and compound through the
+    # adjoint. A Stokes number below 1e-3 or a snow Reynolds number below
+    # 1e-2 means no collection on any physical fit's domain, so the floors
+    # only bound slopes the fits were never valid for.
+    zstokes = jnp.maximum(zstokes, 1.0e-3)
 
     zrey = air_density * zdplanar * zusnow / jnp.maximum(dynamic_viscosity, params.eps)
-    zrey = jnp.maximum(zrey, params.cqtmin)
+    zrey = jnp.maximum(zrey, 1.0e-2)
 
     ll3 = zrey <= 5.0
     ll4 = jnp.logical_and(zrey > 5.0, zrey < 40.0)
@@ -613,7 +620,10 @@ def precip_formation_cold(
     zcsacl = 0.2 * (jnp.log10(zstokes) - jnp.log10(zstcrit) - 2.236) ** 2
     zcsacl = jnp.minimum(zcsacl, 1.0 - params.cqtmin)
     zcsacl = jnp.maximum(zcsacl, 0.0)
-    zcsacl = jnp.sqrt(jnp.maximum(1.0 - zcsacl, 1.0e-30))
+    # 1e-4 floor (efficiency capped at ~0.995), not 1e-30: sqrt at the old
+    # floor has slope 5e14 on the SELECTED branch when the fit saturates,
+    # another per-call adjoint amplifier for no physical content.
+    zcsacl = jnp.sqrt(jnp.maximum(1.0 - zcsacl, 1.0e-4))
 
     ll6 = jnp.logical_and(ll5, zstokes <= 0.06)
     ll7 = jnp.logical_and(ll5, jnp.logical_and(zstokes > 0.06, zstokes <= 0.25))
@@ -843,17 +853,27 @@ def update_precip_fluxes(
 
     # 4) In-cloud Rain/Snow Fluxes and Area-integrated Evaporation/Sublimation
     # in-cloud (area-averaged) rain/snow fluxes before evaporation/sublimation
-    ll1 = precip_cover > params.epsec
+    #
+    # The cover floor is a PHYSICAL minimum precip fraction (1e-4), not
+    # epsec = 1e-12. Two reasons. Forward: flux / max(cover, 1e-12) reports
+    # absurd in-cloud fluxes (x1e12) in nearly-uncovered cells, which the
+    # downstream evaporation then acts on. Reverse: the division VJP forms
+    # -g*x/(cover*cover), up to 1e24 per call for covers just above the old
+    # floor -- one of the ice-regime adjoint amplifiers that break
+    # long-window reverse mode. A precip fraction below 1e-4 is treated as
+    # no precip cover at all.
+    _min_cover = 1.0e-4
+    ll1 = precip_cover > _min_cover
 
-    ztmp1 = (rain_flux + zzdrr) / jnp.maximum(precip_cover, params.epsec)
-    ztmp2 = (snow_flux + zzdrs) / jnp.maximum(precip_cover, params.epsec)
+    ztmp1 = (rain_flux + zzdrr) / jnp.maximum(precip_cover, _min_cover)
+    ztmp2 = (snow_flux + zzdrs) / jnp.maximum(precip_cover, _min_cover)
 
     pfrain = jnp.where(ll1, ztmp1, 0.0)
     pfsnow = jnp.where(ll1, ztmp2, 0.0)
 
     # evaporation / sublimation area-integrated (kg/m2/s)
-    ztmp3 = (zcons2 * pressure_thickness * rain_evap_mmr) / jnp.maximum(precip_cover, params.epsec)
-    ztmp4 = (zcons2 * pressure_thickness * snow_sublimation_mmr) / jnp.maximum(precip_cover, params.epsec)
+    ztmp3 = (zcons2 * pressure_thickness * rain_evap_mmr) / jnp.maximum(precip_cover, _min_cover)
+    ztmp4 = (zcons2 * pressure_thickness * snow_sublimation_mmr) / jnp.maximum(precip_cover, _min_cover)
 
     pfevapr = jnp.where(ll1, ztmp3, 0.0)
     pfsubls = jnp.where(ll1, ztmp4, 0.0)

--- a/jcm/physics/clouds/lohmann_2m/sedimentation_melt.py
+++ b/jcm/physics/clouds/lohmann_2m/sedimentation_melt.py
@@ -132,10 +132,15 @@ def melting_snow_and_ice(
     # ------------------------------------------------------------
     ice_melt_flux = jnp.minimum(params.xsec * ice_flux, melt_capacity)
 
-    has_ice_flux = ice_flux > params.epsec
+    # Guarded at a physical minimum flux (1e-9 kg/m2/s), not epsec = 1e-12:
+    # the ratio's VJP forms -g*x/(flux*flux), up to 1e24 per call for fluxes
+    # just above the old floor (an ice-regime adjoint amplifier). Melting a
+    # number flux out of a sub-1e-9 mass flux is physically nothing.
+    _min_flux = 1.0e-9
+    has_ice_flux = ice_flux > _min_flux
     ice_melt_flux_n = jnp.where(
         has_ice_flux,
-        ice_flux_n * ice_melt_flux / jnp.maximum(ice_flux, params.epsec),
+        ice_flux_n * ice_melt_flux / jnp.maximum(ice_flux, _min_flux),
         0.0,
     )
 


### PR DESCRIPTION
Stacked on #561 (merge that first; this branch then contains only the one commit). Part of the adjoint-horizon campaign documented in [cloud-lifetime-gradients](https://github.com/climate-analytics-lab/cloud-lifetime-gradients).

**Context.** The exact reverse-mode gradient through the 2M scheme grows geometrically with rollout length while the model itself stays smooth (FD O(1) from 24 minutes to 24 hours; exact adjoint ~1e245 at 40 steps). Per-function cotangent taps localize the largest per-call amplifiers (×800–1300) to guard divisions and riming-efficiency slopes in the ice-regime precipitation chain, where machine-epsilon floors (1e-12/1e-30) put reciprocal-squared slopes of 1e12–1e24 on *selected* branches.

**This PR** raises those floors to physical minima: precipitation flux ≥ 1e-9 kg/m²/s, precip cover ≥ 1e-4 (also fixing a forward pathology — ×1e12-inflated "in-cloud" fluxes in nearly-uncovered cells fed the evaporation), Stokes number ≥ 1e-3, snow Reynolds ≥ 1e-2, collection-efficiency sqrt argument ≥ 1e-4. Each is far below the validity range of the fit it guards. All 59 lohmann_2m/cloud_data tests pass unchanged.

**Scope, stated honestly:** the warm condensate loop's distributed gain (~2×10⁴/step through KK2000 depletion factors, accretion survival factors, and saturation adjustment) is *not* addressed here — bounding it means altering well-exercised warm-rain forward behaviour, and the calibration side handles that loop instead with the detached/damped condensate adjoint (JEM-Cal `EchamForward(detach_fast_adjoint=..., fast_adjoint_decay=...)`). Post-fix horizon measurements (detached adjoint at 60/120 steps, testing whether these fixes cure the ice-regime thermo-loop) are running; results will be posted as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aqshaa5nDrxcDWgg1FYw8Z