### PR TITLE
feat(speedy): width-parameterized smooth gates for the sharp physics branches

### DIFF
--- a/jcm/physics/clouds/speedy_condensation.py
+++ b/jcm/physics/clouds/speedy_condensation.py
@@ -12,6 +12,7 @@ import jcm.constants as c
 # alhc is SPEEDY's latent heat in J/g (q is in g/kg). cpd, p0, grav are shared
 # and read as module attributes from jcm.constants.
 from jcm.physics.speedy.physical_constants import alhc
+from jcm.physics.speedy.smoothing import smooth_min
 
 @jit
 def get_large_scale_condensation_tendencies(
@@ -71,7 +72,17 @@ def get_large_scale_condensation_tendencies(
     # Calculate dqlsc and dtlsc where dqa < 0
     negative_dqa_mask = dqa < 0
     dqlsc = dqlsc.at[1:].set(jnp.where(negative_dqa_mask[1:], dqa[1:] * rtlsc, 0.0))
-    dtlsc = dtlsc.at[1:].set(jnp.where(negative_dqa_mask[1:], tfact * jnp.minimum(-dqlsc[1:], dqmax[1:, jnp.newaxis, jnp.newaxis] * psa2), 0.))
+    # The grid-point-storm heating cap is a hard minimum: once a column
+    # saturates it, every parameter's gradient through the heating is
+    # exactly zero. cap_smoothing > 0 (a fraction of the cap) rounds the
+    # corner with the hyperbolic smooth minimum so a residual gradient
+    # survives saturation; 0 keeps the hard cap.
+    cap = dqmax[1:, jnp.newaxis, jnp.newaxis] * psa2
+    dtlsc = dtlsc.at[1:].set(jnp.where(
+        negative_dqa_mask[1:],
+        tfact * smooth_min(-dqlsc[1:], cap, parameters.condensation.cap_smoothing * cap),
+        0.,
+    ))
 
     # Update iptop to first level with condensation (dqa < 0), or keep conv.iptop if no condensation
     condensation_mask = dqa[1:] < 0

--- a/jcm/physics/convection/speedy_convection.py
+++ b/jcm/physics/convection/speedy_convection.py
@@ -17,6 +17,7 @@ import jcm.constants as c
 # SPEEDY-specific value, not the shared SI constant. Shared constants (cpd, p0,
 # grav) are read as module attributes from jcm.constants.
 from jcm.physics.speedy.physical_constants import alhc
+from jcm.physics.speedy.smoothing import smooth_gate, smooth_pos
 
 @jit
 def diagnose_convection(
@@ -111,14 +112,38 @@ def diagnose_convection(
     # Check 3: RH > RH_c at both the surface layer and the PBL top
     qthr0 = parameters.convection.rhbl * qsat[kx-1]
     qthr1 = parameters.convection.rhbl * qsat_sc
-    lqthr = (qa[kx-1] > qthr0) & (qa_sc > qthr1)
 
     case_1 = mask_psa & (ktop1 < kx) & (ktop2 < kx)
-    case_2 = mask_psa & (ktop1 < kx) & ~(ktop2 < kx) & lqthr
 
-    iptop = jnp.where(case_1 | case_2, ktop1, iptop)
+    # The humidity trigger is a value jump: when the PBL-top RH condition
+    # flips, qdif switches between 0 and the finite surface-layer excess.
+    # With trigger_smoothing > 0 (an RH fraction) the case-2 excess is
+    # instead scaled by sigmoid gates on both RH criteria, ramping
+    # convection in over ~2 widths of relative humidity. The iptop
+    # assignment keeps a hard mask (a level index has no smooth
+    # counterpart) but widens its humidity condition by 6 widths so the
+    # discrete activation happens out on the gate's skirt, where the gated
+    # mass flux is at most sigmoid(-6) ~ 2.5e-3 of the excess: the value
+    # jump survives only at that negligible amplitude. Width 0 reproduces
+    # the hard trigger exactly.
+    w_rh = parameters.convection.trigger_smoothing
+    trigger_gate = (
+        smooth_gate(qa[kx-1], qthr0, w_rh * qsat[kx-1])
+        * smooth_gate(qa_sc, qthr1, w_rh * qsat_sc)
+    )
+    lqthr_wide = (
+        (qa[kx-1] > qthr0 - 6.0 * w_rh * qsat[kx-1])
+        & (qa_sc > qthr1 - 6.0 * w_rh * qsat_sc)
+    )
+    case_2_soft = mask_psa & (ktop1 < kx) & ~(ktop2 < kx) & lqthr_wide
+
+    iptop = jnp.where(case_1 | case_2_soft, ktop1, iptop)
     qdif = jnp.where(case_1, jnp.maximum(qa[kx-1] - qthr0, (mse0 - msthr) * rlhc), qdif)
-    qdif = jnp.where(case_2, qa[kx-1] - qthr0, qdif)
+    qdif = jnp.where(
+        case_2_soft,
+        trigger_gate * jnp.maximum(qa[kx-1] - qthr0, 0.0),
+        qdif,
+    )
     return iptop, qdif
 
 @jit
@@ -234,9 +259,12 @@ def get_convection_tendencies(
     # 3.3 Top layer (condensation and detrainment)
     k = iptop - 1
 
-    # Flux of convective precipitation
+    # Flux of convective precipitation. The onset hinge (moisture flux
+    # crossing cloud-top saturation) zeroes the gradient of every
+    # parameter through non-precipitating columns; precnv_smoothing > 0
+    # [g/(m^2 s)] replaces it with a softplus of that half-width.
     qsatb = index_array(pad_array(interpolate(qsat)), k)
-    precnv = jnp.maximum(fuq - fmass * qsatb, 0.0)
+    precnv = smooth_pos(fuq - fmass * qsatb, parameters.convection.precnv_smoothing)
 
     # Net flux of dry static energy and moisture
     i, j = jnp.meshgrid(jnp.arange(ix), jnp.arange(il), indexing="ij")

--- a/jcm/physics/radiation/speedy_shortwave.py
+++ b/jcm/physics/radiation/speedy_shortwave.py
@@ -12,6 +12,9 @@ from jcm.physics.speedy.speedy_coords import (
     PBL_TOP_SIGMA, SpeedyCoords, interp_to_sigma, ozone_sigma_weight,
     stratosphere_mask,
 )
+from jcm.physics.speedy.smoothing import (
+    smooth_clip01, smooth_min, smooth_max, smooth_pos,
+)
 
 # Reference sigma surfaces for the cloud diagnostics in :func:`clouds`. Both
 # diagnostics are tuned to sample the atmosphere at particular *physical*
@@ -471,16 +474,41 @@ def clouds(operand):
     # the vertical grid (see the module-level note on reference sigmas). The
     # cloud-top level ``icltop`` keeps the actual-level argmax from the search
     # above, since the radiation needs a real level index for the cloud top.
+    # cover_smoothing > 0 (an RH/cover fraction) rounds every hinge and
+    # clip in the cover diagnosis below; 0 keeps the original hard
+    # branches. The RH hinge at rhcl1 and the max over reference levels
+    # zero d(cover)/d(rhcl1) and the state gradient wherever a level is
+    # sub-critical or non-dominant; the smooth forms keep exponentially
+    # decaying tails instead.
+    w_cov = parameters.shortwave_radiation.cover_smoothing
     rh = humidity.rh
     rhcl1 = parameters.shortwave_radiation.rhcl1
-    cloudc = jnp.maximum(0.0, interp_to_sigma(rh, fsg, PBL_TOP_SIGMA) - rhcl1)
+    cloudc = smooth_pos(interp_to_sigma(rh, fsg, PBL_TOP_SIGMA) - rhcl1, w_cov)
     for sig_ref in _CLOUDC_REF_SIGMAS:
-        cloudc = jnp.maximum(cloudc, interp_to_sigma(rh, fsg, sig_ref) - rhcl1)
+        cloudc = smooth_max(cloudc, interp_to_sigma(rh, fsg, sig_ref) - rhcl1, w_cov)
 
     # Third for loop (two levels)
     # Perform the calculations (Two Loops)
-    pr1 = jnp.minimum(parameters.shortwave_radiation.pmaxcl, 86.4 * (conv.precnv + condensation.precls))
-    cloudc = jnp.minimum(1.0, parameters.shortwave_radiation.wpcl * jnp.sqrt(jnp.maximum(epsilon, pr1)) + jnp.minimum(1.0, cloudc * rrcl)**2.0)
+    # The precipitation term has three sharp sites: the pmaxcl cap, the
+    # sqrt corner at zero precipitation (slope 1/(2*sqrt(eps)) ~ 1.6e4
+    # with the hard epsilon floor), and the saturation of the total cover
+    # at 1. With cover_smoothing on, the cap and saturation become
+    # hyperbolic minima and the sqrt is regularized as sqrt(pr1 + delta)
+    # with delta = (w*pmaxcl)^2, bounding the corner slope at
+    # 1/(2*w*pmaxcl).
+    pmaxcl = parameters.shortwave_radiation.pmaxcl
+    pr1 = smooth_min(pmaxcl, 86.4 * (conv.precnv + condensation.precls), w_cov * pmaxcl)
+    sqrt_arg = jnp.where(
+        w_cov > 0.0,
+        smooth_pos(pr1, w_cov) + (w_cov * pmaxcl) ** 2,
+        jnp.maximum(epsilon, pr1),
+    )
+    cloudc = smooth_min(
+        1.0,
+        parameters.shortwave_radiation.wpcl * jnp.sqrt(sqrt_arg)
+        + smooth_min(1.0, cloudc * rrcl, w_cov)**2.0,
+        w_cov,
+    )
     cloudc = jnp.where(jnp.isnan(cloudc), 1.0, cloudc)
     icltop = jnp.minimum(conv.iptop, icltop)
 
@@ -493,11 +521,11 @@ def clouds(operand):
 
     # Fourth for loop (Two Loops)
     # 2. Stratocumulus clouds over sea and land
-    fstab = jnp.clip(rgse * (gse - parameters.shortwave_radiation.gse_s0), 0.0, 1.0)
+    fstab = smooth_clip01(rgse * (gse - parameters.shortwave_radiation.gse_s0), w_cov)
     # Stratocumulus clouds over sea
-    clstr = fstab * jnp.maximum(parameters.shortwave_radiation.clsmax - clfact * cloudc, 0.0)
+    clstr = fstab * smooth_pos(parameters.shortwave_radiation.clsmax - clfact * cloudc, w_cov)
     # Stratocumulus clouds over land
-    clstrl = jnp.maximum(clstr, parameters.shortwave_radiation.clsminl) * humidity.rh[kx - 1]
+    clstrl = smooth_max(clstr, parameters.shortwave_radiation.clsminl, w_cov) * humidity.rh[kx - 1]
     clstr = clstr + terrain.fmask * (clstrl - clstr)
     # Cloud cover is a fraction: cap at 1. The land-branch RH amplification
     # above is unbounded when the lowest layer supersaturates (rh > 1), which
@@ -509,7 +537,7 @@ def clouds(operand):
     # downward flux and NaNs the integration within hours). On the validated
     # 8-level grid clstr never exceeds clsmax = 0.6, so this cap is a no-op
     # there.
-    clstr = jnp.minimum(clstr, 1.0)
+    clstr = smooth_min(clstr, 1.0, w_cov)
 
     swrad_out = physics_data.shortwave_rad.copy(gse=gse, icltop=icltop, cloudc=cloudc, cloudstr=clstr, qcloud=qcloud)
     physics_data = physics_data.copy(shortwave_rad=swrad_out)

--- a/jcm/physics/speedy/params.py
+++ b/jcm/physics/speedy/params.py
@@ -1,6 +1,8 @@
 """Date: 1/25/2024.
 For storing variables used by multiple physics schemes.
 """
+import dataclasses
+
 import tree_math
 import jax.numpy as jnp
 from jax import tree_util
@@ -13,16 +15,24 @@ class ConvectionParameters:
     rhbl: jnp.ndarray # Relative humidity threshold in the boundary layer
     entmax: jnp.ndarray # Maximum entrainment as a fraction of cloud-base mass flux
     smf: jnp.ndarray # Ratio between secondary and primary mass flux at cloud-base
+    # Smooth-branch half-widths; 0 = the original hard branches (see
+    # jcm.physics.speedy.smoothing). trigger_smoothing is an RH fraction
+    # smearing the boundary-layer humidity trigger; precnv_smoothing is a
+    # flux [g/(m^2 s)] smearing the convective-precipitation onset hinge.
+    trigger_smoothing: jnp.ndarray = dataclasses.field(default_factory=lambda: jnp.array(0.0))
+    precnv_smoothing: jnp.ndarray = dataclasses.field(default_factory=lambda: jnp.array(0.0))
 
     @classmethod
-    def default(cls):
+    def default(cls, trigger_smoothing=0.0, precnv_smoothing=0.0):
         return cls(
             psmin = jnp.array(0.8),
             trcnv = jnp.array(6.0),
             rhil = jnp.array(0.7),
             rhbl = jnp.array(0.9),
             entmax = jnp.array(0.5),
-            smf = jnp.array(0.8)
+            smf = jnp.array(0.8),
+            trigger_smoothing = jnp.array(trigger_smoothing),
+            precnv_smoothing = jnp.array(precnv_smoothing)
         )
 
     def isnan(self):
@@ -35,14 +45,18 @@ class CondensationParameters:
     rhlsc: jnp.ndarray  # Maximum relative humidity threshold (at sigma=1)
     drhlsc: jnp.ndarray  # Vertical range of relative humidity threshold
     rhblsc: jnp.ndarray # Relative humidity threshold for boundary layer
+    # Half-width (as a fraction of the cap) of the smooth heating-rate cap;
+    # 0 = the original hard minimum (see jcm.physics.speedy.smoothing).
+    cap_smoothing: jnp.ndarray = dataclasses.field(default_factory=lambda: jnp.array(0.0))
 
     @classmethod
-    def default(cls):
+    def default(cls, cap_smoothing=0.0):
         return cls(
             trlsc = jnp.array(4.0),
             rhlsc = jnp.array(0.9),
             drhlsc = jnp.array(0.1),
-            rhblsc = jnp.array(0.95)
+            rhblsc = jnp.array(0.95),
+            cap_smoothing = jnp.array(cap_smoothing)
         )
 
     def isnan(self):
@@ -80,9 +94,15 @@ class ShortwaveRadiationParameters:
     clsminl: jnp.ndarray  # Minimum stratiform cloud cover over land (for RH = 1)
     gse_s0: jnp.ndarray # Gradient of dry static energy corresponding to stratiform cloud cover = 0
     gse_s1: jnp.ndarray  # Gradient of dry static energy corresponding to stratiform cloud cover = 1
+    # Half-width (in cover/RH-fraction units) of the smooth replacements for
+    # the cloud-cover hinges and clips in the diagnosis (RH hinge at rhcl1,
+    # cover saturation at 1, the fstab clip, the stratiform hinges, the
+    # sqrt(precip) corner); 0 = the original hard branches (see
+    # jcm.physics.speedy.smoothing).
+    cover_smoothing: jnp.ndarray = dataclasses.field(default_factory=lambda: jnp.array(0.0))
 
     @classmethod
-    def default(cls):
+    def default(cls, cover_smoothing=0.0):
         return cls(
             albcl = jnp.array(0.43),
             albcls = jnp.array(0.50),
@@ -105,7 +125,8 @@ class ShortwaveRadiationParameters:
             clsmax = jnp.array(0.60),
             clsminl = jnp.array(0.15),
             gse_s0 = jnp.array(0.25),
-            gse_s1 = jnp.array(0.40)
+            gse_s1 = jnp.array(0.40),
+            cover_smoothing = jnp.array(cover_smoothing)
         )
 
     def isnan(self):
@@ -164,9 +185,13 @@ class SurfaceFluxParameters:
     lskineb: jnp.bool   # true : redefine skin temp. from energy balance
 
     hdrag: jnp.ndarray # Height scale for orographic correction
+    # Half-width [g/kg] of the smooth soil-moisture-limited evaporation
+    # onset hinge; 0 = the original hard maximum (see
+    # jcm.physics.speedy.smoothing).
+    evap_smoothing: jnp.ndarray = dataclasses.field(default_factory=lambda: jnp.array(0.0))
 
     @classmethod
-    def default(cls):
+    def default(cls, evap_smoothing=0.0):
         return cls(
             fwind0 = jnp.array(0.95),
             ftemp0 = jnp.array(1.0),
@@ -183,7 +208,8 @@ class SurfaceFluxParameters:
             clambsn = jnp.array(7.0),
             lscasym = True,
             lskineb = True,
-            hdrag = jnp.array(2000.0)
+            hdrag = jnp.array(2000.0),
+            evap_smoothing = jnp.array(evap_smoothing)
         )
 
     def isnan(self):
@@ -199,16 +225,26 @@ class VerticalDiffusionParameters:
     redshc: jnp.ndarray  # Reduction factor of shallow convection in areas of deep convection
     rhgrad: jnp.ndarray  # Maximum gradient of relative humidity (d_RH/d_sigma)
     segrad: jnp.ndarray  # Minimum gradient of dry static energy (d_DSE/d_phi)
+    # Smooth-gate half-widths; 0 = the original hard branches (see
+    # jcm.physics.speedy.smoothing). mse_gate_smoothing [J/kg] smears the
+    # dmse >= 0 shallow-convection / dry-diffusion crossfade (the moisture
+    # flux is proportional to drh, not drh - 0, so the hard gate is a value
+    # jump); rh_gate_smoothing [RH fraction] smears the drh > drh0 onset of
+    # the moisture-diffusion fluxes, a jump for the same reason.
+    mse_gate_smoothing: jnp.ndarray = dataclasses.field(default_factory=lambda: jnp.array(0.0))
+    rh_gate_smoothing: jnp.ndarray = dataclasses.field(default_factory=lambda: jnp.array(0.0))
 
     @classmethod
-    def default(cls):
+    def default(cls, mse_gate_smoothing=0.0, rh_gate_smoothing=0.0):
         return cls(
             trshc = jnp.array(6.0),
             trvdi = jnp.array(24.0),
             trvds = jnp.array(6.0),
             redshc = jnp.array(0.5),
             rhgrad = jnp.array(0.5),
-            segrad = jnp.array(0.1)
+            segrad = jnp.array(0.1),
+            mse_gate_smoothing = jnp.array(mse_gate_smoothing),
+            rh_gate_smoothing = jnp.array(rh_gate_smoothing)
         )
 
     def isnan(self):

--- a/jcm/physics/speedy/smoothing.py
+++ b/jcm/physics/speedy/smoothing.py
@@ -1,0 +1,88 @@
+"""Width-parameterized smooth replacements for hard branches in SPEEDY physics.
+
+The SPEEDY schemes gate fluxes and diagnostics with hard comparisons
+(``drh > drh0``, ``clip(x, 0, 1)``, ``max(x, 0)``). The comparisons whose
+gated quantity does not vanish at the threshold put value jumps in the
+model's parameter and state dependence, and every hinge zeroes a gradient
+on one side. These helpers replace them with sigmoid gates, softplus
+hinges, and hyperbolic min/max of a caller-chosen half-width.
+
+All helpers accept ``width = 0`` and then reproduce the hard operation
+exactly (bit-identical forward), so the default parameters leave SPEEDY
+untouched and the pinned regression references stay valid. The width-0
+branch is guarded with the double-where pattern so it cannot leak a
+division-by-zero cotangent (see JAX_gotchas.md).
+
+The width is a physical scale in the units of the gated variable (an RH
+fraction, an energy in J/kg, a humidity in g/kg): roughly the range over
+which the hard switch is smeared. Choose it small against the natural
+variability of the argument so the forward change stays a perturbation.
+"""
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+
+def _safe_width(width):
+    """Width guarded for use as a divisor when it may be exactly zero."""
+    on = width > 0.0
+    return on, jnp.where(on, width, 1.0)
+
+
+def smooth_gate(x, threshold, width):
+    """Sigmoid gate in [0, 1]: 1 well above ``threshold``, 0 well below.
+
+    ``width = 0`` gives the hard indicator ``(x > threshold)`` as a float.
+    """
+    on, w = _safe_width(width)
+    return jnp.where(
+        on,
+        jax.nn.sigmoid((x - threshold) / w),
+        (x > threshold).astype(jnp.result_type(x)),
+    )
+
+
+def smooth_pos(x, width):
+    """Softplus positive part: ``max(x, 0)`` smeared over ``width``.
+
+    Exact ``jnp.maximum(x, 0)`` at ``width = 0``. Overshoots the hard
+    hinge by ``width·log(2)`` at the corner and decays exponentially into
+    the clipped side.
+    """
+    on, w = _safe_width(width)
+    return jnp.where(on, w * jax.nn.softplus(x / w), jnp.maximum(x, 0.0))
+
+
+def smooth_min(a, b, width):
+    """Hyperbolic smooth minimum; exact ``jnp.minimum`` at ``width = 0``.
+
+    Undershoots the hard minimum by at most ``width/2`` where ``a == b``.
+    The width inside the sqrt is floored to 1 when the gate is off so the
+    unselected branch cannot produce a ``sqrt(0)`` NaN cotangent at
+    ``a == b``.
+    """
+    on, w = _safe_width(width)
+    gap = a - b
+    soft = 0.5 * (a + b - jnp.sqrt(gap * gap + w * w))
+    return jnp.where(on, soft, jnp.minimum(a, b))
+
+
+def smooth_max(a, b, width):
+    """Hyperbolic smooth maximum; exact ``jnp.maximum`` at ``width = 0``."""
+    on, w = _safe_width(width)
+    gap = a - b
+    soft = 0.5 * (a + b + jnp.sqrt(gap * gap + w * w))
+    return jnp.where(on, soft, jnp.maximum(a, b))
+
+
+def smooth_clip01(x, width):
+    """Softplus-pair soft clip to [0, 1]; exact ``jnp.clip(x, 0, 1)`` at 0.
+
+    Identity in the interior, exponential (never exactly flat) tails at
+    the edges, so gradients survive saturation. Same construction as the
+    Sundqvist cover ``smooth_b0`` (mo_cover review B.2.4).
+    """
+    on, w = _safe_width(width)
+    soft = w * jax.nn.softplus(x / w) - w * jax.nn.softplus((x - 1.0) / w)
+    return jnp.where(on, soft, jnp.clip(x, 0.0, 1.0))

--- a/jcm/physics/speedy/speedy_smooth_gradients_test.py
+++ b/jcm/physics/speedy/speedy_smooth_gradients_test.py
@@ -200,6 +200,64 @@ class TestVdiffGateSmoothing:
         assert jnp.isfinite(smooth_grad) and smooth_grad != 0.0
 
 
+class TestVdiffSeFluxOneSided:
+    def test_stable_column_gets_no_reversed_heat_flux(self):
+        """The smoothed shallow-convection SE flux must stay one-sided.
+
+        gate * dmse would go negative below the threshold (a reversed
+        heat flux in stable columns); the softplus hinge keeps it >= 0
+        (Codex review, PR #567).
+        """
+        import dataclasses
+
+        from jcm.forcing import ForcingData
+        from jcm.physics.speedy.params import Parameters
+        from jcm.physics.speedy.physics_data import (
+            ConvectionData, HumidityData, PhysicsData,
+        )
+        from jcm.physics.speedy.speedy_coords import SpeedyCoords
+        from jcm.physics_interface import PhysicsState
+        from jcm.physics.vertical_diffusion.speedy_vdiff import (
+            get_vertical_diffusion_tend,
+        )
+        from jcm.terrain import TerrainData
+
+        kx, ix, il = 8, 1, 1
+        coords = SpeedyCoords.single_column_coords(num_levels=kx)
+        parameters = Parameters.default()
+        parameters = dataclasses.replace(
+            parameters,
+            vertical_diffusion=dataclasses.replace(
+                parameters.vertical_diffusion,
+                mse_gate_smoothing=jnp.array(2000.0),
+            ),
+        )
+        # Stable PBL: dmse ~ -4 kJ/kg, within a few widths of threshold.
+        se = jnp.linspace(340e3, 310e3, kx)[:, None, None] * jnp.ones((kx, ix, il))
+        qsat = jnp.full((kx, ix, il), 10.0)
+        rh = jnp.full((kx, ix, il), 0.5)
+        qa = rh * qsat
+        qa = qa.at[-1].set(qsat[-1] - 1.5)  # dmse = -4286 + 2501*(8.5-10) < 0
+        phi = jnp.linspace(150e3, 0.0, kx)[:, None, None] * jnp.ones((kx, ix, il))
+        humidity = HumidityData.zeros((ix, il), kx, rh=rh, qsat=qsat)
+        convection = ConvectionData.zeros(
+            (ix, il), kx, iptop=jnp.full((ix, il), kx + 1, dtype=int), se=se
+        )
+        physics_data = PhysicsData.zeros(
+            (ix, il), kx, humidity=humidity, convection=convection,
+            speedy_coords=coords,
+        )
+        state = PhysicsState.zeros((kx, ix, il), specific_humidity=qa, geopotential=phi)
+        tend, _ = get_vertical_diffusion_tend(
+            state, physics_data, parameters, ForcingData.ones((ix, il)),
+            TerrainData.single_column(),
+        )
+        # The shallow-convection SE flux warms level kx-2 and cools the
+        # surface layer; with the hinge it must not reverse.
+        assert float(tend.temperature[-2, 0, 0]) >= 0.0
+        assert float(tend.temperature[-1, 0, 0]) <= 0.0
+
+
 class TestLscCapSmoothing:
     def _heating(self, cap_smoothing, rhlsc):
         from jcm.forcing import ForcingData
@@ -329,3 +387,82 @@ class TestCoverSmoothing:
         assert np.isfinite(hard)
         assert abs(near - hard) < 1e-3
         assert abs(nearer - hard) < abs(near - hard)
+
+
+class TestSurfaceEvapSmoothing:
+    def _dry_land_evap(self, evap_smoothing):
+        """Land evaporation on a column whose evap hinge is firmly closed."""
+        import dataclasses
+
+        from jcm.forcing import ForcingData
+        from jcm.physics.speedy.params import Parameters
+        from jcm.physics.speedy.physics_data import (
+            ConvectionData, HumidityData, LWRadiationData, PhysicsData,
+            SurfaceFluxData, SWRadiationData,
+        )
+        from jcm.physics.speedy.speedy_coords import SpeedyCoords, get_speedy_coords
+        from jcm.physics.speedy.test_utils import convert_to_speedy_latitudes
+        from jcm.physics_interface import PhysicsState
+        from jcm.physics.surface.speedy_surface_flux import get_surface_fluxes
+        from jcm.terrain import TerrainData
+
+        kx, ix, il = 8, 64, 32
+        coords = get_speedy_coords(layers=kx, nodal_shape=(ix, il))
+        speedy_coords = SpeedyCoords.from_coordinate_system(coords)
+        xy, zxy = (ix, il), (kx, ix, il)
+        parameters = Parameters.default()
+        parameters = dataclasses.replace(
+            parameters,
+            surface_flux=dataclasses.replace(
+                parameters.surface_flux,
+                evap_smoothing=jnp.array(evap_smoothing),
+            ),
+        )
+        # Mildly dry land: soilw*qsat(tskin) - q1 sits a few tenths of a
+        # g/kg below the hinge across the grid (tskin varies with
+        # latitude), so the hard hinge gives exactly zero evaporation
+        # while the softplus tail is small but ALIVE. That is the regime
+        # where an inconsistent hard evap > 0 mask in the energy balance
+        # hands the dry tail the full latent sensitivity; columns far
+        # below the hinge cannot discriminate because the tail
+        # underflows to zero and the mask never engages.
+        qa = jnp.full(zxy, 10.5)
+        state = PhysicsState.zeros(
+            zxy, jnp.ones(zxy), jnp.ones(zxy), jnp.full(zxy, 300.0), qa,
+            jnp.ones(zxy) * (jnp.arange(kx))[::-1][:, None, None], jnp.ones(xy),
+        )
+        terrain = TerrainData.from_coords(
+            coords, orography=jnp.zeros(xy), fmask=jnp.ones(xy), lfluxland=True
+        )
+        terrain, speedy_c = convert_to_speedy_latitudes(terrain, speedy_coords)
+        physics_data = PhysicsData.zeros(
+            xy, kx,
+            convection=ConvectionData.zeros(xy, kx),
+            humidity=HumidityData.zeros(xy, kx, rh=jnp.full(zxy, 0.9)),
+            surface_flux=SurfaceFluxData.zeros(xy, rlds=jnp.full(xy, 400.0)),
+            shortwave_rad=SWRadiationData.zeros(xy, kx, rsds=jnp.full(xy, 400.0)),
+            longwave_rad=LWRadiationData.zeros(xy, kx),
+            speedy_coords=speedy_c,
+        )
+        forcing = ForcingData.ones(
+            xy,
+            sea_surface_temperature=jnp.full(xy, 292.0),
+            soilw_am=jnp.full(xy, 0.7),
+            stl_am=jnp.full(xy, 288.0),
+        )
+        _, pd = get_surface_fluxes(state, physics_data, parameters, forcing, terrain)
+        return float(jnp.max(jnp.abs(pd.surface_flux.evap[:, :, 0])))
+
+    def test_dry_column_energy_balance_uses_the_smoothed_gate(self):
+        # The skin-temperature energy balance must weight d(Evap)/d(Tskin)
+        # by the hinge derivative: with the hard evap > 0 mask a smoothed
+        # dry column inherits the full latent sensitivity and the balance
+        # adds a spurious O(0.01) evaporation correction (Codex review,
+        # PR #567).
+        hard = self._dry_land_evap(0.0)
+        smooth = self._dry_land_evap(0.1)
+        assert hard == 0.0, "hinge not closed: test is vacuous"
+        assert smooth < 1e-3, (
+            f"dry-column evap {smooth:.3e} with smoothing on: the energy "
+            "balance is applying the hard-mask latent sensitivity"
+        )

--- a/jcm/physics/speedy/speedy_smooth_gradients_test.py
+++ b/jcm/physics/speedy/speedy_smooth_gradients_test.py
@@ -1,0 +1,331 @@
+"""Gradient tests for the smoothed SPEEDY branches.
+
+Each scheme-level test pins the specific unlock its smoothing knob exists
+for: a gradient that is exactly zero (or a forward value that jumps)
+under the hard branches must be finite and nonzero with a positive
+width, and every knob at width 0 must reproduce the hard scheme exactly.
+If one of these regresses to zero the corresponding gate has been
+re-hardened.
+"""
+import dataclasses
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from jcm.physics.speedy.smoothing import (
+    smooth_clip01, smooth_gate, smooth_max, smooth_min, smooth_pos,
+)
+
+# NB: no jax_enable_x64 here: the flag is process-global and would
+# repin the f32 reference-trajectory tolerances of the regression suite.
+
+
+class TestSmoothingPrimitives:
+    """Width-0 exactness and smooth-gradient survival for the helpers."""
+
+    def test_width_zero_reproduces_hard_ops(self):
+        x = jnp.linspace(-2.0, 3.0, 41)
+        assert jnp.array_equal(smooth_pos(x, 0.0), jnp.maximum(x, 0.0))
+        assert jnp.array_equal(smooth_gate(x, 0.5, 0.0), (x > 0.5).astype(x.dtype))
+        assert jnp.array_equal(smooth_min(x, 1.0, 0.0), jnp.minimum(x, 1.0))
+        assert jnp.array_equal(smooth_max(x, 1.0, 0.0), jnp.maximum(x, 1.0))
+        assert jnp.array_equal(smooth_clip01(x, 0.0), jnp.clip(x, 0.0, 1.0))
+
+    def test_width_zero_gradients_are_finite_at_corners(self):
+        # The double-where guard must keep the width-0 branch free of NaN
+        # cotangents exactly at the corner points.
+        for fn, at in (
+            (lambda v: smooth_pos(v, 0.0), 0.0),
+            (lambda v: smooth_min(v, 1.0, 0.0), 1.0),
+            (lambda v: smooth_max(v, 1.0, 0.0), 1.0),
+            (lambda v: smooth_clip01(v, 0.0), 0.0),
+            (lambda v: smooth_clip01(v, 0.0), 1.0),
+        ):
+            g = jax.grad(fn)(jnp.asarray(at))
+            assert jnp.isfinite(g), f"NaN corner gradient in {fn} at {at}"
+
+    def test_smooth_gradients_survive_the_clipped_side(self):
+        w = 0.1
+        for fn, at in (
+            (lambda v: smooth_pos(v, w), -0.3),
+            (lambda v: smooth_gate(v, 0.5, w) * 2.0, 0.2),
+            (lambda v: smooth_min(v, 1.0, w), 1.3),
+            (lambda v: smooth_clip01(v, w), 1.3),
+        ):
+            g = jax.grad(fn)(jnp.asarray(at))
+            assert jnp.isfinite(g) and g != 0.0, (
+                f"smooth gradient dead on the clipped side of {fn}"
+            )
+
+
+def _convection_column(kx=8, rh_pbl_top=0.85):
+    """Build a (kx, 1, 1) column engineered into the case-2 humidity trigger.
+
+    Statically stable in saturation MSE aloft (ktop1 valid) but with dry
+    intermediate levels (ktop2 invalid), so activation rides entirely on
+    the boundary-layer RH criterion; ``rh_pbl_top`` sets how close the
+    PBL-top humidity sits to the rhbl = 0.9 threshold.
+    """
+    from jcm.physics.speedy.speedy_coords import SpeedyCoords
+
+    coords = SpeedyCoords.single_column_coords(num_levels=kx)
+    # Saturation MSE aloft (~345 kJ/kg) sits BETWEEN the PBL-top actual
+    # MSE (~338 kJ/kg) and the surface saturation MSE (~362 kJ/kg):
+    # conditionally unstable (ktop1 valid) without actual-MSE instability
+    # (ktop2 invalid), so activation rides on the RH trigger alone.
+    se = jnp.full((kx, 1, 1), 320e3)
+    se = se.at[-1].set(300e3)
+    se = se.at[-2].set(304e3)
+    qsat = jnp.full((kx, 1, 1), 10.0)
+    qsat = qsat.at[-1].set(25.0)
+    qsat = qsat.at[-2].set(15.0)
+    qa = 0.3 * qsat
+    # Surface layer above threshold; PBL-top layer set by rh_pbl_top.
+    qa = qa.at[-1].set(0.95 * qsat[-1])
+    qa = qa.at[-2].set(rh_pbl_top * qsat[-2])
+    psa = jnp.ones((1, 1))
+    return psa, se, qa, qsat, coords
+
+
+def _diagnose(psa, se, qa, qsat, coords, trigger_smoothing):
+    from jcm.physics.speedy.params import Parameters
+    from jcm.physics.speedy.physics_data import PhysicsData
+    from jcm.physics.convection.speedy_convection import diagnose_convection
+
+    kx = se.shape[0]
+    parameters = Parameters.default()
+    parameters = dataclasses.replace(
+        parameters,
+        convection=dataclasses.replace(
+            parameters.convection,
+            trigger_smoothing=jnp.array(trigger_smoothing),
+        ),
+    )
+    physics_data = PhysicsData.zeros((1, 1), kx, speedy_coords=coords)
+    return diagnose_convection(psa, se, qa, qsat, parameters, physics_data)
+
+
+class TestConvectionTriggerSmoothing:
+    def test_width_zero_matches_hard_trigger(self):
+        for rh in (0.80, 0.895, 0.905, 0.99):
+            psa, se, qa, qsat, coords = _convection_column(rh_pbl_top=rh)
+            iptop0, qdif0 = _diagnose(psa, se, qa, qsat, coords, 0.0)
+            assert jnp.all(jnp.isfinite(qdif0))
+            # Hard trigger: active iff both RH criteria exceed rhbl = 0.9.
+            assert (float(qdif0[0, 0]) > 0.0) == (rh > 0.9)
+
+    def test_smooth_trigger_ramps_and_unlocks_the_gradient(self):
+        # Just below the hard threshold: qdif is exactly zero and so is
+        # its gradient with respect to the PBL-top humidity.
+        def qdif_of_dq(dq, width):
+            psa, se, qa, qsat, coords = _convection_column(rh_pbl_top=0.88)
+            qa = qa.at[-2].add(dq)
+            _, qdif = _diagnose(psa, se, qa, qsat, coords, width)
+            return qdif[0, 0]
+
+        hard_val = qdif_of_dq(jnp.array(0.0), 0.0)
+        hard_grad = jax.grad(qdif_of_dq)(jnp.array(0.0), 0.0)
+        assert hard_val == 0.0 and hard_grad == 0.0
+
+        smooth_val = qdif_of_dq(jnp.array(0.0), 0.02)
+        smooth_grad = jax.grad(qdif_of_dq)(jnp.array(0.0), 0.02)
+        assert smooth_val > 0.0
+        assert jnp.isfinite(smooth_grad) and smooth_grad > 0.0
+
+
+class TestVdiffGateSmoothing:
+    def _tendencies(self, rh_gate_smoothing, drh_scale):
+        from jcm.forcing import ForcingData
+        from jcm.physics.speedy.params import Parameters
+        from jcm.physics.speedy.physics_data import (
+            ConvectionData, HumidityData, PhysicsData,
+        )
+        from jcm.physics.speedy.speedy_coords import SpeedyCoords
+        from jcm.physics_interface import PhysicsState
+        from jcm.physics.vertical_diffusion.speedy_vdiff import (
+            get_vertical_diffusion_tend,
+        )
+        from jcm.terrain import TerrainData
+
+        kx, ix, il = 8, 1, 1
+        coords = SpeedyCoords.single_column_coords(num_levels=kx)
+        parameters = Parameters.default()
+        parameters = dataclasses.replace(
+            parameters,
+            vertical_diffusion=dataclasses.replace(
+                parameters.vertical_diffusion,
+                rh_gate_smoothing=jnp.array(rh_gate_smoothing),
+            ),
+        )
+        # Stable PBL (dmse < 0), RH contrast at the lowest interface just
+        # BELOW the drh0 onset (drh0 = rhgrad * dsigma ~ 0.066), scaled by
+        # drh_scale.
+        se = jnp.linspace(340e3, 310e3, kx)[:, None, None] * jnp.ones((kx, ix, il))
+        qsat = jnp.full((kx, ix, il), 10.0)
+        rh = jnp.full((kx, ix, il), 0.5)
+        rh = rh.at[-1].set(0.5 + drh_scale)
+        qa = rh * qsat
+        phi = jnp.linspace(150e3, 0.0, kx)[:, None, None] * jnp.ones((kx, ix, il))
+        humidity = HumidityData.zeros((ix, il), kx, rh=rh, qsat=qsat)
+        convection = ConvectionData.zeros(
+            (ix, il), kx, iptop=jnp.full((ix, il), kx + 1, dtype=int), se=se
+        )
+        physics_data = PhysicsData.zeros(
+            (ix, il), kx, humidity=humidity, convection=convection,
+            speedy_coords=coords,
+        )
+        state = PhysicsState.zeros((kx, ix, il), specific_humidity=qa, geopotential=phi)
+        tend, _ = get_vertical_diffusion_tend(
+            state, physics_data, parameters, ForcingData.ones((ix, il)),
+            TerrainData.single_column(),
+        )
+        return tend.specific_humidity
+
+    def test_hard_gate_is_a_value_jump_and_smooth_gate_ramps(self):
+        # drh0 at the PBL interface is rhgrad * (fsg[-1] - fsg[-2]) ~ 0.0575.
+        just_below, just_above = 0.050, 0.065
+        hard_lo = self._tendencies(0.0, just_below)
+        hard_hi = self._tendencies(0.0, just_above)
+        # The hard gate switches a finite flux on: the tendency jumps.
+        assert float(jnp.abs(hard_lo).max()) == 0.0
+        assert float(jnp.abs(hard_hi).max()) > 1e-7
+
+        def pbl_qtend(drh_scale, width):
+            return self._tendencies(width, drh_scale)[-1, 0, 0]
+
+        hard_grad = jax.grad(pbl_qtend)(jnp.asarray(just_below), 0.0)
+        smooth_grad = jax.grad(pbl_qtend)(jnp.asarray(just_below), 0.02)
+        assert hard_grad == 0.0
+        assert jnp.isfinite(smooth_grad) and smooth_grad != 0.0
+
+
+class TestLscCapSmoothing:
+    def _heating(self, cap_smoothing, rhlsc):
+        from jcm.forcing import ForcingData
+        from jcm.physics.speedy.params import Parameters
+        from jcm.physics.speedy.physics_data import (
+            ConvectionData, HumidityData, PhysicsData,
+        )
+        from jcm.physics.speedy.speedy_coords import SpeedyCoords
+        from jcm.physics_interface import PhysicsState
+        from jcm.physics.clouds.speedy_condensation import (
+            get_large_scale_condensation_tendencies,
+        )
+        from jcm.terrain import TerrainData
+
+        kx, ix, il = 8, 1, 1
+        coords = SpeedyCoords.single_column_coords(num_levels=kx)
+        parameters = Parameters.default()
+        parameters = dataclasses.replace(
+            parameters,
+            condensation=dataclasses.replace(
+                parameters.condensation,
+                cap_smoothing=jnp.array(cap_smoothing),
+                rhlsc=rhlsc,
+            ),
+        )
+        qsat = jnp.full((kx, ix, il), 10.0)
+        qa = 5.0 * qsat  # wildly supersaturated: the heating cap engages
+        humidity = HumidityData.zeros((ix, il), kx, qsat=qsat)
+        convection = ConvectionData.zeros(
+            (ix, il), kx, iptop=jnp.full((ix, il), kx + 1, dtype=int)
+        )
+        physics_data = PhysicsData.zeros(
+            (ix, il), kx, humidity=humidity, convection=convection,
+            speedy_coords=coords,
+        )
+        state = PhysicsState.zeros((kx, ix, il), specific_humidity=qa)
+        state = state.copy(normalized_surface_pressure=jnp.ones((ix, il)))
+        tend, _ = get_large_scale_condensation_tendencies(
+            state, physics_data, parameters, ForcingData.ones((ix, il)),
+            TerrainData.single_column(),
+        )
+        # Level kx-2: the bottom level's rhref is dominated by the
+        # rhblsc floor, which would zero d/d(rhlsc) structurally.
+        return tend.temperature[-2, 0, 0]
+
+    def test_capped_heating_gradient_survives_with_smoothing(self):
+        hard_grad = jax.grad(self._heating, argnums=1)(0.0, jnp.array(0.9))
+        smooth_grad = jax.grad(self._heating, argnums=1)(0.05, jnp.array(0.9))
+        assert hard_grad == 0.0, "cap not engaged: test is vacuous"
+        assert jnp.isfinite(smooth_grad) and smooth_grad != 0.0
+
+    def test_width_zero_matches_hard_cap(self):
+        assert float(self._heating(0.0, jnp.array(0.9))) == float(
+            self._heating(0.0, jnp.array(0.9))
+        )
+        # And the smooth cap approaches the hard one as the width shrinks.
+        hard = float(self._heating(0.0, jnp.array(0.9)))
+        near = float(self._heating(1e-6, jnp.array(0.9)))
+        assert abs(near - hard) < 1e-8 * max(1.0, abs(hard))
+
+
+class TestCoverSmoothing:
+    def _clstr(self, cover_smoothing, gse_s1):
+        """Stratiform cover on a column whose stability saturates fstab."""
+        from jcm.forcing import ForcingData
+        from jcm.physics.speedy.params import Parameters
+        from jcm.physics.speedy.physics_data import (
+            CondensationData, ConvectionData, HumidityData, PhysicsData,
+        )
+        from jcm.physics.speedy.speedy_coords import SpeedyCoords
+        from jcm.physics_interface import PhysicsState, PhysicsTendency
+        from jcm.physics.radiation.speedy_shortwave import clouds
+        from jcm.terrain import TerrainData
+
+        kx, ix, il = 8, 1, 1
+        coords = SpeedyCoords.single_column_coords(num_levels=kx)
+        parameters = Parameters.default()
+        parameters = dataclasses.replace(
+            parameters,
+            shortwave_radiation=dataclasses.replace(
+                parameters.shortwave_radiation,
+                cover_smoothing=jnp.array(cover_smoothing),
+                gse_s1=gse_s1,
+            ),
+        )
+        # Stable column with gse ~ 0.47, just past gse_s1 = 0.40: the hard
+        # fstab clip saturates at 1 (zero gradient) while the smooth tail
+        # is still well within float range. Dry air keeps the RH cover at
+        # zero.
+        phi = jnp.linspace(60e3, 0.0, kx)[:, None, None] * jnp.ones((kx, ix, il))
+        se = 300e3 + 0.47 * phi
+        qsat = jnp.full((kx, ix, il), 10.0)
+        rh = jnp.full((kx, ix, il), 0.2)
+        humidity = HumidityData.zeros((ix, il), kx, rh=rh, qsat=qsat)
+        convection = ConvectionData.zeros(
+            (ix, il), kx, iptop=jnp.full((ix, il), kx + 1, dtype=int), se=se
+        )
+        condensation = CondensationData.zeros((ix, il), kx)
+        physics_data = PhysicsData.zeros(
+            (ix, il), kx, humidity=humidity, convection=convection,
+            condensation=condensation, speedy_coords=coords,
+        )
+        state = PhysicsState.zeros(
+            (kx, ix, il), specific_humidity=rh * qsat, geopotential=phi
+        )
+        operand = (
+            state, physics_data, parameters,
+            ForcingData.ones((ix, il)), TerrainData.single_column(),
+            PhysicsTendency.zeros(shape=(kx, ix, il)),
+        )
+        _, pd, *_ = clouds(operand)
+        return pd.shortwave_rad.cloudstr[0, 0]
+
+    def test_saturated_fstab_gradient_survives_with_smoothing(self):
+        hard_grad = jax.grad(self._clstr, argnums=1)(0.0, jnp.array(0.40))
+        smooth_grad = jax.grad(self._clstr, argnums=1)(0.05, jnp.array(0.40))
+        assert hard_grad == 0.0, "fstab not saturated: test is vacuous"
+        assert jnp.isfinite(smooth_grad) and smooth_grad != 0.0
+
+    def test_width_zero_matches_hard_cover(self):
+        # Width 0 is exact (the regression suite pins it); small widths
+        # converge as O(sqrt(w)) because the sqrt-corner regularization
+        # replaces sqrt(epsilon) with sqrt(w*log 2) at zero precipitation.
+        hard = float(self._clstr(0.0, jnp.array(0.40)))
+        near = float(self._clstr(1e-7, jnp.array(0.40)))
+        nearer = float(self._clstr(1e-9, jnp.array(0.40)))
+        assert np.isfinite(hard)
+        assert abs(near - hard) < 1e-3
+        assert abs(nearer - hard) < abs(near - hard)

--- a/jcm/physics/surface/speedy_surface_flux.py
+++ b/jcm/physics/surface/speedy_surface_flux.py
@@ -8,7 +8,7 @@ from jcm.forcing import ForcingData
 from jcm.physics.speedy.params import Parameters
 from jcm.physics_interface import PhysicsTendency, PhysicsState
 from jcm.physics.speedy.physics_data import PhysicsData
-from jcm.physics.speedy.smoothing import smooth_pos
+from jcm.physics.speedy.smoothing import smooth_gate, smooth_pos
 import jcm.constants as c
 from jcm.physics.speedy.physical_constants import alhc
 from jcm.physics.speedy.speedy_coords import PBL_TOP_SIGMA, interp_to_sigma
@@ -212,14 +212,23 @@ def get_surface_fluxes(
             hfluxn = hfluxn.at[:, :, 0].set(hfluxn[:, :, 0] - (clamb * (tskin - stl_am)))
             dtskin = tskin + 1.0
 
-            # Compute d(Evap) for a 1-degree increment of Tskin
+            # Compute d(Evap) for a 1-degree increment of Tskin. The
+            # activity weight must be the DERIVATIVE of the (possibly
+            # smoothed) evaporation hinge, not the hard evap > 0 mask:
+            # with evap_smoothing on, the softplus tail makes evap
+            # positive in dry columns, and the hard mask would hand them
+            # the full latent sensitivity, over-damping the skin update
+            # (Codex review, PR #567). smooth_gate is exactly the
+            # softplus derivative, and reproduces the hard mask at
+            # width 0 (evap > 0 iff the hinge argument is > 0).
+            evap_gate = smooth_gate(
+                forcing.soilw_am * qsat0[:, :, 0] - q1[:, :, 0],
+                0.0,
+                parameters.surface_flux.evap_smoothing,
+            )
             qsat0 = qsat0.at[:, :, 1].set(get_qsat(dtskin, psa, 1.0))
             qsat0 = qsat0.at[:, :, 1].set(
-                    jnp.where(
-                        evap[:, :, 0] > 0.0,
-                        forcing.soilw_am * (qsat0[:, :, 1] - qsat0[:, :, 0]),
-                        0.0
-                    )
+                    evap_gate * forcing.soilw_am * (qsat0[:, :, 1] - qsat0[:, :, 0])
                 )
 
             # Redefine skin temperature to balance the heat budget

--- a/jcm/physics/surface/speedy_surface_flux.py
+++ b/jcm/physics/surface/speedy_surface_flux.py
@@ -8,6 +8,7 @@ from jcm.forcing import ForcingData
 from jcm.physics.speedy.params import Parameters
 from jcm.physics_interface import PhysicsTendency, PhysicsState
 from jcm.physics.speedy.physics_data import PhysicsData
+from jcm.physics.speedy.smoothing import smooth_pos
 import jcm.constants as c
 from jcm.physics.speedy.physical_constants import alhc
 from jcm.physics.speedy.speedy_coords import PBL_TOP_SIGMA, interp_to_sigma
@@ -185,8 +186,14 @@ def get_surface_fluxes(
 
         qsat0 = qsat0.at[:, :, 0].set(get_qsat(tskin, psa, 1.0))
 
+        # The soil-moisture-limited evaporation onset is a hinge that
+        # zeroes every gradient through dry land columns (and gates the
+        # d(Evap)/d(Tskin) term in the energy balance below on the same
+        # hard condition). evap_smoothing > 0 [g/kg] rounds it with a
+        # softplus; 0 keeps the hard maximum.
         evap = evap.at[:, :, 0].set(parameters.surface_flux.chl * denvvs[:, :, 1] *\
-                    jnp.maximum(0.0, forcing.soilw_am * qsat0[:, :, 0] - q1[:, :, 0]))
+                    smooth_pos(forcing.soilw_am * qsat0[:, :, 0] - q1[:, :, 0],
+                               parameters.surface_flux.evap_smoothing))
 
         # 3. Computing land-surface energy balance; Adjust skin temperature and heat fluxes
         # 3.1 Emission of lw radiation from the surface and net heat fluxes into land surface

--- a/jcm/physics/vertical_diffusion/speedy_vdiff.py
+++ b/jcm/physics/vertical_diffusion/speedy_vdiff.py
@@ -8,7 +8,7 @@ import jcm.constants as c
 # alhc is SPEEDY's latent heat in J/g (q is in g/kg) — a SPEEDY-specific value.
 # cpd is shared and read as a module attribute from jcm.constants.
 from jcm.physics.speedy.physical_constants import alhc
-from jcm.physics.speedy.smoothing import smooth_gate
+from jcm.physics.speedy.smoothing import smooth_gate, smooth_pos
 from jcm.physics_interface import PhysicsState, PhysicsTendency
 from jcm.physics.speedy.physics_data import PhysicsData
 
@@ -88,7 +88,11 @@ def get_vertical_diffusion_tend(
     # active; the deep-convection index is discrete and stays hard.
     fcnv = jnp.where(icnv > 0, parameters.vertical_diffusion.redshc, 1.0)
 
-    fluxse = g_mse * fcnv * fshcse * dmse
+    # The dry static energy flux has no complementary branch below the
+    # threshold, so it takes a one-sided softplus hinge rather than the
+    # crossfade gate: gate * dmse would turn negative (a reversed heat
+    # flux) in stable columns (Codex review, PR #567).
+    fluxse = fcnv * fshcse * smooth_pos(dmse, w_mse)
     ttenvd = ttenvd.at[nl1 - 1].set(fluxse * rsig[nl1 - 1])
     ttenvd = ttenvd.at[kx - 1].set(-fluxse * rsig[kx - 1])
 

--- a/jcm/physics/vertical_diffusion/speedy_vdiff.py
+++ b/jcm/physics/vertical_diffusion/speedy_vdiff.py
@@ -8,6 +8,7 @@ import jcm.constants as c
 # alhc is SPEEDY's latent heat in J/g (q is in g/kg) — a SPEEDY-specific value.
 # cpd is shared and read as a module attribute from jcm.constants.
 from jcm.physics.speedy.physical_constants import alhc
+from jcm.physics.speedy.smoothing import smooth_gate
 from jcm.physics_interface import PhysicsState, PhysicsTendency
 from jcm.physics.speedy.physics_data import PhysicsData
 
@@ -68,37 +69,38 @@ def get_vertical_diffusion_tend(
     dmse = se[kx - 1] - se[nl1 - 1] + alhc * (qa[kx - 1] - qsat[nl1 -1])
     drh = rh[kx - 1] - rh[nl1 -1]
 
-    # Initialize fcnv array
-    fcnv = jnp.ones((ix, il))
+    # The shallow-convection branch (dmse >= 0) and the PBL moisture
+    # diffusion branch (dmse < 0, drh > drh0) are complementary hard
+    # gates, and both gate fluxes that are proportional to drh rather
+    # than to the distance from the threshold, so each boundary is a
+    # value jump in the tendencies. With mse_gate_smoothing [J/kg] and
+    # rh_gate_smoothing [RH fraction] positive, the branches crossfade:
+    # g_mse + (1 - g_mse) = 1 partitions the column smoothly between the
+    # two regimes, and the drh onsets get their own sigmoid gates. All
+    # contributions are written arithmetically (gate * flux), which is
+    # bit-identical to the original where-selects at width 0 because the
+    # branch conditions are mutually exclusive.
+    w_mse = parameters.vertical_diffusion.mse_gate_smoothing
+    w_rh = parameters.vertical_diffusion.rh_gate_smoothing
+    g_mse = smooth_gate(dmse, 0.0, w_mse)
 
-    # Apply condition where icnv > 0 and set fcnv to redshc
-    fcnv = jnp.where(jnp.logical_and(icnv > 0, dmse >= 0), parameters.vertical_diffusion.redshc, fcnv)
+    # Shallow convection is damped by redshc where deep convection is
+    # active; the deep-convection index is discrete and stays hard.
+    fcnv = jnp.where(icnv > 0, parameters.vertical_diffusion.redshc, 1.0)
 
-    # Calculate fluxse where dmse >= 0.0
-    fluxse = jnp.where(dmse >= 0.0, fcnv * fshcse * dmse, 0)
+    fluxse = g_mse * fcnv * fshcse * dmse
+    ttenvd = ttenvd.at[nl1 - 1].set(fluxse * rsig[nl1 - 1])
+    ttenvd = ttenvd.at[kx - 1].set(-fluxse * rsig[kx - 1])
 
-    # Update ttenvd based on fluxse
-    ttenvd = ttenvd.at[nl1 - 1].set(jnp.where(dmse >= 0.0, fluxse * rsig[nl1 - 1], ttenvd[nl1 - 1]))
-    ttenvd = ttenvd.at[kx - 1].set(jnp.where(dmse >= 0.0, -fluxse * rsig[kx - 1], ttenvd[kx - 1]))
+    g_rh1 = smooth_gate(drh, 0.0, w_rh)
+    fluxq_condition1 = g_mse * g_rh1 * fcnv * fshcq * qsat[kx - 1] * drh
+    qtenvd = qtenvd.at[nl1 - 1].set(fluxq_condition1 * rsig[nl1 - 1])
+    qtenvd = qtenvd.at[kx - 1].set(-fluxq_condition1 * rsig[kx - 1])
 
-    # Calculate fluxq for the first condition (dmse >= 0.0 and drh >= 0.0)
-    fluxq_condition1 = jnp.where((dmse >= 0.0) & (drh >= 0.0), fcnv * fshcq * qsat[kx - 1] * drh, 0)
-
-    # Update qtenvd based on fluxq_condition1
-    qtenvd = qtenvd.at[nl1 - 1].set(jnp.where((dmse >= 0.0) & (drh >= 0.0), fluxq_condition1 * rsig[nl1 - 1], qtenvd[nl1 - 1]))
-    qtenvd = qtenvd.at[kx - 1].set(jnp.where((dmse >= 0.0) & (drh >= 0.0), -fluxq_condition1 * rsig[kx - 1], qtenvd[kx - 1])
-            )
-
-    # Calculate fluxq for the second condition (dmse < 0.0 and drh > drh0)
-    fluxq_condition2 = jnp.where((dmse < 0.0) & (drh > drh0), fvdiq2 * qsat[nl1 - 1] * drh, 0)
-
-    # Update qtenvd based on fluxq_condition2
-    qtenvd = qtenvd.at[nl1 - 1].set(
-        jnp.where((dmse < 0.0) & (drh > drh0), fluxq_condition2 * rsig[nl1 - 1], qtenvd[nl1 - 1])
-    )
-    qtenvd = qtenvd.at[kx - 1].set(
-        jnp.where((dmse < 0.0) & (drh > drh0), -fluxq_condition2 * rsig[kx - 1], qtenvd[kx - 1])
-    )
+    g_rh2 = smooth_gate(drh, drh0, w_rh)
+    fluxq_condition2 = (1.0 - g_mse) * g_rh2 * fvdiq2 * qsat[nl1 - 1] * drh
+    qtenvd = qtenvd.at[nl1 - 1].add(fluxq_condition2 * rsig[nl1 - 1])
+    qtenvd = qtenvd.at[kx - 1].add(-fluxq_condition2 * rsig[kx - 1])
     
     # Step 3: Vertical diffusion of moisture above the PBL.
     #
@@ -122,10 +124,14 @@ def get_vertical_diffusion_tend(
     # Calculate drh for all selected k values across the entire ix and il dimensions
     drh = rh[k_range + 1] - rh[k_range]  # Shape: (ix, il, len(k_range))
 
-    # Calculate fluxq where drh >= drh0
+    # Moisture-diffusion onset: the flux is proportional to drh, so the
+    # hard drh >= drh0 gate is a value jump; smooth it with the same
+    # rh_gate_smoothing sigmoid. The per-interface sigma condition is
+    # static and stays hard.
+    g_rh3 = smooth_gate(drh, drh0[:, jnp.newaxis, jnp.newaxis], w_rh)
     fluxq = jnp.where(
-        (drh >= drh0[:, jnp.newaxis, jnp.newaxis]) & condition[:, jnp.newaxis, jnp.newaxis],
-        fvdiq2[:, jnp.newaxis, jnp.newaxis] * qsat[k_range] * drh,
+        condition[:, jnp.newaxis, jnp.newaxis],
+        g_rh3 * fvdiq2[:, jnp.newaxis, jnp.newaxis] * qsat[k_range] * drh,
         0
     )
 


### PR DESCRIPTION
Stacked on #563 (the nlev-convergence work): that PR made the SPEEDY physics level-agnostic; this one takes a pass at the sharp cuts and branches that remain, so gradients survive them.

## What is sharp, and what kind of sharp

Surveying the SPEEDY schemes for gradient purposes turns up two distinct classes:

- **Value jumps**: hard gates on a quantity that does *not* vanish at the threshold. The convection case-2 humidity trigger (qdif switches between 0 and the finite surface-layer excess when the PBL-top RH criterion flips) and all three vdiff moisture-flux gates (the fluxes are proportional to `drh`, but gated at `drh > drh0` and on the sign of `dmse`, so each boundary switches a finite flux).
- **Hinges and clips**: continuous but with a dead gradient on one side. The LSC grid-point-storm heating cap, the entire cloud-cover diagnosis (RH hinge at `rhcl1`, cover saturation at 1, the `fstab` clip, the stratiform hinges, and a `sqrt(precip)` corner whose slope is `1/(2*sqrt(1e-9))` ~ 1.6e4 at zero precipitation), the convective precipitation onset, and the soil-moisture evaporation onset.

## What this PR does

Adds `jcm/physics/speedy/smoothing.py` (sigmoid gate, softplus hinge, hyperbolic min/max, softplus-pair clip; every helper takes `width = 0` and then reproduces the hard op bit-exactly, with double-where guards so the width-0 branch cannot leak NaN cotangents) and one default-off width knob per scheme group: `convection.trigger_smoothing` / `precnv_smoothing`, `condensation.cap_smoothing`, `shortwave_radiation.cover_smoothing`, `vertical_diffusion.mse_gate_smoothing` / `rh_gate_smoothing`, `surface_flux.evap_smoothing`. Units and the physical reading of each width are documented on the fields.

Two design notes:
- The vdiff shallow-convection and moisture-diffusion regimes are complementary in `dmse`, so their smooth gates crossfade as `g + (1 - g) = 1`; the branch arithmetic is rewritten as `gate * flux`, which is bit-identical to the original where-selects at width 0 (the conditions were mutually exclusive).
- The discrete level selections (cloud-top argmax in convection and cover, the deep-convection index) stay hard: an integer level has no smooth counterpart short of distributing fluxes over levels, which would be a scheme redesign. The convection trigger widens its discrete activation mask by 6 widths so the level assignment lands on the gate's skirt, where the gated mass flux is <= sigmoid(-6) ~ 2.5e-3 of the excess.

## Validation

- `speedy_smooth_gradients_test.py`: per knob, the unlock it exists for — a hard-branch gradient that is exactly zero (convection trigger just below threshold, vdiff flux just below `drh0`, capped LSC heating, saturated `fstab`) must be finite and nonzero with a positive width; width-0 equivalence; finite corner cotangents at width 0; and the O(sqrt(w)) convergence of the sqrt-corner regularization is documented by test.
- All existing SPEEDY suites and the pinned reference-trajectory regressions pass with the defaults (77 passed, 6 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aqshaa5nDrxcDWgg1FYw8Z