### PR TITLE
feat(cosp): COSP joint histograms — clmodis, tau/Reff, LWP+IWP/Reff, lidar SR CFAD, ISCCP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,16 +189,27 @@ the automatic Codex review, and handing back for human review only once
 everything is green), so the details live in one place rather than drifting
 between here and there.
 
-The two things worth repeating because getting them wrong is expensive:
+The repo skills live in `.claude/skills/` — before opening any PR, run the
+**`jcm-local-ci`** skill's gates locally; CI must confirm a result you have
+already seen, not discover it:
 
 ```bash
 ruff check .                     # MUST be clean before EVERY push
-JAX_PLATFORMS=cpu pytest -n 12   # JAX_PLATFORMS=cpu is REQUIRED on GPU hosts
+JAX_PLATFORMS=cpu pytest -n 12 -m "not slow" --cov=jcm --cov-fail-under=90
+JAX_PLATFORMS=cpu pytest -n 4  -m "slow" --cov=jcm \
+    --cov-config=.coveragerc-pr --cov-fail-under=80
 ```
 
-Without `JAX_PLATFORMS=cpu` every xdist worker grabs the same GPU and XLA
-fails with `CUDA_ERROR_OUT_OF_MEMORY` / `dnn_support != nullptr`. And a lint
-error in CI burns a full cycle on something ruff reports locally in seconds.
+Two traps the gates exist to catch. `JAX_PLATFORMS=cpu` is REQUIRED on GPU
+hosts (every xdist worker otherwise grabs the same GPU and XLA fails with
+`CUDA_ERROR_OUT_OF_MEMORY`). And coverage must be measured at **CI
+dependency parity**: CI installs `pip install -e .` with no extras, so code
+gated behind an optional extra (`jcm[cosp]`, ...) counts as UNCOVERED there
+even when its tests pass locally — uninstall the extra before measuring, or
+the gate you cleared locally fails in CI (PR #582 and #598 both hit
+coverage this way). Every Codex/bot inline comment gets an explicit
+threaded reply ("Confirmed and fixed in <sha>" / "Refuted: <evidence>")
+before handing back — see `jcm-local-ci` for the `gh api` one-liner.
 
 Ruff is the only linter (config in `pyproject.toml`); no formatter, no type
 checker, no pre-commit hooks. Tests are `*_test.py` co-located with their

--- a/jcm/config/physics/echam-jam-aci.yaml
+++ b/jcm/config/physics/echam-jam-aci.yaml
@@ -27,6 +27,7 @@ defaults:
 enable_cosp: true
 cosp_calipso: true
 cosp_modis: true
+cosp_isccp: true
 # Subcolumns per gridbox. COSP's canonical value is 100; 40 is the jcm
 # default and trades sampling noise against a roughly linear cost.
 cosp_ncolumns: 40

