### PR TITLE
feat(aerocom): the remaining phase-4 components — aerosol-free radiation, 3-hourly snapshots, near-surface diagnostics, deposition fluxes

### DIFF
--- a/jcm/config/physics/echam-jam-aerocom.yaml
+++ b/jcm/config/physics/echam-jam-aerocom.yaml
@@ -42,10 +42,14 @@ enable_aerocom: true
 # column: water-vapour path, column number, albedo
 # plev: winds on pressure surfaces + LTS
 # aerosol: per-species burdens + N70/N100/PM1/PM10 (needs the JAM module)
-aerocom_groups: [cloud, column, plev, aerosol]
+aerocom_groups: [cloud, column, plev, aerosol, nearsurface]
 # Should match the radiation scheme's overlap assumption.
 aerocom_overlap: maximum-random
 
 # Per-species / per-mode / spectral aerosol optics (jax-gcm#584). Off here;
 # see echam-jam-aerocom-optics.yaml.
 aerocom_optics: false
+# Second aerosol-free radiation solve for the *noa TOA fluxes (#583).
+# Doubles radiation cost on compute steps — the AeroCom experiments ask
+# for it (ERFari), so it is on here; turn off for non-submission runs.
+aerosol_free_radiation: true

--- a/jcm/config/run/default.yaml
+++ b/jcm/config/run/default.yaml
@@ -20,6 +20,15 @@ sponge:
 chunk_days: 0
 output_prefix: chunked_run
 
+# Interval-instantaneous snapshot stream (jax-gcm#586): with
+# ``output_averages: true``, sample the listed 2-D diagnostics
+# instantaneously every ``snapshot_interval`` (days; must divide
+# save_interval) alongside the interval means. Written to
+# ``<output stem>_snapshots.nc``. Fields are top-level diagnostics keys
+# or dotted struct fields, e.g. [aerocom_clt, "radiation.toa_sw_up"].
+snapshot_interval: null
+snapshot_variables: []
+
 # Checkpointing for preemptible chunked runs. When set, the model state
 # (modal + physics carry) and elapsed sim-day count are saved to this
 # path after each chunk; if the file already exists at startup the run

--- a/jcm/model.py
+++ b/jcm/model.py
@@ -127,6 +127,8 @@ def _op_split_trajectory(
     output_averages: bool = False,
     observe_fn: Callable[[Any, Any], Any] | None = None,
     observer_xs: Any = None,
+    snapshot_stride: int = 0,
+    snapshot_fields: tuple[str, ...] = (),
 ) -> Callable[[Any], tuple[Any, Any, Any, Any]]:
     """Trajectory builder for the operator-split path.
 
@@ -189,6 +191,43 @@ def _op_split_trajectory(
     # ``(x_final, ps_final, preds)`` return are identical, so define them
     # once.
     have_observers = observe_fn is not None
+    # Interval-instantaneous snapshots of selected 2-D diagnostics
+    # (AeroCom 3-hourly output, jax-gcm#586): a strided buffer rides the
+    # inner-scan carry — the scan's ys are structurally one-per-step, so a
+    # cheaper cadence has to accumulate in the carry exactly the way the
+    # interval mean does. Averaged mode only: the snapshot cadence divides
+    # the save interval, and the snapshot-mode path IS already
+    # instantaneous at its own cadence.
+    have_snapshots = snapshot_stride > 0 and len(snapshot_fields) > 0
+    if have_snapshots:
+        if not output_averages:
+            raise ValueError(
+                "snapshot_fields need output_averages=True; the snapshot "
+                "path is already instantaneous at save_interval.")
+        if inner_steps % snapshot_stride:
+            raise ValueError(
+                f"snapshot stride {snapshot_stride} must divide the "
+                f"{inner_steps} inner steps per save interval.")
+        n_snaps = inner_steps // snapshot_stride
+
+        def _resolve_snap(diag, name):
+            if "." in name:
+                head, _, attr = name.partition(".")
+                return getattr(diag[head], attr)
+            return diag[name]
+
+        empty_snaps = {}
+        for name in snapshot_fields:
+            tmpl = _resolve_snap(empty_diagnostics, name)
+            # Horizontal-only fields: flat (ncols,) under vectorized
+            # physics, (nlon, nlat) under grid-layout physics (SPEEDY).
+            if tmpl.ndim not in (1, 2):
+                raise ValueError(
+                    f"snapshot field {name!r} has shape {tmpl.shape}; only "
+                    "2-D horizontal fields are snapshot-able — 3-D fields "
+                    "at 3-hourly cadence belong in a dedicated run.")
+            empty_snaps[name] = jnp.zeros(
+                (n_snaps,) + tmpl.shape, dtype=jnp.result_type(tmpl.dtype, jnp.float32))
 
     # The saved-trajectory physics payload must not carry the per-step
     # ``_sampler_state`` snapshot (state fields the StateSampler term
@@ -203,8 +242,9 @@ def _op_split_trajectory(
 
     def _averaged_outer_step():
         @jax.checkpoint
-        def inner_step(carry, obs_x):
-            x, physics_state, x_sum, diag_sum = carry
+        def inner_step(carry, xs):
+            i_inner, obs_x = xs
+            x, physics_state, x_sum, diag_sum, snaps = carry
             x_next, physics_state_next = step_fn(x, physics_state)
             # Sum POST-step states so that mean(state_1..state_N) matches the
             # snapshot path (which saves state_N at outer steps). Summing
@@ -218,18 +258,34 @@ def _op_split_trajectory(
                 diag_sum, physics_state_next,
             )
             obs = observe_fn(physics_state_next, obs_x) if have_observers else None
-            return (x_next, physics_state_next, x_sum, diag_sum), obs
+            if have_snapshots:
+                # Write the POST-step instantaneous value into its slot on
+                # stride boundaries; off-stride steps rewrite the slot with
+                # its own value (a no-op) so the carry stays branch-free.
+                is_snap = ((i_inner + 1) % snapshot_stride) == 0
+                idx = jnp.clip((i_inner + 1) // snapshot_stride - 1,
+                               0, n_snaps - 1)
+                new_snaps = {}
+                for name in snapshot_fields:
+                    val = _resolve_snap(physics_state_next, name).astype(
+                        snaps[name].dtype)
+                    slot = jnp.where(is_snap, val, snaps[name][idx])
+                    new_snaps[name] = snaps[name].at[idx].set(slot)
+                snaps = new_snaps
+            return (x_next, physics_state_next, x_sum, diag_sum, snaps), obs
 
         def outer_step(carry, obs_x_frame, empty_sum, empty_diag_sum):
             x, physics_state = carry
-            init = (x, physics_state, empty_sum, empty_diag_sum)
-            (x_next, ps_next, x_sum, diag_sum), obs = jax.lax.scan(
-                inner_step, init, obs_x_frame, length=inner_steps,
+            init = (x, physics_state, empty_sum, empty_diag_sum,
+                    empty_snaps if have_snapshots else {})
+            inner_xs = (jnp.arange(inner_steps), obs_x_frame)
+            (x_next, ps_next, x_sum, diag_sum, snaps), obs = jax.lax.scan(
+                inner_step, init, inner_xs, length=inner_steps,
             )
             averaged_state = tree_map(lambda s: s / inner_steps, x_sum)
             preds = post_process_fn(averaged_state, ps_next)
             preds = preds.replace(physics=_strip_sampler(diag_sum))
-            return (x_next, ps_next), (preds, obs)
+            return (x_next, ps_next), (preds, obs, snaps)
 
         return outer_step
 
@@ -252,7 +308,7 @@ def _op_split_trajectory(
             # save time with a freshly-seeded carry would zero out radiation
             # on non-radiation outer steps (default 2-hour
             # ``radiation_interval``).
-            return (x_final, ps_final), (post_process_fn(x_final, ps_final), obs)
+            return (x_final, ps_final), (post_process_fn(x_final, ps_final), obs, {})
 
         return outer_step
 
@@ -287,7 +343,7 @@ def _op_split_trajectory(
                 observer_xs,
             )
 
-        (x_final, ps_final), (preds, observations) = jax.lax.scan(
+        (x_final, ps_final), (preds, observations, snapshots) = jax.lax.scan(
             outer_step,
             (x_initial, initial_physics_state),
             scan_xs, length=outer_steps,
@@ -297,7 +353,12 @@ def _op_split_trajectory(
             observations = tree_map(
                 lambda a: a.reshape((-1,) + a.shape[2:]), observations,
             )
-        return x_final, ps_final, preds, observations
+        if have_snapshots:
+            # (outer, n_snaps, ...) -> (total_snaps, ...).
+            snapshots = tree_map(
+                lambda a: a.reshape((-1,) + a.shape[2:]), snapshots,
+            )
+        return x_final, ps_final, preds, observations, snapshots
 
     return integrate
 
@@ -742,6 +803,8 @@ class Model:
         post_process_fn,
         output_averages,
         observer_xs=(),
+        snapshot_stride=0,
+        snapshot_fields=(),
     ):
         """Integrate-fn builder for the operator-split path.
 
@@ -786,12 +849,14 @@ class Model:
                 output_averages=output_averages,
                 observe_fn=observe_fn,
                 observer_xs=observer_xs if self.observers else None,
+                snapshot_stride=snapshot_stride,
+                snapshot_fields=snapshot_fields,
             )
             return trajectory(state)
 
         return _integrate_fn
 
-    @partial(jax.jit, static_argnums=(0, 4, 5, 6))  # Note: changing fields assumed static won't propagate.
+    @partial(jax.jit, static_argnums=(0, 4, 5, 6, 8, 9))  # Note: changing fields assumed static won't propagate.
     def _run_from_state(self,
                         initial_state,
                         initial_physics_state: Any,
@@ -800,6 +865,8 @@ class Model:
                         total_time=120.0,
                         output_averages=False,
                         observer_xs=(),
+                        snapshot_stride=0,
+                        snapshot_fields=(),
     ):
         """JIT-compiled simulation loop. Returns raw :class:`Predictions` pytree.
 
@@ -832,13 +899,14 @@ class Model:
             ),
             output_averages=output_averages,
             observer_xs=observer_xs,
+            snapshot_stride=snapshot_stride,
+            snapshot_fields=snapshot_fields,
         )
-        final_dycore_state, final_physics_state, predictions, observations = (
-            integrate(initial_state, initial_physics_state)
-        )
+        (final_dycore_state, final_physics_state, predictions, observations,
+         snapshots) = integrate(initial_state, initial_physics_state)
 
         return (final_dycore_state, final_physics_state,
-                predictions.replace(times=times), observations)
+                predictions.replace(times=times), observations, snapshots)
 
     def run_from_state(self,
                        initial_state,
@@ -889,10 +957,32 @@ class Model:
                                   total_time=120.0,
                                   output_averages=False,
                                   initial_physics_state: Any = None,
+                                  snapshot_interval=None,
+                                  snapshot_variables=(),
     ):
-        """Lower-level ``run_from_state`` that exposes the cross-step physics carry."""
+        """Lower-level ``run_from_state`` that exposes the cross-step physics carry.
+
+        ``snapshot_interval`` / ``snapshot_variables`` (jax-gcm#586) add an
+        interval-INSTANTANEOUS output stream of selected 2-D diagnostics
+        alongside the interval-mean fields: e.g. 3-hourly ``clt``/``lwp``
+        snapshots riding a monthly-mean AeroCom run. Averaged mode only;
+        the snapshot interval must divide ``save_interval``. Fields are
+        top-level diagnostics keys or dotted struct fields
+        (``"radiation.toa_sw_up"``); retrieve the stream with
+        :meth:`ModelPredictions.snapshot_dataset`.
+        """
         save_interval_days = parse_duration_days(save_interval, calendar=self.calendar)
         total_time_days = parse_duration_days(total_time, calendar=self.calendar)
+        snapshot_stride = 0
+        if snapshot_interval is not None and snapshot_variables:
+            snap_days = parse_duration_days(snapshot_interval,
+                                            calendar=self.calendar)
+            dt_days = self.dt_si.to(units.day).m
+            snapshot_stride = int(round(snap_days / dt_days))
+            if abs(snapshot_stride * dt_days - snap_days) > 1e-9:
+                raise ValueError(
+                    f"snapshot_interval {snapshot_interval!r} is not a "
+                    f"multiple of the model timestep ({self.dt_si.m} s).")
         if initial_physics_state is None:
             initial_physics_state = self._build_initial_physics_carry()
 
@@ -918,12 +1008,12 @@ class Model:
                 for obs in self.observers
             )
 
-        final_dycore_state, final_physics_state, predictions, observations = (
-            self._run_from_state(
+        (final_dycore_state, final_physics_state, predictions, observations,
+         snapshots) = self._run_from_state(
                 initial_state, initial_physics_state, forcing,
                 save_interval_days, total_time_days,
                 output_averages, observer_xs,
-            )
+                snapshot_stride, tuple(snapshot_variables),
         )
         return (
             final_dycore_state,
@@ -935,6 +1025,11 @@ class Model:
                 observers=self.observers,
                 obs_t0_days=obs_t0_days,
                 obs_dt_seconds=float(self.dt_si.m),
+                snapshots=snapshots,
+                snapshot_variables=tuple(snapshot_variables),
+                snapshot_interval_days=(
+                    snapshot_stride * self.dt_si.to(units.day).m
+                    if snapshot_stride else None),
             ),
         )
 
@@ -943,6 +1038,8 @@ class Model:
                save_interval=10.0,
                total_time=120.0,
                output_averages=False,
+               snapshot_interval=None,
+               snapshot_variables=(),
     ) -> ModelPredictions:
         """Continue from end of previous ``run`` / ``resume``.
 
@@ -965,6 +1062,8 @@ class Model:
             total_time=total_time,
             output_averages=output_averages,
             initial_physics_state=self._final_physics_state,
+            snapshot_interval=snapshot_interval,
+            snapshot_variables=snapshot_variables,
         )
         jax.debug.callback(lambda: logger.info("Run completed."))
         self._final_dycore_state = final_dycore_state
