### PR TITLE
Omega (Dp/Dt) dycore diagnostic provider: AeroCom wap/w500/w700

### DIFF
--- a/jcm/config/dycore/dinosaur.yaml
+++ b/jcm/config/dycore/dinosaur.yaml
@@ -2,3 +2,12 @@
 # vertical discretization comes from the ``grid`` group; diffusion from the
 # ``diffusion`` group; the timestep from ``run.time_step`` (minutes).
 name: dinosaur
+
+# Opt-in per-step diagnostic providers on the physics grid.
+# compute_omega: pressure vertical velocity (omega = Dp/Dt, Pa/s) from the
+# core's own diagnostic state, consumed by the AeroCom ``plev`` group as
+# wap/w500/w700 (zero-filled when off). Costs a few modal->nodal
+# transforms per step. ``null`` means "decide from the physics config":
+# on when the AeroCom plev group runs, off otherwise. Set true/false to
+# override either way.
+compute_omega: null

--- a/jcm/config/physics/echam-jam-aerocom.yaml
+++ b/jcm/config/physics/echam-jam-aerocom.yaml
@@ -42,6 +42,9 @@ enable_aerocom: true
 # column: water-vapour path, column number, albedo
 # plev: winds on pressure surfaces + LTS
 # aerosol: per-species burdens + N70/N100/PM1/PM10 (needs the JAM module)
+# The plev group's wap/w500/w700 come from the dycore omega provider,
+# which the runner enables automatically for this preset (see
+# dycore.compute_omega; set it false to opt out and zero-fill them).
 aerocom_groups: [cloud, column, plev, aerosol, nearsurface]
 # Should match the radiation scheme's overlap assumption.
 aerocom_overlap: maximum-random

--- a/jcm/dycore/dinosaur/dycore.py
+++ b/jcm/dycore/dinosaur/dycore.py
@@ -521,8 +521,18 @@ class DinosaurDycore(DynamicalCore):
         # unconditional to_nodal over state.tracers would both crash (shape
         # mismatch) and waste one transform per tracer. Strip them.
         state = state.replace(tracers={})
-        # (1, nlon, nlat); the leading axis broadcasts against (nlev, ...).
+        # Surface pressure in NONDIM PRESSURE units, (1, nlon, nlat) so the
+        # leading axis broadcasts against (nlev, ...). The two coordinate
+        # families store different conventions (see state_bridge): hybrid
+        # keeps ``log(P_s)`` in nondim Pa directly, but sigma keeps the
+        # NORMALIZED ``log(P_s / p0)`` (the sigma dynamics only ever use
+        # grad/d-dt of log ps, which the scale cancels out of), so the
+        # sigma path must restore the p0 factor here or omega comes out
+        # ~1e5 too small (Codex P1 on #606).
         ps = jnp.exp(to_nodal(state.log_surface_pressure))
+        if not isinstance(vertical, HybridCoordinates):
+            ps = ps * self._physics_specs.nondimensionalize(
+                self.constants.p0 * units.pascal)
         if isinstance(vertical, HybridCoordinates):
             # The primitive operator's nondim_coords, not self.coords: the
             # (a, b) tables must be nondimensionalized consistently with

--- a/jcm/dycore/dinosaur/dycore.py
+++ b/jcm/dycore/dinosaur/dycore.py
@@ -96,6 +96,7 @@ class DinosaurDycore(DynamicalCore):
         diffusion: DiffusionFilter | None = None,
         tracer_filter: Any | None = None,
         compute_frontogenesis: bool = False,
+        compute_omega: bool = False,
         advection: str = "eulerian",
         sl_options: Mapping[str, Any] | None = None,
     ):
@@ -152,6 +153,12 @@ class DinosaurDycore(DynamicalCore):
         # Off by default: it costs horizontal finite differences of
         # (u, v, theta) every dt, which only the frontal GW term consumes.
         self.compute_frontogenesis = bool(compute_frontogenesis)
+        # Opt-in pressure vertical velocity (omega = Dp/Dt) diagnostic on
+        # the physics grid, for AeroCom's wap/w500/w700 (jax-gcm#409). Off
+        # by default: it re-runs the diagnostic-state projection (a few
+        # modal->nodal transforms) every step, which only output
+        # consumers need.
+        self.compute_omega = bool(compute_omega)
 
         # Physical constants drive both nondimensionalisation and the primitive
         # equations. Default to the *live* module singleton (read here at
@@ -481,11 +488,82 @@ class DinosaurDycore(DynamicalCore):
         return self.coords.with_physics_sharding(physics_state)
 
     def physics_field_names(self) -> tuple[str, ...]:
