### PR TITLE
fix(pyses): assembled ne30pg3 terrain bundle; guard placeholder land masks

### DIFF
--- a/.claude/skills/derecho-jcm-runs/reference/data_paths.md
+++ b/.claude/skills/derecho-jcm-runs/reference/data_paths.md
@@ -22,8 +22,11 @@ Ozone and oxidants are **level-resolved from level-independent sources**
 (FZJ vmro3 on 66 plev; WACCM L66): the `<g>_l47` and `<g>_l95` dirs both
 exist for every grid — there is no "L95-only" special case. Any config
 path also accepts `hf://bundles/...` directly (cache-first resolver;
-prefetch on a login node). `bundles/ne30pg3/sso.nc` serves the pySES
-native-terrain path. `registry.json` has sha256 for every file.
+prefetch on a login node). `bundles/ne30pg3/terrain.nc` serves the pySES
+native-terrain path (fully assembled: LANDFRAC land fraction + GLL
+orography — the raw SSO product's placeholder `lsm` made the old
+`sso.nc` an all-land trap, #596). `registry.json` has sha256 for every
+file.
 
 Era semantics: `pd` = 2005–2014 climatologies; `pi` = 1850s emissions/
 ozone/oxidants with 1870–1879 SST/ice (earliest observed decade).

--- a/.claude/skills/jcm-local-ci/SKILL.md
+++ b/.claude/skills/jcm-local-ci/SKILL.md
@@ -74,6 +74,13 @@ replying — Codex has been right (forcing unit conventions) and wrong
   August). Before believing a red local run, rerun a sample of the
   failures serially; better, don't share the node with heavy I/O jobs
   during the run.
+- **Never run two coverage suites concurrently in one worktree.**
+  pytest-cov erases `.coverage.*` at startup and combines at exit, so a
+  fast-gate run (or a stray `rm .coverage*`) deletes an overlapping
+  slow job's in-flight worker data — all its tests pass but whole
+  modules lose credit (76%, then 0.00%, on a tree whose true number
+  was 85%). Sequence the gates, or give the slow PBS job its own
+  worktree.
 - **Capture pytest's exit via `PIPESTATUS[0]`**, never `$?` after a
   `| tail` — and never pipe the slow suite through `tail` at all (a
   segfault's context ends up truncated).

--- a/docs/source/design/data_mirror.md
+++ b/docs/source/design/data_mirror.md
@@ -24,8 +24,11 @@ reads directly: `terrain.nc`, `forcing_{pi,pd}.nc`,
 `emissions_{pi,pd}.nc`, `dms.nc`, `dust.nc`, and per level count
 (`<grid>_l{47,95}/`) `ozone_{pi,pd}.nc` and `oxidants_{pi,pd}.nc`.
 Supported grids: `t63`, `t106` (Gaussian) and `ne30pg3` (native columns,
-SSO only — the pySES path interpolates the Gaussian forcing files and
-uses the native CESM CEDS emissions product).
+`terrain.nc` only — the pySES path interpolates the Gaussian forcing
+files and uses the native CESM CEDS emissions product). The ne30pg3
+`terrain.nc` is fully assembled: GMTED2010 SSO statistics, land fraction
+from the CESM topo `LANDFRAC` (SSO zeroed below 10% land), and exact
+GLL-node orography (`orog_gll` = `PHIS_gll`/g).
 
 ## Fetching at runtime
 
