### PR TITLE
perf(pyses): require pyses >= 0.1.3.1 — 1.41x faster, 0.56x memory, and a tracer-hypervis correctness fix

### DIFF
--- a/.claude/skills/kubernetes-jcm-runs/scripts/mkjob.py
+++ b/.claude/skills/kubernetes-jcm-runs/scripts/mkjob.py
@@ -86,10 +86,13 @@ def pip_commands(preset: str, site: dict) -> list[str]:
     but it declares ``torch>=2.12.0`` — 2-3 GB of wheels that also ship
     their own nvidia-* CUDA libraries, which can shadow the ones jax's CUDA
     build resolves against. The dev-box environment that produced the
-    validated ne30 runs has pyses 0.1.3a2 and **no torch at all**, so the
-    dependency is unused on this code path. Install it ``--no-deps`` with
-    its one genuinely-needed non-jax dependency (frozendict) named
-    explicitly; numpy/jax/jaxlib/setuptools are already in the image.
+    validated ne30 runs has **no torch at all**, so the dependency is unused
+    on this code path. Install it ``--no-deps`` with its one
+    genuinely-needed non-jax dependency (frozendict) named explicitly;
+    numpy/jax/jaxlib/setuptools are already in the image.
+
+    Keep the pin at or above the pyproject floor (0.1.3.1) — older wheels are
+    much slower on GPU and have an upstream tracer-hyperviscosity bug.
 
     Derived from the preset rather than a hardcoded list, and added only
     where needed — putting a dycore on the spectral runs' path would make
@@ -98,7 +101,7 @@ def pip_commands(preset: str, site: dict) -> list[str]:
     cmds = [" ".join(repr(x) for x in site["extra_pip"])]
     if any(o.startswith("dycore=pyses") for o in _preset_overrides(preset)):
         cmds.append("'frozendict>=2.4.7'")
-        cmds.append("--no-deps 'pyses==0.1.3a2'")
+        cmds.append("--no-deps 'pyses==0.1.3.1'")
     return [f"pip install --no-cache-dir {c} 2>&1 | tail -2" for c in cmds]
 
 

--- a/docs/source/design/pyses_cam_se_dycore.md
+++ b/docs/source/design/pyses_cam_se_dycore.md
@@ -31,7 +31,7 @@ forcing interpolation, output regrid weights).
 - **pg2 physics grid, from pyses itself.** Physics on the GLL nodes imprints
   the element structure onto the forcing; physics therefore runs on 2×2
   quasi-equal-area finite-volume cells per element (Hannah et al. 2021).
-  pySES ≥ 0.1.3a2 ships the remap machinery
+  pySES ≥ 0.1.3.1 ships the remap machinery
   (`pyses.dynamical_cores.finite_volume_grid`); jcm only wraps it
   (`FVPhysicsGrid`) into the `(nlev, 1, ncol)` layout, adds seam-safe
   cell-centre coordinates (Cartesian averaging — direct longitude averaging

--- a/jcm/dycore/pyses/physics_grid.py
+++ b/jcm/dycore/pyses/physics_grid.py
@@ -9,7 +9,7 @@ noise. Following Hannah et al. (2021, JAMES, doi:10.1029/2020MS002419) —
 and the developer prototype — physics runs instead on a quasi-equal-area
 finite-volume grid of ``nf × nf`` sub-cells per element (``pg2``: nf = 2).
 
-pyses 0.1.3a2 **ships** the element-local remap machinery
+pyses **ships** the element-local remap machinery
 (:mod:`pyses.dynamical_cores.finite_volume_grid`): ``init_fv_grid`` builds
 the reference operators + per-element metric, ``gll_to_fv`` is the
 area-weighted GLL→cell average and ``fv_to_gll`` its density-weighted

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,12 +48,13 @@ cosp = [
     "jax-cosp @ git+https://github.com/climate-analytics-lab/jax-cosp.git",
 ]
 
-# pySES CAM-SE spectral-element dynamical core (jcm/dycore/pyses). Pre-release
-# pin: 0.1.3a2 is the first build that ships the pg2 physics-grid coupling
-# machinery (pyses.dynamical_cores.finite_volume_grid) this backend uses.
+# pySES CAM-SE spectral-element dynamical core (jcm/dycore/pyses).
+# Floor is 0.1.3.1: earlier builds lower the SE contractions to per-gridpoint
+# cuBLAS GEMMs on GPU (1.4x slower, 1.8x memory at ne30L47) and carry an
+# upstream tracer-hyperviscosity bug active on the quasi_uniform path.
 # Install with `pip install jcm[pyses]`.
 pyses = [
-    "pyses>=0.1.3a2",
+    "pyses>=0.1.3.1",
 ]
 
 


### PR DESCRIPTION
Raises the pySES floor to 0.1.3.1. Relates to #595.

`0.1.3a2` predates the upstream GPU kernel-fusion series and a tracer
hyperviscosity fix, both of which land on the path the canonical ne30 config
takes.

**Performance** — the SE metric and GLL derivative contractions were
einsums, which XLA lowers to one cuBLAS GEMM per grid point on GPU (upstream
`3e626be1`, `cd212b23`, `d927a3f2`). Measured at ne30L47 + `echam-jam` + f32,
one A100-80GB, converged chunks:

| build | s/sim day | peak device |
|---|---|---|
| 0.1.3a2 | 493.6 | 62.1 GiB |
| 0.1.3.1 | 350.9 | 35.0 GiB |

**Correctness** — upstream `fd8f283b`, *"major bug when tracer hypervis is
enabled"*: the tracer biharmonic's first Laplacian used
`d_mass * tracer_mass` instead of `tracer_mass`.
`init_hypervis_config_const` — the `quasi_uniform` path
`dycore/pyses_ne30l47.yaml` selects — always sets `nu_tracer`, so this was
active in every ne30 run so far. Fields from the 365-day year are
provisional until the change is quantified.

The k8s generator's exact pin moves with the floor. `jcm/dycore/pyses/`
tests pass (42) against 0.1.3.1; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)