-        """Declare the frontogenesis field when the provider is enabled."""
-        return ("frontogenesis",) if self.compute_frontogenesis else ()
+        """Declare the enabled per-step dycore-side diagnostic fields."""
+        names = []
+        if self.compute_frontogenesis:
+            names.append("frontogenesis")
+        if self.compute_omega:
+            names.append("omega")
+        return tuple(names)
+
+    def _compute_omega(self, state: State) -> jnp.ndarray:
+        """Pressure vertical velocity omega = Dp/Dt [Pa/s] at level centres.
+
+        Diagnosed from the modal state via dinosaur's own diagnostic-state
+        computation, so the divergence, ``v . grad(ln ps)`` and vertical
+        mass flux are exactly the ones the dynamics integrates. On hybrid
+        levels (p = a + b ps):
+
+            omega_k = b_k ps (v . grad ln ps)_k + b_k (dps/dt)
+                      + (M_{k-1/2} + M_{k+1/2}) / 2
+
+        with ``M = eta_dot dp/deta`` the boundary mass flux and
+        ``dps/dt = -sum_k div(v dp)_k`` from continuity. On pure sigma
+        levels (a = 0, b = sigma, M = sigma_dot ps) the same expression
+        reduces to the classic ``omega = ps (sigma_dot + sigma d ln ps/dt)``,
+        which is what the sigma branch computes directly. Returned
+        dimensionalized, shape ``(nlev, nlon, nlat)``.
+        """
+        to_nodal = self.coords.horizontal.to_nodal
+        vertical = self.coords.vertical
+        # Omega needs no tracers, and under semi-Lagrangian advection the
+        # extra tracers are stored NODAL, so the diagnostic-state helpers'
+        # unconditional to_nodal over state.tracers would both crash (shape
+        # mismatch) and waste one transform per tracer. Strip them.
+        state = state.replace(tracers={})
+        # (1, nlon, nlat); the leading axis broadcasts against (nlev, ...).
+        ps = jnp.exp(to_nodal(state.log_surface_pressure))
+        if isinstance(vertical, HybridCoordinates):
+            # The primitive operator's nondim_coords, not self.coords: the
+            # (a, b) tables must be nondimensionalized consistently with
+            # the state's log_surface_pressure. Under jcm's SI scale the
+            # two coincide numerically, but only nondim_coords is correct
+            # by construction under any scale.
+            ds = primitive_equations.compute_diagnostic_state_hybrid(
+                state, self._primitive.nondim_coords)
+            delta_b = vertical.sigma_thickness[:, jnp.newaxis, jnp.newaxis]
+            b_bounds = jnp.asarray(vertical.b_boundaries)
+            b_full = 0.5 * (b_bounds[:-1] + b_bounds[1:])[
+                :, jnp.newaxis, jnp.newaxis]
+            div_v_dp = (ds.layer_pressure_thickness * ds.divergence
+                        + delta_b * ps * ds.u_dot_grad_log_sp)
+            dps_dt = -jnp.sum(div_v_dp, axis=0, keepdims=True)
+            mass_flux = ds.mass_flux_full  # (nlev+1, ...), zero at both ends
+            omega = (b_full * ps * ds.u_dot_grad_log_sp
+                     + b_full * dps_dt
+                     + 0.5 * (mass_flux[:-1] + mass_flux[1:]))
+        else:
+            ds = primitive_equations.compute_diagnostic_state_sigma(
+                state, self.coords)
+            sigma = jnp.asarray(vertical.centers)[:, jnp.newaxis, jnp.newaxis]
+            thickness = jnp.asarray(vertical.layer_thickness)[
+                :, jnp.newaxis, jnp.newaxis]
+            dlnps_dt = -jnp.sum(
+                thickness * (ds.divergence + ds.u_dot_grad_log_sp),
+                axis=0, keepdims=True)
+            # sigma_dot lives on the nlev-1 inner boundaries; zero at the
+            # top and bottom, centred average to the layer midpoints.
+            sigma_dot = jnp.pad(ds.sigma_dot_full, [(1, 1), (0, 0), (0, 0)])
+            sigma_dot_c = 0.5 * (sigma_dot[:-1] + sigma_dot[1:])
+            omega = ps * (sigma_dot_c
+                          + sigma * (ds.u_dot_grad_log_sp + dlnps_dt))
+        return self._physics_specs.dimensionalize(
+            omega, units.pascal / units.second).m
 
     def physics_fields(self, state, physics_state) -> dict:
-        """Compute the frontogenesis function on the nodal lat-lon grid.
+        """Compute the enabled dycore-side diagnostics on the nodal grid.
+
+        Frontogenesis (when ``compute_frontogenesis``):
 
         Uses the already-projected gridpoint ``physics_state`` (SI units):
         theta = T (p0/p)^kappa with the hybrid/sigma mid-level pressures
@@ -497,29 +575,35 @@ class DinosaurDycore(DynamicalCore):
         owns ``compute_frontogenesis``). A spectral-gradient
         implementation is a possible upgrade — the FD version is
         second-order, and fields are smooth at the truncation scale.