@@ -44,10 +47,13 @@ python -m jcm.main physics=echam-jam grid=echam_t63_l47_hybrid \
 ```
 
 The pySES backend takes the native bundle directly —
-`dycore.terrain_file=hf://bundles/ne30pg3/sso.nc` maps file columns onto
-the physics columns one-for-one (unit-sphere nearest neighbor) and takes
-GLL-node orography from the file's `orog_gll` (CESM topo `PHIS_gll`),
-replacing the old packaged-T63 downscale. The same `hf://` forcing files
+`dycore.terrain_file=hf://bundles/ne30pg3/terrain.nc` maps file columns
+onto the physics columns one-for-one (unit-sphere nearest neighbor) and
+takes GLL-node orography from the file's `orog_gll` (CESM topo
+`PHIS_gll`), replacing the old packaged-T63 downscale. (`build_terrain`
+refuses a file whose mean land fraction exceeds 0.9 — that is the
+signature of a raw SSO product's DEM-validity placeholder `lsm`, which
+would silently produce an all-land planet; see #596.) The same `hf://` forcing files
 work there too (the column loader interpolates from any regular lon/lat
 grid).
 

--- a/docs/source/design/data_mirror.md
+++ b/docs/source/design/data_mirror.md
@@ -47,10 +47,13 @@ python -m jcm.main physics=echam-jam grid=echam_t63_l47_hybrid \
 ```
 
 The pySES backend takes the native bundle directly —
-`dycore.terrain_file=hf://bundles/ne30pg3/terrain.nc` maps file columns
-onto the physics columns one-for-one (unit-sphere nearest neighbor) and
+`dycore.terrain_file=hf://bundles/ne30pg3/terrain.nc` samples the file
+cells onto the physics columns by unit-sphere nearest neighbor and
 takes GLL-node orography from the file's `orog_gll` (CESM topo
-`PHIS_gll`), replacing the old packaged-T63 downscale. (`build_terrain`
+`PHIS_gll`), replacing the old packaged-T63 downscale. The bundle keeps
+full pg3 resolution (48,600 cells) while pySES physics runs on pg2
+columns (21,600), so the dycore's column-count warning is expected and
+benign for this pairing. (`build_terrain`
 refuses a file whose mean land fraction exceeds 0.9 — that is the
 signature of a raw SSO product's DEM-validity placeholder `lsm`, which
 would silently produce an all-land planet; see #596.) The same `hf://` forcing files

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -34,6 +34,12 @@ corrections, listed here because they change climate:
   small islands retain orography).
 - PI (1850s; SST/ice = 1870–1879 mean) and PD (2005–2014) eras ship for
   every product.
+- The native ne30pg3 terrain published as ``bundles/ne30pg3/sso.nc``
+  carried a DEM-validity placeholder ``lsm`` (99.8 % land) instead of a
+  land-sea mask; it is replaced by the assembled
+  ``bundles/ne30pg3/terrain.nc`` (CESM ``LANDFRAC`` land fraction, exact
+  GLL orography), and the pySES ``build_terrain`` now rejects any
+  terrain file averaging >0.9 land as a placeholder (#596).
 
 v2.0.0b1
 --------

--- a/jcm/config/dycore/pyses_ne30l47.yaml
+++ b/jcm/config/dycore/pyses_ne30l47.yaml
@@ -40,8 +40,11 @@ compute_frontogenesis: false
 # Terrain source. Null -> the packaged T63 climatology (a downscale).
 # Preferred: the assembled native ne30pg3 terrain bundle (GMTED2010 SSO,
 # CESM LANDFRAC land fraction, exact GLL orography from the topo
-# product's PHIS_gll), used column-for-column —
+# product's PHIS_gll) —
 #   terrain_file: hf://bundles/ne30pg3/terrain.nc
+# The bundle keeps full pg3 resolution (48,600 cells); pySES's pg2
+# physics columns (21,600) nearest-neighbor sample it, so the logged
+# column-count warning is expected and benign here.
 # Regular lon/lat jcm-canonical terrain files also work (bilinearly
 # interpolated onto the columns). hf:// paths resolve via jcm.data.remote.
 terrain_file: null

--- a/jcm/config/dycore/pyses_ne30l47.yaml
+++ b/jcm/config/dycore/pyses_ne30l47.yaml
@@ -38,9 +38,10 @@ tracer_substeps: 5
 dyn_substeps_per_tracer: -1
 compute_frontogenesis: false
 # Terrain source. Null -> the packaged T63 climatology (a downscale).
-# Preferred: the native ne30pg3 GMTED2010 SSO bundle, used column-for-column
-# with exact GLL orography from the CESM topo product —
-#   terrain_file: hf://bundles/ne30pg3/sso.nc
+# Preferred: the assembled native ne30pg3 terrain bundle (GMTED2010 SSO,
+# CESM LANDFRAC land fraction, exact GLL orography from the topo
+# product's PHIS_gll), used column-for-column —
+#   terrain_file: hf://bundles/ne30pg3/terrain.nc
 # Regular lon/lat jcm-canonical terrain files also work (bilinearly
 # interpolated onto the columns). hf:// paths resolve via jcm.data.remote.
 terrain_file: null

--- a/jcm/data/mirror/build_mirror.py
+++ b/jcm/data/mirror/build_mirror.py
@@ -189,7 +189,11 @@ def stage_bundles() -> None:
 
     d = UPLOAD / "bundles" / "ne30pg3"
     d.mkdir(parents=True, exist_ok=True)
-    shutil.copy(BUILD / "sso" / "sso_gmted2010_ne30pg3.nc", d / "sso.nc")
+    # terrain.nc, matching the Gaussian bundles: the file is the fully
+    # assembled terrain (LANDFRAC lsm + orog_gll), and the old sso.nc
+    # name invited grabbing a raw SSO product instead (#596)
+    shutil.copy(BUILD / "sso" / "sso_gmted2010_ne30pg3.nc",
+                d / "terrain.nc")
     print("bundles: done", flush=True)
 
 

--- a/jcm/data/mirror/build_mirror.py
+++ b/jcm/data/mirror/build_mirror.py
@@ -194,6 +194,9 @@ def stage_bundles() -> None:
     # name invited grabbing a raw SSO product instead (#596)
     shutil.copy(BUILD / "sso" / "sso_gmted2010_ne30pg3.nc",
                 d / "terrain.nc")
+    # a rerun over a pre-#596 upload tree must not re-register the trap
+    # file under its old name
+    (d / "sso.nc").unlink(missing_ok=True)
     print("bundles: done", flush=True)
 
 

--- a/jcm/dycore/pyses/dycore.py
+++ b/jcm/dycore/pyses/dycore.py
@@ -498,7 +498,7 @@ class PysesCamSEDycore(DynamicalCore):
                 unit_sphere_vectors as _unit)
 
             if "ncol" in ds.dims:
-                # Native unstructured file (e.g. bundles/ne30pg3/sso.nc):
+                # Native unstructured file (e.g. bundles/ne30pg3/terrain.nc):
                 # map each model column to the nearest file column on the
                 # unit sphere — the identity up to ordering when the file
                 # is on the same grid, with no interpolation smoothing.
@@ -540,6 +540,17 @@ class PysesCamSEDycore(DynamicalCore):
 
             orog_col = np.maximum(sample("orog", col_lon, col_lat), 0.0)
             fmask_col = np.clip(sample("lsm", col_lon, col_lat), 0.0, 1.0)
+            # >90% land is almost certainly a DEM-validity placeholder
+            # (raw SSO products mark ~all pixels valid), not a land-sea
+            # mask — refuse rather than silently run an all-land planet
+            # (#596)
+            if fmask_col.mean() > 0.9:
+                raise ValueError(
+                    f"terrain file {source_file}: 'lsm' averages "
+                    f"{fmask_col.mean():.2f} land — this looks like a "
+                    "DEM-validity placeholder from a raw SSO product, "
+                    "not a land-sea mask. Use an assembled terrain "
+                    "bundle (e.g. hf://bundles/ne30pg3/terrain.nc).")
             sso_col = {}
             for name in _SSO_NAMES:
                 vals = sample(name, col_lon, col_lat)

