### PR TITLE
perf(radiation): unrolled z-recurrence in RRTMGP (20-41% faster solves on GPU)

### DIFF
--- a/jcm/physics/radiation/rrtmgp.py
+++ b/jcm/physics/radiation/rrtmgp.py
@@ -327,7 +327,14 @@ def prepare_rrtmgp_data(
             pressure_1d, dp_bottom, dp_top, nlev, halo,
         ),
         "sg_map": sg_map,
-        "use_scan": True,
+        # Unrolled z-recurrence (the jax-rrtmgp default). The lax.scan
+        # variant moveaxis's z to the leading axis for every vertical sweep;
+        # on an A100 (4096 columns x 62 levels, f32) that costs 20% (LW) /
+        # 41% (SW) of the solve relative to the unrolled slice-indexed loop
+        # — the same layout effect RRTMGP.jl measured on GPUs. The unrolled
+        # HLO is larger (one slice per level per sweep), which only shows up
+        # as a modest one-off compile-time cost.
+        "use_scan": False,
     }
 
 


### PR DESCRIPTION
## Summary

One-line flip of the hardcoded `"use_scan": True` → `False` in the dict `prepare_rrtmgp_data` hands to jax-rrtmgp, with the rationale documented in place.

## Why

The `lax.scan` recurrence path in jax-rrtmgp `moveaxis`'s z to the leading axis for every vertical sweep. Benchmarked on an A100 (4096 columns × 62 levels, f32, g128/g112 lookups), scan vs the library-default unrolled slice-indexed loop:

| solve | scan / unrolled |
|---|---|
| LW | 1.20 |
| SW | 1.41 |

This is the same column-layout effect the RRTMGP.jl team reported on GPUs (column-first layout cut their LW kernels 25–36%).

## Validation

- Output equivalence at L47 through `radiation_scheme_rrtmgp` under both settings: LW heating **bitwise identical**; SW within 5e-6 relative (XLA fusion reassociation in the unrolled graph); all surface/TOA flux diagnostics ≤1.3e-7.
- `jcm/physics/radiation/rrtmgp_test.py`: 28/28 pass with the flip.
- Cost: larger unrolled HLO → modest one-off compile-time increase only.

Companion jax-rrtmgp accuracy work (independent of this): climate-analytics-lab/jax-rrtmgp#17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xp7fvAnh4mfw7WRXFd1e3x