### PR TITLE
fix(pyses): ozone climatology must use the flattened column layout

### DIFF
--- a/jcm/dycore/pyses/forcing.py
+++ b/jcm/dycore/pyses/forcing.py
@@ -302,6 +302,22 @@ def attach_jam_forcing(forcing, col_lon, col_lat, *, nlev,
                 o3 = o3[..., ::-1]
             lon = np.asarray(ds["lon"].values, dtype=float)
         cols = _leaf_to_columns(o3, lon, lat, col_lon, col_lat)
+        # Collapse the backend's (1, ncol) horizontal pair into the single
+        # flattened column axis ``OzoneClimatology`` documents:
+        # ``(ntime, nlev, ncols)``. Ozone is the exception among the leaves
+        # attached here. The others keep (1, ncol) to match the pySES state's
+        # horizontal layout, and their consumers ravel or reshape to the
+        # term's view -- ``oxidant_field_from_vmr`` explicitly reshapes to
+        # ``temperature.shape``, for instance. Ozone's consumers do NOT: the
+        # spectral loader already flattens to (ntime, nlev, nlon*nlat), so
+        # RRTMGP takes ``chemistry.ozone_vmr`` straight to ``lev_to_col``
+        # (a plain ``.T``). ``forcing`` is handed to terms UNFLATTENED by
+        # ``_compute_tendencies_columns``, so a leaf that keeps the extra
+        # axis reaches radiation as (ncol, 1, nlev) and the per-column slice
+        # is (1, nlev) -- which is how an ne30 run died in
+        # ``_to_3d_with_filled_halo`` with "Cannot broadcast to shape with
+        # fewer dimensions: arr_shape=(1, 47) shape=(47,)".
+        cols = np.asarray(cols).reshape(cols.shape[:-2] + (-1,))
         seconds_per_month = 30.4375 * 86400.0            # match from_file
         ts = make_time_series(
             jnp.asarray(cols, dtype=jnp.float32),

--- a/jcm/dycore/pyses/forcing_test.py
+++ b/jcm/dycore/pyses/forcing_test.py
@@ -152,11 +152,44 @@ class AttachJamForcingTest(unittest.TestCase):
         self.assertTrue(bool(clim.is_loaded()))
         leaf = clim.o3_ppmv
         self.assertIsInstance(leaf, TimeSeries)
-        self.assertEqual(leaf.values.shape, (12, nlev, 1, _NCOL))
+        # (ntime, nlev, ncols) -- the horizontal FLATTENED, unlike the
+        # oxidant leaves above which keep the backend's (1, ncol) pair. This
+        # asymmetry is the OzoneClimatology contract, not an oversight:
+        # ``forcing`` reaches terms unflattened, oxidants get reshaped to
+        # ``temperature.shape`` by their consumer, and ozone does not -- it
+        # goes straight to RRTMGP's ``lev_to_col`` transpose. An earlier
+        # version of this assertion expected (12, nlev, 1, ncol) and so
+        # locked in the extra axis; every ne30 run with prescribed ozone
+        # then died in the radiation halo padder with
+        # "arr_shape=(1, 47) shape=(47,)".
+        self.assertEqual(leaf.values.shape, (12, nlev, _NCOL))
         self.assertEqual(int(leaf.align_mode), WRAP_YEAR)
         np.testing.assert_allclose(                      # ppmv, per level
-            np.asarray(leaf.values[0, :, 0, 0]),
+            np.asarray(leaf.values[0, :, 0]),
             np.arange(1, nlev + 1, dtype=float), rtol=1e-6)
+
+    def test_ozone_leaf_rank_matches_the_spectral_loader(self):
+        """Both backends must hand radiation the same-rank ozone.
+
+        The consumer cannot tell which backend produced its forcing, so a
+        per-backend rank is a latent shape bug in whichever one radiation
+        was not developed against.
+        """
+        nlev = 4
+        data = np.full((12, nlev, _LAT.size, _LON.size), 2.0e-6)
+        ds = xr.Dataset(
+            {"O3": (("time", "level", "lat", "lon"), data,
+                    {"units": "mole/mole"})},
+            coords={"time": np.arange(12), "level": np.arange(nlev),
+                    "lat": _LAT, "lon": _LON},
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            forcing = _attach(ozone_file=_write(tmp, "ozone.nc", ds))
+        leaf = forcing.ozone_climatology.o3_ppmv
+        # Post-select (what a term actually sees) must be 2-D (nlev, ncols),
+        # matching the column-vectorized state's rank.
+        self.assertEqual(leaf.values.ndim, 3)            # (ntime, nlev, ncols)
+        self.assertEqual(np.asarray(leaf.values[0]).ndim, 2)
 
     def test_ozone_level_mismatch_rejected(self):
         ds = xr.Dataset(

--- a/jcm/physics/forcing/echam_boundary_conditions.py
+++ b/jcm/physics/forcing/echam_boundary_conditions.py
@@ -192,6 +192,25 @@ class EchamBoundaryConditions(PhysicsTerm):
             # ``jcm.data.bc.interpolate_ozone``) — straight slice, no
             # online vertical interp.
             ozone_vmr_ppmv = forcing.ozone_climatology.o3_ppmv
+            # Enforce the OzoneClimatology contract here, at trace time,
+            # rather than letting a violation travel. Unlike the oxidant
+            # fields -- whose consumer reshapes to ``temperature.shape`` --
+            # this array is handed to RRTMGP's ``lev_to_col`` as a plain
+            # transpose, so an extra horizontal axis does not fail here: it
+            # fails much later inside the radiation halo padder with a shape
+            # error that names neither ozone nor the loader that produced it.
+            # ``forcing`` reaches terms UNFLATTENED, so every loader owes the
+            # flattened ``(nlev, ncols)`` layout the state already has.
+            if ozone_vmr_ppmv.ndim != state.temperature.ndim:
+                raise ValueError(
+                    "forcing.ozone_climatology.o3_ppmv has "
+                    f"{ozone_vmr_ppmv.ndim} dims {ozone_vmr_ppmv.shape}, but "
+                    f"the physics view is {state.temperature.ndim}-D "
+                    f"{state.temperature.shape}. OzoneClimatology must be "
+                    "stored with the horizontal already flattened to the "
+                    "term view -- (ntime, nlev, ncols) pre-select. Fix the "
+                    "loader that built this forcing."
+                )
         else:
             from jcm.physics.chemistry.simple_chemistry import (
                 ChemistryParameters,


### PR DESCRIPTION
## The bug

Every ne30 run with prescribed ozone dies on its first step, inside the RRTMGP halo padder:

```
ValueError: Cannot broadcast to shape with fewer dimensions: arr_shape=(1, 47) shape=(47,)
  jcm/physics/radiation/rrtmgp.py:154 in _to_3d_with_filled_halo   <- vmr_fields["o3"]
```

(and identically `arr_shape=(1, 95) shape=(95,)` at L95).

## Root cause

`OzoneClimatology` documents a **flattened** contract — `(ntime, nlev, ncols)` pre-select, `(nlev, ncols)` after — and the dinosaur loader honours it, storing `(ntime, nlev, nlon*nlat)`.

The pySES loader instead reused `_leaf_to_columns`' `(1, ncol)` horizontal pair, producing `(ntime, nlev, 1, ncol)`.

That extra axis survives all the way to radiation because `ComposablePhysics._compute_tendencies_columns` hands `forcing` to terms **unflattened** — it reshapes the state and the dycore fields, but not the forcing. So each loader owes the term view directly.

The other pySES leaves are unaffected, for reasons that do not apply to ozone:

- surface fields (`dms_seawater`, `dust_source`) are ravelled by their consumers, and `1 * ncol == ncol`;
- `oxidant_field_from_vmr` explicitly reshapes to `temperature.shape`, and documents that it accepts either layout.

Ozone's consumer does neither: `chemistry.ozone_vmr` goes straight to RRTMGP's `lev_to_col`, which is a plain `.T`. On a 3-D array that yields `(ncol, 1, nlev)`, so the per-column slice is `(1, nlev)` instead of `(nlev,)`.

## Changes

1. **Flatten the trailing `(1, ncol)`** in the pySES ozone attach, so the leaf matches the documented contract.
2. **Check the rank where the climatology is consumed** (`echam_boundary_conditions`). Without this, a violation does not fail at the loader — it surfaces much later as a shape error deep inside radiation that names neither ozone nor the loader that produced it. The check makes any future loader fail with a message that names both.
3. **Fix the test that locked the bug in.** `test_ozone_climatology_on_columns` asserted `(12, nlev, 1, ncol)` — the buggy shape — which is why this was never caught. Corrected, with a note on why ozone's layout differs from the oxidant leaf directly above it, plus a new test that both backends agree on rank.

## Validation

- `jcm/dycore/pyses/forcing_test.py` — 9 passed.
- Leaf shape at ne30L47: `(12, 47, 21600)` → per-step `(47, 21600)`, i.e. `(nlev, ncols)`.
- **End-to-end step on CPU** through the full physics chain including RRTMGP — the code that was throwing. Building the model was *not* sufficient to catch this, which is how it got through an earlier pre-flight.
- **30-day GPU benchmark at ne30L47 on an A100**: 7.2 sim days/hr, converged to 0.04 %, 30/30 days, zero NaN. This is the first complete ne30 benchmark; the previous attempt truncated.

## How it was found

Running a T63/T106/ne30 x L47/L95 resolution sweep off the new data mirror (#590). Both ne30 arms failed immediately; the spectral arms were unaffected, since they go through the dinosaur loader that already honoured the contract.