### PR TITLE
fix(k8s): scope the run completion gate to the current attempt

### DIFF
--- a/.claude/skills/kubernetes-jcm-runs/scripts/mkrun.py
+++ b/.claude/skills/kubernetes-jcm-runs/scripts/mkrun.py
@@ -180,14 +180,19 @@ if grep -qiE "unhealthy|NaN vars: *[1-9]" /tmp/attempt.log; then
   grep -iE "unhealthy|NaN vars: *[1-9]" /tmp/attempt.log | tail -3
   exit 1
 fi
+# `|| true` is load-bearing under `set -euo pipefail`: "no output this
+# attempt" is a state we must INSPECT, but a no-match grep exits 1 and
+# pipefail propagates that out of the command substitution, which would abort
+# the script before the empty-LAST branch below could run — marking a genuine
+# completion-restart as failed. Same for RESUMED.
 LAST=$(grep -oE "_day[0-9]+\\.nc" /tmp/attempt.log | grep -oE "[0-9]+" \\
-       | sort -n | tail -1)
+       | sort -n | tail -1 || true)
 if [ -z "$LAST" ]; then
   # No output this attempt. Distinguish the one benign case — the run was
   # already finished and the pod merely restarted — from a no-op resume,
   # which must NOT look like success.
   RESUMED=$(grep -oE "Resumed from checkpoint .* at sim-day [0-9.]+" \\
-            /tmp/attempt.log | grep -oE "[0-9.]+$" | tail -1)
+            /tmp/attempt.log | grep -oE "[0-9.]+$" | tail -1 || true)
   if [ -n "$RESUMED" ] && [ "${{RESUMED%%.*}}" -ge {a.days} ]; then
     echo "=== already complete: checkpoint at day $RESUMED of {a.days}, nothing to do ==="
     exit 0

--- a/.claude/skills/kubernetes-jcm-runs/scripts/mkrun.py
+++ b/.claude/skills/kubernetes-jcm-runs/scripts/mkrun.py
@@ -152,26 +152,53 @@ done
 if [ -f "{rundir}/{a.name}.ckpt" ]; then
   echo "=== resuming from $(ls -la {rundir}/{a.name}.ckpt | awk '{{print $5}}') byte checkpoint ==="
 fi
+# run.log is append-only ACROSS pod restarts (that is what makes the
+# eviction-resume design debuggable), so every gate below must read only THIS
+# attempt's slice. Grepping the cumulative log gets both verdicts wrong:
+#   * completion: an attempt that integrated NOTHING inherits the previous
+#     attempt's "_day365.nc" line and the Job is marked Complete. That is how
+#     a no-op resume — e.g. a stale or foreign checkpoint already at/past the
+#     target — reports success having done no work.
+#   * health: one bad chunk that a later attempt already recovered from fails
+#     the Job forever.
+# Record the byte offset first and slice from it.
+ATTEMPT_START=$(stat -c%s "{rundir}/run.log" 2>/dev/null || echo 0)
 set +e
 PYTHONPATH={pythonpath} MAM4_JAX_ENABLE_X64={"0" if a.f32 else "1"} \\
   python -m jcm.main {overrides} 2>&1 | tee -a {rundir}/run.log
 RC=${{PIPESTATUS[0]}}
 set -e
+tail -c +$((ATTEMPT_START + 1)) "{rundir}/run.log" > /tmp/attempt.log
 
 # jcm.runners.run_chunked BREAKS OUT of its loop and returns NORMALLY when
 # bail_on_unhealthy trips, so jcm.main exits 0 even though the year stopped
 # at the first bad chunk. Without this check Kubernetes marks a 365-day Job
 # Complete after 30 days of output — the worst kind of failure, because it
 # looks like success. Verify the health verdict and the day count.
-if grep -qiE "unhealthy|NaN vars: *[1-9]" {rundir}/run.log; then
+if grep -qiE "unhealthy|NaN vars: *[1-9]" /tmp/attempt.log; then
   echo "FATAL: health gate tripped — run stopped early, not complete"