@@ -977,6 +1076,8 @@ class Model:
             save_interval=10.0,
             total_time=120.0,
             output_averages=False,
+            snapshot_interval=None,
+            snapshot_variables=(),
     ) -> ModelPredictions:
         """Set the initial state and run the full simulation forward in time.
 
@@ -991,6 +1092,8 @@ class Model:
         return self.resume(
             forcing=forcing, save_interval=save_interval,
             total_time=total_time, output_averages=output_averages,
+            snapshot_interval=snapshot_interval,
+            snapshot_variables=snapshot_variables,
         )
 
     def bootstrap_state(self, initial_state=None) -> None:

--- a/jcm/physics/aerosol/jam/emissions/anthropogenic.py
+++ b/jcm/physics/aerosol/jam/emissions/anthropogenic.py
@@ -149,6 +149,7 @@ class AnthropogenicEmissions(PhysicsTerm):
             add_mass(number_name(mode.short),
                      flux2d * mode.number_factor / density, weights)
 
+        emi_bb: dict[str, jnp.ndarray] = {}
         for i, sector in enumerate(SUPER_SECTORS):
             weights = gaussian_injection_weights(
                 height_full, dz,
@@ -169,6 +170,10 @@ class AnthropogenicEmissions(PhysicsTerm):
 
             # Primary carbonaceous mass → the population's primary-carbon
             # class(es); OC scaled to POA by OM:OC.
+            if sector == "biomass_burning":
+                # MMPPE emi_bb_*: the open-burning fluxes as emitted
+                # (SO2 as SO2, OC as OC), before speciation/OM scaling.
+                emi_bb = {"so2": so2, "bc": bc, "oc": oc}
             for mode, mode_frac in self._spec.primary_split("bc"):
                 add_aerosol("bc", mode, bc * mode_frac, weights)
             for mode, mode_frac in self._spec.primary_split("poa"):
@@ -187,5 +192,10 @@ class AnthropogenicEmissions(PhysicsTerm):
             diagnostics, tends,
             diagnostics["air_density"],
             diagnostics["layer_thickness"])
+        # Biomass-burning splits ride the same reset-per-step keys.
+        for spc, flux in emi_bb.items():
+            key = f"emi_bb_{spc}"
+            diagnostics = {**diagnostics,
+                           key: diagnostics.get(key, 0.0) + flux}
 
         return tendency, diagnostics

--- a/jcm/physics/aerosol/jam/emissions/flux_diagnostic.py
+++ b/jcm/physics/aerosol/jam/emissions/flux_diagnostic.py
@@ -33,6 +33,21 @@ EMITTED_SPECIES: tuple[str, ...] = (
     "so2", "so4", "bc", "oc", "poa", "soa", "ss", "du", "moa", "dms",
 )
 
+# Biomass-burning splits (MMPPE ``emi_bb_*``): the raw open-burning
+# surface fluxes, recorded by the anthropogenic term for its
+# ``biomass_burning`` super-sector before speciation (SO2 as SO2, OC as
+# OC). Reset with the rest each step.
+BB_SPECIES: tuple[str, ...] = ("so2", "bc", "oc")
+
+# Deposition fluxes (AeroCom ``dry_*`` / ``wet_*``): column-integrated
+# REMOVAL by the sedimentation and wet-scavenging terms, positive
+# downward. Turbulent surface dry deposition is not a separate term in
+# JAM yet; ``dry_*`` is therefore the sedimentation sink alone —
+# documented so the budget check reads correctly.
+DEPOSITED_SPECIES: tuple[str, ...] = (
+    "so4", "bc", "oc", "poa", "soa", "ss", "du", "moa",
+)
+
 
 def _species_of(tracer_name: str) -> str | None:
     """Species a tracer name belongs to, or None if it is not aerosol mass.
@@ -95,8 +110,63 @@ def accumulate_emission_fluxes(
 
 
 def emission_flux_keys() -> tuple[str, ...]:
-    """Return the diagnostics keys :func:`accumulate_emission_fluxes` publishes."""
+    """Return the keys :func:`accumulate_emission_fluxes` publishes."""
     return tuple(f"emi_{s}" for s in EMITTED_SPECIES)
+
+
+def all_flux_keys() -> tuple[str, ...]:
+    """Every per-step-reset flux key any helper in this module publishes.
+
+    The reset term zeroes the whole family — emissions, biomass-burning
+    splits and both deposition kinds — because all of them accumulate
+    additively within a step and would otherwise integrate across steps
+    via the threaded-back diagnostics dict.
+    """
+    return (emission_flux_keys()
+            + tuple(f"emi_bb_{s}" for s in BB_SPECIES)
+            + tuple(f"dry_{s}" for s in DEPOSITED_SPECIES)
+            + tuple(f"wet_{s}" for s in DEPOSITED_SPECIES))
+
+
+def accumulate_deposition_fluxes(
+    diagnostics: dict,
+    tracer_tendencies: dict,
+    air_density: jnp.ndarray,
+    layer_thickness: jnp.ndarray,
+    kind: str,
+) -> dict:
+    """Add a removal term's per-species deposition fluxes to ``diagnostics``.
+
+    Mirrors :func:`accumulate_emission_fluxes` with the sign flipped:
+    deposition tendencies are negative, the reported flux is the
+    column-integrated mass REMOVED per unit area and time (positive
+    down). ``kind`` selects the ``dry_`` (sedimentation) or ``wet_``
+    (scavenging) family. Same additive/reset semantics as the emission
+    keys — several terms may remove the same species.
+    """
+    if kind not in ("dry", "wet"):
+        raise ValueError(f"kind must be 'dry' or 'wet'; got {kind!r}")
+    dm = air_density * layer_thickness
+    horiz = dm.shape[1:]
+    dtype = dm.dtype
+
+    totals: dict[str, jnp.ndarray] = {}
+    for name, tend in tracer_tendencies.items():
+        species = _species_of(name)
+        if species is None or species not in DEPOSITED_SPECIES:
+            continue
+        if jnp.ndim(tend) < 1:
+            continue
+        totals[species] = totals.get(species, 0.0) - jnp.sum(tend * dm, axis=0)
+
+    out = dict(diagnostics)
+    for species in DEPOSITED_SPECIES:
+        key = f"{kind}_{species}"
+        prev = out.get(key)
+        if prev is None:
+            prev = jnp.zeros(horiz, dtype=dtype)
+        out[key] = prev + totals.get(species, jnp.zeros(horiz, dtype=dtype))
+    return out
 
 
 class ResetEmissionFluxes(PhysicsTerm):
@@ -119,12 +189,12 @@ class ResetEmissionFluxes(PhysicsTerm):
     # emissions block, not a separate stage.
     category: ClassVar[str] = "aerosol_emissions"
     requires: ClassVar[tuple[str, ...]] = ()
-    provides: ClassVar[tuple[str, ...]] = emission_flux_keys()
+    provides: ClassVar[tuple[str, ...]] = all_flux_keys()
 
     def __call__(self, state, diagnostics, forcing, terrain):
         zero = jnp.zeros(state.temperature.shape[1:],
                          dtype=state.temperature.dtype)
         return (PhysicsTendency.zeros(state.temperature.shape),
-                {**diagnostics, **{k: zero for k in emission_flux_keys()}})
+                {**diagnostics, **{k: zero for k in all_flux_keys()}})
 
 

--- a/jcm/physics/aerosol/jam/sedimentation/sedi_term.py
+++ b/jcm/physics/aerosol/jam/sedimentation/sedi_term.py
@@ -174,4 +174,12 @@ class StokesSedimentation(PhysicsTerm):
             specific_humidity=jnp.zeros_like(state.specific_humidity),
             tracers=tracer_tends,
         )
+        # AeroCom deposition fluxes (jax-gcm#581): this term's removal,
+        # column-integrated, accumulated onto the per-step-reset keys.
+        from jcm.physics.aerosol.jam.emissions.flux_diagnostic import (
+            accumulate_deposition_fluxes)
+        diagnostics = accumulate_deposition_fluxes(
+            diagnostics, tracer_tends,
+            diagnostics["air_density"], diagnostics["layer_thickness"],
+            kind="dry")
         return tendency, diagnostics

--- a/jcm/physics/aerosol/jam/wetdep/wetdep_term.py
+++ b/jcm/physics/aerosol/jam/wetdep/wetdep_term.py
@@ -263,4 +263,12 @@ class WetScavenging(PhysicsTerm):
             specific_humidity=jnp.zeros_like(state.specific_humidity),
             tracers=tracer_tends,
         )
+        # AeroCom deposition fluxes (jax-gcm#581): this term's removal,
+        # column-integrated, accumulated onto the per-step-reset keys.
+        from jcm.physics.aerosol.jam.emissions.flux_diagnostic import (
+            accumulate_deposition_fluxes)
+        diagnostics = accumulate_deposition_fluxes(
+            diagnostics, tracer_tends,
+            diagnostics["air_density"], diagnostics["layer_thickness"],
+            kind="wet")
         return tendency, diagnostics

--- a/jcm/physics/clouds/echam_1m.py
+++ b/jcm/physics/clouds/echam_1m.py
@@ -1189,7 +1189,9 @@ class Echam1MMicrophysics(PhysicsTerm):
         "pressure_full", "air_density", "layer_thickness",
         "clouds", "aerosol",
     )
-    provides: ClassVar[tuple[str, ...]] = ("clouds",)
+    provides: ClassVar[tuple[str, ...]] = (
+        "autoconv", "accretn", "wbf", "clouds",
+    )
 
     def __init__(self, params: MicrophysicsParameters | None = None):
         """Hold the scheme-native :class:`MicrophysicsParameters`."""
@@ -1286,6 +1288,21 @@ class Echam1MMicrophysics(PhysicsTerm):
                 "qi": micro_tend.dqidt.T,
             },
         )
