### PR TITLE
[SCM] allow start date forcing in SingleColumnModel experiments

### DIFF
--- a/jcm/date.py
+++ b/jcm/date.py
@@ -166,11 +166,12 @@ def date_from_sim_time(
     Date arithmetic uses non-differentiable operations, so elapsed time is
     excluded from automatic differentiation before deriving the date.
     """
+    SECONDS_PER_DAY = 86400  # 24 hours in seconds
     sim_time = jax.lax.stop_gradient(sim_time)
     return DateData.set_date(
         model_time=start_date + jdt.Timedelta(
-            days=jnp.floor(sim_time / 86400).astype(jnp.int32),
-            seconds=jnp.round(sim_time % 86400).astype(jnp.int32),
+            days=jnp.floor(sim_time / SECONDS_PER_DAY).astype(jnp.int32),
+            seconds=jnp.round(sim_time % SECONDS_PER_DAY).astype(jnp.int32),
         ),
         model_step=jnp.int32(sim_time / dt_seconds),
         dt_seconds=float(dt_seconds),

--- a/jcm/date.py
+++ b/jcm/date.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import jax
 import jax.numpy as jnp
 import tree_math
 import jax_datetime as jdt
@@ -152,6 +153,29 @@ class DateData:
             model_step=model_step if model_step is not None else self.model_step,
             dt_seconds=dt_seconds if dt_seconds is not None else self.dt_seconds,
         )
+
+
+def date_from_sim_time(
+    start_date: jdt.Datetime,
+    sim_time: jnp.ndarray,
+    dt_seconds: float,
+    calendar: str = DEFAULT_CALENDAR,
+) -> DateData:
+    """Build ``DateData`` from elapsed simulation seconds.
+
+    Date arithmetic uses non-differentiable operations, so elapsed time is
+    excluded from automatic differentiation before deriving the date.
+    """
+    sim_time = jax.lax.stop_gradient(sim_time)
+    return DateData.set_date(
+        model_time=start_date + jdt.Timedelta(
+            days=jnp.floor(sim_time / 86400).astype(jnp.int32),
+            seconds=jnp.round(sim_time % 86400).astype(jnp.int32),
+        ),
+        model_step=jnp.int32(sim_time / dt_seconds),
+        dt_seconds=float(dt_seconds),
+        calendar=calendar,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/jcm/date_test.py
+++ b/jcm/date_test.py
@@ -1,5 +1,5 @@
 import unittest
-from jcm.date import fraction_of_year_elapsed, DateData, parse_duration_days
+from jcm.date import date_from_sim_time, fraction_of_year_elapsed, DateData, parse_duration_days
 from jcm.model import Model
 import jax_datetime as jdt
 import jax.numpy as jnp
@@ -55,6 +55,17 @@ class TestDateUnit(unittest.TestCase):
         # copy with a new dt overrides.
         d3 = d.copy(dt=jdt.to_datetime('2001-04-01'))
         self.assertAlmostEqual(float(d3.tyear()), 90/365, places=4)
+
+    def test_date_from_sim_time(self):
+        date = date_from_sim_time(
+            start_date=jdt.to_datetime('2001-01-01'),
+            sim_time=jnp.asarray(86461.0),
+            dt_seconds=30.0,
+            calendar='gregorian',
+        )
+        self.assertEqual(int(date.dt.delta.days), int(jdt.to_datetime('2001-01-02').delta.days))
+        self.assertEqual(int(date.dt.delta.seconds), 61)
+        self.assertEqual(int(date.model_step), 2882)
 
     def test_overflow(self):
         model = Model(

--- a/jcm/model.py
+++ b/jcm/model.py
@@ -26,7 +26,7 @@ import pandas as pd
 from functools import partial
 import logging
 
-from jcm.date import DateData, parse_duration_days
+from jcm.date import DateData, date_from_sim_time, parse_duration_days
 from jcm.forcing import ForcingData, default_forcing
 from jcm.physics_interface import (
     PhysicsState, Physics, compute_physics_step_gridpoint, verify_state,
@@ -393,15 +393,9 @@ class Model:
         self._final_physics_state = None
 
     def _date_from_sim_time(self, sim_time) -> DateData:
-        # Stop gradient: date/calendar computations use non-differentiable ops
-        # (floor, round, int casts) and should not be part of the AD graph.
-        sim_time = jax.lax.stop_gradient(sim_time)
-        return DateData.set_date(
-            model_time=self.start_date + jdt.Timedelta(
-                days=jnp.floor(sim_time / 86400).astype(jnp.int32),
-                seconds=jnp.round(sim_time % 86400).astype(jnp.int32),
-            ),
-            model_step=jnp.int32(sim_time / self.dt_si.m),
+        return date_from_sim_time(
+            self.start_date,
+            sim_time,
             dt_seconds=float(self.dt_si.m),
             calendar=self.calendar,
         )

--- a/jcm/single_column_model.py
+++ b/jcm/single_column_model.py
@@ -13,6 +13,14 @@ builds a duck-typed ``(1, 1)`` coords stub so column-based physics can
 cache its coord-dependent transforms (lat, vertical-level transforms,
 etc.) without dragging in a full horizontal grid.
 
+Forcing is re-selected every step from ``start_date + step * dt_seconds``
+via ``ForcingData.select``, mirroring ``Model``'s per-step
+``forcing.select(date)``. That is what drives the solar cycle: a
+user-built ``ForcingData`` carries a null ``SolarGeometry``, so a column
+whose forcing is never re-selected sees a frozen sun and produces no
+diurnal cycle in shortwave — set ``start_date`` to the real date of the
+prescribed states to get physical insolation.
+
 Multiple columns at unrelated locations should be run in parallel one
 layer above the SCM (e.g. ``jax.vmap`` over a list of
 ``(lat, lon, column_state)`` triples).
@@ -29,11 +37,13 @@ from typing import Any, Callable
 
 import jax
 import jax.numpy as jnp
+import jax_datetime as jdt
 import numpy as np
 import tree_math
 from jax import lax
 from jax.tree_util import tree_map
 
+from jcm.date import DateData
 from jcm.forcing import ForcingData
 from jcm.physics_interface import (
     Physics,
@@ -186,6 +196,13 @@ class SingleColumnModel:
         forcing: Optional single-column ``ForcingData`` (shape ``(1, 1)``);
             defaults to ``ForcingData.zeros((1, 1))``.
         dt_seconds: Physics timestep in seconds (default 1800).
+        start_date: ``jax_datetime.Datetime`` for the start of the run. Each
+            scan step advances it by ``dt_seconds`` and re-selects ``forcing``
+            for that date, which is what gives the column its solar cycle (see
+            :meth:`_date_at_step`). Mirrors ``Model``'s argument of the same
+            name.
+        calendar: Calendar string (``"365_day"`` or ``"gregorian"``) used for
+            the date/forcing selection.
         apply_tracer_tendencies: When ``False`` tracers are reported
             diagnostically but not advanced.
         relaxation_timescales: Optional ``{var_name: tau_seconds}`` mapping.
@@ -205,6 +222,8 @@ class SingleColumnModel:
         terrain: TerrainData | None = None,
         forcing: ForcingData | None = None,
         dt_seconds: float = 1800.0,
+        start_date: jdt.Datetime = None,
+        calendar: str = "365_day",
         apply_tracer_tendencies: bool = True,
         relaxation_timescales: dict[str, float] | None = None,
     ) -> None:
@@ -214,6 +233,9 @@ class SingleColumnModel:
         self.lat_deg = float(lat_deg)
         self.lon_deg = float(lon_deg)
         self.dt_seconds = float(dt_seconds)
+        self.start_date = (jdt.to_datetime('2000-01-01') if start_date is None
+                           else start_date)
+        self.calendar = calendar
         self.apply_tracer_tendencies = apply_tracer_tendencies
         self.relaxation_timescales = dict(relaxation_timescales or {})
 
@@ -235,6 +257,27 @@ class SingleColumnModel:
     @staticmethod
     def _stack_states(states: list[PhysicsState]) -> PhysicsState:
         return tree_map(lambda *arrays: jnp.stack(arrays, axis=0), *states)
+
+    def _date_at_step(self, time_idx) -> DateData:
+        """``DateData`` for scan step ``time_idx``.
+
+        Mirrors ``Model._date_from_sim_time``: the same floor/round split into
+        whole days plus seconds, and the same stop_gradient (date/calendar math
+        uses non-differentiable floor/round/int casts and must stay out of the
+        AD graph, or ``jax.grad`` through a run would break).
+        """
+        sim_time = jax.lax.stop_gradient(
+            jnp.asarray(time_idx, dtype=jnp.float32) * self.dt_seconds
+        )
+        return DateData.set_date(
+            model_time=self.start_date + jdt.Timedelta(
+                days=jnp.floor(sim_time / 86400).astype(jnp.int32),
+                seconds=jnp.round(sim_time % 86400).astype(jnp.int32),
+            ),
+            model_step=jnp.int32(time_idx),
+            dt_seconds=float(self.dt_seconds),
+            calendar=self.calendar,
+        )
 
     def _make_step_fn(
         self,
@@ -258,8 +301,15 @@ class SingleColumnModel:
 
             grid_state = _column_state_to_grid(column_state, nlev)
             clamped = verify_state(grid_state)
+            # Re-select forcing for this step's date, exactly as ``Model`` does
+            # each step. This is what populates ``SolarGeometry`` (and slices any
+            # ``TimeSeries`` leaves); without it the sun is frozen at the null
+            # geometry of a user-built ``ForcingData`` and the column has no
+            # diurnal cycle.
+            forcing_now = forcing.select(self._date_at_step(time_idx),
+                                         calendar=self.calendar)
             tendencies_grid, new_physics_data = physics.compute_tendencies(
-                clamped, forcing, terrain,
+                clamped, forcing_now, terrain,
                 prev_physics_data=physics_data,
             )
             tendencies = _squeeze_tendency(tendencies_grid)

--- a/jcm/single_column_model.py
+++ b/jcm/single_column_model.py
@@ -35,7 +35,7 @@ import tree_math
 from jax import lax
 from jax.tree_util import tree_map
 
-from jcm.date import DateData
+from jcm.date import date_from_sim_time
 from jcm.forcing import ForcingData
 from jcm.physics_interface import (
     Physics,
@@ -249,27 +249,6 @@ class SingleColumnModel:
     def _stack_states(states: list[PhysicsState]) -> PhysicsState:
         return tree_map(lambda *arrays: jnp.stack(arrays, axis=0), *states)
 
-    def _date_at_step(self, time_idx) -> DateData:
-        """``DateData`` for scan step ``time_idx``.
-
-        Mirrors ``Model._date_from_sim_time``: the same floor/round split into
-        whole days plus seconds, and the same stop_gradient (date/calendar math
-        uses non-differentiable floor/round/int casts and must stay out of the
-        AD graph, or ``jax.grad`` through a run would break).
-        """
-        sim_time = jax.lax.stop_gradient(
-            jnp.asarray(time_idx, dtype=jnp.float32) * self.dt_seconds
-        )
-        return DateData.set_date(
-            model_time=self.start_date + jdt.Timedelta(
-                days=jnp.floor(sim_time / 86400).astype(jnp.int32),
-                seconds=jnp.round(sim_time % 86400).astype(jnp.int32),
-            ),
-            model_step=jnp.int32(time_idx),
-            dt_seconds=float(self.dt_seconds),
-            calendar=self.calendar,
-        )
-
     def _make_step_fn(
         self,
         forcing: ForcingData,
@@ -292,8 +271,14 @@ class SingleColumnModel:
 
             grid_state = _column_state_to_grid(column_state, nlev)
             clamped = verify_state(grid_state)
-            forcing_now = forcing.select(self._date_at_step(time_idx),
-                                         calendar=self.calendar)
+            sim_time = jnp.asarray(time_idx, dtype=jnp.float32) * self.dt_seconds
+            date = date_from_sim_time(
+                self.start_date,
+                sim_time,
+                dt_seconds=self.dt_seconds,
+                calendar=self.calendar,
+            )
+            forcing_now = forcing.select(date, calendar=self.calendar)
             tendencies_grid, new_physics_data = physics.compute_tendencies(
                 clamped, forcing_now, terrain,
                 prev_physics_data=physics_data,

--- a/jcm/single_column_model.py
+++ b/jcm/single_column_model.py
@@ -13,14 +13,6 @@ builds a duck-typed ``(1, 1)`` coords stub so column-based physics can
 cache its coord-dependent transforms (lat, vertical-level transforms,
 etc.) without dragging in a full horizontal grid.
 
-Forcing is re-selected every step from ``start_date + step * dt_seconds``
-via ``ForcingData.select``, mirroring ``Model``'s per-step
-``forcing.select(date)``. That is what drives the solar cycle: a
-user-built ``ForcingData`` carries a null ``SolarGeometry``, so a column
-whose forcing is never re-selected sees a frozen sun and produces no
-diurnal cycle in shortwave — set ``start_date`` to the real date of the
-prescribed states to get physical insolation.
-
 Multiple columns at unrelated locations should be run in parallel one
 layer above the SCM (e.g. ``jax.vmap`` over a list of
 ``(lat, lon, column_state)`` triples).
@@ -198,9 +190,8 @@ class SingleColumnModel:
         dt_seconds: Physics timestep in seconds (default 1800).
         start_date: ``jax_datetime.Datetime`` for the start of the run. Each
             scan step advances it by ``dt_seconds`` and re-selects ``forcing``
-            for that date, which is what gives the column its solar cycle (see
-            :meth:`_date_at_step`). Mirrors ``Model``'s argument of the same
-            name.
+            for that date, which gives the column its solar cycle.
+            Mirrors ``Model``'s argument of the same name.
         calendar: Calendar string (``"365_day"`` or ``"gregorian"``) used for
             the date/forcing selection.
         apply_tracer_tendencies: When ``False`` tracers are reported
@@ -301,11 +292,6 @@ class SingleColumnModel:
 
             grid_state = _column_state_to_grid(column_state, nlev)
             clamped = verify_state(grid_state)
-            # Re-select forcing for this step's date, exactly as ``Model`` does
-            # each step. This is what populates ``SolarGeometry`` (and slices any
-            # ``TimeSeries`` leaves); without it the sun is frozen at the null
-            # geometry of a user-built ``ForcingData`` and the column has no
-            # diurnal cycle.
             forcing_now = forcing.select(self._date_at_step(time_idx),
                                          calendar=self.calendar)
             tendencies_grid, new_physics_data = physics.compute_tendencies(

--- a/jcm/single_column_model_test.py
+++ b/jcm/single_column_model_test.py
@@ -2,6 +2,7 @@
 
 import unittest
 
+import jax_datetime as jdt
 import jax.numpy as jnp
 import pytest
 from dinosaur.sigma_coordinates import SigmaCoordinates
@@ -9,7 +10,7 @@ from dinosaur.sigma_coordinates import SigmaCoordinates
 from jcm.constants import grav
 from jcm.physics.held_suarez.held_suarez_physics import held_suarez_physics
 from jcm.physics.echam.echam_terms import echam_physics
-from jcm.physics_interface import PhysicsState
+from jcm.physics_interface import Physics, PhysicsState, PhysicsTendency
 from jcm.single_column_model import SCMPredictions, SingleColumnModel
 from jcm.utils import create_initial_tracers, create_single_column_state
 
@@ -28,6 +29,17 @@ def _make_column_state(nlev: int) -> PhysicsState:
         normalized_surface_pressure=jnp.asarray(1.0),
         tracers={'qc': jnp.zeros(nlev), 'qi': jnp.zeros(nlev)},
     )
+
+
+class _SolarGeometryPhysics(Physics):
+    """Expose selected solar geometry as a deterministic tendency."""
+
+    def compute_tendencies(self, state, forcing, terrain, prev_physics_data=None):
+        tendencies = PhysicsTendency.zeros(
+            state.temperature.shape,
+            temperature=jnp.full_like(state.temperature, forcing.solar.tyear),
+        )
+        return tendencies, prev_physics_data
 
 
 class TestSCMConstruction(unittest.TestCase):
@@ -90,6 +102,40 @@ class TestSCMHeldSuarez(unittest.TestCase):
         states = [self.column_state, self.column_state]
         predictions = scm.run(states)
         self.assertEqual(predictions.tendencies.temperature.shape, (2, 8))
+
+
+class TestSCMForcing(unittest.TestCase):
+    """Regression tests for per-step forcing selection."""
+
+    def test_forcing_selection_tracks_start_date_and_step(self):
+        column_state = _make_column_state(nlev=8)
+        scm = SingleColumnModel(
+            physics=_SolarGeometryPhysics(),
+            vertical=SigmaCoordinates.equidistant(8),
+            dt_seconds=86400.0,
+            start_date=jdt.to_datetime('2000-01-01'),
+            calendar='365_day',
+        )
+
+        predictions = scm.run([column_state, column_state])
+        selected_tyear = predictions.tendencies.temperature[:, 0]
+        expected_tyear = jnp.array([
+            scm._date_at_step(step).tyear(scm.calendar) for step in range(2)
+        ])
+        self.assertTrue(jnp.allclose(selected_tyear, expected_tyear))
+
+        june_scm = SingleColumnModel(
+            physics=_SolarGeometryPhysics(),
+            vertical=SigmaCoordinates.equidistant(8),
+            start_date=jdt.to_datetime('2000-06-21'),
+            calendar='365_day',
+        )
+        june_predictions = june_scm.run([column_state])
+        june_tyear = june_predictions.tendencies.temperature[0, 0]
+        self.assertTrue(jnp.allclose(
+            june_tyear, june_scm._date_at_step(0).tyear(june_scm.calendar),
+        ))
+        self.assertNotAlmostEqual(float(june_tyear), float(selected_tyear[0]))
 
 
 class TestSCMEcham(unittest.TestCase):

--- a/jcm/single_column_model_test.py
+++ b/jcm/single_column_model_test.py
@@ -8,6 +8,7 @@ import pytest
 from dinosaur.sigma_coordinates import SigmaCoordinates
 
 from jcm.constants import grav
+from jcm.date import date_from_sim_time
 from jcm.physics.held_suarez.held_suarez_physics import held_suarez_physics
 from jcm.physics.echam.echam_terms import echam_physics
 from jcm.physics_interface import Physics, PhysicsState, PhysicsTendency
@@ -120,7 +121,13 @@ class TestSCMForcing(unittest.TestCase):
         predictions = scm.run([column_state, column_state])
         selected_tyear = predictions.tendencies.temperature[:, 0]
         expected_tyear = jnp.array([
-            scm._date_at_step(step).tyear(scm.calendar) for step in range(2)
+            date_from_sim_time(
+                scm.start_date,
+                step * scm.dt_seconds,
+                scm.dt_seconds,
+                scm.calendar,
+            ).tyear(scm.calendar)
+            for step in range(2)
         ])
         self.assertTrue(jnp.allclose(selected_tyear, expected_tyear))
 
@@ -133,7 +140,13 @@ class TestSCMForcing(unittest.TestCase):
         june_predictions = june_scm.run([column_state])
         june_tyear = june_predictions.tendencies.temperature[0, 0]
         self.assertTrue(jnp.allclose(
-            june_tyear, june_scm._date_at_step(0).tyear(june_scm.calendar),
+            june_tyear,
+            date_from_sim_time(
+                june_scm.start_date,
+                0.0,
+                june_scm.dt_seconds,
+                june_scm.calendar,
+            ).tyear(june_scm.calendar),
         ))
         self.assertNotAlmostEqual(float(june_tyear), float(selected_tyear[0]))
 


### PR DESCRIPTION
## Describe your changes

Expose a `start_date` param in `jcm/single_column_model.py` to allow for a specific start date to a single column experiment. For my use case, this enables running experiments on different dates and comparing against DOE ARM observational data.

## Issue ticket number and link
None; can create an issue if desired.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