--- a/jcm/dycore/pyses/pyses_dycore_test.py
+++ b/jcm/dycore/pyses/pyses_dycore_test.py
@@ -170,7 +170,7 @@ class TestPysesDycoreProtocol(unittest.TestCase):
         orog = 100.0 + np.abs(col_lat)                  # distinct per column
         ds = xr.Dataset(
             {"orog": ("ncol", orog),
-             "lsm": ("ncol", np.ones_like(orog)),
+             "lsm": ("ncol", np.full_like(orog, 0.3)),
              **{name: ("ncol", np.full_like(orog, 0.25))
                 for name in ("orostd", "orosig", "orogam", "orothe",
                              "oropic", "oroval")},
@@ -186,10 +186,18 @@ class TestPysesDycoreProtocol(unittest.TestCase):
             np.testing.assert_allclose(
                 np.asarray(terrain.orog).reshape(-1), orog, rtol=1e-5)
             np.testing.assert_allclose(
+                np.asarray(terrain.fmask).reshape(-1), 0.3, rtol=1e-5)
+            np.testing.assert_allclose(
                 np.asarray(terrain.orosig).reshape(-1), 0.25, rtol=1e-5)
             np.testing.assert_allclose(
                 np.asarray(dc._orog_gll).reshape(-1),
                 50.0 + np.abs(gll_lat), rtol=1e-5)
+            # a ~all-land lsm is a DEM-validity placeholder, not a mask —
+            # build_terrain must refuse it rather than clip (#596)
+            with tempfile.NamedTemporaryFile(suffix=".nc") as f:
+                ds.assign(lsm=("ncol", np.ones_like(orog))).to_netcdf(f.name)
+                with self.assertRaisesRegex(ValueError, "placeholder"):
+                    dc.build_terrain(source_file=f.name)
         finally:
             # build_terrain mutates dycore caches by documented design —
             # restore the class fixture's real-geography terrain

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -191,14 +191,10 @@ def _pyses_preset(levels: int) -> list[str]:
       because composing a config is not the same as building the model.)
     * no TERRAIN override — pySES bilinearly interpolates the packaged T63
       field onto its columns, so the horizontal grid need not match. The
-      mirror's native ``hf://bundles/ne30pg3/sso.nc`` is deliberately NOT
-      used despite the dycore config recommending it: its ``lsm`` is the
-      DEM-validity placeholder its own attrs warn about (mean 0.998, against
-      a true land fraction of ~0.335 in ``bundles/t63/terrain.nc``), so it
-      would run an essentially all-land planet — silently, since the dycore
-      just clips it to [0, 1]. It also lacks the ``orog_gll`` the same
-      comment promises. See jax-gcm#596; revisit once an assembled bundle
-      exists.
+      assembled native ``hf://bundles/ne30pg3/terrain.nc`` (real LANDFRAC
+      land fraction + exact GLL orography; the fix for jax-gcm#596) is
+      deliberately not used here so the sweep stays comparable with the
+      validated 2026-07 campaign, which ran on the packaged T63 downscale.
     * but ozone IS still level-validated. "Column sampling has no exact-grid
       requirement" covers the HORIZONTAL grid only — an L47 ozone file is
       rejected by an L95 run whatever the backend. L95 therefore needs the


### PR DESCRIPTION
Fixes #596.

## Root cause

The correctly assembled ne30pg3 terrain file (CESM `LANDFRAC` land fraction, SSO zeroed below 10% land, exact `PHIS_gll`/g GLL orography) has existed in the mirror build tree since the `stage_sso` upgrade — but the bundles staging step was never rerun after that rebuild, so the file that reached the mirror as `bundles/ne30pg3/sso.nc` was an earlier raw Tier-A SSO product whose `lsm` is a DEM-validity placeholder (mean 0.998) and which lacks `orog_gll`.

## Changes

- **`build_mirror.stage_bundles`** now stages the ne30pg3 file as **`terrain.nc`**, matching the Gaussian bundles — the `sso.nc` name was itself part of the trap.
- **`PysesCamSEDycore.build_terrain` refuses** any terrain file whose mean land fraction exceeds 0.9 with a pointed error, instead of clipping and silently running an all-land planet.
- **`pyses_ne30l47.yaml`** comment now recommends `hf://bundles/ne30pg3/terrain.nc`; `tools/benchmark.py` and the skill `data_paths.md` notes updated to the post-fix state.
- Native-columns dycore test now asserts `fmask` round-trip and that a placeholder (all-land) `lsm` raises; release notes + `data_mirror.md` updated.

## Validation of the assembled file (build tree)

- `lsm` ≡ `clip(LANDFRAC, 0, 1)` exactly (mean 0.286 vs the trap file's 0.998)
- `orog_gll` ≡ `PHIS_gll`/9.80665 exactly (48,602 GLL nodes)
- SSO fields exactly 0 over <10% land columns; column orography r = 0.99 vs CESM topo

## Mirror publication status

The upload tree is restaged (`terrain.nc` in, `sso.nc` removed, `registry.json` rebuilt — 44,454 entries) but **not yet pushed to HF**: the publish (which includes deleting the live `sso.nc`) is held for explicit approval. One atomic commit is prepared.

## Local CI (Actions quota exhausted)

- lint: `ruff check .` clean
- fast gate (develop node, `-n 12`): 1568 passed, coverage 94% ≥ 90%
- slow gate (develop node, `-n 4`): 78 passed, coverage 85% ≥ 80% (dev baseline measured at the same 85%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EYsAZJeaPcP2DAzzxtXRN