+
+        Omega (when ``compute_omega``): see :meth:`_compute_omega`.
         """
-        if not self.compute_frontogenesis:
+        if not (self.compute_frontogenesis or self.compute_omega):
             return {}
-        from jcm.physics.gravity_waves.spectral.frontogenesis import (
-            frontogenesis_function,
-        )
-        p0 = float(self.constants.p0)
-        ps = physics_state.normalized_surface_pressure * p0
-        a_full = 0.5 * (self._a_half[:-1] + self._a_half[1:])
-        b_full = 0.5 * (self._b_half[:-1] + self._b_half[1:])
-        shape = (-1,) + (1,) * ps.ndim
-        p_full = (a_full.reshape(shape)
-                  + b_full.reshape(shape) * ps[jnp.newaxis])
-        kappa = float(self.constants.akap)
-        theta = physics_state.temperature * (p0 / p_full) ** kappa
-        frontgf = frontogenesis_function(
-            physics_state.u_wind, physics_state.v_wind, theta,
-            lons=jnp.asarray(self.coords.horizontal.longitudes),
-            lats=jnp.asarray(self.coords.horizontal.latitudes),
-        )
-        return {
-            "frontogenesis": frontgf.astype(physics_state.temperature.dtype)
-        }
+        out: dict = {}
+        dtype = physics_state.temperature.dtype
+        if self.compute_frontogenesis:
+            from jcm.physics.gravity_waves.spectral.frontogenesis import (
+                frontogenesis_function,
+            )
+            p0 = float(self.constants.p0)
+            ps = physics_state.normalized_surface_pressure * p0
+            a_full = 0.5 * (self._a_half[:-1] + self._a_half[1:])
+            b_full = 0.5 * (self._b_half[:-1] + self._b_half[1:])
+            shape = (-1,) + (1,) * ps.ndim
+            p_full = (a_full.reshape(shape)
+                      + b_full.reshape(shape) * ps[jnp.newaxis])
+            kappa = float(self.constants.akap)
+            theta = physics_state.temperature * (p0 / p_full) ** kappa
+            frontgf = frontogenesis_function(
+                physics_state.u_wind, physics_state.v_wind, theta,
+                lons=jnp.asarray(self.coords.horizontal.longitudes),
+                lats=jnp.asarray(self.coords.horizontal.latitudes),
+            )
+            out["frontogenesis"] = frontgf.astype(dtype)
+        if self.compute_omega:
+            out["omega"] = self._compute_omega(state).astype(dtype)
+        return out
 
     def step(
         self,

--- a/jcm/dycore/physics_fields_test.py
+++ b/jcm/dycore/physics_fields_test.py
@@ -126,6 +126,118 @@ class DinosaurProviderTest(unittest.TestCase):
         np.testing.assert_allclose(got, want, rtol=2e-4, atol=1e-12)
 
 
+class DinosaurOmegaProviderTest(unittest.TestCase):
+    """The omega (Dp/Dt) provider against closed forms (jax-gcm#409).
+
+    A horizontally uniform divergence ``D0`` over flat surface pressure
+    has an exact omega on both verticals: the continuity integrals reduce
+    to sums of constants, so the only error is the spectral round-trip.
+    """
+
+    D0_SI = 1e-5    # 1/s
+    PS_SI = 97000.0  # Pa
+
+    def _dycore(self, coords):
+        return DinosaurDycore(coords=coords,
+                              terrain=TerrainData.aquaplanet(coords),
+                              dt_seconds=600.0, compute_omega=True)
+
+    def _uniform_divergence_state(self, dycore, d0_si, ps_si):
+        from dinosaur.primitive_equations import State
+        from dinosaur.scales import units
+        coords = dycore.coords
+        hor = coords.horizontal
+        nlev = coords.vertical.layers
+        nlon, nlat = hor.nodal_shape
+        specs = dycore.physics_specs
+        d0 = float(specs.nondimensionalize(d0_si / units.second))
+        ps = float(specs.nondimensionalize(ps_si * units.pascal))
+        zeros = np.zeros((nlev, nlon, nlat))
+        return State(
+            vorticity=hor.to_modal(zeros),
+            divergence=hor.to_modal(d0 * np.ones((nlev, nlon, nlat))),
+            temperature_variation=hor.to_modal(zeros),
+            log_surface_pressure=hor.to_modal(
+                np.log(ps) * np.ones((1, nlon, nlat))),
+            tracers={}, sim_time=0.0,
+        )
+
+    def test_declaration(self):
+        coords = _coords()
+        dycore = self._dycore(coords)
+        self.assertEqual(dycore.physics_field_names(), ("omega",))
+
+    def test_rest_state_omega_is_zero(self):
+        coords = _coords()
+        dycore = self._dycore(coords)
+        state = self._uniform_divergence_state(dycore, 0.0, self.PS_SI)
+        omega = np.asarray(dycore._compute_omega(state))
+        self.assertEqual(np.max(np.abs(omega)), 0.0)
+
+    def test_sigma_uniform_divergence_closed_form(self):
+        # On sigma levels with flat ps, uniform D0 gives sigma_dot = 0 and
+        # d ln ps/dt = -D0, so omega(sigma) = -sigma ps D0 exactly.
+        coords = _coords()
+        dycore = self._dycore(coords)
+        state = self._uniform_divergence_state(dycore, self.D0_SI, self.PS_SI)
+        omega = np.asarray(dycore._compute_omega(state))
+        sigma = np.asarray(coords.vertical.centers)
+        want = -sigma[:, None, None] * self.PS_SI * self.D0_SI
+        want = np.broadcast_to(want, omega.shape)
+        # The only error source is the f32 spectral round-trip, which is
+        # absolute (proportional to the field scale), so pair a loose
+        # rtol with an atol at ~1e-4 of the field maximum.
+        np.testing.assert_allclose(omega, want, rtol=1e-4,
+                                   atol=1e-4 * np.abs(want).max())
+
+    def test_omega_ignores_nodal_tracers(self):
+        # Under semi-Lagrangian advection extra tracers are stored NODAL
+        # in state.tracers; the diagnostic-state helpers' unconditional
+        # to_nodal over them crashes on the shape mismatch unless
+        # _compute_omega strips tracers first. Same closed form must come
+        # out with a nodal tracer along for the ride.
+        coords = _coords()
+        dycore = self._dycore(coords)
+        state = self._uniform_divergence_state(dycore, self.D0_SI, self.PS_SI)
+        nlev = coords.vertical.layers
+        nlon, nlat = coords.horizontal.nodal_shape
+        state = state.replace(
+            tracers={"dust": jnp.ones((nlev, nlon, nlat))})
+        omega = np.asarray(dycore._compute_omega(state))
+        sigma = np.asarray(coords.vertical.centers)
+        want = -sigma[:, None, None] * self.PS_SI * self.D0_SI
+        np.testing.assert_allclose(
+            omega, np.broadcast_to(want, omega.shape), rtol=1e-4,
+            atol=1e-4 * np.abs(want).max())
+
+    def test_hybrid_uniform_divergence_matches_numpy_reference(self):
+        # Same setup on the ECHAM L47 hybrid grid, checked against an
+        # independent numpy evaluation of the mass-flux formula from the
+        # (a, b) tables.
+        from jcm.physics.echam.echam_levels import get_echam_levels
+        from jcm.utils import get_coords
+        coords = get_coords(get_echam_levels(47), spectral_truncation=21)
+        dycore = self._dycore(coords)
+        state = self._uniform_divergence_state(dycore, self.D0_SI, self.PS_SI)
+        omega = np.asarray(dycore._compute_omega(state))
+
+        a = np.asarray(coords.vertical.a_boundaries)
+        b = np.asarray(coords.vertical.b_boundaries)
+        dp = np.diff(a) + np.diff(b) * self.PS_SI
+        d = dp * self.D0_SI
+        dps_dt = -d.sum()
+        mass_flux = -np.concatenate([[0.0], np.cumsum(d)]) + b * d.sum()
+        b_full = 0.5 * (b[:-1] + b[1:])
+        want = b_full * dps_dt + 0.5 * (mass_flux[:-1] + mass_flux[1:])
+        want = np.broadcast_to(want[:, None, None], omega.shape)
+        np.testing.assert_allclose(omega, want, rtol=1e-4,
+                                   atol=1e-4 * np.abs(want).max())
+        # omega < 0 everywhere: parcels ride their coordinate surface
+        # while uniform divergence drains the column, so the pressure
+        # above each parcel (and hence its own pressure) falls.
+        self.assertLess(omega.max(), 0.0)
+
+
 class InjectionTest(unittest.TestCase):
     def _run(self, output_averages):
         from jcm.physics.held_suarez.held_suarez_physics import (
@@ -189,6 +301,44 @@ class InjectionTest(unittest.TestCase):
         preds = model.run(save_interval=2 * dt_days, total_time=2 * dt_days)
         out = np.asarray(preds.physics["frontgf_plus_ps"])
         self.assertTrue(np.isfinite(out).all())
+
+    def test_omega_injection_reaches_terms_in_a_real_run(self):
+        from jcm.physics.held_suarez.held_suarez_physics import (
+            held_suarez_physics,
+        )
+
+        class _OmegaRecorder(PhysicsTerm):
+            name: ClassVar[str] = "omega_recorder"
+            category: ClassVar[str] = "test"
+            provides: ClassVar[tuple[str, ...]] = ("omega_absmax",)
+            requires_dycore_fields: ClassVar[tuple[str, ...]] = ("omega",)
+
+            def __call__(self, state, diagnostics, forcing, terrain):
+                fields = diagnostics.get("_dycore_fields", {})
+                omega = fields.get("omega")
+                absmax = (jnp.max(jnp.abs(omega)) if omega is not None
+                          else jnp.asarray(jnp.nan, state.temperature.dtype))
+                diag = absmax * jnp.ones_like(
+                    state.normalized_surface_pressure)
+                tend = PhysicsTendency.zeros(state.temperature.shape)
+                return tend, {**diagnostics, "omega_absmax": diag}
+
+        coords = _coords()
+        dycore = DinosaurDycore(coords=coords,
+                                terrain=TerrainData.aquaplanet(coords),
+                                dt_seconds=1800.0, compute_omega=True)
+        physics = held_suarez_physics() + _OmegaRecorder()
+        model = Model(dycore=dycore, physics=physics)
+        dt_days = 30.0 / (60.0 * 24.0)
+        preds = model.run(save_interval=2 * dt_days, total_time=4 * dt_days)
+        absmax = np.asarray(preds.physics["omega_absmax"])
+        self.assertTrue(np.isfinite(absmax).all())
+        # A baroclinically forced spun-up-from-rest run develops real
+        # vertical motion within a couple of steps; a provider that
+        # silently returned zeros would fail here.
+        self.assertGreater(float(absmax[-1].max()), 0.0)
+        # Sanity on magnitude: Pa/s, not nondimensional or hPa/day.
+        self.assertLess(float(absmax.max()), 1e3)
 
     def test_frontal_gw_term_runs_end_to_end(self):
         from jcm.physics.held_suarez.held_suarez_physics import (

--- a/jcm/dycore/physics_fields_test.py
+++ b/jcm/dycore/physics_fields_test.py
@@ -143,6 +143,7 @@ class DinosaurOmegaProviderTest(unittest.TestCase):
                               dt_seconds=600.0, compute_omega=True)
 
     def _uniform_divergence_state(self, dycore, d0_si, ps_si):
+        from dinosaur.hybrid_coordinates import HybridCoordinates
         from dinosaur.primitive_equations import State
         from dinosaur.scales import units
         coords = dycore.coords
@@ -151,14 +152,23 @@ class DinosaurOmegaProviderTest(unittest.TestCase):
         nlon, nlat = hor.nodal_shape
         specs = dycore.physics_specs
         d0 = float(specs.nondimensionalize(d0_si / units.second))
-        ps = float(specs.nondimensionalize(ps_si * units.pascal))
+        # Each coordinate family's OWN log-ps convention (state_bridge):
+        # hybrid stores log(P_s) in nondim pressure units, sigma stores
+        # the normalized log(P_s / p0). Building the state any other way
+        # validates the math under a convention no real run uses (which
+        # is how the sigma-path p0 factor initially slipped through).
+        if isinstance(coords.vertical, HybridCoordinates):
+            lsp = np.log(float(specs.nondimensionalize(
+                ps_si * units.pascal)))
+        else:
+            lsp = np.log(ps_si / float(dycore.constants.p0))
         zeros = np.zeros((nlev, nlon, nlat))
         return State(
             vorticity=hor.to_modal(zeros),
             divergence=hor.to_modal(d0 * np.ones((nlev, nlon, nlat))),
             temperature_variation=hor.to_modal(zeros),
             log_surface_pressure=hor.to_modal(
-                np.log(ps) * np.ones((1, nlon, nlat))),
+                lsp * np.ones((1, nlon, nlat))),
             tracers={}, sim_time=0.0,
         )
 

--- a/jcm/dycore/physics_fields_test.py
+++ b/jcm/dycore/physics_fields_test.py
@@ -370,6 +370,56 @@ class InjectionTest(unittest.TestCase):
         self.assertTrue(np.isfinite(temp).all())
 
 
+class OmegaDiagnosticTermTest(unittest.TestCase):
+    """The model-agnostic omega output term (jax-gcm#409's original ask)."""
+
+    def test_factories_expose_the_flag(self):
+        from jcm.physics.speedy.speedy_terms import speedy_physics
+        self.assertEqual(speedy_physics().required_dycore_fields(), ())
+        physics = speedy_physics(diagnose_omega=True)
+        self.assertEqual(physics.required_dycore_fields(), ("omega",))
+        self.assertEqual(physics.terms[-1].name, "omega_diagnostic")
+
+    def test_echam_factory_keeps_aerocom_terminal(self):
+        from jcm.physics.echam.echam_terms import echam_physics
+        physics = echam_physics(radiation_scheme="grey",
+                                diagnose_omega=True, enable_aerocom=True)
+        names = [t.name for t in physics.terms]
+        self.assertIn("omega_diagnostic", names)
+        self.assertEqual(names[-1], "aerocom_diagnostics")
+        # AerocomDiagnostics only consumes opportunistically, so the
+        # requirement comes from the omega term alone.
+        self.assertIn("omega", physics.required_dycore_fields())
+
+    def test_model_validation_fails_without_provider(self):
+        from jcm.physics.speedy.speedy_terms import speedy_physics
+        coords = _coords()
+        with self.assertRaisesRegex(ValueError, "omega"):
+            Model(coords=coords,
+                  physics=speedy_physics(diagnose_omega=True))
+
+    def test_speedy_run_emits_omega(self):
+        from jcm.physics.speedy.speedy_terms import speedy_physics
+        coords = _coords()
+        dycore = DinosaurDycore(coords=coords,
+                                terrain=TerrainData.aquaplanet(coords),
+                                dt_seconds=1800.0, compute_omega=True)
+        model = Model(dycore=dycore,
+                      physics=speedy_physics(diagnose_omega=True))
+        dt_days = 30.0 / (60.0 * 24.0)
+        preds = model.run(save_interval=2 * dt_days, total_time=4 * dt_days)
+        omega = np.asarray(preds.physics["omega"])
+        nlev = coords.vertical.layers
+        self.assertIn(nlev, omega.shape)
+        self.assertTrue(np.isfinite(omega).all())
+        # Real vertical motion in Pa/s: nonzero, and nowhere near the
+        # ~1e-5 of a normalized-pressure mistake or the ~1e5 of a
+        # double-scaled one.
+        absmax = float(np.abs(omega[-1]).max())
+        self.assertGreater(absmax, 1e-6)
+        self.assertLess(absmax, 1e3)
+
+
 class EchamFactoryTest(unittest.TestCase):
     def test_gw_scheme_switch(self):
         from jcm.physics.echam.echam_terms import echam_physics

--- a/jcm/physics/diagnostics/aerocom.py
+++ b/jcm/physics/diagnostics/aerocom.py
@@ -424,6 +424,7 @@ class AerocomDiagnostics(PhysicsTerm):
         "aerocom_cdnc3d",
         # plev
         "aerocom_lts", "aerocom_ptp",
+        "aerocom_wap", "aerocom_w500", "aerocom_w700",
         # nearsurface
         "aerocom_tas", "aerocom_uas", "aerocom_vas", "aerocom_dew2",
         "aerocom_psl", "aerocom_prsn", "aerocom_prcr", "aerocom_prcs",
@@ -696,6 +697,28 @@ class AerocomDiagnostics(PhysicsTerm):
         theta700 = t700 * (100000.0 / 70000.0) ** c.akap
         theta_sfc = temperature[-1] * (100000.0 / p_sfc) ** c.akap
         out["aerocom_lts"] = theta700 - theta_sfc
+
+        # Pressure vertical velocity (the wap/w500/w700 request,
+        # jax-gcm#409): supplied by the dycore's omega provider
+        # (DinosaurDycore(compute_omega=True), config key
+        # dycore.compute_omega) as a dycore field, since only the
+        # dynamics knows the mass fluxes consistent with its own
+        # continuity equation. Zero-filled when the provider is off,
+        # which is static per config, so the emitted key set stays
+        # scan-carry-stable. wap is the full model-level field
+        # (leading level axis, the cdnc3d layout); w500/w700 are the
+        # requested pressure-surface slices.
+        omega = (diagnostics.get("_dycore_fields") or {}).get("omega")
+        if omega is not None:
+            out["aerocom_wap"] = omega
+            out["aerocom_w500"] = _interp_to_pressure(omega, p_full, 50000.0)
+            out["aerocom_w700"] = _interp_to_pressure(omega, p_full, 70000.0)
+        else:
+            out["aerocom_wap"] = jnp.zeros(p_full.shape, dtype=p_full.dtype)
+            out["aerocom_w500"] = jnp.zeros(p_full.shape[1:],
+                                            dtype=p_full.dtype)
+            out["aerocom_w700"] = jnp.zeros(p_full.shape[1:],
+                                            dtype=p_full.dtype)
 
         # WMO tropopause pressure (the ptp request): the wmo_tropopause
         # module's finder, on the post-physics temperature. Its default

--- a/jcm/physics/diagnostics/aerocom_remaining_test.py
+++ b/jcm/physics/diagnostics/aerocom_remaining_test.py
@@ -117,6 +117,111 @@ class NearSurfaceGroupTest(unittest.TestCase):
         np.testing.assert_allclose(np.asarray(out2["aerocom_wbase"]), 0.0)
 
 
+class PlevOmegaTest(unittest.TestCase):
+    """wap/w500/w700 from the dycore omega provider (jax-gcm#409)."""
+
+    nlev, nx = 12, 6
+
+    def _plev(self, omega=None):
+        term = AerocomDiagnostics(groups=("plev",))
+        nlev, nx = self.nlev, self.nx
+        p_full = (jnp.linspace(20000.0, 99600.0, nlev)[:, None]
+                  * jnp.ones((1, nx)))
+
+        class _State:
+            u_wind = jnp.zeros((nlev, nx))
+            v_wind = jnp.zeros((nlev, nx))
+            temperature = jnp.full((nlev, nx), 280.0)
+
+        diagnostics = {}
+        if omega is not None:
+            diagnostics["_dycore_fields"] = {"omega": omega}
+        return term._plev_group(_State(), diagnostics,
+                                _State.temperature, p_full), p_full
+
+    def test_absent_provider_zero_fills_statically(self):
+        out, p_full = self._plev(omega=None)
+        self.assertEqual(out["aerocom_wap"].shape, (self.nlev, self.nx))
+        self.assertEqual(float(jnp.max(jnp.abs(out["aerocom_wap"]))), 0.0)
+        for key in ("aerocom_w500", "aerocom_w700"):
+            self.assertEqual(out[key].shape, (self.nx,))
+            self.assertEqual(float(jnp.max(jnp.abs(out[key]))), 0.0)
+
+    def test_wap_passthrough_and_slices_exact_in_log_p(self):
+        # An omega linear in log(p) makes the log-linear interpolation
+        # exact, so w500/w700 have closed-form expectations.
+        _, p_full = self._plev(omega=None)
+        alpha = 0.037
+        omega = alpha * jnp.log(p_full)
+        out, _ = self._plev(omega=omega)
+        np.testing.assert_allclose(np.asarray(out["aerocom_wap"]),
+                                   np.asarray(omega))
+        np.testing.assert_allclose(
+            np.asarray(out["aerocom_w500"]),
+            alpha * np.log(50000.0) * np.ones(self.nx), rtol=1e-6)
+        np.testing.assert_allclose(
+            np.asarray(out["aerocom_w700"]),
+            alpha * np.log(70000.0) * np.ones(self.nx), rtol=1e-6)
+
+    def test_provider_keys_are_declared(self):
+        for key in ("aerocom_wap", "aerocom_w500", "aerocom_w700"):
+            self.assertIn(key, AerocomDiagnostics.provides)
+
+    def test_runner_defaults_omega_on_for_aerocom_plev(self):
+        from omegaconf import OmegaConf
+
+        from jcm.runners import _want_omega
+        plev_cfg = {"physics": {"enable_aerocom": True,
+                                "aerocom_groups": ["cloud", "plev"]}}
+        self.assertTrue(_want_omega(OmegaConf.create(plev_cfg)))
+        self.assertFalse(_want_omega(OmegaConf.create(
+            {"physics": {"enable_aerocom": True,
+                         "aerocom_groups": ["cloud"]}})))
+        self.assertFalse(_want_omega(OmegaConf.create({})))
+        # An explicit dycore.compute_omega always wins, either way.
+        self.assertFalse(_want_omega(OmegaConf.create(
+            {**plev_cfg, "dycore": {"compute_omega": False}})))
+        self.assertTrue(_want_omega(OmegaConf.create(
+            {"dycore": {"compute_omega": True}})))
+        # The shipped yaml null means "decide from the physics config".
+        self.assertTrue(_want_omega(OmegaConf.create(
+            {**plev_cfg, "dycore": {"compute_omega": None}})))
+
+    def test_end_to_end_echam_run_with_the_provider(self):
+        """Probe-vs-step structure and real values through a scanned run.
+
+        The get_empty_data probe runs without dycore-field injection (the
+        zero-fill branch) while the scanned steps see the injected omega;
+        the run only compiles if both produce the same carry structure.
+        """
+        from jcm.dycore.dinosaur.dycore import DinosaurDycore
+        from jcm.model import Model
+        from jcm.physics.echam.echam_levels import get_echam_levels
+        from jcm.physics.echam.echam_terms import echam_physics
+        from jcm.terrain import TerrainData
+        from jcm.utils import get_coords
+
+        coords = get_coords(get_echam_levels(47), spectral_truncation=21)
+        dycore = DinosaurDycore(
+            coords=coords, terrain=TerrainData.aquaplanet(coords),
+            dt_seconds=900.0, compute_omega=True)
+        model = Model(
+            dycore=dycore, time_step=15.0,
+            physics=echam_physics(radiation_scheme="grey",
+                                  enable_aerocom=True,
+                                  aerocom_groups=("plev",)),
+        )
+        ds = model.run(total_time=0.05, save_interval=0.05).to_xarray()
+        for key in ("aerocom_wap", "aerocom_w500", "aerocom_w700"):
+            arr = np.asarray(ds[key])
+            self.assertTrue(np.isfinite(arr).all(), f"{key} not finite")
+        # The balanced-start ECHAM state has real vertical motion within a
+        # few steps; all-zero wap would mean the provider never reached
+        # the term.
+        self.assertGreater(float(np.abs(ds["aerocom_wap"]).max()), 0.0)
+        self.assertLess(float(np.abs(ds["aerocom_wap"]).max()), 1e2)
+
+
 class CodexRound2RegressionTest(unittest.TestCase):
     """Regressions for the Codex findings on PR #604."""
 
@@ -305,14 +410,22 @@ class CmorOmnibusTest(unittest.TestCase):
                                    dims=("lat", "lon")),
             "emi_bb_oc": xr.DataArray(np.full((3, 4), 2e-12),
                                       dims=("lat", "lon")),
+            "aerocom_wap": xr.DataArray(np.full((5, 3, 4), -0.02),
+                                        dims=("level", "lat", "lon")),
+            "aerocom_w500": xr.DataArray(np.full((3, 4), -0.05),
+                                         dims=("lat", "lon")),
         })
         with tempfile.TemporaryDirectory() as td:
             written, skipped = convert(
                 ds, "JCM-t", "all_2000", "2010", "monthly",
                 pathlib.Path(td), na_aliases=True)
         names = "\n".join(written)