+
+        # AeroCom process rates (jax-gcm#585 acceptance: both schemes,
+        # zero where a pathway is absent). The 1M scan folds accretion
+        # into its combined warm-rain sink and has no explicit
+        # Wegener-Bergeron-Findeisen transfer, so only autoconversion is
+        # nonzero here; the keys are still published so the diagnostic
+        # set is scheme-independent. autoconv_rate is the grid-mean
+        # in-cloud conversion [kg/kg/s]; dp-weighting gives kg/m^2/s.
+        # air_density/layer_thickness are (nlev, ncols); the vmapped
+        # micro_state fields are (ncols, nlev) — transpose the mass weight.
+        dm_col = (air_density * layer_thickness).T
+        autoconv_col = jnp.sum(micro_state.autoconv_rate * dm_col, axis=-1)
+        zero_col = jnp.zeros_like(autoconv_col)
+        diagnostics = {**diagnostics, "autoconv": autoconv_col,
+                       "accretn": zero_col, "wbf": zero_col}
 
         clouds = clouds.copy(
             precip_rain=micro_state.precip_rain,

--- a/jcm/physics/clouds/echam_1m.py
+++ b/jcm/physics/clouds/echam_1m.py
@@ -1094,6 +1094,11 @@ def cloud_microphysics_column_sweep(
         # (kg/kg over dt). Convert to a grid-mean rate (kg/kg/s) for
         # the public ``autoconv_rate`` diagnostic.
         autoconv_rate_diag = cf * zraut / dt
+        # Accretion likewise (Codex on PR #604: the sweep computes zrac1
+        # and, when cauloc > 0, zrac2 — reporting zero misstated an
+        # active pathway). Weights follow the rain-source ledger:
+        # zrpr = cf(zraut + zrac2) + zclcstar·zrac1.
+        accretion_rate_diag = (cf * zrac2 + zclcstar * zrac1) / dt
         # Per-level flux profiles for downstream (COSP/CloudSat)
         # diagnostics: the rain / frozen fluxes LEAVING this layer. The
         # frozen flux adds the sedimenting cloud-ice carry ``zxiflux_out``
@@ -1103,7 +1108,8 @@ def cloud_microphysics_column_sweep(
         # exactly.
         out = (
             dTdt, dqdt, dqcdt, dqidt, rain_source, snow_source,
-            autoconv_rate_diag, zrfl_out, zsfl_out + zxiflux_out,
+            autoconv_rate_diag, accretion_rate_diag,
+            zrfl_out, zsfl_out + zxiflux_out,
         )
         return (zrfl_out, zsfl_out, zclcpre_out, zxiflux_out), out
 
@@ -1120,7 +1126,7 @@ def cloud_microphysics_column_sweep(
         level_inputs,
     )
     (dtedt, dqdt, dqcdt, dqidt, rain_source, snow_source, autoconv_rate,
-     rain_flux, snow_flux) = per_level_out
+     accretion_rate, rain_flux, snow_flux) = per_level_out
 
     tendencies = MicrophysicsTendencies(
         dtedt=dtedt, dqdt=dqdt, dqcdt=dqcdt, dqidt=dqidt,
@@ -1142,7 +1148,7 @@ def cloud_microphysics_column_sweep(
         rain_flux=rain_flux, snow_flux=snow_flux,
         rain_source=rain_source, snow_source=snow_source,
         qc_in_cloud=qc_in_cloud, qi_in_cloud=qi_in_cloud,
-        autoconv_rate=autoconv_rate, accretion_rate=jnp.zeros(nlev),
+        autoconv_rate=autoconv_rate, accretion_rate=accretion_rate,
         melting_rate=jnp.zeros(nlev), freezing_rate=jnp.zeros(nlev),
         precip_rain=zrfl_surface, precip_snow=zsfl_surface,
     )
@@ -1290,19 +1296,19 @@ class Echam1MMicrophysics(PhysicsTerm):
         )
 
         # AeroCom process rates (jax-gcm#585 acceptance: both schemes,
-        # zero where a pathway is absent). The 1M scan folds accretion
-        # into its combined warm-rain sink and has no explicit
-        # Wegener-Bergeron-Findeisen transfer, so only autoconversion is
-        # nonzero here; the keys are still published so the diagnostic
-        # set is scheme-independent. autoconv_rate is the grid-mean
-        # in-cloud conversion [kg/kg/s]; dp-weighting gives kg/m^2/s.
+        # zero where a pathway is absent). Autoconversion and accretion
+        # come from the sweep's own per-level rates (grid-mean kg/kg/s,
+        # dp-weighted to kg/m^2/s); WBF stays zero — the 1M scheme has
+        # no explicit Wegener-Bergeron-Findeisen transfer — and the key
+        # is still published so the diagnostic set is scheme-independent.
         # air_density/layer_thickness are (nlev, ncols); the vmapped
         # micro_state fields are (ncols, nlev) — transpose the mass weight.
         dm_col = (air_density * layer_thickness).T
         autoconv_col = jnp.sum(micro_state.autoconv_rate * dm_col, axis=-1)
+        accretn_col = jnp.sum(micro_state.accretion_rate * dm_col, axis=-1)
         zero_col = jnp.zeros_like(autoconv_col)
         diagnostics = {**diagnostics, "autoconv": autoconv_col,
-                       "accretn": zero_col, "wbf": zero_col}
+                       "accretn": accretn_col, "wbf": zero_col}
 
         clouds = clouds.copy(
             precip_rain=micro_state.precip_rain,

--- a/jcm/physics/clouds/echam_1m_test.py
+++ b/jcm/physics/clouds/echam_1m_test.py
@@ -351,6 +351,36 @@ class TestColumnSweepMicrophysics:
         assert float(state.precip_rain) > 1e-6
         assert float(state.precip_snow) == 0.0
 
+    def test_accretion_rate_diagnosed_when_rain_falls_through_cloud(self):
+        """Rain falling through a cloudy deck must report accretion.
+
+        Regression for the Codex finding on #604: ``accretn`` was
+        published as zero because the per-level accretion rate never
+        left the sweep. A liquid deck spanning several near-saturated
+        levels forms rain aloft that falls through cloud below, so
+        both in-cloud (zrac2) and below-anvil (zrac1) accretion fire.
+        """
+        from jcm.physics.clouds.sundqvist import saturation_specific_humidity
+        cfg = MicrophysicsParameters.default()
+        nlev = 20
+        T = jnp.linspace(280.0, 295.0, nlev)
+        p = jnp.linspace(20000.0, 100000.0, nlev)
+        qsw = jax.vmap(saturation_specific_humidity)(p, T)
+        q = 0.95 * qsw
+        qc = jnp.zeros(nlev).at[5:12].set(1e-3)
+        qi = jnp.zeros(nlev)
+        cf = jnp.where(qc > 0, 0.7, 0.0)
+        rho = p / (287.0 * T)
+        dz = jnp.full(nlev, 500.0)
+        ndrop = jnp.full(nlev, 1e8)
+        _, state = cloud_microphysics_column_sweep(
+            T, q, p, qc, qi, cf, rho, dz, ndrop, dt=1800.0, config=cfg,
+        )
+        assert state.accretion_rate.shape == (nlev,)
+        assert float(jnp.max(state.accretion_rate)) > 0.0
+        # No accretion outside the deck.
+        assert float(jnp.max(state.accretion_rate[:5])) == 0.0
+
     def test_subsaturated_column_evaporates_rain(self):
         """A dry column under a cloud must evaporate falling rain.
 

--- a/jcm/physics/diagnostics/aerocom.py
+++ b/jcm/physics/diagnostics/aerocom.py
@@ -47,6 +47,7 @@ from typing import ClassVar
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 import jcm.constants as c
 from jcm.forcing import ForcingData
@@ -697,18 +698,71 @@ class AerocomDiagnostics(PhysicsTerm):
         out["aerocom_lts"] = theta700 - theta_sfc
 
         # WMO tropopause pressure (the ptp request): the wmo_tropopause
-        # module's finder, on the post-physics temperature. Zero-filled
-        # when the height field is unavailable (static per config).
+        # module's finder, on the post-physics temperature. Its default
+        # search indices (13..35) encode the L47 grid; on other grids they
+        # can miss the tropopause entirely (L95: indices 13-34 sit at
+        # 31-501 Pa — Codex review on PR #604). Derive the window from the
+        # column-mean pressures instead: the WMO search belongs between
+        # ~40 hPa and ~550 hPa on any grid. jnp.searchsorted on a traced
+        # mean profile would give traced (unusable) slice bounds, so the
+        # bounds come from a Python-level reduction over the STATIC level
+        # structure: mean pressure per level is computed with lax-free
+        # numpy on the hybrid coefficients when available, else falls back
+        # to the finder's defaults on 47-level grids only.
         z_full = diagnostics.get("height_full")
+        nlev = p_full.shape[0]
         if z_full is not None:
             from jcm.physics.diagnostics.wmo_tropopause import (
                 find_tropopause_level)
-            out["aerocom_ptp"] = find_tropopause_level(
-                temperature.T, p_full.T, z_full.T)
+            ref_p = self._nominal_level_pressures(nlev)
+            if ref_p is not None:
+                ncctop = int(np.searchsorted(ref_p, 4000.0))
+                nccbot = int(np.searchsorted(ref_p, 55000.0))
+                nccbot = max(nccbot, ncctop + 2)
+                out["aerocom_ptp"] = find_tropopause_level(
+                    temperature.T, p_full.T, z_full.T,
+                    ncctop=ncctop, nccbot=nccbot)
+            elif nlev == 47:
+                out["aerocom_ptp"] = find_tropopause_level(
+                    temperature.T, p_full.T, z_full.T)
+            else:
+                # No nominal pressures and not the grid the defaults were
+                # tuned for: a constant-fallback ptp would be misleading.
+                out["aerocom_ptp"] = jnp.zeros(p_full.shape[1:],
+                                               dtype=p_full.dtype)
         else:
             out["aerocom_ptp"] = jnp.zeros(p_full.shape[1:],
                                            dtype=p_full.dtype)
         return out
+
+    def _nominal_level_pressures(self, nlev):
+        """Return static nominal mid-level pressures [Pa], or None.
+
+        Cached from ``cache_coords`` when the model provides a vertical
+        coordinate with sigma centers; used to derive grid-independent
+        tropopause search bounds as PYTHON ints (slice bounds must be
+        static under jit).
+        """
+        ref = getattr(self, "_ref_level_pressures", None)
+        if ref is not None and len(ref) == nlev:
+            return ref
+        return None
+
+    def cache_coords(self, coords) -> None:
+        """Record nominal level pressures for the tropopause window."""
+        try:
+            vertical = coords.vertical
+            # Both forms are dimensionless sigma at level centres; nominal
+            # pressure follows by scaling with the reference surface
+            # pressure (hybrid coordinates fold their (a, b) into the
+            # sigma centres at this reference).
+            if hasattr(vertical, "centers"):
+                sigma = np.asarray(vertical.centers)
+            else:
+                sigma = np.asarray(vertical.get_sigma_centers(101325.0))
+            self._ref_level_pressures = sigma * 101325.0
+        except Exception:  # pragma: no cover - defensive; coords vary
+            self._ref_level_pressures = None
 
     def _nearsurface_group(self, state, diagnostics, terrain,
                            temperature, p_full) -> dict:
@@ -741,7 +795,10 @@ class AerocomDiagnostics(PhysicsTerm):
         q_low = _post_physics(state, diagnostics, "specific_humidity")[-1]
         u_low = _post_physics(state, diagnostics, "u_wind")[-1]
         v_low = _post_physics(state, diagnostics, "v_wind")[-1]
-        p_sfc = p_full[-1]
+        # The ACTUAL surface pressure, not the lowest level-centre pressure:
+        # at L47 the two differ by ~400 Pa even over ocean, which would bias
+        # psl and the dew point directly (Codex review on PR #604).
+        p_sfc = state.normalized_surface_pressure.reshape(ncols_shape) * c.p0
 
         sfc = diagnostics.get("surface")
         t_skin = getattr(sfc, "surface_temperature", None)

--- a/jcm/physics/diagnostics/aerocom.py
+++ b/jcm/physics/diagnostics/aerocom.py
@@ -384,6 +384,12 @@ class AerocomDiagnostics(PhysicsTerm):
         Column burdens per aerosol tracer plus ``N70``/``N100`` and
         ``PM1``/``PM10`` from the modal state. Requires the JAM aerosol
         module; silently inactive without it.
+    ``nearsurface``
+        2 m temperature/dew point, 10 m winds (neutral log-profile
+        interpolation, see :meth:`_nearsurface_group`), sea-level
+        pressure, the convective/stratiform x rain/snow precipitation
+        split (``prcr``/``prcs``/``prsn``) and the activation cloud-base
+        updraft ``wbase``.
 
     Everything is emitted as grid-box means, per the protocol Q/A —
     in-cloud values are formed in the analysis, after time-averaging.
@@ -416,13 +422,18 @@ class AerocomDiagnostics(PhysicsTerm):
         "aerocom_prw", "aerocom_cdnum", "aerocom_icnum", "aerocom_albedo",
         "aerocom_cdnc3d",
         # plev
-        "aerocom_lts",
+        "aerocom_lts", "aerocom_ptp",
+        # nearsurface
+        "aerocom_tas", "aerocom_uas", "aerocom_vas", "aerocom_dew2",
+        "aerocom_psl", "aerocom_prsn", "aerocom_prcr", "aerocom_prcs",
+        "aerocom_wbase",
         # aerosol (per-tracer burdens are named from the active tracer set)
         "aerocom_N70", "aerocom_N100", "aerocom_PM1", "aerocom_PM10",
         *(f"aerocom_burden_{sp}" for sp in _BURDEN_SPECIES),
     )
 
-    ALL_GROUPS: ClassVar[tuple[str, ...]] = ("cloud", "column", "plev", "aerosol")
+    ALL_GROUPS: ClassVar[tuple[str, ...]] = (
+        "cloud", "column", "plev", "aerosol", "nearsurface")
 
     def __init__(
         self,
@@ -511,6 +522,9 @@ class AerocomDiagnostics(PhysicsTerm):
             out.update(self._plev_group(state, diagnostics, temperature, p_full))
         if "aerosol" in self.groups:
             out.update(self._aerosol_group(state, diagnostics, p_half))
+        if "nearsurface" in self.groups:
+            out.update(self._nearsurface_group(
+                state, diagnostics, terrain, temperature, p_full))
 
         tendency = PhysicsTendency(
             u_wind=jnp.zeros_like(state.u_wind),
@@ -681,6 +695,124 @@ class AerocomDiagnostics(PhysicsTerm):
         theta700 = t700 * (100000.0 / 70000.0) ** c.akap
         theta_sfc = temperature[-1] * (100000.0 / p_sfc) ** c.akap
         out["aerocom_lts"] = theta700 - theta_sfc
+
+        # WMO tropopause pressure (the ptp request): the wmo_tropopause
+        # module's finder, on the post-physics temperature. Zero-filled
+        # when the height field is unavailable (static per config).
+        z_full = diagnostics.get("height_full")
+        if z_full is not None:
+            from jcm.physics.diagnostics.wmo_tropopause import (
+                find_tropopause_level)
+            out["aerocom_ptp"] = find_tropopause_level(
+                temperature.T, p_full.T, z_full.T)
+        else:
+            out["aerocom_ptp"] = jnp.zeros(p_full.shape[1:],
+                                           dtype=p_full.dtype)
+        return out
+
+    def _nearsurface_group(self, state, diagnostics, terrain,
+                           temperature, p_full) -> dict:
+        """2 m / 10 m diagnostics, sea-level pressure, precipitation split.
+
+        The 2 m temperature and 10 m winds interpolate between the surface
+        and the lowest model level with the NEUTRAL logarithmic profile,
+        using the tile-averaged momentum roughness the surface term
+        publishes (heat roughness = 0.1 z0m, the model's own ratio).
+        Stability corrections are deliberately omitted in this first
+        version: they modify the 2 m values by O(1 K) in strongly
+        stable/unstable layers, which matters for NWP verification but not
+        for the AeroCom context fields — documented so nobody mistakes
+        this for a Monin-Obukhov implementation. ``dew2`` converts the
+        (well-mixed) lowest-level specific humidity to a dew point at
+        surface pressure via the inverted Magnus formula. ``psl`` is the
+        standard WMO reduction with the 6.5 K/km lapse. ``wbase`` is the
+        SAME updraft the 2M activation uses (fact_tke sqrt(2 TKE),
+        lohmann_2m fact_tke = 0.7), sampled at the diagnosed cloud base.
+        Convective precipitation is split rain/snow by the lowest-level
+        temperature (the melt criterion the COSP hook already uses).
+        """
+        clouds = diagnostics["clouds"]
+        z_full = diagnostics.get("height_full")
+        z_half = diagnostics.get("height_half")
+        ncols_shape = state.temperature.shape[1:]
+        out: dict[str, jnp.ndarray] = {}
+
+        t_low = temperature[-1]
+        q_low = _post_physics(state, diagnostics, "specific_humidity")[-1]
+        u_low = _post_physics(state, diagnostics, "u_wind")[-1]
+        v_low = _post_physics(state, diagnostics, "v_wind")[-1]
+        p_sfc = p_full[-1]
+
+        sfc = diagnostics.get("surface")
+        t_skin = getattr(sfc, "surface_temperature", None)
+        z0m = getattr(sfc, "roughness_length", None)
+        if t_skin is None or z0m is None or z_full is None or z_half is None:
+            zero = jnp.zeros(ncols_shape, dtype=temperature.dtype)
+            for k in ("tas", "uas", "vas", "dew2", "wbase"):
+                out[f"aerocom_{k}"] = zero
+        else:
+            z_agl = jnp.maximum(z_full[-1] - z_half[-1], 10.0)
+            z0m = jnp.clip(z0m.reshape(ncols_shape), 1e-5, 2.0)
+            z0h = 0.1 * z0m
+            # Neutral log-profile ratios; winds vanish at z0m, scalars
+            # reach the skin value at z0h.
+            r10 = jnp.log(10.0 / z0m) / jnp.log(z_agl / z0m)
+            r2 = jnp.log(2.0 / z0h) / jnp.log(z_agl / z0h)
+            t_skin = t_skin.reshape(ncols_shape)
+            out["aerocom_tas"] = t_skin + (t_low - t_skin) * jnp.clip(r2, 0.0, 1.0)
+            out["aerocom_uas"] = u_low * jnp.clip(r10, 0.0, 1.0)
+            out["aerocom_vas"] = v_low * jnp.clip(r10, 0.0, 1.0)
+            # Magnus inversion: e = q p / (eps + (1-eps) q); Td from
+            # ln(e/611.2) = 17.62 Td / (Td + 243.12) (Td in Celsius).
+            eps_rd = 0.622
+            e_pa = jnp.maximum(
+                q_low * p_sfc / (eps_rd + (1.0 - eps_rd) * q_low), 1e-3)
+            ln_ratio = jnp.log(e_pa / 611.2)
+            td_c = 243.12 * ln_ratio / (17.62 - ln_ratio)
+            out["aerocom_dew2"] = jnp.minimum(
+                td_c + 273.15, out["aerocom_tas"])
+
+            # Cloud-base updraft from the vdiff TKE (see docstring).
+            vdiff = diagnostics.get("vertical_diffusion")
+            tke = getattr(vdiff, "tke", None)
+            if tke is None:
+                out["aerocom_wbase"] = jnp.zeros(ncols_shape,
+                                                 dtype=temperature.dtype)
+            else:
+                nlev = temperature.shape[0]
+                tke = tke.reshape(-1, nlev).T if tke.shape[0] != nlev                     else tke.reshape(nlev, -1)
+                w_act = 0.7 * jnp.sqrt(jnp.maximum(2.0 * tke, 0.0))
+                cf = clouds.cloud_fraction
+                cloudy = cf > THRES_CLD
+                # Lowest cloudy level, TOA-first: flip, argmax, unflip.
+                rev = cloudy[::-1]
+                k_base = nlev - 1 - jnp.argmax(rev, axis=0)
+                take = jnp.take_along_axis(w_act, k_base[None, ...], axis=0)[0]
+                has_cloud = jnp.any(cloudy, axis=0)
+                out["aerocom_wbase"] = jnp.where(has_cloud, take, 0.0)
+
+        # Sea-level pressure, WMO reduction (T_star at the surface from the
+        # lowest level with the standard 6.5 K/km lapse; mean of T_star and
+        # T at msl in the exponent denominator).
+        orog = jnp.reshape(terrain.orog, ncols_shape) if terrain is not None             else jnp.zeros(ncols_shape)
+        t_star = t_low + 0.0065 * (
+            (z_full[-1] - z_half[-1]) if z_full is not None else 0.0)
+        t_msl = t_star + 0.0065 * orog
+        rd = 287.04
+        out["aerocom_psl"] = p_sfc * jnp.exp(
+            c.grav * orog / (rd * 0.5 * (t_star + t_msl)))
+
+        # Precipitation split: large-scale rain/snow come straight from the
+        # cloud scheme; convective is split by the lowest-level temperature.
+        conv = diagnostics.get("convection")
+        prc = getattr(conv, "precip_conv", None)
+        prc = (prc.reshape(ncols_shape) if prc is not None
+               else jnp.zeros(ncols_shape))
+        frozen = t_low < c.tmelt
+        prcs = jnp.where(frozen, prc, 0.0)
+        out["aerocom_prcr"] = prc - prcs
+        out["aerocom_prcs"] = prcs
+        out["aerocom_prsn"] = clouds.precip_snow.reshape(ncols_shape) + prcs
         return out
 
     def _aerosol_group(self, state, diagnostics, p_half) -> dict:

--- a/jcm/physics/diagnostics/aerocom_remaining_test.py
+++ b/jcm/physics/diagnostics/aerocom_remaining_test.py
@@ -1,0 +1,309 @@
+"""Tests for the AeroCom omnibus additions (#583, #586, #581 residuals)."""
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from jcm.physics.diagnostics.aerocom import AerocomDiagnostics
+
+
+class NearSurfaceGroupTest(unittest.TestCase):
+    """The nearsurface group: 2 m/10 m, psl, precip split, wbase."""
+
+    def _diag(self, nlev=6, nx=3, z0=0.1, orog=0.0, t_low=290.0,
+              conv_precip=2e-5, tke=0.5):
+        class _Clouds:
+            cloud_fraction = jnp.zeros((nlev, nx)).at[3].set(0.6)
+            precip_snow = jnp.full((nx,), 1e-5)
+            precip_rain = jnp.full((nx,), 3e-5)
+
+        class _Surface:
+            surface_temperature = jnp.full((nx,), 288.0)
+            roughness_length = jnp.full((nx,), z0)
+
+        class _Conv:
+            precip_conv = jnp.full((nx,), conv_precip)
+
+        class _Vdiff:
+            pass
+        _Vdiff.tke = jnp.full((nx, nlev), tke)  # (ncol, nlev) layout
+
+        class _Terrain:
+            pass
+        _Terrain.orog = jnp.full((nx,), orog)
+
+        p_full = jnp.linspace(20000.0, 100000.0, nlev)[:, None] * jnp.ones((1, nx))
+        z_full = jnp.linspace(15000.0, 50.0, nlev)[:, None] * jnp.ones((1, nx)) + orog
+        z_half = jnp.linspace(16000.0, 0.0, nlev + 1)[:, None] * jnp.ones((1, nx)) + orog
+        diagnostics = {
+            "clouds": _Clouds(), "surface": _Surface(),
+            "convection": _Conv(), "vertical_diffusion": _Vdiff(),
+            "height_full": z_full, "height_half": z_half,
+        }
+
+        class _State:
+            temperature = jnp.full((nlev, nx), 260.0).at[-1].set(t_low)
+            specific_humidity = jnp.full((nlev, nx), 5e-3)
+            u_wind = jnp.full((nlev, nx), 10.0)
+            v_wind = jnp.full((nlev, nx), -5.0)
+            tracers: dict = {}
+
+        term = AerocomDiagnostics(groups=("nearsurface",))
+        state = _State()
+        out = term._nearsurface_group(
+            state, diagnostics, _Terrain(), state.temperature, p_full)
+        return out, state, diagnostics
+
+    def test_neutral_log_law_wind_ratio_is_exact(self):
+        out, state, diag = self._diag(z0=0.1)
+        z_agl = float(diag["height_full"][-1, 0] - diag["height_half"][-1, 0])
+        want = 10.0 * np.log(10.0 / 0.1) / np.log(z_agl / 0.1)
+        np.testing.assert_allclose(np.asarray(out["aerocom_uas"]), want,
+                                   rtol=1e-6)
+
+    def test_tas_lies_between_skin_and_lowest_level(self):
+        out, state, _ = self._diag(t_low=290.0)
+        tas = np.asarray(out["aerocom_tas"])
+        self.assertTrue(((tas >= 288.0) & (tas <= 290.0)).all())
+
+    def test_dew_point_never_exceeds_tas(self):
+        out, _, _ = self._diag()
+        self.assertTrue((np.asarray(out["aerocom_dew2"])
+                         <= np.asarray(out["aerocom_tas"]) + 1e-6).all())
+
+    def test_psl_equals_ps_at_sea_level(self):
+        out, _, _ = self._diag(orog=0.0)
+        np.testing.assert_allclose(np.asarray(out["aerocom_psl"]), 100000.0,
+                                   rtol=1e-6)
+
+    def test_psl_exceeds_ps_over_orography(self):
+        out, _, _ = self._diag(orog=1500.0)
+        self.assertTrue((np.asarray(out["aerocom_psl"]) > 100000.0).all())
+
+    def test_warm_surface_conv_precip_is_rain(self):
+        out, _, _ = self._diag(t_low=290.0, conv_precip=2e-5)
+        np.testing.assert_allclose(np.asarray(out["aerocom_prcr"]), 2e-5)
+        np.testing.assert_allclose(np.asarray(out["aerocom_prcs"]), 0.0)
+        np.testing.assert_allclose(np.asarray(out["aerocom_prsn"]), 1e-5)
+
+    def test_cold_surface_conv_precip_is_snow(self):
+        out, _, _ = self._diag(t_low=260.0, conv_precip=2e-5)
+        np.testing.assert_allclose(np.asarray(out["aerocom_prcs"]), 2e-5)
+        np.testing.assert_allclose(np.asarray(out["aerocom_prsn"]), 3e-5)
+
+    def test_wbase_is_the_activation_updraft_at_cloud_base(self):
+        out, _, _ = self._diag(tke=0.5)
+        want = 0.7 * np.sqrt(2.0 * 0.5)
+        np.testing.assert_allclose(np.asarray(out["aerocom_wbase"]), want,
+                                   rtol=1e-6)
+
+    def test_no_cloud_gives_zero_wbase(self):
+        out, state, diag = self._diag()
+        diag["clouds"].cloud_fraction = jnp.zeros_like(
+            diag["clouds"].cloud_fraction)
+        term = AerocomDiagnostics(groups=("nearsurface",))
+        p_full = jnp.linspace(20000.0, 100000.0, 6)[:, None] * jnp.ones((1, 3))
+        out2 = term._nearsurface_group(
+            state, diag, None, state.temperature, p_full)
+        np.testing.assert_allclose(np.asarray(out2["aerocom_wbase"]), 0.0)
+
+
+class FluxFamilyTest(unittest.TestCase):
+    """Deposition fluxes and the emission/deposition/burden budget."""
+
+    def test_deposition_flux_sign_and_species(self):
+        from jcm.physics.aerosol.jam.emissions.flux_diagnostic import (
+            accumulate_deposition_fluxes)
+        nlev, nx = 4, 2
+        rho = jnp.full((nlev, nx), 1.0)
+        dz = jnp.full((nlev, nx), 100.0)
+        tends = {"m_bc_a4": jnp.full((nlev, nx), -1e-12),
+                 "n_a4": jnp.full((nlev, nx), -1.0)}
+        out = accumulate_deposition_fluxes({}, tends, rho, dz, kind="dry")
+        # Removal (negative tendency) reports a POSITIVE downward flux.
+        np.testing.assert_allclose(np.asarray(out["dry_bc"]),
+                                   nlev * 100.0 * 1e-12, rtol=1e-6)
+        np.testing.assert_allclose(np.asarray(out["dry_so4"]), 0.0)
+
+    def test_reset_covers_the_whole_flux_family(self):
+        from jcm.physics.aerosol.jam.emissions.flux_diagnostic import (
+            ResetEmissionFluxes, all_flux_keys)
+        self.assertIn("emi_bb_bc", all_flux_keys())
+        self.assertIn("dry_du", all_flux_keys())
+        self.assertIn("wet_so4", all_flux_keys())
+        self.assertEqual(set(ResetEmissionFluxes.provides), set(all_flux_keys()))
+
+    def test_inert_species_budget_closes_over_one_jam_step(self):
+        """Emission - dry - wet ~= d(burden)/dt for BC over one step.
+
+        BC has no chemistry source/sink, so over a single physics step the
+        column budget must close to roundoff: the tracers' total tendency
+        IS emission + transportless-removal, and the flux diagnostics
+        integrate exactly those tendencies.
+        """
+        import jcm.physics.aerosol.jam.emissions.flux_diagnostic as fd
+        nlev, nx = 5, 2
+        rho = jnp.full((nlev, nx), 1.0)
+        dz = jnp.full((nlev, nx), 200.0)
+        emis = {"m_bc_a4": jnp.zeros((nlev, nx)).at[-1].set(2e-12)}
+        dep = {"m_bc_a4": jnp.full((nlev, nx), -3e-13)}
+        wet = {"m_bc_a4": jnp.full((nlev, nx), -1e-13)}
+        d = fd.accumulate_emission_fluxes({}, emis, rho, dz)
+        d = fd.accumulate_deposition_fluxes(d, dep, rho, dz, kind="dry")
+        d = fd.accumulate_deposition_fluxes(d, wet, rho, dz, kind="wet")
+        total_tend = jax.tree_util.tree_map(
+            lambda *xs: sum(xs), emis, dep, wet)
+        dburden_dt = jnp.sum(total_tend["m_bc_a4"] * rho * dz, axis=0)
+        closure = (np.asarray(d["emi_bc"]) - np.asarray(d["dry_bc"])
+                   - np.asarray(d["wet_bc"]))
+        # Both sides are exactly balanced here (closure = 0), so the
+        # comparison needs an absolute floor: rtol alone cannot compare
+        # a float32-roundoff residual against an exact zero.
+        np.testing.assert_allclose(closure, np.asarray(dburden_dt),
+                                   rtol=1e-6, atol=1e-16)
+
+
+class SnapshotStreamTest(unittest.TestCase):
+    """The 3-hourly instantaneous output stream (#586)."""
+
+    def test_snapshots_match_a_snapshot_mode_run(self):
+        """Strided snapshots equal the instantaneous states a fine-grained
+        snapshot-mode run saves at the same times (SPEEDY T31, 4 steps).
+        """
+        from jcm.model import Model
+        from jcm.physics.speedy.speedy_coords import get_speedy_coords
+
+        dt_min = 30.0
+        dt_days = dt_min / 1440.0
+        model = Model(coords=get_speedy_coords(), time_step=dt_min)
+        # Averaged run: one save interval of 4 steps, snapshots every 2.
+        preds = model.run(save_interval=4 * dt_days, total_time=4 * dt_days,
+                          output_averages=True,
+                          snapshot_interval=2 * dt_days,
+                          snapshot_variables=("_shortwave_rad.cloudc",))
+        snaps = preds.snapshots
+        self.assertIsNotNone(snaps)
+        arr = np.asarray(snaps["_shortwave_rad.cloudc"])
+        self.assertEqual(arr.shape[0], 2)  # 4 steps / stride 2
+
+        # Reference: fine-grained snapshot-mode run saving every 2 steps —
+        # its saved frames ARE the instantaneous states at the same times.
+        model2 = Model(coords=get_speedy_coords(), time_step=dt_min)
+        ref = model2.run(save_interval=2 * dt_days, total_time=4 * dt_days,
+                         output_averages=False)
+        ref_cc = np.asarray(jax.device_get(ref.physics["_shortwave_rad"].cloudc))
+        np.testing.assert_allclose(arr, ref_cc.reshape(arr.shape), rtol=1e-6)
+
+    def test_snapshot_dataset_axes(self):
+        from jcm.model import Model
+        from jcm.physics.speedy.speedy_coords import get_speedy_coords
+
+        dt_days = 30.0 / 1440.0
+        model = Model(coords=get_speedy_coords(), time_step=30.0)
+        preds = model.run(save_interval=4 * dt_days, total_time=4 * dt_days,
+                          output_averages=True,
+                          snapshot_interval=2 * dt_days,
+                          snapshot_variables=("_shortwave_rad.cloudc",))
+        ds = preds.snapshot_dataset()
+        self.assertIsNotNone(ds)
+        self.assertIn("snap_time", ds.dims)
+        self.assertEqual(ds["_shortwave_rad_cloudc"].dims,
+                         ("snap_time", "lon", "lat"))
+
+    def test_snapshots_require_averaged_mode(self):
+        from jcm.model import Model
+        from jcm.physics.speedy.speedy_coords import get_speedy_coords
+
+        dt_days = 30.0 / 1440.0
+        model = Model(coords=get_speedy_coords(), time_step=30.0)
+        with self.assertRaises(ValueError):
+            model.run(save_interval=4 * dt_days, total_time=4 * dt_days,
+                      output_averages=False,
+                      snapshot_interval=2 * dt_days,
+                      snapshot_variables=("_shortwave_rad.cloudc",))
+
+
+class CmorOmnibusTest(unittest.TestCase):
+    def test_new_fields_reach_submission_files(self):
+        import pathlib
+        import tempfile
+
+        import xarray as xr
+        from tools.aerocom_cmor import convert
+
+        ds = xr.Dataset({
+            "radiation.toa_sw_up_noa": xr.DataArray(np.full((3, 4), 90.0),
+                                                    dims=("lat", "lon")),
+            "aerocom_tas": xr.DataArray(np.full((3, 4), 288.0),
+                                        dims=("lat", "lon")),
+            "dry_bc": xr.DataArray(np.full((3, 4), 1e-12),
+                                   dims=("lat", "lon")),
+            "emi_bb_oc": xr.DataArray(np.full((3, 4), 2e-12),
+                                      dims=("lat", "lon")),
+        })
+        with tempfile.TemporaryDirectory() as td:
+            written, skipped = convert(
+                ds, "JCM-t", "all_2000", "2010", "monthly",
+                pathlib.Path(td), na_aliases=True)
+        names = "\n".join(written)
+        for var in ("rsutnoa", "rsut_na", "tas", "drybc", "emi_bb_oc"):
+            self.assertIn(f"_{var}_", names)
+        self.assertEqual(skipped, [])
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class AerosolFreeRadiationTest(unittest.TestCase):
+    """The #583 noa fluxes: a second solve with aerosol optics zeroed."""
+
+    def test_grey_scheme_is_rejected(self):
+        from jcm.physics.echam.echam_terms import echam_physics
+        with self.assertRaises(ValueError):
+            echam_physics(radiation_scheme="grey",
+                          aerosol_free_radiation=True)
+
+    def test_flag_off_leaves_noa_fields_zero(self):
+        from jcm.physics.radiation.radiation_types import RadiationData
+        r = RadiationData.zeros((8,), 5)
+        np.testing.assert_allclose(np.asarray(r.toa_sw_up_noa), 0.0)
+
+
+import pytest  # noqa: E402
+
+
+@pytest.mark.slow
+class AerosolFreeRadiationSlowTest(unittest.TestCase):
+    """One real RRTMGP step: noa differs from all-sky iff aerosol is present."""
+
+    def test_noa_fluxes_differ_with_aerosol_and_match_without(self):
+        from jcm.model import Model
+        from jcm.physics.echam.echam_levels import get_echam_levels
+        from jcm.physics.echam.echam_terms import echam_physics
+        from jcm.runners import inject_jw_profile
+        from jcm.terrain import TerrainData
+        from jcm.utils import get_coords
+
+        coords = get_coords(get_echam_levels(47), spectral_truncation=21)
+        physics = echam_physics(
+            radiation_scheme="rrtmgp", cloud_scheme="2m",
+            aerosol_module="macv2sp", aerosol_free_radiation=True,
+            checkpoint_terms=False)
+        model = Model(coords=coords, terrain=TerrainData.aquaplanet(coords),
+                      physics=physics, time_step=12.0)
+        inject_jw_profile(model, rh=0.6)
+        dt_days = 12.0 / 1440.0
+        preds = model.resume(save_interval=dt_days, total_time=dt_days)
+        rad = preds.physics["radiation"]
+        sw_noa = np.asarray(jax.device_get(rad.toa_sw_up_noa))
+        sw_all = np.asarray(jax.device_get(rad.toa_sw_up))
+        self.assertTrue(np.isfinite(sw_noa).all())
+        # MACv2-SP puts nonzero anthropogenic AOD in 2005 defaults, so the
+        # aerosol-free SW must differ measurably somewhere sunlit...
+        self.assertGreater(np.abs(sw_noa - sw_all).max(), 1e-3)
+        # ...while the LW (MACv2-SP models SW effects only) stays equal.
+        lw_noa = np.asarray(jax.device_get(rad.toa_lw_up_noa))
+        lw_all = np.asarray(jax.device_get(rad.toa_lw_up))
+        np.testing.assert_allclose(lw_noa, lw_all, rtol=1e-5)

--- a/jcm/physics/diagnostics/aerocom_remaining_test.py
+++ b/jcm/physics/diagnostics/aerocom_remaining_test.py
@@ -33,7 +33,11 @@ class NearSurfaceGroupTest(unittest.TestCase):
             pass
         _Terrain.orog = jnp.full((nx,), orog)
 
-        p_full = jnp.linspace(20000.0, 100000.0, nlev)[:, None] * jnp.ones((1, nx))
+        # Lowest level-centre pressure deliberately BELOW the surface
+        # pressure (p0), as in any real hybrid grid — so a psl computed
+        # from p_full[-1] (the Codex #604 P1) cannot pass the sea-level
+        # identity test below.
+        p_full = jnp.linspace(20000.0, 99600.0, nlev)[:, None] * jnp.ones((1, nx))
         z_full = jnp.linspace(15000.0, 50.0, nlev)[:, None] * jnp.ones((1, nx)) + orog
         z_half = jnp.linspace(16000.0, 0.0, nlev + 1)[:, None] * jnp.ones((1, nx)) + orog
         diagnostics = {
@@ -47,6 +51,8 @@ class NearSurfaceGroupTest(unittest.TestCase):
             specific_humidity = jnp.full((nlev, nx), 5e-3)
             u_wind = jnp.full((nlev, nx), 10.0)
             v_wind = jnp.full((nlev, nx), -5.0)
+            # psl/dew2 read the true surface pressure (Codex on #604).
+            normalized_surface_pressure = jnp.ones((nx,))
             tracers: dict = {}
 
         term = AerocomDiagnostics(groups=("nearsurface",))
@@ -73,13 +79,15 @@ class NearSurfaceGroupTest(unittest.TestCase):
                          <= np.asarray(out["aerocom_tas"]) + 1e-6).all())
 
     def test_psl_equals_ps_at_sea_level(self):
+        import jcm.constants as c
         out, _, _ = self._diag(orog=0.0)
-        np.testing.assert_allclose(np.asarray(out["aerocom_psl"]), 100000.0,
+        np.testing.assert_allclose(np.asarray(out["aerocom_psl"]), c.p0,
                                    rtol=1e-6)
 
     def test_psl_exceeds_ps_over_orography(self):
+        import jcm.constants as c
         out, _, _ = self._diag(orog=1500.0)
-        self.assertTrue((np.asarray(out["aerocom_psl"]) > 100000.0).all())
+        self.assertTrue((np.asarray(out["aerocom_psl"]) > c.p0).all())
 
     def test_warm_surface_conv_precip_is_rain(self):
         out, _, _ = self._diag(t_low=290.0, conv_precip=2e-5)
@@ -107,6 +115,62 @@ class NearSurfaceGroupTest(unittest.TestCase):
         out2 = term._nearsurface_group(
             state, diag, None, state.temperature, p_full)
         np.testing.assert_allclose(np.asarray(out2["aerocom_wbase"]), 0.0)
+
+
+class CodexRound2RegressionTest(unittest.TestCase):
+    """Regressions for the Codex findings on PR #604."""
+
+    def test_tropopause_window_derived_from_level_pressures(self):
+        """An L95-like grid must search near 40-550 hPa, not indices 13-35."""
+        term = AerocomDiagnostics(groups=("plev",))
+
+        class _Vert:
+            # 95 sigma centres crowding the stratosphere like the L95 grid.
+            centers = np.concatenate([
+                np.geomspace(3e-6, 0.05, 60), np.linspace(0.06, 0.995, 35)])
+
+        class _Coords:
+            vertical = _Vert()
+
+        term.cache_coords(_Coords())
+        ref = term._nominal_level_pressures(95)
+        self.assertIsNotNone(ref)
+        ncctop = int(np.searchsorted(ref, 4000.0))
+        nccbot = int(np.searchsorted(ref, 55000.0))
+        # The window must cover the real tropopause pressures, far from
+        # the L47-tuned defaults (13..35 sit at 31-501 Pa on this grid).
+        self.assertGreater(ncctop, 35)
+        self.assertGreater(nccbot, ncctop + 2)
+        self.assertLess(ref[ncctop], 5000.0)
+        self.assertGreater(ref[nccbot - 1], 10000.0)
+
+    def test_save_predictions_writes_the_snapshot_file(self):
+        import pathlib
+        import tempfile
+
+        import xarray as xr
+        from jcm.runners import save_predictions
+
+        class _Preds:
+            def to_xarray(self):
+                return xr.Dataset({"t": xr.DataArray(np.zeros(3),
+                                                     dims=("x",))})
+
+            def snapshot_dataset(self):
+                return xr.Dataset({"clt": xr.DataArray(
+                    np.zeros((2, 3)), dims=("snap_time", "x"))})
+
+        with tempfile.TemporaryDirectory() as td:
+            out = pathlib.Path(td) / "run.nc"
+            save_predictions(_Preds(), out)
+            self.assertTrue(out.exists())
+            self.assertTrue((pathlib.Path(td) / "run_snapshots.nc").exists())
+
+    def test_run_config_declares_snapshot_keys(self):
+        import yaml
+        cfg = yaml.safe_load(open("jcm/config/run/default.yaml"))
+        self.assertIn("snapshot_interval", cfg)
+        self.assertIn("snapshot_variables", cfg)
 
 
 class FluxFamilyTest(unittest.TestCase):

--- a/jcm/physics/echam/echam_terms.py
+++ b/jcm/physics/echam/echam_terms.py
@@ -83,6 +83,7 @@ def echam_physics(
     cosp_calipso: bool = False,
     cosp_modis: bool = False,
     cosp_isccp: bool = False,
+    aerosol_free_radiation: bool = False,
     enable_aerocom: bool = False,
     aerocom_groups: tuple[str, ...] = ("cloud", "column"),
     aerocom_overlap: str = "maximum-random",
@@ -192,8 +193,21 @@ def echam_physics(
         cosp_isccp: Also run the ISCCP (ICARUS) simulator on that
             realization (``clisccp`` tau/CTP histogram and
             ``cltisccp``); see jax-gcm#597.
+        aerosol_free_radiation: Run a SECOND RRTMGP solve per compute
+            step with the aerosol optics zeroed, emitting the AeroCom
+            ``*noa`` TOA fluxes (rsutnoa/rlutnoa and clear-sky
+            variants) for instantaneous-ERFari diagnosis (jax-gcm#583).
+            Roughly doubles the radiation cost on compute steps;
+            RRTMGP only.
 
     """
+    if aerosol_free_radiation and radiation_scheme != "rrtmgp":
+        raise ValueError(
+            "aerosol_free_radiation=True needs radiation_scheme='rrtmgp' — "
+            "the grey and emulated schemes carry no aerosol optics to zero, "
+            f"so radiation_scheme={radiation_scheme!r} would silently emit "
+            "all-zero *noa fluxes.")
+
     convection_p = convection or ConvectionParameters.default()
     clouds_p = clouds or CloudParameters.default()
     microphysics_p = microphysics or MicrophysicsParameters.default()
@@ -216,8 +230,10 @@ def echam_physics(
         # compute_cre doubles the RRTMGP work on radiation steps (a second
         # full clear-sky solve) purely for the CRE diagnostic — production
         # throughput runs can turn it off.
-        rad_term = RRTMGPRadiation(params=radiation_p,
-                                   compute_cre=radiation_compute_cre)
+        rad_term = RRTMGPRadiation(
+            params=radiation_p,
+            compute_cre=radiation_compute_cre,
+            aerosol_free_diagnostics=aerosol_free_radiation)
     elif radiation_scheme == "grey":
         rad_term = GreyTwoStreamRadiation(params=radiation_p)
     elif radiation_scheme == "emulated":

--- a/jcm/physics/radiation/grey_two_stream/radiation_scheme.py
+++ b/jcm/physics/radiation/grey_two_stream/radiation_scheme.py
@@ -574,6 +574,12 @@ def radiation_scheme(
         surface_lw_up=surface_lw_up,
         toa_sw_up_clear=toa_sw_up_clear,
         toa_lw_up_clear=toa_lw_up_clear,
+        # Aerosol-free fluxes are an RRTMGP-only diagnostic (#583); the
+        # grey scheme carries no aerosol optics, so these stay zero.
+        toa_sw_up_noa=jnp.zeros_like(toa_sw_up_clear),
+        toa_lw_up_noa=jnp.zeros_like(toa_lw_up_clear),
+        toa_sw_up_clear_noa=jnp.zeros_like(toa_sw_up_clear),
+        toa_lw_up_clear_noa=jnp.zeros_like(toa_lw_up_clear),
         # Grey two-stream has no McICA sub-columns; the radiation-view
         # cloud-cover diagnostic is defined as 0 here (see RadiationData).
         total_cloud_cover=jnp.zeros_like(olr),
@@ -835,6 +841,10 @@ class GreyTwoStreamRadiation(PhysicsTerm):
             toa_sw_down=_column_vector(
                 diagnostics_vmapped.toa_sw_down, ncols,
             ),
+            toa_sw_up_noa=jnp.zeros((ncols,)),
+            toa_lw_up_noa=jnp.zeros((ncols,)),
+            toa_sw_up_clear_noa=jnp.zeros((ncols,)),
+            toa_lw_up_clear_noa=jnp.zeros((ncols,)),
             toa_sw_up_clear=_column_vector(
                 diagnostics_vmapped.toa_sw_up_clear, ncols,
             ),

--- a/jcm/physics/radiation/nn_emulator_scheme.py
+++ b/jcm/physics/radiation/nn_emulator_scheme.py
@@ -169,6 +169,10 @@ def radiation_scheme_emulated(
         # is a follow-up. Zeros for now so downstream consumers don't
         # see stale data in the diagnostic key.
         toa_sw_up_clear=jnp.zeros_like(sw_flux_up[0]),
+        toa_sw_up_noa=jnp.zeros_like(sw_flux_up[0]),
+        toa_lw_up_noa=jnp.zeros_like(sw_flux_up[0]),
+        toa_sw_up_clear_noa=jnp.zeros_like(sw_flux_up[0]),
+        toa_lw_up_clear_noa=jnp.zeros_like(sw_flux_up[0]),
         toa_lw_up_clear=jnp.zeros_like(lw_flux_up[0]),
         # No sub-column machinery in the emulator: McICA cloud cover is 0.
         total_cloud_cover=jnp.zeros_like(sw_flux_up[0]),
@@ -400,6 +404,10 @@ class NNEmulatorRadiation(PhysicsTerm):
             toa_sw_down=_column_vector_emulated(
                 diagnostics_vmapped.toa_sw_down, ncols,
             ),
+            toa_sw_up_noa=jnp.zeros((ncols,)),
+            toa_lw_up_noa=jnp.zeros((ncols,)),
+            toa_sw_up_clear_noa=jnp.zeros((ncols,)),
+            toa_lw_up_clear_noa=jnp.zeros((ncols,)),
             toa_sw_up_clear=_column_vector_emulated(
                 diagnostics_vmapped.toa_sw_up_clear, ncols,
             ),

--- a/jcm/physics/radiation/radiation_types.py
+++ b/jcm/physics/radiation/radiation_types.py
@@ -176,6 +176,14 @@ class RadiationData:
     # onto the ``"clouds"`` diagnostic key for downstream consumers.
     toa_sw_up_clear: jnp.ndarray     # Clear-sky TOA upward SW [W/m²] (ncols,)
     toa_lw_up_clear: jnp.ndarray     # Clear-sky TOA OLR [W/m²] (ncols,)
+    # Aerosol-free TOA fluxes (AeroCom *noa / *_na, jax-gcm#583): a second
+    # radiation call with the aerosol OPTICS zeroed but the cloud state
+    # untouched (cdnc_factor kept, so ERFari is isolated from ERFaci).
+    # All-zero unless RRTMGPRadiation(aerosol_free_diagnostics=True).
+    toa_sw_up_noa: jnp.ndarray       # Aerosol-free TOA upward SW [W/m²] (ncols,)
+    toa_lw_up_noa: jnp.ndarray       # Aerosol-free TOA OLR [W/m²] (ncols,)
+    toa_sw_up_clear_noa: jnp.ndarray  # Aerosol-free clear-sky TOA SW up (ncols,)
+    toa_lw_up_clear_noa: jnp.ndarray  # Aerosol-free clear-sky TOA OLR (ncols,)
 
     # Total (2-D) cloud cover as the radiation sees it: fraction of McICA
     # g-point sub-columns (pooled LW+SW draws) with ≥1 cloudy layer, under
@@ -214,6 +222,10 @@ class RadiationData:
             toa_sw_down=jnp.zeros(nodal_shape),
             toa_sw_up_clear=jnp.zeros(nodal_shape),
             toa_lw_up_clear=jnp.zeros(nodal_shape),
+            toa_sw_up_noa=jnp.zeros(nodal_shape),
+            toa_lw_up_noa=jnp.zeros(nodal_shape),
+            toa_sw_up_clear_noa=jnp.zeros(nodal_shape),
+            toa_lw_up_clear_noa=jnp.zeros(nodal_shape),
             total_cloud_cover=jnp.zeros(nodal_shape),
             step=jnp.int32(0),
         )
@@ -239,6 +251,10 @@ class RadiationData:
             'toa_sw_down': self.toa_sw_down,
             'toa_sw_up_clear': self.toa_sw_up_clear,
             'toa_lw_up_clear': self.toa_lw_up_clear,
+            'toa_sw_up_noa': self.toa_sw_up_noa,
+            'toa_lw_up_noa': self.toa_lw_up_noa,
+            'toa_sw_up_clear_noa': self.toa_sw_up_clear_noa,
+            'toa_lw_up_clear_noa': self.toa_lw_up_clear_noa,
             'total_cloud_cover': self.total_cloud_cover,
             'step': self.step,
         }

--- a/jcm/physics/radiation/rrtmgp.py
+++ b/jcm/physics/radiation/rrtmgp.py
@@ -447,6 +447,10 @@ def prepare_icon_data(
         # outside the beam-split context.
         toa_sw_up_clear=jnp.zeros_like(toa_sw_up),
         toa_lw_up_clear=jnp.zeros_like(toa_lw_up),
+        toa_sw_up_noa=jnp.zeros_like(toa_sw_up),
+        toa_lw_up_noa=jnp.zeros_like(toa_sw_up),
+        toa_sw_up_clear_noa=jnp.zeros_like(toa_sw_up),
+        toa_lw_up_clear_noa=jnp.zeros_like(toa_sw_up),
         total_cloud_cover=jnp.zeros_like(toa_sw_up),
         # ``step`` is owned by the enclosing ``RRTMGPRadiation`` carry —
         # the standalone scheme emits 0 and the term bumps the counter
@@ -991,6 +995,7 @@ class RRTMGPRadiation(PhysicsTerm):
         params: RadiationParameters | None = None,
         base_seed: int = 0,
         compute_cre: bool = True,
+        aerosol_free_diagnostics: bool = False,
     ):
         """Hold the scheme-native :class:`RadiationParameters`.
 
@@ -1013,6 +1018,10 @@ class RRTMGPRadiation(PhysicsTerm):
         # without an extra pytree leaf.
         self._base_seed = int(base_seed)
         self._compute_cre = bool(compute_cre)
+        # AeroCom *noa fluxes (jax-gcm#583): a SECOND full radiation solve
+        # per compute step with the aerosol optics zeroed. Roughly doubles
+        # the (dominant) radiation cost on compute steps, so opt-in only.
+        self._aerosol_free = bool(aerosol_free_diagnostics)
         self._coords_cached = False
         # Eagerly create the global RRTMGP instance now (loads netCDF
         # gas-optics + cloud-optics tables). Otherwise the first jit
@@ -1232,11 +1241,68 @@ class RRTMGPRadiation(PhysicsTerm):
             cols["r_eff_liq_um"], cols["r_eff_ice_um"],
         )
 
+        # Aerosol-free companion solve (jax-gcm#583): identical inputs but
+        # with the aerosol OPTICS zeroed — cdnc_factor and Nccn are kept so
+        # the cloud field is bit-identical and the difference to the all-sky
+        # fluxes is the instantaneous aerosol radiative effect (ERFari
+        # numerator), not an aerosol-cloud response. Zeroing the optical
+        # depths alone suffices (extinction scales everything), but ssa/asy
+        # are zeroed too so no path reads an unweighted property.
+        if self._aerosol_free:
+            aerosol_noa = cols["aerosol"].copy(
+                aod_profile=jnp.zeros_like(aerosol_for_vmap.aod_profile),
+                ssa_profile=jnp.zeros_like(aerosol_for_vmap.ssa_profile),
+                asy_profile=jnp.zeros_like(aerosol_for_vmap.asy_profile),
+                aod_total=jnp.zeros_like(aerosol_for_vmap.aod_total),
+                aod_anthropogenic=jnp.zeros_like(
+                    aerosol_for_vmap.aod_anthropogenic),
+                aod_background=jnp.zeros_like(aerosol_for_vmap.aod_background),
+                aod_sw_per_band=jnp.zeros_like(aerosol_for_vmap.aod_sw_per_band),
+                ssa_sw_per_band=jnp.zeros_like(aerosol_for_vmap.ssa_sw_per_band),
+                asy_sw_per_band=jnp.zeros_like(aerosol_for_vmap.asy_sw_per_band),
+                aod_lw_per_band=jnp.zeros_like(aerosol_for_vmap.aod_lw_per_band),
+                ssa_lw_per_band=jnp.zeros_like(aerosol_for_vmap.ssa_lw_per_band),
+                asy_lw_per_band=jnp.zeros_like(aerosol_for_vmap.asy_lw_per_band),
+            )
+            _, diagnostics_noa = _maybe_chunked_vmap(
+                radiation_scheme_rrtmgp, _in_axes,
+            )(
+                cols["temperature"], cols["specific_humidity"],
+                cols["pressure_full"], cols["pressure_half"],
+                cols["layer_thickness"], cols["air_density"],
+                cols["cloud_water"], cols["cloud_ice"], cols["cloud_fraction"],
+                cols["surface_temperature"], cols["surface_albedo_vis"],
+                cols["surface_albedo_nir"], cols["surface_emissivity"],
+                solar, cols["latitudes"], cols["longitudes"],
+                params, aerosol_noa, cols["column_indices"],
+                model_step, base_seed, compute_cre,
+                cols["ozone_vmr"], cols["co2_vmr"], cols["ch4_vmr"],
+                cols["n2o_vmr"],
+                cols["r_eff_liq_um"], cols["r_eff_ice_um"],
+            )
+            noa = dict(
+                toa_sw_up_noa=_column_vector_rrtmgp(
+                    diagnostics_noa.toa_sw_up, ncols),
+                toa_lw_up_noa=_column_vector_rrtmgp(
+                    diagnostics_noa.toa_lw_up, ncols),
+                toa_sw_up_clear_noa=_column_vector_rrtmgp(
+                    diagnostics_noa.toa_sw_up_clear, ncols),
+                toa_lw_up_clear_noa=_column_vector_rrtmgp(
+                    diagnostics_noa.toa_lw_up_clear, ncols),
+            )
+        else:
+            zero_col = jnp.zeros((ncols,))
+            noa = dict(
+                toa_sw_up_noa=zero_col, toa_lw_up_noa=zero_col,
+                toa_sw_up_clear_noa=zero_col, toa_lw_up_clear_noa=zero_col,
+            )
+
         # Per-gpoint flux profiles are summed over g-points inside the
         # vmapped per-column compute, so flux arrays are (ncols, nlev+1)
         # — only a transpose is needed (DO NOT use the grey path's
         # transpose+sum, the per-band axis is already gone).
         rad_out = RadiationData(
+            **noa,
             cos_zenith=_column_vector_rrtmgp(diagnostics_vmapped.cos_zenith, ncols),
             surface_albedo_vis=_column_vector_rrtmgp(
                 diagnostics_vmapped.surface_albedo_vis, ncols,

--- a/jcm/predictions.py
+++ b/jcm/predictions.py
@@ -37,7 +37,9 @@ class ModelPredictions:
 
     def __init__(self, predictions: Predictions, coords, physics: Physics,  # noqa: D107
                  dycore=None, observations=None, observers=(),
-                 obs_t0_days=None, obs_dt_seconds=None):
+                 obs_t0_days=None, obs_dt_seconds=None,
+                 snapshots=None, snapshot_variables=(),
+                 snapshot_interval_days=None):
         self._predictions = predictions
         self._coords = coords
         self._physics = physics
@@ -46,6 +48,9 @@ class ModelPredictions:
         self._observers = tuple(observers)
         self._obs_t0_days = obs_t0_days
         self._obs_dt_seconds = obs_dt_seconds
+        self._snapshots = snapshots
+        self._snapshot_variables = tuple(snapshot_variables)
+        self._snapshot_interval_days = snapshot_interval_days
 
     @property
     def dynamics(self):
@@ -63,6 +68,43 @@ class ModelPredictions:
     def observations(self):
         """Raw per-timestep observer samples (tuple of dicts), or ``None``."""
         return self._observations
+
+    @property
+    def snapshots(self):
+        """Raw interval-instantaneous snapshot arrays, or ``None``."""
+        return self._snapshots
+
+    def snapshot_dataset(self):
+        """Interval-instantaneous 2-D snapshots as one xarray Dataset.
+
+        The AeroCom 3-hourly stream (jax-gcm#586): each requested variable
+        comes back as ``(snap_time, lon, lat)`` at the snapshot cadence,
+        with ``snap_time`` in days from the window start (first snapshot
+        one interval in, matching the post-step sampling convention).
+        Empty dict semantics: returns ``None`` when the run requested no
+        snapshots.
+        """
+        if not self._snapshots or self._snapshot_interval_days is None:
+            return None
+        import xarray as xr
+
+        snaps = jax.device_get(self._snapshots)
+        nlon, nlat = self._coords.horizontal.nodal_shape
+        first = next(iter(snaps.values()))
+        n = first.shape[0]
+        t = (np.arange(1, n + 1) * self._snapshot_interval_days)
+        data = {}
+        for name, arr in snaps.items():
+            arr = np.asarray(arr).reshape(n, nlon, nlat)
+            data[name.replace(".", "_")] = (("snap_time", "lon", "lat"), arr)
+        lon = self._coords.horizontal.nodal_axes[0] * 180.0 / np.pi
+        lat = np.arcsin(self._coords.horizontal.nodal_axes[1]) * 180.0 / np.pi
+        return xr.Dataset(
+            data,
+            coords={"snap_time": t, "lon": lon, "lat": lat},
+            attrs={"snapshot_interval_days": self._snapshot_interval_days,
+                   "sampling": "instantaneous (post-step)"},
+        )
 
     def observation_datasets(self):
         """Per-timestep virtual-observation output as xarray Datasets.

--- a/jcm/runners.py
+++ b/jcm/runners.py
@@ -1298,6 +1298,8 @@ def _run_full(cfg: DictConfig, model: Model | None = None) -> ModelPredictions:
             save_interval=cfg.run.save_interval,
             total_time=cfg.run.total_time,
             output_averages=cfg.run.output_averages,
+            snapshot_interval=cfg.run.get("snapshot_interval"),
+            snapshot_variables=tuple(cfg.run.get("snapshot_variables") or ()),
         )
     if cfg.init.kind == "jw":
         inject_jw_profile(model, rh=float(cfg.init.get("rh", 0.6)))
@@ -1306,6 +1308,8 @@ def _run_full(cfg: DictConfig, model: Model | None = None) -> ModelPredictions:
             save_interval=cfg.run.save_interval,
             total_time=cfg.run.total_time,
             output_averages=cfg.run.output_averages,
+            snapshot_interval=cfg.run.get("snapshot_interval"),
+            snapshot_variables=tuple(cfg.run.get("snapshot_variables") or ()),
         )
     if cfg.init.kind == "balanced_isothermal":
         inject_balanced_isothermal_profile(model)
@@ -1314,6 +1318,8 @@ def _run_full(cfg: DictConfig, model: Model | None = None) -> ModelPredictions:
             save_interval=cfg.run.save_interval,
             total_time=cfg.run.total_time,
             output_averages=cfg.run.output_averages,
+            snapshot_interval=cfg.run.get("snapshot_interval"),
+            snapshot_variables=tuple(cfg.run.get("snapshot_variables") or ()),
         )
     raise ValueError(f"Unknown init.kind={cfg.init.kind!r}")
 
@@ -1501,6 +1507,9 @@ def run_chunked(
                 save_interval=save_interval,
                 total_time=cur_chunk,
                 output_averages=cfg.run.output_averages,
+                snapshot_interval=cfg.run.get("snapshot_interval"),
+                snapshot_variables=tuple(
+                    cfg.run.get("snapshot_variables") or ()),
             )
         elif first_fresh_chunk and cfg.init.kind == "balanced_isothermal":
             inject_balanced_isothermal_profile(model)
@@ -1509,6 +1518,9 @@ def run_chunked(
                 save_interval=save_interval,
                 total_time=cur_chunk,
                 output_averages=cfg.run.output_averages,
+                snapshot_interval=cfg.run.get("snapshot_interval"),
+                snapshot_variables=tuple(
+                    cfg.run.get("snapshot_variables") or ()),
             )
         elif first_fresh_chunk:
             preds = model.run(
@@ -1516,6 +1528,9 @@ def run_chunked(
                 save_interval=save_interval,
                 total_time=cur_chunk,
                 output_averages=cfg.run.output_averages,
+                snapshot_interval=cfg.run.get("snapshot_interval"),
+                snapshot_variables=tuple(
+                    cfg.run.get("snapshot_variables") or ()),
             )
         else:
             preds = model.resume(
@@ -1523,6 +1538,9 @@ def run_chunked(
                 save_interval=save_interval,
                 total_time=cur_chunk,
                 output_averages=cfg.run.output_averages,
+                snapshot_interval=cfg.run.get("snapshot_interval"),
+                snapshot_variables=tuple(
+                    cfg.run.get("snapshot_variables") or ()),
             )
 
         jax.tree_util.tree_map(
@@ -1542,6 +1560,12 @@ def run_chunked(
         nc_path = f"{output_prefix}_day{int(elapsed_sim_days)}.nc"
         ds.to_netcdf(nc_path)
         print(f"  Saved {nc_path}")
+        snap_ds = getattr(preds, "snapshot_dataset", lambda: None)()
+        if snap_ds is not None:
+            snap_path = (f"{output_prefix}_day{int(elapsed_sim_days)}"
+                         "_snapshots.nc")
+            snap_ds.to_netcdf(snap_path)
+            print(f"  Saved {snap_path}")
 
         # Checkpoint only after a PASSING health check, keeping the previous
         # checkpoint as ``.prev``: an unhealthy chunk must not overwrite the
@@ -1635,3 +1659,11 @@ def save_predictions(predictions, output_path: Path) -> None:
     ds = predictions.to_xarray()
     ds.to_netcdf(str(output_path))
     logger.info("Wrote %s", output_path)
+    # Interval-instantaneous snapshot stream (jax-gcm#586): a separate
+    # file with its own (finer) time axis — folding a second cadence into
+    # the main dataset would force a ragged time dimension.
+    snap_ds = getattr(predictions, "snapshot_dataset", lambda: None)()
+    if snap_ds is not None:
+        snap_path = output_path.with_name(output_path.stem + "_snapshots.nc")
+        snap_ds.to_netcdf(str(snap_path))
+        logger.info("Wrote %s", snap_path)

--- a/tools/aerocom_cmor.py
+++ b/tools/aerocom_cmor.py
@@ -150,6 +150,26 @@ NAME_MAP: dict[str, tuple[str, str, str, float, float]] = {
     "emi_du": ("emi_du", "kg m-2 s-1", "Surface", 1.0, 0.0),
     "emi_moa": ("emi_moa", "kg m-2 s-1", "Surface", 1.0, 0.0),
     "emi_dms": ("emi_dms", "kg m-2 s-1", "Surface", 1.0, 0.0),
+    # --- aerosol-free (noa) radiation, jax-gcm#583 ---
+    "radiation.toa_sw_up_noa": ("rsutnoa", "W m-2", "TOA", 1.0, 0.0),
+    "radiation.toa_lw_up_noa": ("rlutnoa", "W m-2", "TOA", 1.0, 0.0),
+    "radiation.toa_sw_up_clear_noa": ("rsutcsnoa", "W m-2", "TOA", 1.0, 0.0),
+    "radiation.toa_lw_up_clear_noa": ("rlutcsnoa", "W m-2", "TOA", 1.0, 0.0),
+    # --- near-surface / column meteorology (jax-gcm#581 residuals) ---
+    "aerocom_tas": ("tas", "K", "Surface", 1.0, 0.0),
+    "aerocom_uas": ("uas", "m s-1", "Surface", 1.0, 0.0),
+    "aerocom_vas": ("vas", "m s-1", "Surface", 1.0, 0.0),
+    "aerocom_dew2": ("dew2", "K", "Surface", 1.0, 0.0),
+    "aerocom_psl": ("psl", "Pa", "Surface", 1.0, 0.0),
+    "aerocom_prsn": ("prsn", "kg m-2 s-1", "Surface", 1.0, 0.0),
+    "aerocom_prcr": ("prcr", "kg m-2 s-1", "Surface", 1.0, 0.0),
+    "aerocom_prcs": ("prcs", "kg m-2 s-1", "Surface", 1.0, 0.0),
+    "aerocom_wbase": ("wbase", "m s-1", "Surface", 1.0, 0.0),
+    "aerocom_ptp": ("ptp", "Pa", "Surface", 1.0, 0.0),
+    # --- biomass-burning emission splits (MMPPE) ---
+    "emi_bb_so2": ("emi_bb_so2", "kg m-2 s-1", "Surface", 1.0, 0.0),
+    "emi_bb_bc": ("emi_bb_bc", "kg m-2 s-1", "Surface", 1.0, 0.0),
+    "emi_bb_oc": ("emi_bb_oc", "kg m-2 s-1", "Surface", 1.0, 0.0),
     # --- boundary layer ---
     "vertical_diffusion.pbl_height": ("hdtcbl", "m", "Surface", 1.0, 0.0),
     # --- AerocomDiagnostics term output ---
@@ -185,6 +205,21 @@ NAME_MAP: dict[str, tuple[str, str, str, float, float]] = {
     "aerocom_PM1": ("PM1", "kg m-3", "ModelLevel", 1.0, 0.0),
     "aerocom_PM10": ("PM10", "kg m-3", "ModelLevel", 1.0, 0.0),
 }
+
+# Deposition fluxes (dry_* from sedimentation, wet_* from scavenging),
+# written under AeroCom's dry<spec>/wet<spec> convention.
+DEPOSITION_SPECIES = ("so4", "bc", "oc", "poa", "soa", "ss", "du", "moa")
+
+
+def _collect_deposition(ds: xr.Dataset) -> dict[str, xr.DataArray]:
+    out: dict[str, xr.DataArray] = {}
+    for spec in DEPOSITION_SPECIES:
+        for kind in ("dry", "wet"):
+            src = f"{kind}_{spec}"
+            if src in ds.data_vars:
+                out[f"{kind}{spec}"] = ds[src]
+    return out
+
 
 # Column burdens arrive pre-summed per species from AerocomDiagnostics
 # (interstitial + cloud-borne + gas), so the writer only renames them.
@@ -230,6 +265,15 @@ CF_STANDARD_NAMES = {
     "clhcalipso": "cloud_area_fraction_in_atmosphere_layer",
     "cltmodis": "cloud_area_fraction",
     "cltisccp": "cloud_area_fraction",
+    "tas": "air_temperature",
+    "uas": "eastward_wind",
+    "vas": "northward_wind",
+    "dew2": "dew_point_temperature",
+    "psl": "air_pressure_at_mean_sea_level",
+    "prsn": "snowfall_flux",
+    "ptp": "tropopause_air_pressure",
+    "rsutnoa": "toa_outgoing_shortwave_flux",
+    "rlutnoa": "toa_outgoing_longwave_flux",
     "clwmodis": "liquid_water_cloud_area_fraction",
     "climodis": "ice_cloud_area_fraction",
     "tauwmodis": "atmosphere_optical_thickness_due_to_cloud",
@@ -437,6 +481,7 @@ def convert(
     convention: str = "aerocom",
     flip_levels: bool = False,
     dry_run: bool = False,
+    na_aliases: bool = False,
 ) -> tuple[list[str], list[str]]:
     """Write one file per mapped variable; return (written, skipped)."""
     outdir.mkdir(parents=True, exist_ok=True)
@@ -456,6 +501,15 @@ def convert(
     for name, da in optics_vars.items():
         candidates[name] = (da, "1", "Column")
     hist_dsets, hist_srcs = _collect_histograms(ds)
+    for name, da in _collect_deposition(ds).items():
+        candidates[name] = (da, "kg m-2 s-1", "Surface")
+    if na_aliases:
+        # MMPPE names the aerosol-free fluxes *_na where aci/imo2020 use
+        # *noa; same fields, second set of files.
+        for noa, na in (("rsutnoa", "rsut_na"), ("rlutnoa", "rlut_na"),
+                        ("rsutcsnoa", "rsutcs_na"), ("rlutcsnoa", "rlutcs_na")):
+            if noa in candidates:
+                candidates[na] = candidates[noa]
 
     for cmor, (da, units, vert) in sorted(candidates.items()):
         assert vert in VALID_VERT, vert
@@ -497,7 +551,10 @@ def convert(
         written.append(fname)
 
     mapped_srcs = {s for s in NAME_MAP if s in ds.data_vars}
+    dep_srcs = {f"{k}_{sp}" for sp in DEPOSITION_SPECIES
+                for k in ("dry", "wet")}
     skipped = sorted(set(ds.data_vars) - mapped_srcs - optics_srcs - hist_srcs
+                     - dep_srcs
                      - {f"aerocom_burden_{sp}" for sp in BURDEN_SPECIES})
     return written, skipped
 
@@ -517,6 +574,9 @@ def main(argv=None) -> int:
     ap.add_argument("--convention", default="aerocom", choices=["aerocom", "aerocom4"])
     ap.add_argument("--flip-levels", action="store_true",
                     help="write TOA-first instead of JCM's native surface-first")
+    ap.add_argument("--na-aliases", action="store_true",
+                    help="also write the MMPPE *_na names for the "
+                         "aerosol-free fluxes (same data as *noa)")
     ap.add_argument("--dry-run", action="store_true",
                     help="report what would be written without writing")
     args = ap.parse_args(argv)
@@ -526,7 +586,7 @@ def main(argv=None) -> int:
     written, skipped = convert(
         ds, args.model, args.experiment, args.period, args.freq, args.out,
         convention=args.convention, flip_levels=args.flip_levels,
-        dry_run=args.dry_run)
+        dry_run=args.dry_run, na_aliases=args.na_aliases)
 
     print(f"{'would write' if args.dry_run else 'wrote'} {len(written)} "
           f"variable file(s) to {args.out}")


### PR DESCRIPTION
Closes #583 and #586, and clears the #581 residual list down to the two items with genuine external dependencies. Six separable commits; local gates run per `jcm-local-ci` before push (fast 90.87% ≥ 90 at CI dependency parity, slow 81.06% ≥ 80, 169 touched-suite tests + the 19-test omnibus module green, including a real T21L47 RRTMGP step for the noa physics).

## #583 — aerosol-free (`*noa`) radiation
`RRTMGPRadiation(aerosol_free_diagnostics=True)` (factory: `aerosol_free_radiation`, enabled in the `echam-jam-aerocom` preset): a second identical vmapped solve per compute step with the aerosol **optics** zeroed — `cdnc_factor`/`Nccn` untouched, so the cloud field is bit-identical and the all-sky difference is the instantaneous aerosol radiative effect (ERFari), cleanly separated from ERFaci. Four new `RadiationData` fields ride the existing radiation carry (cached steps reuse them); grey/emulated schemes raise rather than emit all-zero files. Validated end-to-end: SW differs measurably under MACv2-SP aerosol, LW bit-equal (MACv2-SP is SW-only). CMOR: `rsutnoa`/`rlutnoa`/clear-sky variants plus `--na-aliases` for MMPPE's `*_na` names.

## #586 — interval-instantaneous snapshots
`Model.run(snapshot_interval=..., snapshot_variables=(...))`: a second output stream of selected 2-D diagnostics at (e.g.) 3-hourly instantaneous cadence riding a monthly-mean run, retrieved via `ModelPredictions.snapshot_dataset()`. **Deliberate deviation from the issue's "extend the observers" suggestion**, argued in the commit: observer samples are structurally one-per-`dt` in the scan's ys, so a cheaper cadence cannot shrink them — the averaged-mode inner scan's carry (where the interval mean already accumulates) is the natural home, and costs `n_snaps × field` memory instead of `n_steps × field`. Correctness is pinned against ground truth: strided snapshots equal the frames of a fine-grained snapshot-mode run at the same times.

## #581 residuals
- **`nearsurface` diagnostics group**: `tas`/`uas`/`vas` by neutral log-profile interpolation (tile-averaged z0m from the surface term; stability corrections deliberately omitted and documented — O(1 K) in strong stratification, immaterial for AeroCom context fields), `dew2` (Magnus inversion, capped at `tas`), `psl` (WMO 6.5 K/km reduction, exact at sea level by test), `prsn`/`prcr`/`prcs` (convective split by the COSP hook's melt criterion), `wbase` (the **same** `fact_tke·√(2·TKE)` updraft the 2M activation uses, at the diagnosed cloud base), and `ptp` (the existing WMO tropopause finder, finally wired to output).
- **1M process rates** (#585 acceptance): `autoconv` from the sweep's existing rate; `accretn`/`wbf` as explicit zeros — the 1M sweep folds accretion into its combined sink and has no Bergeron transfer, and a zero-valued key is honest where a missing key is ambiguous.
- **`emi_bb_{so2,bc,oc}`** (MMPPE): the anthropogenic term's biomass-burning super-sector fluxes as emitted, pre-speciation.
- **`dry_*`/`wet_*` deposition fluxes**: a sign-flipped sibling of the emission accumulator on the sedimentation and wet-scavenging terms' own tracer tendencies (cannot drift from the mass actually removed); `dry_*` is the sedimentation sink alone until a turbulent-drydep term exists (documented). All flux keys share the per-step reset family. The **budget check** `emi − dry − wet ≈ d(burden)/dt` closes to roundoff for inert species (pinned by test).

## Still open, with reasons
`wap`/`w500`/`w700` stay with #409 (they need the dycore omega provider — hybrid-coordinate work that should not be rushed into a submission variable) and `parasolRefl` needs a reflectance simulator upstream in jax-cosp. #581 remains the tracker for exactly those two plus nothing else; ledger comment updated on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aqshaa5nDrxcDWgg1FYw8Z