-  grep -iE "unhealthy|NaN vars: *[1-9]" {rundir}/run.log | tail -3
+  grep -iE "unhealthy|NaN vars: *[1-9]" /tmp/attempt.log | tail -3
   exit 1
 fi
-LAST=$(grep -oE "_day[0-9]+\\.nc" {rundir}/run.log | grep -oE "[0-9]+" \\
+LAST=$(grep -oE "_day[0-9]+\\.nc" /tmp/attempt.log | grep -oE "[0-9]+" \\
        | sort -n | tail -1)
-if [ -z "$LAST" ] || [ "$LAST" -lt {a.days} ]; then
-  echo "FATAL: reached day ${{LAST:-0}} of {a.days} — incomplete"
+if [ -z "$LAST" ]; then
+  # No output this attempt. Distinguish the one benign case — the run was
+  # already finished and the pod merely restarted — from a no-op resume,
+  # which must NOT look like success.
+  RESUMED=$(grep -oE "Resumed from checkpoint .* at sim-day [0-9.]+" \\
+            /tmp/attempt.log | grep -oE "[0-9.]+$" | tail -1)
+  if [ -n "$RESUMED" ] && [ "${{RESUMED%%.*}}" -ge {a.days} ]; then
+    echo "=== already complete: checkpoint at day $RESUMED of {a.days}, nothing to do ==="
+    exit 0
+  fi
+  echo "FATAL: this attempt wrote no output and resumed at day ${{RESUMED:-0}}"
+  echo "       of {a.days} — no progress made. Check for a stale or foreign"
+  echo "       checkpoint at {rundir}/{a.name}.ckpt."
+  exit 1
+fi
+if [ "$LAST" -lt {a.days} ]; then
+  echo "FATAL: reached day $LAST of {a.days} — incomplete"
   exit 1
 fi
 echo "=== finished $(date -u +%FT%TZ), day $LAST of {a.days}, rc=$RC ==="

--- a/.claude/skills/kubernetes-jcm-runs/scripts/mkrun_gate_test.sh
+++ b/.claude/skills/kubernetes-jcm-runs/scripts/mkrun_gate_test.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Behaviour test for the run-completion gate that mkrun.py generates.
+#
+# This extracts the gate straight out of the generated manifest and runs it
+# under the SAME `set -euo pipefail` the container uses. That matters: an
+# earlier version of this test reimplemented the gate in a plain function, so
+# it passed while the real script aborted at the first no-match `grep` —
+# pipefail propagates the 1 out of a command substitution and `set -e` kills
+# the script before the empty-LAST branch can run. Test the artefact, under
+# the artefact's shell options, or the test is theatre.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PY="${JCM_PYTHON:-python}"
+DAYS=365
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+RUNDIR="$TMP/runs/testrun"
+mkdir -p "$RUNDIR"
+
+# Extract the generated script, then keep only the gate (everything from the
+# attempt-slice onward) and repoint it at the temp rundir.
+"$PY" "$HERE/mkrun.py" --name testrun --days "$DAYS" 2>/dev/null \
+  | "$PY" -c 'import json,sys; print(json.load(sys.stdin)["spec"]["template"]["spec"]["containers"][0]["command"][-1])' \
+  > "$TMP/full.sh"
+sed -n '/^tail -c +\$((ATTEMPT_START/,$p' "$TMP/full.sh" \
+  | sed "s#/runs/testrun#$RUNDIR#g" > "$TMP/gate.sh"
+[ -s "$TMP/gate.sh" ] || { echo "FAILED to extract gate from generated script"; exit 1; }
+
+fails=0
+run_gate() {  # $1 = bytes already in run.log before this attempt
+  ( set -euo pipefail
+    ATTEMPT_START="$1"
+    RC=0
+    # shellcheck disable=SC1090
+    source "$TMP/gate.sh" ) >"$TMP/out" 2>&1
+  echo $?
+}
+
+check() {  # name want_rc got_rc
+  if [ "$2" = "$3" ]; then
+    printf '  PASS  %-46s (rc=%s)\n' "$1" "$3"
+  else
+    printf '  FAIL  %-46s want rc=%s got rc=%s\n' "$1" "$2" "$3"
+    sed 's/^/          /' "$TMP/out"
+    fails=$((fails + 1))
+  fi
+}
+
+L="$RUNDIR/run.log"
+
+# 1. Genuine completion, then the pod restarts and re-runs the container.
+#    THIS is the case codex caught: no _dayN.nc in the new slice.
+printf 'Saved predictions to run_day365.nc\n' > "$L"
+off=$(stat -c%s "$L")
+printf 'Resumed from checkpoint %s/testrun.ckpt at sim-day 365.0\n' "$RUNDIR" >> "$L"
+check "restart after genuine completion" 0 "$(run_gate "$off")"
+
+# 2. No-op resume: stale/foreign checkpoint behind the target, no progress.
+printf 'Saved predictions to run_day365.nc\n' > "$L"
+off=$(stat -c%s "$L")
+printf 'Resumed from checkpoint %s/testrun.ckpt at sim-day 6.0\n' "$RUNDIR" >> "$L"
+check "no-op resume from stale checkpoint" 1 "$(run_gate "$off")"
+
+# 3. Attempt produced nothing at all and never even logged a resume.
+printf 'Saved predictions to run_day365.nc\n' > "$L"
+off=$(stat -c%s "$L")
+printf 'some unrelated chatter\n' >> "$L"
+check "no output and no resume line" 1 "$(run_gate "$off")"
+
+# 4. Normal completion within this attempt.
+printf 'Resumed at sim-day 300.0\nSaved predictions to run_day365.nc\n' > "$L"
+check "normal completion" 0 "$(run_gate 0)"
+
+# 5. Evicted mid-year.
+printf 'Saved predictions to run_day120.nc\n' > "$L"
+check "evicted mid-year is incomplete" 1 "$(run_gate 0)"
+
+# 6. Health trip in THIS attempt.
+printf 'Saved predictions to run_day365.nc\natmosphere unhealthy\n' > "$L"
+check "unhealthy this attempt" 1 "$(run_gate 0)"
+
+# 7. Health trip in a PREVIOUS attempt, recovered since.
+printf 'NaN vars: 3/176\n' > "$L"
+off=$(stat -c%s "$L")
+printf 'Saved predictions to run_day365.nc\n' >> "$L"
+check "recovered-from NaN in earlier attempt" 0 "$(run_gate "$off")"
+
+if [ "$fails" -eq 0 ]; then echo "all gate tests passed"; else
+  echo "$fails gate test(s) failed"; exit 1; fi


### PR DESCRIPTION
`run.log` is append-only **across pod restarts** — deliberately, it is what
makes the eviction-resume design debuggable — but both gates in `mkrun.py`
grepped the cumulative log, so both gave the wrong verdict on a resumed run.

**Completion (silent success).** `LAST` took the max `_dayN.nc` over *all*
attempts, so an attempt that integrated nothing inherited the previous
attempt's progress and the Job was marked Complete.

Hit for real: a benchmark resumed from another preset's leftover checkpoint
at sim-day 6 with a 4-day target, integrated 0 days, exited 0. (The
underlying "should we be resuming at all" problem is added to #591; this PR
only stops the no-op being reported as success.)

**Health (fails forever).** One bad chunk from an earlier attempt that a
later attempt recovered from failed the Job on every subsequent restart.

## Change

Capture `run.log`'s byte offset before the run; grade both gates on that
slice only. An attempt with no output is no longer ambiguous:

- log shows it resumed at/past the target → genuinely finished, pod merely
  restarted → exit 0;
- otherwise → no-op, fail loudly and name the checkpoint to inspect.

## Testing

Behaviour-tested against synthetic logs — **8/8**, including reproducing
both old misverdicts:

| scenario | expected | result |
|---|---|---|
| restart after genuine completion | 0 | pass |
| no-op resume, stale ckpt behind target | 1 | pass |
| *old* cumulative grep on the same log | (silent success) | reproduced |
| normal completion | 0 | pass |
| evicted mid-year | 1 | pass |
| health trip this attempt | 1 | pass |
| recovered-from trip in earlier attempt | 0 | pass |
| *old* cumulative health grep | (fails forever) | reproduced |

Generated manifest's script passes `bash -n`; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)