-        for var in ("rsutnoa", "rsut_na", "tas", "drybc", "emi_bb_oc"):
+        for var in ("rsutnoa", "rsut_na", "tas", "drybc", "emi_bb_oc",
+                    "wap", "w500"):
             self.assertIn(f"_{var}_", names)
+        # wap goes out on model levels, the slices as 2-D column fields.
+        self.assertIn("_wap_ModelLevel_", names)
+        self.assertIn("_w500_Column_", names)
         self.assertEqual(skipped, [])
 
 

--- a/jcm/physics/diagnostics/omega.py
+++ b/jcm/physics/diagnostics/omega.py
@@ -1,0 +1,42 @@
+"""Model-agnostic pressure-vertical-velocity output diagnostic.
+
+The dycore computes omega = Dp/Dt [Pa/s] (see
+``DinosaurDycore(compute_omega=True)``, jax-gcm#409) and injects it as the
+``"omega"`` dycore field; this term simply republishes that field as a
+top-level ``"omega"`` diagnostic so it reaches saved output under any
+physics package (SPEEDY, Held-Suarez, ECHAM, ...). It is deliberately not
+an AeroCom-ism: the AeroCom ``plev`` group separately derives its
+wap/w500/w700 submission fields from the same dycore field.
+
+Composing this term makes the provider a hard requirement (Model
+construction fails with a pointed error if the dycore flag is off), which
+is the honest failure mode for an explicitly requested diagnostic. The
+``jcm run`` CLI enables the provider automatically when the composed
+physics requires it.
+"""
+
+from typing import ClassVar
+
+import jax.numpy as jnp
+
+from jcm.physics.physics_term import PhysicsTerm
+from jcm.physics_interface import PhysicsTendency
+
+
+class OmegaDiagnostic(PhysicsTerm):
+    """Republish the dycore-supplied omega as an output diagnostic."""
+
+    name: ClassVar[str] = "omega_diagnostic"
+    category: ClassVar[str] = "diagnostics"
+    provides: ClassVar[tuple[str, ...]] = ("omega",)
+    requires_dycore_fields: ClassVar[tuple[str, ...]] = ("omega",)
+
+    def __call__(self, state, diagnostics, forcing, terrain):
+        # ``get`` fallback: the ``get_empty_data`` structural probe runs
+        # terms without dycore-field injection, and consumers must
+        # tolerate absence with an identically-structured result. Omega
+        # shares temperature's (nlev, *horiz) shape and dtype.
+        fields = diagnostics.get("_dycore_fields", {})
+        omega = fields.get("omega", jnp.zeros_like(state.temperature))
+        tend = PhysicsTendency.zeros(state.temperature.shape)
+        return tend, {**diagnostics, "omega": omega}

