### PR TITLE
feat(provenance): record run provenance in every output file

### DIFF
--- a/.coveragerc-pr
+++ b/.coveragerc-pr
@@ -35,6 +35,7 @@ omit =
     jcm/data/regridding.py
     jcm/data/mirror/registry.py
     jcm/data/remote.py
+    jcm/provenance.py
     # PR-only: utility / orchestration modules. The fast-test suite
     # exercises these thoroughly; the slow integration tests only
     # touch them through entry-point shims.

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,6 +4,15 @@ Release Notes
 Unreleased — issue-backlog tidy-up
 ----------------------------------
 
+- **Run provenance recorded in every output file** (#591): netCDF global
+  attributes (``jcm_prov_*``) carry the git SHA/branch/dirty state of
+  every imported editable library, precision flags and devices, the
+  resolved boundary files actually opened (size+mtime; content sha256
+  with ``JCM_HASH_INPUTS=1``), whether ozone was prescribed or analytic,
+  and a single 12-hex run hash for at-a-glance "same setup" checks. A
+  ``<output>.nc.provenance.json`` sidecar holds the fully composed
+  Hydra config, and one log line at startup summarises SHAs / precision
+  / ozone source.
 - **Betts-Miller default shallow flavor is now ``SHALLOWER``** (was
   Isca's nominal ``SIMP``, which zeroes the shallow branch and is always
   overridden in practice — #524). Runs using the default Betts-Miller

--- a/jcm/provenance.py
+++ b/jcm/provenance.py
@@ -103,7 +103,7 @@ def probe_environment() -> dict:
     import jax
 
     devices = jax.devices()
-    return {
+    env = {
         "python": platform.python_version(),
         "hostname": socket.gethostname(),
         "user": getpass.getuser(),
@@ -113,6 +113,13 @@ def probe_environment() -> dict:
         "device_kind": devices[0].device_kind,
         "device_count": len(devices),
     }
+    try:
+        # On GPU this carries the CUDA runtime/driver versions.
+        env["platform_version"] = (
+            jax.extend.backend.get_backend().platform_version)
+    except Exception:  # noqa: BLE001 — best-effort, backend-dependent
+        pass
+    return env
 
 
 def describe_input(path: str) -> dict:
@@ -227,6 +234,10 @@ def attrs() -> dict:
     prov = collect()
     out = {
         "jcm_prov_created": prov["created"],
+        # attrs() runs at output time, so this stamps the write — with
+        # ``created`` it brackets the run without a separate end hook.
+        "jcm_prov_written": datetime.now(
+            timezone.utc).isoformat(timespec="seconds"),
         "jcm_prov_run_hash": prov["run_hash"],
         "jcm_prov_code": json.dumps(prov["code"], sort_keys=True),
         "jcm_prov_environment": json.dumps(prov["environment"],

--- a/jcm/provenance.py
+++ b/jcm/provenance.py
@@ -39,6 +39,9 @@ logger = logging.getLogger(__name__)
 #: when already imported — an absent entry means "not part of this run".
 _EDITABLE_LIBS = ("jcm", "dinosaur", "rrtmgp", "mam4_jax", "jax_cosp",
                   "pyses")
+#: Module-name -> distribution-name where they differ.
+_DIST_NAMES = {"rrtmgp": "jax-rrtmgp", "mam4_jax": "mam4-jax",
+               "jax_cosp": "jax-cosp"}
 #: Packaged dependencies recorded by version only.
 _VERSION_LIBS = ("jax", "jaxlib", "numpy", "xarray", "flax")
 #: Environment variables that silently change precision or compilation.
@@ -68,10 +71,13 @@ def probe_code() -> dict:
             continue
         path = str(Path(mod.__file__).resolve().parent)
         entry: dict = {"path": path}
-        try:
-            entry["version"] = metadata.version(name.replace("_", "-"))
-        except metadata.PackageNotFoundError:
-            pass
+        # Module and distribution names differ (rrtmgp -> jax-rrtmgp).
+        for dist in (_DIST_NAMES.get(name, name), name.replace("_", "-")):
+            try:
+                entry["version"] = metadata.version(dist)
+                break
+            except metadata.PackageNotFoundError:
+                pass
         top = _git(path, "rev-parse", "--show-toplevel")
         if top:
             entry["sha"] = _git(top, "rev-parse", "HEAD")
@@ -130,7 +136,13 @@ def describe_input(path: str) -> dict:
 
 
 def start_run(cfg=None) -> None:
-    """Capture code/env/config at run start and reset the input registry."""
+    """Reset the registries and capture the config at run start.
+
+    Code and environment are probed lazily (and re-probed on every
+    :func:`collect`): the model build imports configuration-selected
+    libraries (pyses, mam4_jax, …) and can flip the live x64 setting
+    *after* run start, so an eager snapshot here would miss them.
+    """
     config_yaml = None
     if cfg is not None:
         from omegaconf import OmegaConf
@@ -143,13 +155,10 @@ def start_run(cfg=None) -> None:
             config_yaml = OmegaConf.to_yaml(cfg, resolve=False)
     _state["base"] = {
         "created": datetime.now(timezone.utc).isoformat(timespec="seconds"),
-        "code": probe_code(),
-        "environment": probe_environment(),
         "config_yaml": config_yaml,
     }
     _state["inputs"] = {}
     _state["facts"] = {}
-    logger.info("provenance: %s", summary())
 
 
 def record_input(requested, resolved=None) -> None:
@@ -169,14 +178,24 @@ def record_fact(key: str, value) -> None:
 
 
 def collect() -> dict:
-    """Return the full provenance record (captures the base lazily)."""
+    """Return the full provenance record.
+
+    Code and environment are probed fresh each call (a handful of git
+    subprocesses — negligible next to a netCDF write), so libraries the
+    model build imported lazily and any post-start x64 flip are captured.
+    """
     if _state["base"] is None:
         start_run()
     prov = dict(_state["base"])
+    prov["code"] = probe_code()
+    prov["environment"] = probe_environment()
     prov["inputs"] = dict(_state["inputs"])
     prov["facts"] = dict(_state["facts"])
     hash_material = {
-        "code": {k: v.get("sha", v.get("version"))
+        # A dirty tree is a different code state than its HEAD: fold the
+        # working-tree diff fingerprint into the identity.
+        "code": {k: (v.get("sha", v.get("version")),
+                     v.get("dirty_diff_sha"))
                  for k, v in prov["code"].items()},
         "config": prov["config_yaml"],
         "inputs": {k: v.get("sha256", (v.get("size"), v.get("mtime")))
@@ -190,12 +209,12 @@ def collect() -> dict:
 
 
 def summary() -> str:
-    """One log line: SHAs, precision, ozone source."""
-    base = _state["base"] or {}
+    """One log line: SHAs, precision, ozone source (probed fresh)."""
+    code = probe_code()
+    env = probe_environment()
     shas = ", ".join(
         f"{k}={v['sha'][:8]}{'+dirty' if v.get('dirty') else ''}"
-        for k, v in base.get("code", {}).items() if "sha" in v)
-    env = base.get("environment", {})
+        for k, v in code.items() if "sha" in v)
     ozone = _state["facts"].get("ozone_source", "?")
     return (f"{shas or 'no git trees'}; "
             f"x64={env.get('jax_enable_x64')}; "

--- a/jcm/provenance.py
+++ b/jcm/provenance.py
@@ -1,0 +1,235 @@
+"""Run provenance capture (#591).
+
+Records what actually produced an output file — code versions (git SHA +
+dirty state of every editable install *actually imported*), precision and
+hardware, the resolved boundary files opened, the ozone source, and a
+single run hash — and attaches it as netCDF global attributes plus a
+``<output>.provenance.json`` sidecar carrying the fully composed config.
+
+The probe inspects ``sys.modules`` in the running process, so a
+``PYTHONPATH`` override is reflected as *what was imported*, not what was
+requested. Input files funnel through ``runners._resolve_data_path`` and
+are recorded here as they resolve; content hashing of multi-GB inputs is
+opt-in (``JCM_HASH_INPUTS=1``) — size + mtime is the default descriptor.
+
+Lifecycle: :func:`start_run` at run start (captures code/env/config and
+resets the input registry), :func:`record_input` / :func:`record_fact`
+during model build, :func:`attrs` / :func:`write_sidecar` at output time
+(inputs and the run hash are finalized lazily, after the build has
+touched every file).
+"""
+
+from __future__ import annotations
+
+import getpass
+import hashlib
+import json
+import logging
+import os
+import platform
+import socket
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: Libraries whose working tree changes what a run computes. Probed only
+#: when already imported — an absent entry means "not part of this run".
+_EDITABLE_LIBS = ("jcm", "dinosaur", "rrtmgp", "mam4_jax", "jax_cosp",
+                  "pyses")
+#: Packaged dependencies recorded by version only.
+_VERSION_LIBS = ("jax", "jaxlib", "numpy", "xarray", "flax")
+#: Environment variables that silently change precision or compilation.
+_ENV_FLAGS = ("JAX_ENABLE_X64", "MAM4_JAX_ENABLE_X64", "XLA_FLAGS",
+              "JCM_CACHE_DIR")
+
+_state: dict = {"base": None, "inputs": {}, "facts": {}}
+
+
+def _git(path: str, *args: str) -> str | None:
+    try:
+        out = subprocess.run(["git", "-C", path, *args],
+                             capture_output=True, text=True, timeout=10)
+        return out.stdout.strip() if out.returncode == 0 else None
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+
+def probe_code() -> dict:
+    """Path + version + git SHA/branch/dirty for every imported key library."""
+    from importlib import metadata
+
+    code: dict = {}
+    for name in _EDITABLE_LIBS:
+        mod = sys.modules.get(name)
+        if mod is None or not getattr(mod, "__file__", None):
+            continue
+        path = str(Path(mod.__file__).resolve().parent)
+        entry: dict = {"path": path}
+        try:
+            entry["version"] = metadata.version(name.replace("_", "-"))
+        except metadata.PackageNotFoundError:
+            pass
+        top = _git(path, "rev-parse", "--show-toplevel")
+        if top:
+            entry["sha"] = _git(top, "rev-parse", "HEAD")
+            entry["branch"] = _git(top, "rev-parse", "--abbrev-ref", "HEAD")
+            status = _git(top, "status", "--porcelain")
+            entry["dirty"] = bool(status)
+            if status:
+                # Distinguish two dirty trees without shipping the diff.
+                diff = _git(top, "diff", "HEAD") or ""
+                entry["dirty_diff_sha"] = hashlib.sha256(
+                    diff.encode()).hexdigest()[:12]
+        code[name] = entry
+    for name in _VERSION_LIBS:
+        try:
+            code[name] = {"version": metadata.version(name)}
+        except metadata.PackageNotFoundError:
+            pass
+    return code
+
+
+def probe_environment() -> dict:
+    """Precision flags, devices, host — the silent run-shapers."""
+    import jax
+
+    devices = jax.devices()
+    return {
+        "python": platform.python_version(),
+        "hostname": socket.gethostname(),
+        "user": getpass.getuser(),
+        "jax_enable_x64": bool(jax.config.jax_enable_x64),
+        "env": {k: os.environ[k] for k in _ENV_FLAGS if k in os.environ},
+        "platform": devices[0].platform,
+        "device_kind": devices[0].device_kind,
+        "device_count": len(devices),
+    }
+
+
+def describe_input(path: str) -> dict:
+    """Size + mtime descriptor; content sha256 when JCM_HASH_INPUTS=1."""
+    d: dict = {}
+    try:
+        st = os.stat(path)
+        d["size"] = st.st_size
+        d["mtime"] = datetime.fromtimestamp(
+            st.st_mtime, tz=timezone.utc).isoformat(timespec="seconds")
+    except OSError:
+        d["missing"] = True
+        return d
+    if os.environ.get("JCM_HASH_INPUTS") == "1":
+        h = hashlib.sha256()
+        with open(path, "rb") as f:
+            for block in iter(lambda: f.read(1 << 22), b""):
+                h.update(block)
+        d["sha256"] = h.hexdigest()
+    return d
+
+
+def start_run(cfg=None) -> None:
+    """Capture code/env/config at run start and reset the input registry."""
+    config_yaml = None
+    if cfg is not None:
+        from omegaconf import OmegaConf
+        from omegaconf.errors import OmegaConfBaseException
+        try:
+            config_yaml = OmegaConf.to_yaml(cfg, resolve=True)
+        except OmegaConfBaseException:
+            # hydra:-runtime interpolations only resolve inside a live
+            # Hydra app; the unresolved form still records every choice.
+            config_yaml = OmegaConf.to_yaml(cfg, resolve=False)
+    _state["base"] = {
+        "created": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "code": probe_code(),
+        "environment": probe_environment(),
+        "config_yaml": config_yaml,
+    }
+    _state["inputs"] = {}
+    _state["facts"] = {}
+    logger.info("provenance: %s", summary())
+
+
+def record_input(requested, resolved=None) -> None:
+    """Record a boundary/input file the run resolved (deduped by path)."""
+    resolved = str(resolved if resolved is not None else requested)
+    if not os.path.isfile(resolved):
+        return
+    entry = describe_input(resolved)
+    if str(requested) != resolved:
+        entry["requested"] = str(requested)
+    _state["inputs"][resolved] = entry
+
+
+def record_fact(key: str, value) -> None:
+    """Record a run-shaping fact (e.g. ozone_source = prescribed/analytic)."""
+    _state["facts"][key] = value
+
+
+def collect() -> dict:
+    """Return the full provenance record (captures the base lazily)."""
+    if _state["base"] is None:
+        start_run()
+    prov = dict(_state["base"])
+    prov["inputs"] = dict(_state["inputs"])
+    prov["facts"] = dict(_state["facts"])
+    hash_material = {
+        "code": {k: v.get("sha", v.get("version"))
+                 for k, v in prov["code"].items()},
+        "config": prov["config_yaml"],
+        "inputs": {k: v.get("sha256", (v.get("size"), v.get("mtime")))
+                   for k, v in prov["inputs"].items()},
+        "x64": prov["environment"]["jax_enable_x64"],
+    }
+    prov["run_hash"] = hashlib.sha256(
+        json.dumps(hash_material, sort_keys=True, default=str).encode()
+    ).hexdigest()[:12]
+    return prov
+
+
+def summary() -> str:
+    """One log line: SHAs, precision, ozone source."""
+    base = _state["base"] or {}
+    shas = ", ".join(
+        f"{k}={v['sha'][:8]}{'+dirty' if v.get('dirty') else ''}"
+        for k, v in base.get("code", {}).items() if "sha" in v)
+    env = base.get("environment", {})
+    ozone = _state["facts"].get("ozone_source", "?")
+    return (f"{shas or 'no git trees'}; "
+            f"x64={env.get('jax_enable_x64')}; "
+            f"{env.get('device_count')}x{env.get('device_kind')}; "
+            f"ozone={ozone}")
+
+
+def attrs() -> dict:
+    """Flat netCDF-safe global attributes (nested parts as JSON strings)."""
+    prov = collect()
+    out = {
+        "jcm_prov_created": prov["created"],
+        "jcm_prov_run_hash": prov["run_hash"],
+        "jcm_prov_code": json.dumps(prov["code"], sort_keys=True),
+        "jcm_prov_environment": json.dumps(prov["environment"],
+                                           sort_keys=True),
+        "jcm_prov_inputs": json.dumps(prov["inputs"], sort_keys=True),
+    }
+    for key, value in prov["facts"].items():
+        out[f"jcm_prov_{key}"] = str(value)
+    if prov["config_yaml"] is not None:
+        # The composed config is too large for attributes (it goes in the
+        # sidecar); the hash makes "same config" checkable from attrs.
+        out["jcm_prov_config_sha"] = hashlib.sha256(
+            prov["config_yaml"].encode()).hexdigest()[:12]
+    return out
+
+
+def write_sidecar(output_path) -> Path:
+    """Write ``<output>.provenance.json`` with the full record + config."""
+    output_path = Path(output_path)
+    sidecar = output_path.with_suffix(output_path.suffix +
+                                      ".provenance.json")
+    sidecar.parent.mkdir(parents=True, exist_ok=True)
+    sidecar.write_text(json.dumps(collect(), indent=1, sort_keys=True,
+                                  default=str))
+    return sidecar

--- a/jcm/provenance_test.py
+++ b/jcm/provenance_test.py
@@ -98,6 +98,9 @@ class RegistryAndHashTest(unittest.TestCase):
         for key, value in attrs.items():
             self.assertTrue(key.startswith("jcm_prov_"), key)
             self.assertIsInstance(value, str)
+        # created (run start) and written (output time) bracket the run.
+        self.assertIn("jcm_prov_created", attrs)
+        self.assertIn("jcm_prov_written", attrs)
         # nested parts round-trip through JSON
         self.assertIn("jcm", json.loads(attrs["jcm_prov_code"]))
 

--- a/jcm/provenance_test.py
+++ b/jcm/provenance_test.py
@@ -1,0 +1,157 @@
+"""Tests for run provenance capture (#591)."""
+import hashlib
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from jcm import provenance
+
+
+class ProbeCodeTest(unittest.TestCase):
+    def test_jcm_probed_with_git_state(self):
+        code = provenance.probe_code()
+        self.assertIn("jcm", code)
+        entry = code["jcm"]
+        self.assertTrue(Path(entry["path"]).is_dir())
+        # This test runs from a git worktree, so the git triple must be
+        # present and well-formed.
+        self.assertRegex(entry["sha"], r"^[0-9a-f]{40}$")
+        self.assertIsInstance(entry["dirty"], bool)
+        if entry["dirty"]:
+            self.assertRegex(entry["dirty_diff_sha"], r"^[0-9a-f]{12}$")
+
+    def test_version_libs_recorded(self):
+        code = provenance.probe_code()
+        self.assertIn("jax", code)
+        self.assertIn("version", code["jax"])
+
+
+class ProbeEnvironmentTest(unittest.TestCase):
+    def test_environment_fields(self):
+        env = provenance.probe_environment()
+        self.assertIn(env["jax_enable_x64"], (True, False))
+        self.assertGreaterEqual(env["device_count"], 1)
+        self.assertTrue(env["hostname"])
+        self.assertIn("platform", env)
+
+
+class DescribeInputTest(unittest.TestCase):
+    def test_size_mtime_default_and_hash_opt_in(self):
+        with tempfile.NamedTemporaryFile(suffix=".nc") as f:
+            f.write(b"hello provenance")
+            f.flush()
+            d = provenance.describe_input(f.name)
+            self.assertEqual(d["size"], 16)
+            self.assertIn("mtime", d)
+            self.assertNotIn("sha256", d)
+            try:
+                os.environ["JCM_HASH_INPUTS"] = "1"
+                d = provenance.describe_input(f.name)
+            finally:
+                os.environ.pop("JCM_HASH_INPUTS", None)
+            self.assertEqual(
+                d["sha256"],
+                hashlib.sha256(b"hello provenance").hexdigest())
+
+    def test_missing_file_flagged(self):
+        d = provenance.describe_input("/nonexistent/never.nc")
+        self.assertTrue(d["missing"])
+
+
+class RegistryAndHashTest(unittest.TestCase):
+    def setUp(self):
+        provenance.start_run()
+
+    def test_record_input_dedup_and_missing_skipped(self):
+        provenance.record_input("/nonexistent/never.nc")
+        with tempfile.NamedTemporaryFile(suffix=".nc") as f:
+            f.write(b"x")
+            f.flush()
+            provenance.record_input(f.name)
+            provenance.record_input("hf://bundles/x.nc", f.name)
+            prov = provenance.collect()
+        self.assertEqual(len(prov["inputs"]), 1)
+        entry = next(iter(prov["inputs"].values()))
+        self.assertEqual(entry["requested"], "hf://bundles/x.nc")
+
+    def test_run_hash_stable_and_input_sensitive(self):
+        h0 = provenance.collect()["run_hash"]
+        self.assertEqual(provenance.collect()["run_hash"], h0)
+        self.assertRegex(h0, r"^[0-9a-f]{12}$")
+        with tempfile.NamedTemporaryFile(suffix=".nc") as f:
+            f.write(b"data")
+            f.flush()
+            provenance.record_input(f.name)
+            self.assertNotEqual(provenance.collect()["run_hash"], h0)
+
+    def test_facts_reach_attrs_and_summary(self):
+        provenance.record_fact("ozone_source", "prescribed:/x/ozone.nc")
+        attrs = provenance.attrs()
+        self.assertEqual(attrs["jcm_prov_ozone_source"],
+                         "prescribed:/x/ozone.nc")
+        self.assertIn("ozone=prescribed:/x/ozone.nc", provenance.summary())
+
+    def test_attrs_are_netcdf_safe_strings(self):
+        attrs = provenance.attrs()
+        for key, value in attrs.items():
+            self.assertTrue(key.startswith("jcm_prov_"), key)
+            self.assertIsInstance(value, str)
+        # nested parts round-trip through JSON
+        self.assertIn("jcm", json.loads(attrs["jcm_prov_code"]))
+
+    def test_config_hashed_into_attrs_and_sidecar(self):
+        from omegaconf import OmegaConf
+        provenance.start_run(OmegaConf.create({"run": {"total_time": 10}}))
+        attrs = provenance.attrs()
+        self.assertRegex(attrs["jcm_prov_config_sha"], r"^[0-9a-f]{12}$")
+        with tempfile.TemporaryDirectory() as d:
+            sidecar = provenance.write_sidecar(Path(d) / "out.nc")
+            self.assertEqual(sidecar.name, "out.nc.provenance.json")
+            full = json.loads(sidecar.read_text())
+            self.assertIn("total_time: 10", full["config_yaml"])
+            self.assertEqual(full["run_hash"], attrs["jcm_prov_run_hash"])
+
+
+class SavePredictionsAttachesTest(unittest.TestCase):
+    def test_netcdf_attrs_and_sidecar_written(self):
+        import xarray as xr
+
+        from jcm.runners import save_predictions
+
+        class _Preds:
+            def to_xarray(self):
+                return xr.Dataset({"t": ("x", [1.0])})
+
+        provenance.start_run()
+        with tempfile.TemporaryDirectory() as d:
+            out = Path(d) / "run.nc"
+            save_predictions(_Preds(), out)
+            with xr.open_dataset(out) as ds:
+                self.assertIn("jcm_prov_run_hash", ds.attrs)
+                self.assertIn("jcm_prov_code", ds.attrs)
+            sidecar = Path(d) / "run.nc.provenance.json"
+            self.assertTrue(sidecar.exists())
+            self.assertEqual(json.loads(sidecar.read_text())["run_hash"],
+                             ds.attrs["jcm_prov_run_hash"])
+
+
+class ResolveDataPathRecordsTest(unittest.TestCase):
+    def test_resolver_feeds_the_registry(self):
+        from jcm.runners import _resolve_data_path
+        provenance.start_run()
+        with tempfile.NamedTemporaryFile(suffix=".nc") as f:
+            f.write(b"terrain")
+            f.flush()
+            out = _resolve_data_path(f.name)
+            self.assertEqual(out, f.name)
+            self.assertIn(f.name, provenance.collect()["inputs"])
+        # non-file strings pass through without registering
+        provenance.start_run()
+        _resolve_data_path("auto")
+        self.assertEqual(provenance.collect()["inputs"], {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jcm/runners.py
+++ b/jcm/runners.py
@@ -20,6 +20,7 @@ import jax
 import jax.numpy as jnp
 from omegaconf import DictConfig
 
+from jcm import provenance
 from jcm.diffusion import DiffusionFilter
 from jcm.model import Model, ModelPredictions
 from jcm.terrain import TerrainData
@@ -383,13 +384,17 @@ def _resolve_data_path(path):
     """
     if isinstance(path, str) and path.startswith("hf://"):
         from jcm.data.remote import fetch
-        return fetch(path[len("hf://"):])
+        resolved = fetch(path[len("hf://"):])
+        provenance.record_input(path, resolved)
+        return resolved
     if (not isinstance(path, (str, bytes, Mapping))
             and isinstance(path, Iterable)):
         # emissions_file may be a list of paths (incl. Hydra ListConfig).
         # Mappings/bytes pass through untouched — iterating them would
         # silently turn a mis-typed config into a list of keys/ints.
         return [_resolve_data_path(p) for p in path]
+    if isinstance(path, str):
+        provenance.record_input(path)   # no-op unless it is a real file
     return path
 
 
@@ -889,6 +894,10 @@ def build_forcing(cfg: DictConfig, coords, dycore=None):
                 ozone_file = None
         elif ozone_file in ("", "null", "none"):
             ozone_file = None
+        provenance.record_fact(
+            "ozone_source",
+            f"prescribed:{ozone_file}" if ozone_file
+            else "analytic (no ozone file)")
 
         file = (_resolve_data_path(cfg.forcing.get("file", None))
                 or _pyses_default_bc("forcing.nc"))
@@ -987,10 +996,13 @@ def _attach_ozone(forcing, forcing_cfg, coords):
     ozone_file = _resolve_data_path(
         forcing_cfg.get("ozone_file", None))
     if ozone_file in (None, "", "null"):
+        provenance.record_fact("ozone_source", "analytic (no ozone_file)")
         return forcing
     if ozone_file == "auto":
         ozone_file = _resolve_auto_ozone(coords)
         if ozone_file is None:
+            provenance.record_fact(
+                "ozone_source", "analytic (auto found no packaged match)")
             logging.warning(
                 "forcing.ozone_file=auto: no packaged jcm/data/bc/*/ozone.nc "
                 "matches this grid — falling back to the ANALYTIC ozone "
@@ -1017,6 +1029,8 @@ def _attach_ozone(forcing, forcing_cfg, coords):
         nlon=int(nlon), nlat=int(nlat), nlev=int(nlev),
         lat_deg=lat_deg, lon_deg=lon_deg,
     )
+    provenance.record_fact("ozone_source", f"prescribed:{ozone_file}")
+    provenance.record_input(ozone_file)
     if forcing is None:
         forcing = default_forcing(coords.horizontal)
     return forcing.copy(ozone_climatology=climatology)
@@ -1288,6 +1302,11 @@ def run(cfg: DictConfig, model: Model | None = None):
     # dynamical core (which reads the live jcm.constants singleton at
     # construction) and the attribute-access physics both pick them up. Only base
     # fields may be set; derived constants (rd, cvd, rgrav, vtmpc*) follow.
+    # Capture provenance before the model build so every input file the
+    # build resolves lands in the registry (#591); logs the one-line
+    # summary of code SHAs / precision / devices.
+    provenance.start_run(cfg)
+
     constants_overrides = cfg.get("constants", None)
     if constants_overrides:
         import jcm.constants as _jcm_constants
@@ -1588,12 +1607,15 @@ def run_chunked(
         print_report(report)
 
         nc_path = f"{output_prefix}_day{int(elapsed_sim_days)}.nc"
+        ds.attrs.update(provenance.attrs())
         ds.to_netcdf(nc_path)
+        provenance.write_sidecar(nc_path)
         print(f"  Saved {nc_path}")
         snap_ds = getattr(preds, "snapshot_dataset", lambda: None)()
         if snap_ds is not None:
             snap_path = (f"{output_prefix}_day{int(elapsed_sim_days)}"
                          "_snapshots.nc")
+            snap_ds.attrs.update(provenance.attrs())
             snap_ds.to_netcdf(snap_path)
             print(f"  Saved {snap_path}")
 
@@ -1687,7 +1709,9 @@ def save_predictions(predictions, output_path: Path) -> None:
         )
         return
     ds = predictions.to_xarray()
+    ds.attrs.update(provenance.attrs())
     ds.to_netcdf(str(output_path))
+    provenance.write_sidecar(output_path)
     logger.info("Wrote %s", output_path)
     # Interval-instantaneous snapshot stream (jax-gcm#586): a separate
     # file with its own (finer) time axis — folding a second cadence into
@@ -1695,5 +1719,6 @@ def save_predictions(predictions, output_path: Path) -> None:
     snap_ds = getattr(predictions, "snapshot_dataset", lambda: None)()
     if snap_ds is not None:
         snap_path = output_path.with_name(output_path.stem + "_snapshots.nc")
+        snap_ds.attrs.update(provenance.attrs())
         snap_ds.to_netcdf(str(snap_path))
         logger.info("Wrote %s", snap_path)

--- a/jcm/runners.py
+++ b/jcm/runners.py
@@ -1615,6 +1615,7 @@ def run_chunked(
 
         nc_path = f"{output_prefix}_day{int(elapsed_sim_days)}.nc"
         ds.attrs.update(provenance.attrs())
+        ds.attrs["jcm_prov_chunk_wall_seconds"] = round(chunk_wall, 1)
         ds.to_netcdf(nc_path)
         provenance.write_sidecar(nc_path)
         print(f"  Saved {nc_path}")

--- a/jcm/runners.py
+++ b/jcm/runners.py
@@ -813,8 +813,11 @@ def _pyses_default_bc(filename: str) -> str:
     """Resolve the packaged T63 boundary file (temporary downscale)."""
     import jcm
 
-    return str(Path(jcm.__file__).resolve().parent / "data" / "bc" / "t63"
+    path = str(Path(jcm.__file__).resolve().parent / "data" / "bc" / "t63"
                / filename)
+    # A fallback actually opened is provenance like any explicit file.
+    provenance.record_input(path)
+    return path
 
 
 def _pyses_lid_sponge_term(dycore, sponge_cfg):
@@ -1302,9 +1305,10 @@ def run(cfg: DictConfig, model: Model | None = None):
     # dynamical core (which reads the live jcm.constants singleton at
     # construction) and the attribute-access physics both pick them up. Only base
     # fields may be set; derived constants (rd, cvd, rgrav, vtmpc*) follow.
-    # Capture provenance before the model build so every input file the
-    # build resolves lands in the registry (#591); logs the one-line
-    # summary of code SHAs / precision / devices.
+    # Reset the provenance registries before the model build so every
+    # input file the build resolves lands in them (#591); the code/env
+    # probe and the summary log happen after the build, once the
+    # config-selected libraries are actually imported.
     provenance.start_run(cfg)
 
     constants_overrides = cfg.get("constants", None)
@@ -1331,6 +1335,9 @@ def _run_full(cfg: DictConfig, model: Model | None = None) -> ModelPredictions:
         model = build_model(cfg)
 
     forcing = build_forcing(cfg, model.coords, dycore=getattr(model, "dycore", None))
+    # After model + forcing construction: config-selected libraries are
+    # imported and the ozone source is decided, so the summary is accurate.
+    logger.info("provenance: %s", provenance.summary())
     chunk_days = float(cfg.run.get("chunk_days", 0.0) or 0.0)
     if chunk_days > 0:
         return run_chunked(


### PR DESCRIPTION
Implements all three slices of #591.

## What gets captured

**Code** — `jcm/provenance.py` probes `sys.modules` in the running process, so a `PYTHONPATH` override reports *what was imported*, not what was requested (the in-process analogue of `tools/benchmark.py`'s subprocess probe). For each imported editable library (jcm, dinosaur, jax-rrtmgp, mam4-jax, jax-cosp, pyses): resolved path, version, git SHA, branch, dirty flag, and a 12-hex dirty-diff hash so two dirty trees are distinguishable without shipping the diff. Packaged deps (jax, jaxlib, numpy, xarray, flax) by version.

**Environment** — `jax_enable_x64` read from the live JAX config (not the env request), `MAM4_JAX_ENABLE_X64` / `XLA_FLAGS` / `JCM_CACHE_DIR` when set, device platform/kind/count, hostname, user, Python version.

**Inputs** — every boundary file funnels through `runners._resolve_data_path`, which now records into the provenance registry: the resolved local path plus, when different, what was requested (so `hf://…` shows both). Size + mtime by default; content sha256 opt-in via `JCM_HASH_INPUTS=1` (multi-GB inputs make hashing-by-default too slow, per the issue's open question).

**Ozone source** — recorded as an explicit fact (`prescribed:<path>` / `analytic (auto found no packaged match)` / `analytic (no ozone_file)`) at all three resolution sites, including the pySES branch. This was the incident where a silent fallback changed the physics.

**Run hash** — 12-hex sha256 over code SHAs + composed config + input descriptors + x64 flag: two files claiming "same setup" are checkable at a glance.

## Where it goes

1. `jcm_prov_*` **netCDF global attributes** on every output file — main, `_snapshots`, and each chunk of a chunked run (nested parts as JSON strings; the composed config as a hash, since the full text is too large for attributes).
2. **`<output>.nc.provenance.json` sidecar** with the full record including the fully composed Hydra config (`resolve=True`, falling back to unresolved YAML outside a live Hydra app, where `${hydra:…}` interpolations cannot resolve — found by the existing CLI tests).
3. **One startup log line**: `jcm=<sha8>+dirty, …; x64=False; 4xNVIDIA A100…; ozone=prescribed:…`.

Chunked/resumed segments each carry their own record (each `run()` re-captures), rather than overwriting a shared one.

Also namespaces the natural follow-up: the run hash is exactly the provenance key #592's compilation-cache discussion wanted.

## Tests

`jcm/provenance_test.py` (12): git probe well-formedness, env fields, size/mtime vs opt-in sha256, registry dedup + missing-file skip, run-hash stability and input-sensitivity, facts→attrs→summary, netCDF-safe attribute types, config sha + sidecar round-trip, `_resolve_data_path` feeding the registry, and a full `save_predictions` round-trip asserting attrs land in the file and the sidecar matches. `jcm/provenance.py` added to `.coveragerc-pr`'s fast-tested-utility omit list per that file's documented mechanism.

## Local CI (develop node, sequential gates)

lint clean; fast 1611 passed, 94% ≥ 90%; slow 79 passed, 85% ≥ 80%.

Closes #591.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EYsAZJeaPcP2DAzzxtXRN