### PR TITLE
fix(sso): make LottMillerSso work on any horizontal layout

### DIFF
--- a/jcm/physics/gravity_waves/sso/lott_miller.py
+++ b/jcm/physics/gravity_waves/sso/lott_miller.py
@@ -913,13 +913,31 @@ class LottMillerSso(PhysicsTerm):
         terrain: TerrainData,
     ) -> tuple[PhysicsTendency, dict]:
         """Compute u/v/T tendencies from Lott-Miller SSO."""
-        nlev, ncols = state.temperature.shape
+        # The drag is a per-column scheme, vmapped over columns below, so it
+        # does not care how the host lays the horizontal out. Flatten whatever
+        # trailing axes it uses into a single column axis and restore the
+        # shape on the way out. Unpacking ``nlev, ncols`` instead restricted
+        # the term to a column-vectorized host, which a grid-based physics
+        # package cannot supply: SPEEDY's shortwave computes zonal averages
+        # and so needs a real longitude axis, and ``ComposablePhysics.__add__``
+        # inherits ``vectorize_columns`` from its left operand.
+        horiz = state.temperature.shape[1:]
+        nlev = state.temperature.shape[0]
+
+        def _cols(x):
+            """Flatten the horizontal of a level-major field to one axis."""
+            return x.reshape(x.shape[0], -1)
+
         dt = diagnostics["_dt_seconds"]
         params = self.params.get_value()
 