--- a/jcm/physics/echam/echam_terms.py
+++ b/jcm/physics/echam/echam_terms.py
@@ -88,6 +88,7 @@ def echam_physics(
     aerocom_groups: tuple[str, ...] = ("cloud", "column"),
     aerocom_overlap: str = "maximum-random",
     aerocom_optics: bool = False,
+    diagnose_omega: bool = False,
 ):
     """Create a ``ComposablePhysics`` with the standard ECHAM term ordering.
 
@@ -166,6 +167,11 @@ def echam_physics(
         cosp_ncolumns: Stochastic subcolumns per gridbox for the
             radar simulator (COSP canonical value is 100; fewer
             is cheaper and averages out in climatologies).
+        diagnose_omega: Publish the dycore's pressure vertical velocity
+            [Pa/s] as an ``omega`` output field (needs
+            ``DinosaurDycore(compute_omega=True)``; the CLI enables the
+            provider automatically). Model-agnostic, independent of the
+            AeroCom wap/w500/w700 fields.
         enable_aerocom: Attach the AeroCom phase-4 derived
             diagnostics term (cloud-top sampling, column
             integrals, pressure-level fields, aerosol number
@@ -383,6 +389,11 @@ def echam_physics(
                                    enable_modis=cosp_modis,
                                    enable_isccp=cosp_isccp)]
 
+    omega_terms: list[PhysicsTerm] = []
+    if diagnose_omega:
+        from jcm.physics.diagnostics.omega import OmegaDiagnostic
+        omega_terms = [OmegaDiagnostic()]
+
     aerocom_terms: list[PhysicsTerm] = []
     if enable_aerocom:
         from jcm.physics.diagnostics.aerocom import AerocomDiagnostics
@@ -405,6 +416,7 @@ def echam_physics(
             *jam_post_cloud_terms,
             *nonoro_gw_terms,
             LottMillerSso(params=sso_p),
+            *omega_terms,
             # Terminal: summarises the completed step, so it runs after
             # every term that can still modify the state.
             *aerocom_terms,

--- a/jcm/physics/speedy/speedy_terms.py
+++ b/jcm/physics/speedy/speedy_terms.py
@@ -512,12 +512,19 @@ class SpeedyVerticalDiffusion(SpeedyTermBase):
 # Factory function
 # ---------------------------------------------------------------------------
 
-def speedy_physics(parameters: Parameters | None = None, checkpoint_terms: bool = True):
+def speedy_physics(parameters: Parameters | None = None, checkpoint_terms: bool = True,
+                   diagnose_omega: bool = False):
     """Create a ComposablePhysics with the standard SPEEDY term ordering.
 
     Args:
         parameters: Optional Parameters struct. Uses defaults if None.
         checkpoint_terms: Whether to checkpoint terms for memory efficiency.
