### PR TITLE
docs: cite the published GMD paper (JCM v1.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,11 +187,20 @@ work should target the `dev` branch; clean release points are merged to
 If you use JAX-GCM in your research, please cite:
 
 ```bibtex
-@software{jax_gcm,
-  title = {JAX-GCM: A Differentiable General Circulation Model},
-  author = {J. Madan, E. Davenport, et al.},
-  year = {2025},
-  url = {https://github.com/climate-analytics-lab/jax-gcm}
+@article{jcm_gmd_2026,
+  title   = {{JCM} v1.1: a differentiable, intermediate-complexity atmospheric model},
+  author  = {Davenport, Ellen H. and Madan, J. Varan and Gjini, Rebecca and
+             Brzenski, Jared and Ho, Nick and Hsu, Tien-Yiao and Liang, Yueshan and
+             Liu, Zhixing and Manivannan, Veeramakali and Pham, Eric and
+             Vutukuru, Rohith and Williams, Andrew I. L. and Yang, Zhiqi and
+             Yu, Rose and Lutsko, Nicholas J. and Hoyer, Stephan and
+             Watson-Parris, Duncan},
+  journal = {Geoscientific Model Development},
+  volume  = {19},
+  pages   = {6451--6466},
+  year    = {2026},
+  doi     = {10.5194/gmd-19-6451-2026},
+  url     = {https://gmd.copernicus.org/articles/19/6451/2026/}
 }
 ```
 


### PR DESCRIPTION
## Describe your changes

Replaces the placeholder `@software` citation at the end of the README with the now-published paper:

> Davenport, E. H., Madan, J. V., Gjini, R., Brzenski, J., Ho, N., Hsu, T.-Y., Liang, Y., Liu, Z., Manivannan, V., Pham, E., Vutukuru, R., Williams, A. I. L., Yang, Z., Yu, R., Lutsko, N. J., Hoyer, S., and Watson-Parris, D.: **JCM v1.1: a differentiable, intermediate-complexity atmospheric model**, Geosci. Model Dev., 19, 6451–6466, 2026. https://gmd.copernicus.org/articles/19/6451/2026/

Note: author list and page range were taken from the article's indexing (the Copernicus site is not reachable from this sandbox) — worth a 10-second glance against the paper's own "How to cite" box before merging. The same stale citation block exists in the `dev` README; it will pick this up at the next `main`→`dev` sync, or I can open a matching PR to `dev`.

## Issue ticket number and link

n/a — README hygiene.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas (n/a — docs only)
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works (n/a — docs only)
- [ ] New and existing unit tests pass locally with my changes (n/a — docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADJidn7kEkemMmjCYZbpQJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ADJidn7kEkemMmjCYZbpQJ)_