-        pressure_full = diagnostics["pressure_full"]
-        pressure_half = diagnostics["pressure_half"]
-        height_full = diagnostics["height_full"]
+        pressure_full = _cols(diagnostics["pressure_full"])
+        pressure_half = _cols(diagnostics["pressure_half"])
+        height_full = _cols(diagnostics["height_full"])
+        temperature = _cols(state.temperature)
+        u_wind = _cols(state.u_wind)
+        v_wind = _cols(state.v_wind)
+        ncols = temperature.shape[1]
 
         layer_mass = (
             (pressure_half[1:, :] - pressure_half[:-1, :])
@@ -954,7 +972,7 @@ class LottMillerSso(PhysicsTerm):
             out_axes=(0, 0),
         )(
             pressure_full, pressure_half, layer_mass,
-            state.temperature, state.u_wind, state.v_wind, height_full,
+            temperature, u_wind, v_wind, height_full,
             terrain.orog.reshape(-1), terrain.orog.reshape(-1),
             terrain.orostd.reshape(-1), terrain.orosig.reshape(-1),
             terrain.orogam.reshape(-1), terrain.orothe.reshape(-1),
@@ -964,10 +982,15 @@ class LottMillerSso(PhysicsTerm):
 
         dt_temperature = tend.dissip / _physical_constants.cpd
 
+        # vmap returns (ncols, nlev); transpose to level-major, then restore
+        # the host's horizontal shape.
+        def _grid(x):
+            return x.T.reshape((nlev,) + horiz)
+
         return PhysicsTendency(
-            u_wind=tend.dudt.T,
-            v_wind=tend.dvdt.T,
-            temperature=dt_temperature.T,
+            u_wind=_grid(tend.dudt),
+            v_wind=_grid(tend.dvdt),
+            temperature=_grid(dt_temperature),
             specific_humidity=jnp.zeros_like(state.specific_humidity),
             tracers={},
         ), diagnostics

--- a/jcm/physics/gravity_waves/sso/lott_miller_host_test.py
+++ b/jcm/physics/gravity_waves/sso/lott_miller_host_test.py
@@ -1,0 +1,129 @@
+"""LottMillerSso must run on whatever horizontal layout the host uses.
+
+The drag is a per-column scheme vmapped over columns, so a whole
+``(nlev, nlon, nlat)`` grid and a column-vectorized ``(nlev, ncols)`` block
+holding the same columns must produce the same tendency. The term previously
+unpacked ``nlev, ncols = state.temperature.shape``, which restricted it to the
+column-vectorized layout.
+
+The pressure and height diagnostics are built directly here rather than via
+MoistAirColumnState, so these tests exercise LottMillerSso alone.
+"""
+
+import unittest
+
+import numpy as np
+
+from jcm import constants as pc
+from jcm.physics.gravity_waves.sso.lott_miller import LottMillerSso
+from jcm.physics_interface import PhysicsState
+from jcm.terrain import TerrainData
+from jcm.utils import get_coords
+
+NLEV = 8
+
+
+def _setup():
+    coords = get_coords(np.linspace(0.0, 1.0, NLEV + 1), spectral_truncation=21)
+    # Real orography: a flat world produces identically zero drag, and every
+    # comparison below would then pass without testing anything.
+    from importlib import resources
+    bc = resources.files("jcm.data.bc.t30.clim")
+    terrain = TerrainData.from_file(bc / "terrain.nc", coords=coords)
+    return coords, terrain
+
+
+def _fields(nlon, nlat):
+    """Build a sheared, stratified atmosphere that launches real drag."""
+    rng = np.random.default_rng(0)
+    lev = np.linspace(0.1, 1.0, NLEV).reshape(NLEV, 1, 1)
+    shape = (NLEV, nlon, nlat)
+    return {
+        "temperature": (200.0 + 90.0 * lev
+                        + rng.normal(0, 1.0, shape)).astype("f4"),
+        "u_wind": rng.normal(8.0, 4.0, shape).astype("f4"),
+        "v_wind": rng.normal(0.0, 4.0, shape).astype("f4"),
+        "geopotential": np.broadcast_to(
+            pc.grav * 16000.0 * (1.0 - lev), shape).astype("f4"),
+    }
+
+
+def _diagnostics(sigma_half, sigma_full, geopotential, surface_pressure):
+    """Pressure and height diagnostics in the layout the caller supplies."""
+    vshape = (-1,) + (1,) * surface_pressure.ndim
+    return {
+        "_dt_seconds": 1800.0,
+        "pressure_full": (sigma_full.reshape(vshape)
+                          * surface_pressure[np.newaxis]),
+        "pressure_half": (sigma_half.reshape(vshape)
+                          * surface_pressure[np.newaxis]),
+        "height_full": geopotential / pc.grav,
+    }
+
+
+def _run(as_grid):
+    coords, terrain = _setup()
+    nlon, nlat = coords.horizontal.nodal_shape
+    f = _fields(nlon, nlat)
+
+    def lay(x):
+        return x if as_grid else x.reshape(x.shape[0], -1)
+
+    ps = np.full((nlon, nlat), 1.0e5, dtype="f4")
+    ps = ps if as_grid else ps.reshape(-1)
+
+    sigma_full = np.asarray(coords.vertical.centers, dtype="f4")
+    sigma_half = np.asarray(coords.vertical.boundaries, dtype="f4")
+
+    state = PhysicsState(
+        u_wind=lay(f["u_wind"]), v_wind=lay(f["v_wind"]),
+        temperature=lay(f["temperature"]),
+        specific_humidity=lay(np.full_like(f["temperature"], 3.0)),
+        geopotential=lay(f["geopotential"]),
+        normalized_surface_pressure=ps,
+    )
+    term = LottMillerSso()
+    term.cache_coords(coords)
+    tend, _ = term(
+        state,
+        _diagnostics(sigma_half, sigma_full, lay(f["geopotential"]), ps),
+        None, terrain)
+    return tend, (nlon, nlat)
+
+
+class TestHostLayouts(unittest.TestCase):
+    def test_grid_host_returns_grid_shaped_tendencies(self):
+        # The layout that used to raise.
+        tend, (nlon, nlat) = _run(as_grid=True)
+        self.assertEqual(tend.u_wind.shape, (NLEV, nlon, nlat))
+        self.assertEqual(tend.v_wind.shape, (NLEV, nlon, nlat))
+        self.assertEqual(tend.temperature.shape, (NLEV, nlon, nlat))
+
+    def test_column_host_returns_column_shaped_tendencies(self):
+        tend, (nlon, nlat) = _run(as_grid=False)
+        self.assertEqual(tend.u_wind.shape, (NLEV, nlon * nlat))
+
+    def test_the_drag_is_actually_non_zero(self):
+        # Guards every comparison here: with flat orography the scheme returns
+        # zeros and the layouts would agree without proving anything.
+        tend, _ = _run(as_grid=True)
+        self.assertGreater(float(np.abs(np.asarray(tend.u_wind)).max()), 0.0)
+
+    def test_layouts_agree_column_for_column(self):
+        grid, (nlon, nlat) = _run(as_grid=True)
+        flat, _ = _run(as_grid=False)
+        for name in ("u_wind", "v_wind", "temperature"):
+            g = np.asarray(getattr(grid, name)).reshape(NLEV, nlon * nlat)
+            f = np.asarray(getattr(flat, name))
+            np.testing.assert_allclose(g, f, rtol=1e-5, atol=1e-8,
+                                       err_msg=name)
+
+    def test_tendencies_are_finite(self):
+        tend, _ = _run(as_grid=True)
+        for name in ("u_wind", "v_wind", "temperature"):
+            self.assertTrue(
+                np.isfinite(np.asarray(getattr(tend, name))).all(), name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`LottMillerSso` opened with

```python
nlev, ncols = state.temperature.shape
```

then `vmap`ped over axis 1 and transposed its output, so it only ran on a column-vectorized `(nlev, ncols)` host and raised on a whole `(nlev, nlon, nlat)` grid:

```
ValueError: too many values to unpack (expected 2)
```

The drag itself is a per-column scheme, so it has no reason to care how the host lays out the horizontal.

`ComposablePhysics(vectorize_columns=True)` is not a workaround here. `__add__` inherits that flag from its **left** operand, and a grid-based package cannot simply switch: `speedy_shortwave.get_zonal_average_fields` computes zonal averages and needs a real longitude axis, which flattening destroys. So composing `LottMillerSso` with SPEEDY was not possible in either configuration.

Fixed by flattening whatever trailing axes the host uses into one column axis, running the existing `vmap` unchanged, and restoring the shape on the way out. No branching on rank, and the column-vectorized path is unchanged.

## Test plan

New `lott_miller_host_test.py` builds the pressure and height diagnostics directly rather than going through `MoistAirColumnState`, so it exercises this term alone:

- grid `(nlev, nlon, nlat)` and column `(nlev, ncols)` hosts both return correctly shaped tendencies
- the two layouts agree column for column
- tendencies are finite

It uses the real T30 orography deliberately. With flat orography the scheme returns identically zero and every comparison passes without testing anything, so there is an explicit assertion that the drag is non-zero.

Results:

- **4 of the 5 new tests fail without the fix**; all pass with it. The survivor is `test_column_host_returns_column_shaped_tendencies`, the layout that already worked.
- `pytest jcm/physics/gravity_waves/` — 70 passed.
- `ruff check jcm/physics/gravity_waves/sso/` clean.

Verified beyond unit tests by composing `speedy_physics() + MoistAirColumnState() + LottMillerSso()` and running 450 simulated days at T31, finite throughout.

This is a shape fix only. It makes no claim that the scheme's parameters or its `nktopg`/`ntop` level indices are appropriate for any particular host resolution.

Related: #587 fixes the same class of issue in `MoistAirColumnState`. The two are independent and this PR does not depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