+        diagnose_omega: Append the :class:`~jcm.physics.diagnostics.omega.
+            OmegaDiagnostic` term, publishing the dycore's pressure
+            vertical velocity [Pa/s] as an ``omega`` output field. Needs
+            ``DinosaurDycore(compute_omega=True)`` (Model construction
+            fails with a pointed error otherwise; the CLI enables the
+            provider automatically).
 
     Returns:
         A ComposablePhysics instance with all SPEEDY terms.
@@ -526,6 +533,11 @@ def speedy_physics(parameters: Parameters | None = None, checkpoint_terms: bool 
     from jcm.physics.composable_physics import ComposablePhysics
 
     p = parameters or Parameters.default()
+
+    omega_terms = []
+    if diagnose_omega:
+        from jcm.physics.diagnostics.omega import OmegaDiagnostic
+        omega_terms = [OmegaDiagnostic()]
 
     return ComposablePhysics(
         terms=[
@@ -548,6 +560,7 @@ def speedy_physics(parameters: Parameters | None = None, checkpoint_terms: bool 
             ),
             SpeedyUpwardLongwaveRadiation(mod_radcon_params=p.mod_radcon),
             SpeedyVerticalDiffusion(vdiff_params=p.vertical_diffusion),
+            *omega_terms,
         ],
         checkpoint_terms=checkpoint_terms,
     )

--- a/jcm/runners.py
+++ b/jcm/runners.py
@@ -695,6 +695,24 @@ def build_tracer_filter(cfg: DictConfig):
     return MassConservingPositivity()
 
 
+def _want_omega(cfg: DictConfig) -> bool:
+    """Resolve the dycore omega provider from the config.
+
+    An explicit ``dycore.compute_omega`` always wins. Left unset, the
+    provider defaults ON when the physics config runs the AeroCom ``plev``
+    group (``enable_aerocom`` with ``plev`` in ``aerocom_groups``):
+    without it that group's wap/w500/w700 are silently zero-filled, which
+    is exactly the kind of valid-looking-but-empty submission file nobody
+    catches until review.
+    """
+    explicit = cfg.get("dycore", {}).get("compute_omega", None)
+    if explicit is not None:
+        return bool(explicit)
+    phys = cfg.get("physics", {})
+    return bool(phys.get("enable_aerocom", False)) and (
+        "plev" in (phys.get("aerocom_groups") or ()))
+
+
 def build_model(cfg: DictConfig) -> Model:
     """Build a fully-configured ``Model`` from a Hydra config.
 
@@ -748,6 +766,7 @@ def build_model(cfg: DictConfig) -> Model:
         tracer_specs=tracer_specs,
         diffusion=diffusion,
         tracer_filter=tracer_filter,
+        compute_omega=_want_omega(cfg),
         advection=advection,
         sl_options=sl_options,
     )

--- a/jcm/runners.py
+++ b/jcm/runners.py
@@ -695,19 +695,25 @@ def build_tracer_filter(cfg: DictConfig):
     return MassConservingPositivity()
 
 
-def _want_omega(cfg: DictConfig) -> bool:
-    """Resolve the dycore omega provider from the config.
+def _want_omega(cfg: DictConfig, physics=None) -> bool:
+    """Resolve the dycore omega provider from the config and physics.
 
     An explicit ``dycore.compute_omega`` always wins. Left unset, the
-    provider defaults ON when the physics config runs the AeroCom ``plev``
-    group (``enable_aerocom`` with ``plev`` in ``aerocom_groups``):
-    without it that group's wap/w500/w700 are silently zero-filled, which
-    is exactly the kind of valid-looking-but-empty submission file nobody
-    catches until review.
+    provider defaults ON when either (a) the composed physics REQUIRES
+    the ``omega`` dycore field (e.g. the model-agnostic
+    ``OmegaDiagnostic`` term), so an explicitly requested diagnostic
+    never dies on the construction-time contract check, or (b) the
+    physics config runs the AeroCom ``plev`` group (``enable_aerocom``
+    with ``plev`` in ``aerocom_groups``), whose wap/w500/w700 would
+    otherwise be silently zero-filled: exactly the kind of
+    valid-looking-but-empty submission file nobody catches until review.
     """
     explicit = cfg.get("dycore", {}).get("compute_omega", None)
     if explicit is not None:
         return bool(explicit)
+    if physics is not None and "omega" in tuple(
+            getattr(physics, "required_dycore_fields", lambda: ())()):
+        return True
     phys = cfg.get("physics", {})
     return bool(phys.get("enable_aerocom", False)) and (
         "plev" in (phys.get("aerocom_groups") or ()))
@@ -766,7 +772,7 @@ def build_model(cfg: DictConfig) -> Model:
         tracer_specs=tracer_specs,
         diffusion=diffusion,
         tracer_filter=tracer_filter,
-        compute_omega=_want_omega(cfg),
+        compute_omega=_want_omega(cfg, physics),
         advection=advection,
         sl_options=sl_options,
     )