--- a/jcm/physics/diagnostics/cosp_cloudsat.py
+++ b/jcm/physics/diagnostics/cosp_cloudsat.py
@@ -44,6 +44,24 @@ protocols request (jax-gcm#581):
 * MODIS ``cltmodis`` / ``clwmodis`` / ``climodis`` / ``tauwmodis`` /
   ``tauimodis`` / ``reffclwmodis`` / ``reffclimodis``.
 
+The joint histograms those simulators compute anyway are emitted too
+(jax-gcm#597), flattened to a trailing bin-channel axis that the output
+layer expands to ``<name>.<i>`` fields (the ``cosp_precip_cover`` pattern;
+``tools/aerocom_cmor.py`` reassembles them into properly-binned CF files):
+
+* MODIS ``clmodis`` (tau x CTP), ``jpdftaureliqmodis`` /
+  ``jpdftaureicemodis`` (tau x Reff) and the LWP/IWP x Reff pair
+  (``lwpreffmodis`` / ``iwpreffmodis``, Pincus et al. 2023);
+* CALIPSO ``cfadLidarsr532`` (scattering ratio x height);
+* ISCCP ``clisccp`` (tau x CTP) and ``cltisccp``, via ``enable_isccp``:
+  the ICARUS simulator on the same SCOPS realization, with the 10.5-um
+  cloud emissivity derived from the condensate paths
+  (1 - exp(-k W), Stephens 1978 liquid / Ebert & Curry 1992 ice).
+
+Bin-axis order in the flattened channel is C-order (tau-major for the
+tau x CTP histograms); the CTP axis is surface-first, as the jcosp
+drivers emit it (matching cosp.F90's output flip).
+
 ``parasolRefl`` is NOT available: jax-cosp carries the PARASOL optical-depth
 inputs (``tau_sfc_liq``/``tau_sfc_ice``) but no reflectance simulator, so
 that one AeroCom field needs upstream work.
@@ -121,8 +139,49 @@ def _layer_optical_depth(clouds, pressure_half, qc, qi):
     return tau_liq + tau_ice
 
 
+def _lw_emissivity(qc, qi, pressure_half):
+    """Gridbox-mean 10.5-um cloud emissivity per layer, for ISCCP.
+
+    The standard COSP host-side closure: ``dem = 1 - exp(-(k_l W_l + k_i
+    W_i))`` on the layer condensate paths, with broadband-window mass
+    absorption coefficients (diffusivity folded in) of 0.158 m2 g-1 for
+    liquid (Stephens 1978) and 0.0735 m2 g-1 for ice (Ebert & Curry 1992,
+    mid-size crystals). jcm's radiation does not expose a per-layer LW
+    cloud emissivity, so this is derived here the way the ECHAM and CAM
+    COSP interfaces derive theirs; the ISCCP CTP retrieval is sensitive
+    to it only through the partial-emissivity adjustment of thin cloud.
+    """
+    dm = jnp.diff(pressure_half, axis=0) / c.grav
+    k_liq = 158.0   # m2/kg
+    k_ice = 73.5    # m2/kg
+    return 1.0 - jnp.exp(-(k_liq * qc * dm + k_ice * qi * dm))
+
+
+def _flat_hist(hist):
+    """Flatten a (nb1, nb2, ncols) joint histogram to (ncols, nb1*nb2).
+
+    The leading ncols axis and trailing flat bin-channel axis are what the
+    output layer's multi-channel expansion expects (it emits one 2-D field
+    per channel, ``<name>.<i>``); the C-order flattening (bin1-major) is
+    what ``tools/aerocom_cmor.py`` inverts when it reassembles the binned
+    file.
+    """
+    nb1, nb2 = hist.shape[0], hist.shape[1]
+    return jnp.moveaxis(hist, -1, 0).reshape(hist.shape[-1], nb1 * nb2)
+
+
 # Values at or below this are the COSP R_UNDEF missing-data sentinel.
 _R_UNDEF_THRESHOLD = -1e20
+
+
+def _defined(x):
+    """Map COSP R_UNDEF sentinels (dark / cloud-free retrievals) to zero.
+
+    Emitting the huge negative sentinel would poison time averages; these
+    are grid-box means the protocol explicitly does NOT divide by cloud
+    cover, so a cloud-free (or night) box legitimately contributes zero.
+    """
+    return jnp.where(x > _R_UNDEF_THRESHOLD, x, 0.0)
 
 
 class CloudsatCosp(PhysicsTerm):
@@ -158,14 +217,20 @@ class CloudsatCosp(PhysicsTerm):
         "cosp_warm_rain",
         # CALIPSO (enable_calipso)
         "cltcalipso", "cllcalipso", "clmcalipso", "clhcalipso",
+        "cfadLidarsr532",
         # MODIS (enable_modis)
         "cltmodis", "clwmodis", "climodis", "tauwmodis", "tauimodis",
         "reffclwmodis", "reffclimodis", "lwpmodis", "iwpmodis",
+        "clmodis", "jpdftaureliqmodis", "jpdftaureicemodis",
+        "lwpreffmodis", "iwpreffmodis",
+        # ISCCP (enable_isccp)
+        "clisccp", "cltisccp",
     )
 
     def __init__(self, ncolumns: int = 40, overlap: int = 3, seed: int = 0,
                  lut_path=None, enable_calipso: bool = False,
-                 enable_modis: bool = False):
+                 enable_modis: bool = False, enable_isccp: bool = False,
+                 isccp_emsfc_lw: float = 0.98):
         """Configure the simulator; loads the radar Z-scale LUT eagerly.
 
         ncolumns trades subcolumn sampling noise against cost (COSP's
@@ -195,6 +260,8 @@ class CloudsatCosp(PhysicsTerm):
         # simulator costs nothing rather than being masked out.
         self.enable_calipso = bool(enable_calipso)
         self.enable_modis = bool(enable_modis)
+        self.enable_isccp = bool(enable_isccp)
+        self.isccp_emsfc_lw = float(isccp_emsfc_lw)
 
     def __call__(
         self,
@@ -283,22 +350,46 @@ class CloudsatCosp(PhysicsTerm):
 
         p_half = diagnostics["pressure_half"]
 
-        if self.enable_modis:
-            # One SCOPS draw feeds radar and imager together (COSP's own
-            # wiring), so the subcolumn sampling is paid once. MODIS needs
-            # the gridbox-mean 0.67 um layer optical depths of stratiform
-            # and convective cloud; jcm detrains convective condensate into
-            # the same qc/qi fields and carries no separate convective
-            # cloud, so all of it is presented as stratiform (matching the
-            # conv_frac = 0 choice above).
+        isccp_out = None
+        if self.enable_modis or self.enable_isccp:
+            # One SCOPS draw feeds radar, imager and ISCCP together (COSP's
+            # own wiring), so the subcolumn sampling is paid once. MODIS
+            # needs the gridbox-mean 0.67 um layer optical depths of
+            # stratiform and convective cloud; jcm detrains convective
+            # condensate into the same qc/qi fields and carries no separate
+            # convective cloud, so all of it is presented as stratiform
+            # (matching the conv_frac = 0 choice above). ISCCP additionally
+            # needs the 10.5-um cloud emissivity (derived from the same
+            # condensate, see _lw_emissivity), the skin temperature and a
+            # day mask; its boxptop also completes the MODIS low-cloud CTP
+            # substitution, exactly as in cosp.F90.
             dtau_s = _layer_optical_depth(clouds, p_half, qc_pm, qi_pm)
             dtau_c = jnp.zeros_like(dtau_s)
+            isccp_kwargs = {}
+            if self.enable_isccp:
+                sfc = diagnostics.get("surface")
+                skt = getattr(sfc, "surface_temperature", None)
+                if skt is None:
+                    skt = temperature[-1]  # lowest-layer T as skin proxy
+                rad = diagnostics.get("radiation")
+                toa_sw = getattr(rad, "toa_sw_down", None)
+                sunlit = None if toa_sw is None else (toa_sw > 0.0)
+                isccp_kwargs = dict(
+                    run_isccp=True,
+                    dem_s=_lw_emissivity(qc_pm, qi_pm, p_half),
+                    dem_c=jnp.zeros_like(dtau_c),
+                    skt=skt, emsfc_lw=self.isccp_emsfc_lw, sunlit=sunlit)
             joint = simulate_cloudsat_modis(
                 inputs, self._lut, dtau_s, dtau_c, p_half, key=key,
-                ncolumns=self.ncolumns, overlap=self.overlap)
+                ncolumns=self.ncolumns, overlap=self.overlap,
+                **isccp_kwargs)
             # ``ModisOutputs`` wraps optics/subcolumn/column; the column
-            # stage holds the gridbox statistics AeroCom asks for.
-            out, modis_out = joint.cloudsat, joint.modis.column
+            # stage holds the gridbox statistics AeroCom asks for. MODIS
+            # fields are only EMITTED when enable_modis, even though the
+            # joint driver computes them whenever ISCCP runs.
+            out = joint.cloudsat
+            modis_out = joint.modis.column if self.enable_modis else None
+            isccp_out = joint.isccp.column if self.enable_isccp else None
         else:
             out = simulate_cloudsat(inputs, self._lut, key=key,
                                     ncolumns=self.ncolumns,
@@ -307,15 +398,6 @@ class CloudsatCosp(PhysicsTerm):
 
         extra: dict = {}
         if modis_out is not None:
-            # MODIS marks dark (night) and cloud-free retrievals with the
-            # COSP R_UNDEF sentinel (a large negative number). Emitting it
-            # would poison the time average, so it is mapped to zero: these
-            # are grid-box means and the protocol Q/A is explicit that they
-            # are NOT divided by cloud cover, so a cloud-free box legitimately
-            # contributes zero.
-            def _defined(x):
-                return jnp.where(x > _R_UNDEF_THRESHOLD, x, 0.0)
-
             # jcosp reports the MODIS cloud fractions in percent and the
             # AeroCom/CFMIP request is a fraction, so convert here rather
             # than leaving a factor of 100 for the post-processor.
@@ -329,6 +411,24 @@ class CloudsatCosp(PhysicsTerm):
                 "reffclimodis": _defined(modis_out.size_ice),
                 "lwpmodis": _defined(modis_out.lwp),
                 "iwpmodis": _defined(modis_out.iwp),
+                # Joint histograms (jax-gcm#597), percent -> fraction like
+                # the scalar covers; accumulating the per-step fields gives
+                # the time-MEAN histogram, which is what CFMIP expects.
+                "clmodis": _flat_hist(_defined(modis_out.tau_vs_ctp)) * 0.01,
+                "jpdftaureliqmodis":
+                    _flat_hist(_defined(modis_out.tau_vs_reff_liq)) * 0.01,
+                "jpdftaureicemodis":
+                    _flat_hist(_defined(modis_out.tau_vs_reff_ice)) * 0.01,
+                "lwpreffmodis":
+                    _flat_hist(_defined(modis_out.lwp_vs_reff_liq)) * 0.01,
+                "iwpreffmodis":
+                    _flat_hist(_defined(modis_out.iwp_vs_reff_ice)) * 0.01,
+            })
+
+        if isccp_out is not None:
+            extra.update({
+                "clisccp": _flat_hist(_defined(isccp_out.fq_isccp)) * 0.01,
+                "cltisccp": _defined(isccp_out.totalcldarea) * 0.01,
             })
 
         if self.enable_calipso:
@@ -406,5 +506,9 @@ class CloudsatCosp(PhysicsTerm):
 
         # cldlayer is (4, *batch) = low / mid / high / total, in percent.
         low, mid, high, total = (col.cldlayer[i] * 0.01 for i in range(4))
-        return {"cllcalipso": low, "clmcalipso": mid,
+        # The scattering-ratio CFAD is already a fraction (of subcolumns,
+        # per height bin); flatten (SR_BINS, nvgrid, ncols) to the
+        # channel-expansion layout like the other joint histograms.
+        extra_cfad = {"cfadLidarsr532": _flat_hist(col.cfad_sr)}
+        return {**extra_cfad, "cllcalipso": low, "clmcalipso": mid,
                 "clhcalipso": high, "cltcalipso": total}

--- a/jcm/physics/diagnostics/cosp_cloudsat_test.py
+++ b/jcm/physics/diagnostics/cosp_cloudsat_test.py
@@ -269,3 +269,155 @@ class CalipsoModisTest(unittest.TestCase):
         diag = self._run()
         for key in ("cltcalipso", "cltmodis"):
             self.assertNotIn(key, diag)
+
+
+@unittest.skipUnless(HAVE_JCOSP, "jax-cosp not installed")
+class JointHistogramTest(unittest.TestCase):
+    """The COSP joint histograms (jax-gcm#597) ride the same realization."""
+
+    @classmethod
+    def setUpClass(cls):
+        state, diagnostics, forcing, terrain = _setup()
+        clouds = diagnostics["clouds"]
+        reff_liq = jnp.where(clouds.qc > 0.0, 10.0, 0.0)
+        reff_ice = jnp.where(clouds.qi > 0.0, 30.0, 0.0)
+        diagnostics = {**diagnostics,
+                       "clouds": clouds.copy(r_eff_liq=reff_liq,
+                                             r_eff_ice=reff_ice)}
+        cls.setup = (state, diagnostics, forcing, terrain)
+
+    def _run(self, **kw):
+        from jcm.physics.diagnostics.cosp_cloudsat import CloudsatCosp
+        term = CloudsatCosp(ncolumns=20, seed=1, **kw)
+        state, diagnostics, forcing, terrain = self.setup
+        return term(state, diagnostics, forcing, terrain)[1]
+
+    def test_modis_histograms_emitted_with_expected_channels(self):
+        from jcosp import config as jc
+        diag = self._run(enable_modis=True)
+        ncols = np.asarray(diag["cltmodis"]).shape[-1]
+        expect = {
+            "clmodis": jc.NUM_MODIS_TAU_BINS * jc.NUM_MODIS_PRES_BINS,
+            "jpdftaureliqmodis":
+                jc.NUM_MODIS_TAU_BINS * jc.NUM_MODIS_REFF_LIQ_BINS,
+            "jpdftaureicemodis":
+                jc.NUM_MODIS_TAU_BINS * jc.NUM_MODIS_REFF_ICE_BINS,
+            "lwpreffmodis":
+                jc.NUM_MODIS_LWP_BINS * jc.NUM_MODIS_REFF_LIQ_BINS,
+            "iwpreffmodis":
+                jc.NUM_MODIS_IWP_BINS * jc.NUM_MODIS_REFF_ICE_BINS,
+        }
+        for key, nbins in expect.items():
+            arr = np.asarray(diag[key])
+            self.assertEqual(arr.shape, (ncols, nbins), key)
+            self.assertTrue((arr >= 0.0).all() and (arr <= 1.0 + 1e-6).all(),
+                            f"{key} not a fraction")
+
+    def test_clmodis_sums_to_the_total_cloud_fraction(self):
+        """Summing the tau/CTP histogram over its bins recovers cltmodis.
+
+        Both are subcolumn fractions of the SAME retrieval set; the
+        histogram merely bins it. (The tau >= 0.3 MODIS detection floor
+        applies to both, so the identity is exact up to float error.)
+        """
+        diag = self._run(enable_modis=True)
+        hist_sum = np.asarray(diag["clmodis"]).sum(axis=-1)
+        clt = np.asarray(diag["cltmodis"])
+        np.testing.assert_allclose(hist_sum, clt, atol=1e-5)
+
+    def test_calipso_cfad_emitted_and_bounded(self):
+        from jcosp import config as jc
+        diag = self._run(enable_calipso=True)
+        arr = np.asarray(diag["cfadLidarsr532"])
+        ncols = np.asarray(diag["cltcalipso"]).shape[-1]
+        self.assertEqual(arr.shape, (ncols, jc.SR_BINS * jc.N_VGRID))
+        self.assertTrue((arr >= 0.0).all() and (arr <= 1.0 + 1e-6).all())
+
+    def test_isccp_histogram_and_total_cover(self):
+        from jcosp import config as jc
+        diag = self._run(enable_isccp=True)
+        ncols = np.asarray(diag["cosp_warm_rain"]).shape[-1]
+        cli = np.asarray(diag["clisccp"])
+        self.assertEqual(
+            cli.shape, (ncols, jc.NUM_ISCCP_TAU_BINS * jc.NUM_ISCCP_PRES_BINS))
+        clt = np.asarray(diag["cltisccp"])
+        self.assertTrue((clt >= 0.0).all() and (clt <= 1.0 + 1e-6).all())
+        # The seeded cloud deck must be visible to ICARUS.
+        self.assertGreater(clt.max(), 0.0)
+        # MODIS fields must NOT be emitted by the ISCCP-only configuration,
+        # even though the joint driver computes them internally.
+        self.assertNotIn("cltmodis", diag)
+
+    def test_radar_diagnostics_unchanged_by_isccp(self):
+        base = self._run()
+        with_isccp = self._run(enable_isccp=True)
+        np.testing.assert_array_equal(np.asarray(base["cosp_warm_rain"]),
+                                      np.asarray(with_isccp["cosp_warm_rain"]))
+
+    def test_factory_passes_the_isccp_flag(self):
+        from jcm.physics.diagnostics.cosp_cloudsat import CloudsatCosp
+        from jcm.physics.echam.echam_terms import echam_physics
+        physics = echam_physics(enable_cosp=True, cosp_isccp=True,
+                                checkpoint_terms=False)
+        terms = [t for t in physics.terms if isinstance(t, CloudsatCosp)]
+        self.assertEqual(len(terms), 1)
+        self.assertTrue(terms[0].enable_isccp)
+
+    def test_histograms_absent_when_flags_off(self):
+        diag = self._run()
+        for key in ("clmodis", "cfadLidarsr532", "clisccp", "cltisccp",
+                    "jpdftaureliqmodis", "lwpreffmodis"):
+            self.assertNotIn(key, diag)
+
+
+@unittest.skipUnless(HAVE_JCOSP, "jax-cosp not installed")
+class HistogramCmorTest(unittest.TestCase):
+    """The CMOR writer reassembles the flattened histogram channels."""
+
+    def test_bin_tables_match_jcosp(self):
+        """The writer's hard-coded bin tables must mirror jcosp's config."""
+        import tools.aerocom_cmor as cm
+        from jcosp import config as jc
+        np.testing.assert_allclose(cm._TAU_EDGES, jc.MODIS_HIST_TAU)
+        np.testing.assert_allclose(cm._TAU_CENTERS, jc.MODIS_HIST_TAU_CENTERS)
+        np.testing.assert_allclose(cm._CTP_CENTERS_PA, jc.MODIS_HIST_PRES_CENTERS)
+        np.testing.assert_allclose(cm._REFF_LIQ_EDGES, jc.MODIS_HIST_REFF_LIQ)
+        np.testing.assert_allclose(cm._REFF_ICE_EDGES, jc.MODIS_HIST_REFF_ICE)
+        np.testing.assert_allclose(cm._LWP_EDGES, jc.MODIS_HIST_LWP)
+        np.testing.assert_allclose(cm._IWP_EDGES, jc.MODIS_HIST_IWP)
+        np.testing.assert_allclose(cm._SR_EDGES, jc.CALIPSO_HIST_BSCT)
+        self.assertEqual(cm._CFAD_NLEV, jc.N_VGRID)
+        self.assertEqual(cm._CFAD_DZ, jc.VGRID_ZSTEP)
+
+    def test_roundtrip_reassembly(self):
+        """clmodis.<i> channels come back as a binned, bounded variable."""
+        import pathlib
+        import tempfile
+
+        import xarray as xr
+        from tools.aerocom_cmor import convert
+
+        rng = np.random.default_rng(0)
+        n1, n2 = 7, 7
+        vals = rng.uniform(0.0, 0.02, size=(n1 * n2, 3, 4))
+        ds = xr.Dataset({
+            f"clmodis.{i}": xr.DataArray(vals[i], dims=("lat", "lon"))
+            for i in range(n1 * n2)
+        })
+        with tempfile.TemporaryDirectory() as td:
+            written, skipped = convert(
+                ds, "JCM-t", "all_2000", "2010", "monthly", pathlib.Path(td))
+            fname = [f for f in written if "_clmodis_" in f]
+            self.assertEqual(len(fname), 1)
+            got = xr.open_dataset(pathlib.Path(td) / fname[0])
+        self.assertEqual(got["clmodis"].dims, ("tau", "plev7", "lat", "lon"))
+        # Percent, C-order (tau-major) inverse of the flattening.
+        np.testing.assert_allclose(
+            got["clmodis"].values, vals.reshape(n1, n2, 3, 4) * 100.0,
+            rtol=1e-6)
+        # CF bounds present and attached.
+        self.assertIn("tau_bnds", got)
+        self.assertEqual(got["tau"].attrs["bounds"], "tau_bnds")
+        self.assertEqual(got["clmodis"].attrs["units"], "%")
+        # Consumed channels are not reported as unmapped.
+        self.assertTrue(all(not s.startswith("clmodis.") for s in skipped))

--- a/jcm/physics/diagnostics/cosp_cloudsat_test.py
+++ b/jcm/physics/diagnostics/cosp_cloudsat_test.py
@@ -421,3 +421,29 @@ class HistogramCmorTest(unittest.TestCase):
         self.assertEqual(got["clmodis"].attrs["units"], "%")
         # Consumed channels are not reported as unmapped.
         self.assertTrue(all(not s.startswith("clmodis.") for s in skipped))
+
+    def test_cltisccp_reaches_a_submission_file(self):
+        """The scalar ISCCP cover must be written, not silently skipped.
+
+        Codex on PR #598: clisccp was reassembled but cltisccp had no
+        NAME_MAP entry, so the ACI preset lost one of its advertised
+        ISCCP products with only the skipped-report to notice.
+        """
+        import pathlib
+        import tempfile
+
+        import xarray as xr
+        from tools.aerocom_cmor import convert
+
+        ds = xr.Dataset({"cltisccp": xr.DataArray(
+            np.full((3, 4), 0.5), dims=("lat", "lon"))})
+        with tempfile.TemporaryDirectory() as td:
+            written, skipped = convert(
+                ds, "JCM-t", "all_2000", "2010", "monthly", pathlib.Path(td))
+            self.assertNotIn("cltisccp", skipped)
+            fname = [f for f in written if "_cltisccp_" in f]
+            self.assertEqual(len(fname), 1)
+            got = xr.open_dataset(pathlib.Path(td) / fname[0])
+        np.testing.assert_allclose(got["cltisccp"].values, 50.0)
+        self.assertEqual(got["cltisccp"].attrs["standard_name"],
+                         "cloud_area_fraction")

--- a/jcm/physics/echam/echam_terms.py
+++ b/jcm/physics/echam/echam_terms.py
@@ -82,6 +82,7 @@ def echam_physics(
     cosp_ncolumns: int = 40,
     cosp_calipso: bool = False,
     cosp_modis: bool = False,
+    cosp_isccp: bool = False,
     enable_aerocom: bool = False,
     aerocom_groups: tuple[str, ...] = ("cloud", "column"),
     aerocom_overlap: str = "maximum-random",
@@ -185,7 +186,12 @@ def echam_physics(
         cosp_modis: Also run the MODIS imager simulator on that
             realization (``cltmodis``, ``clwmodis``, ``climodis``,
             ``tauwmodis``, ``tauimodis``, ``reffclwmodis``,
-            ``reffclimodis``, ``lwpmodis``, ``iwpmodis``).
+            ``reffclimodis``, ``lwpmodis``, ``iwpmodis``, and the
+            joint histograms ``clmodis`` / ``jpdftaure*modis`` /
+            ``lwpreffmodis`` / ``iwpreffmodis``).
+        cosp_isccp: Also run the ISCCP (ICARUS) simulator on that
+            realization (``clisccp`` tau/CTP histogram and
+            ``cltisccp``); see jax-gcm#597.
 
     """
     convection_p = convection or ConvectionParameters.default()
@@ -358,7 +364,8 @@ def echam_physics(
         from jcm.physics.diagnostics.cosp_cloudsat import CloudsatCosp
         cosp_terms = [CloudsatCosp(ncolumns=cosp_ncolumns,
                                    enable_calipso=cosp_calipso,
-                                   enable_modis=cosp_modis)]
+                                   enable_modis=cosp_modis,
+                                   enable_isccp=cosp_isccp)]
 
     aerocom_terms: list[PhysicsTerm] = []
     if enable_aerocom:

--- a/tools/aerocom_cmor.py
+++ b/tools/aerocom_cmor.py
@@ -114,6 +114,10 @@ NAME_MAP: dict[str, tuple[str, str, str, float, float]] = {
     # Muelmenstaedt et al. (2020). Not a CMIP variable, kept under its own
     # name so the submission still carries it.
     "cosp_warm_rain": ("cospwarmrain", "1", "Column", 1.0, 0.0),
+    # ISCCP total cloud area (tau >= 0.3), stored as a fraction like the
+    # other simulator covers; CMIP wants percent. The clisccp histogram is
+    # reassembled separately (see _HISTOGRAMS below).
+    "cltisccp": ("cltisccp", "%", "Column", 100.0, 0.0),
     # --- spectral aerosol optics (jax-gcm#584) ---
     # These come from the diagnostic Mie pass at the OBSERVATION
     # wavelengths, so ``od550aer`` here is at exactly 550 nm. It is listed
@@ -225,6 +229,7 @@ CF_STANDARD_NAMES = {
     "clmcalipso": "cloud_area_fraction_in_atmosphere_layer",
     "clhcalipso": "cloud_area_fraction_in_atmosphere_layer",
     "cltmodis": "cloud_area_fraction",
+    "cltisccp": "cloud_area_fraction",
     "clwmodis": "liquid_water_cloud_area_fraction",
     "climodis": "ice_cloud_area_fraction",
     "tauwmodis": "atmosphere_optical_thickness_due_to_cloud",

--- a/tools/aerocom_cmor.py
+++ b/tools/aerocom_cmor.py
@@ -277,6 +277,107 @@ def _collect_burdens(ds: xr.Dataset) -> dict[str, xr.DataArray]:
     return out
 
 
+# COSP joint histograms: emitted by the model as flattened bin channels
+# ``<name>.<i>`` (the output layer's multi-channel expansion), reassembled
+# here into properly-binned variables with CF bounds. Bin tables mirror
+# jcosp/config.py (cosp_config.F90 / Pincus et al. 2023) and are
+# cross-checked against the live jcosp values by
+# ``CmorWriterTest.test_histogram_bins_match_jcosp``. Axis order of the
+# flat channel is C-order, first axis major; the CTP axes are
+# surface-first, as the jcosp drivers emit them (cosp.F90's output flip).
+_TAU_CENTERS = [0.15, 0.80, 2.45, 6.5, 16.2, 41.5, 100.0]
+_TAU_EDGES = [0.0, 0.3, 1.3, 3.6, 9.4, 23.0, 60.0, 10000.0]
+_CTP_CENTERS_PA = [90000.0, 74000.0, 62000.0, 50000.0, 37500.0, 24500.0, 9000.0]
+_CTP_EDGES_PA = [100000.0, 80000.0, 68000.0, 56000.0, 44000.0, 31000.0,
+                 18000.0, 0.0]
+_REFF_LIQ_EDGES = [0.0, 4.0e-6, 8e-6, 1.0e-5, 1.25e-5, 1.5e-5, 2.0e-5,
+                   3.0e-5, 1.0e-2]
+_REFF_ICE_EDGES = [0.0, 5.0e-6, 1.0e-5, 2.0e-5, 3.0e-5, 4.0e-5, 5.0e-5,
+                   6.0e-5, 1.0e-2]
+_LWP_EDGES = [0.0, 0.01, 0.03, 0.06, 0.10, 0.15, 0.25, 20.0]
+_IWP_EDGES = [0.0, 0.02, 0.05, 0.10, 0.20, 0.40, 1.00, 20.0]
+# CALIPSO SR CFAD: 15 scattering-ratio bins x 40 height levels (480 m).
+# SR edges are cosp_config.F90's calipso_histBsct (-1 is the "no signal"
+# floor; 999 the physical SR cap).
+_SR_EDGES = [-1.0, 0.01, 1.2, 3.0, 5.0, 7.0, 10.0, 15.0, 20.0, 25.0, 30.0,
+             40.0, 50.0, 60.0, 80.0, 999.0]
+_CFAD_NLEV, _CFAD_DZ = 40, 480.0
+
+
+def _centers(edges):
+    return [0.5 * (a + b) for a, b in zip(edges[:-1], edges[1:])]
+
+
+# name -> (dim1 name, centers1, edges1, dim2 name, centers2, edges2,
+#          units, scale, standard_name or None)
+_HISTOGRAMS = {
+    "clmodis": ("tau", _TAU_CENTERS, _TAU_EDGES,
+                "plev7", _CTP_CENTERS_PA, _CTP_EDGES_PA,
+                "%", 100.0, "cloud_area_fraction_in_atmosphere_layer"),
+    "clisccp": ("tau", _TAU_CENTERS, _TAU_EDGES,
+                "plev7", _CTP_CENTERS_PA, _CTP_EDGES_PA,
+                "%", 100.0, "cloud_area_fraction_in_atmosphere_layer"),
+    "jpdftaureliqmodis": ("tau", _TAU_CENTERS, _TAU_EDGES,
+                          "effectiveRadiusLiq", _centers(_REFF_LIQ_EDGES),
+                          _REFF_LIQ_EDGES, "%", 100.0, None),
+    "jpdftaureicemodis": ("tau", _TAU_CENTERS, _TAU_EDGES,
+                          "effectiveRadiusIce", _centers(_REFF_ICE_EDGES),
+                          _REFF_ICE_EDGES, "%", 100.0, None),
+    "lwpreffmodis": ("lwp", _centers(_LWP_EDGES), _LWP_EDGES,
+                     "effectiveRadiusLiq", _centers(_REFF_LIQ_EDGES),
+                     _REFF_LIQ_EDGES, "%", 100.0, None),
+    "iwpreffmodis": ("iwp", _centers(_IWP_EDGES), _IWP_EDGES,
+                     "effectiveRadiusIce", _centers(_REFF_ICE_EDGES),
+                     _REFF_ICE_EDGES, "%", 100.0, None),
+    "cfadLidarsr532": ("scatratio", _centers(_SR_EDGES), _SR_EDGES,
+                       "alt40", [(_CFAD_NLEV - 1 - i) * _CFAD_DZ + _CFAD_DZ / 2
+                                 for i in range(_CFAD_NLEV)], None,
+                       "1", 1.0,
+                       "histogram_of_backscattering_ratio_over_height_above_reference_ellipsoid"),
+}
+
+
+def _collect_histograms(ds: xr.Dataset) -> tuple[dict[str, xr.Dataset], set[str]]:
+    """Reassemble flattened ``<name>.<i>`` histogram channels.
+
+    Returns per-histogram single-variable Datasets (the variable plus its
+    bin coordinates and CF ``bounds`` variables) and the set of source
+    channel names consumed, so the skipped-variables report stays honest.
+    """
+    out: dict[str, xr.Dataset] = {}
+    consumed: set[str] = set()
+    for name, (d1, c1, e1, d2, c2, e2, units, scale, std) in _HISTOGRAMS.items():
+        n1, n2 = len(c1), len(c2)
+        srcs = [f"{name}.{i}" for i in range(n1 * n2)]
+        if not all(v in ds.data_vars for v in srcs):
+            continue
+        channels = xr.concat([ds[v] for v in srcs], dim="__bin__")
+        stacked = channels.data.reshape((n1, n2) + channels.shape[1:]) * scale
+        da = xr.DataArray(
+            stacked,
+            dims=(d1, d2) + tuple(channels.dims[1:]),
+            coords={d1: c1, d2: c2,
+                    **{k: v for k, v in channels.coords.items()
+                       if k in channels.dims}},
+            name=name,
+        )
+        attrs = {"units": units, "long_name": name}
+        if std is not None:
+            attrs["standard_name"] = std
+        pieces = {name: da}
+        for dim, edges in ((d1, e1), (d2, e2)):
+            if edges is None:
+                continue
+            bounds = [[a, b] for a, b in zip(edges[:-1], edges[1:])]
+            pieces[f"{dim}_bnds"] = xr.DataArray(
+                bounds, dims=(dim, "bnds"), name=f"{dim}_bnds")
+            da.coords[dim].attrs["bounds"] = f"{dim}_bnds"
+        da.attrs.update(attrs)
+        out[name] = xr.Dataset(pieces)
+        consumed.update(srcs)
+    return out, consumed
+
+
 # jcm species -> AeroCom component suffix. The three organic species
 # (primary, secondary, marine) are reported as one ``oa`` component, which
 # is what the protocol asks for; the raw per-species fields stay in the
@@ -349,6 +450,7 @@ def convert(
     optics_vars, optics_srcs = _collect_optics(ds)
     for name, da in optics_vars.items():
         candidates[name] = (da, "1", "Column")
+    hist_dsets, hist_srcs = _collect_histograms(ds)
 
     for cmor, (da, units, vert) in sorted(candidates.items()):
         assert vert in VALID_VERT, vert
@@ -376,8 +478,21 @@ def convert(
             out.to_netcdf(outdir / fname)
         written.append(fname)
 
+    # Joint histograms are whole Datasets (variable + bin bounds), written
+    # outside the DataArray loop above.
+    for name, hds in sorted(hist_dsets.items()):
+        fname = _filename(convention, model, experiment, name, "Column",
+                          period, freq)
+        if not dry_run:
+            hds.attrs.update(
+                model_id=model, experiment_id=experiment, frequency=freq,
+                vertical_coordinate_type="Column",
+            )
+            hds.to_netcdf(outdir / fname)
+        written.append(fname)
+
     mapped_srcs = {s for s in NAME_MAP if s in ds.data_vars}
-    skipped = sorted(set(ds.data_vars) - mapped_srcs - optics_srcs
+    skipped = sorted(set(ds.data_vars) - mapped_srcs - optics_srcs - hist_srcs
                      - {f"aerocom_burden_{sp}" for sp in BURDEN_SPECIES})
     return written, skipped
 


### PR DESCRIPTION
Closes #597. The last piece of #581's C.2: the joint histograms the satellite community actually evaluates cloud regimes against.

## What

Emits, on the **same single SCOPS realization** as the radar (COSP's own wiring, so the sampling is paid once):

| product | fields | gate |
|---|---|---|
| MODIS tau x CTP | `clmodis` | `cosp_modis` |
| MODIS tau x Reff | `jpdftaureliqmodis`, `jpdftaureicemodis` | `cosp_modis` |
| MODIS water path x Reff (Pincus et al. 2023) | `lwpreffmodis`, `iwpreffmodis` | `cosp_modis` |
| CALIPSO SR CFAD (GOCCP 15x40) | `cfadLidarsr532` | `cosp_calipso` |
| **ISCCP (newly wired)** | `clisccp`, `cltisccp` | new `cosp_isccp` |

The MODIS/CALIPSO histograms were **already computed and discarded** — emitting them is ~free. ISCCP is a new (LUT-free) pass on the existing subcolumn draw via the joint driver's `run_isccp` path; the 10.5-um cloud emissivity is derived from the condensate paths with the standard COSP host-side closure (`1 - exp(-kW)`, Stephens 1978 liquid / Ebert & Curry 1992 ice — documented in `_lw_emissivity`), skin temperature comes from the surface term (lowest-layer T fallback), and the day mask from TOA insolation. ISCCP's `boxptop` also completes the MODIS low-cloud CTP substitution, exactly as in cosp.F90. MODIS fields are only *emitted* under `cosp_modis`, even though the joint driver computes them whenever ISCCP runs (pinned by test).

## Output design

Histograms are flattened to a trailing bin-channel axis — the established `cosp_precip_cover` pattern, expanded by the output layer to `<name>.<i>` fields — rather than teaching `data_to_xarray` two-bin-axis shapes (its dims lookup is shape-keyed, and same-length bin axes from different histograms would collide; deviation from the issue's "labelled bin coordinates in the raw output" noted here deliberately). Stored as fractions like the scalar covers; `output_averages` accumulation gives the **time-mean histogram**, the CFMIP convention (docstring says so, so nobody "fixes" it).

`tools/aerocom_cmor.py` reassembles the channels into properly-binned single-variable submission files: bin-centre coordinates, CF `bounds` variables attached to each axis, percent units, C-order inverse of the flattening, CTP surface-first (the jcosp drivers' output convention). Its hard-coded bin tables are **cross-checked against the live jcosp config by test**, and consumed channels stay out of the skipped-variables coverage report.

`echam-jam-aci` now enables ISCCP alongside CALIPSO/MODIS.

## Tests (75 diagnostics tests pass)

Channel counts against jcosp config for all six histograms; the `clmodis`-sums-to-`cltmodis` identity; CFAD/ISCCP boundedness and seeded-cloud visibility; radar outputs bit-unchanged by the extra simulator; MODIS keys absent in an ISCCP-only configuration; factory flag pass-through; CMOR round-trip (percent scaling, C-order inverse, bounds attached, honest skipped report); bin-table/jcosp cross-check.

## Not included

`parasolRefl` (no reflectance simulator in jax-cosp), the CALIPSO phase/temperature and OPAQ diagnostics (not yet ported upstream), and cost re-measurement on GPU for the ISCCP increment (expected small — LUT-free arithmetic on the existing draw; will measure on the next AeroCom bench run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aqshaa5nDrxcDWgg1FYw8Z