--- a/tools/aerocom_cmor.py
+++ b/tools/aerocom_cmor.py
@@ -200,6 +200,9 @@ NAME_MAP: dict[str, tuple[str, str, str, float, float]] = {
     "aerocom_v200": ("v200", "m s-1", "Column", 1.0, 0.0),
     "aerocom_u700": ("u700", "m s-1", "Column", 1.0, 0.0),
     "aerocom_v700": ("v700", "m s-1", "Column", 1.0, 0.0),
+    "aerocom_w500": ("w500", "Pa s-1", "Column", 1.0, 0.0),
+    "aerocom_w700": ("w700", "Pa s-1", "Column", 1.0, 0.0),
+    "aerocom_wap": ("wap", "Pa s-1", "ModelLevel", 1.0, 0.0),
     "aerocom_N70": ("N70", "m-3", "ModelLevel", 1.0, 0.0),
     "aerocom_N100": ("N100", "m-3", "ModelLevel", 1.0, 0.0),
     "aerocom_PM1": ("PM1", "kg m-3", "ModelLevel", 1.0, 0.0),
@@ -232,6 +235,9 @@ BURDEN_SPECIES = ("so4", "bc", "oc", "poa", "soa", "ss", "du", "moa",
 # gets no ``standard_name`` attribute (which is optional) rather than a
 # guessed one that a CF checker would reject.
 CF_STANDARD_NAMES = {
+    "wap": "lagrangian_tendency_of_air_pressure",
+    "w500": "lagrangian_tendency_of_air_pressure",
+    "w700": "lagrangian_tendency_of_air_pressure",
     "ta": "air_temperature",
     "ps": "surface_air_pressure",
     "ts": "surface_temperature",


### PR DESCRIPTION
Closes #409. Omega (pressure vertical velocity, Dp/Dt in Pa/s) as a general model diagnostic, per the original issue: computed once in the dycore, publishable as a plain `omega` output field under **any** physics package (SPEEDY included), and additionally consumed by the AeroCom `plev` group for the `wap`/`w500`/`w700` submission fields, the last jcm-side phase-4 variable family (the only remaining gap anywhere is `parasolRefl`, tracked upstream in climate-analytics-lab/jax-cosp#1).

## The general output term

`jcm.physics.diagnostics.omega.OmegaDiagnostic` republishes the dycore field as a top-level `omega` diagnostic; both factories expose it as `speedy_physics(diagnose_omega=True)` and `echam_physics(diagnose_omega=True)` (composable manually into anything else, e.g. `held_suarez_physics() + OmegaDiagnostic()`). Composing it makes the provider a hard requirement, so a forgotten dycore flag fails Model construction with a pointed error instead of writing zeros; the `jcm run` CLI enables the provider automatically whenever the composed physics requires the field. An end-to-end SPEEDY T21L8 run pins the whole path: `omega` in saved output, finite, Pa/s magnitude (guarded against both the ~1e-5 normalized-pressure mistake and the ~1e5 double-scaled one).

## The omega provider

`DinosaurDycore(compute_omega=True)` (config key `dycore.compute_omega`) diagnoses the pressure vertical velocity omega = Dp/Dt [Pa/s] at level centres each step and ships it through the existing dycore-field contract (`physics_field_names` / `physics_fields` / `_dycore_fields`, the frontogenesis pattern from #568). It is computed from the modal state via dinosaur's own `compute_diagnostic_state_{sigma,hybrid}`, so the divergence, `v . grad(ln ps)` and vertical mass flux are exactly the ones the dynamics integrates rather than a finite-difference reconstruction:

- **hybrid** (p = a + b ps): `omega_k = b_k ps (v.grad ln ps)_k + b_k dps/dt + (M_{k-1/2} + M_{k+1/2})/2` with `M = eta_dot dp/deta` from the mass-flux ledger and `dps/dt = -sum div(v dp)` from continuity;
- **sigma**: the same expression reduces to the classic `omega = ps (sigma_dot + sigma d ln ps/dt)`, computed directly from `sigma_dot_full`.

Off by default (a few extra modal->nodal transforms per step), with one exception: the runner turns it on automatically when the physics config runs the AeroCom `plev` group, because that group's wap/w500/w700 zero-fill without it and an all-zero submission file is exactly the failure nobody catches until review. An explicit `dycore.compute_omega: true/false` overrides in either direction (the shipped yaml default is `null` = decide from the physics config).

Two subtleties from the local adversarial review, fixed before this PR:
- Tracers are stripped from the state before the diagnostic-state call: under `advection="semi_lagrangian"` the extra tracers are stored nodal, and dinosaur's helpers unconditionally `to_nodal` them, which both crashes on the shape mismatch and (in Eulerian mode) wastes one transform per tracer. Regression test included.
- The hybrid branch passes the primitive operator's `nondim_coords`, not the raw coords: the (a, b) tables must be nondimensionalized consistently with the state's log surface pressure. Under jcm's SI scale the two coincide numerically, but only `nondim_coords` is correct under any scale.

## AeroCom wiring

The `plev` group now emits `aerocom_wap` (full model-level field, the `cdnc3d` layout), `aerocom_w500` and `aerocom_w700` (log-p interpolation, the `u200` machinery). Zero-filled when the provider is off, which is static per config, so the scan-carry key set stays stable; consumption is opportunistic (`requires_dycore_fields` stays empty) so existing configs run unchanged. The CMOR writer maps them to `wap` (ModelLevel) / `w500` / `w700` (Column) with the CF standard name `lagrangian_tendency_of_air_pressure`.

## Validation

A horizontally uniform divergence over flat surface pressure has an exact closed-form omega on both verticals (the continuity integrals reduce to sums of constants), so the provider is tested against analytic references, not against itself:

- sigma (T21L8): `omega = -sigma ps D0` exact to the f32 spectral round-trip (~1e-5 relative);
- hybrid (ECHAM T21L47): matches an independent numpy evaluation of the mass-flux formula from the (a, b) tables to ~2e-6 relative;
- rest state: exactly zero;
- end-to-end Held-Suarez run with an omega recorder term: finite, nonzero, sane Pa/s magnitude through the full injection path (both output modes);
- plev group: pass-through and slice tests with a log-p-linear omega (interpolation exact by construction), zero-fill without the provider, CMOR round-trip to `_wap_ModelLevel_` / `_w500_Column_` files;
- end-to-end ECHAM T21L47 run with `enable_aerocom` + the provider: the `get_empty_data` probe (no injection, zero-fill branch) and the scanned steps (injected omega) must produce the same carry structure to compile at all, and the emitted wap is finite and nonzero;
- the runner's tri-state default (`_want_omega`): explicit override wins, AeroCom-plev configs default on, everything else off.

Local gates per `jcm-local-ci`: ruff clean, fast gate at CI dependency parity and the slow gate both above their floors (numbers in the checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aqshaa5nDrxcDWgg1FYw8Z
