### PR TITLE
fix(diffusion): ECHAM lmidatm hyperdiffusion for every hybrid grid, including L95 (#579)

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,6 +4,26 @@ Release Notes
 Unreleased — issue-backlog tidy-up
 ----------------------------------
 
+- **ECHAM hyperdiffusion now covers every hybrid grid, including L95**
+  (#579). ``diffusion.kind=auto`` matched on ``layers == 47``, so the L95
+  middle-atmosphere grids — which exist precisely to resolve the
+  stratosphere — silently fell back to SPEEDY's uniform del² profile, and
+  pinning an L47 profile on them failed with an opaque broadcast error.
+  The ECHAM6.3 ``mo_hdiff.f90::sudif`` tables are now ported in full
+  (T31L47, T63L47, **T63L95**, T127L95, T255L95) and the ``setdyn.f90``
+  ``dampth`` timescales with them, selected per ``(truncation, layers)``.
+  Truncations ECHAM does not tabulate borrow the nearest tabulated
+  profile in log space and interpolate ``dampth`` along ECHAM's own
+  slope. A hybrid grid that still finds no profile now warns instead of
+  falling back silently, and a length-mismatched pin is rejected at build
+  time with a message naming the config key and the grid.
+
+  **This changes results on T85L47.** Its base timescale was a hard-coded
+  3 h that did not sit on ECHAM's own T63→T127 slope; it is now derived
+  as 3.63 h, so damping is slightly weaker. T63L47 — the tuned and
+  validated target — is bit-identical, as is every SPEEDY and
+  Held-Suarez configuration. T106/T119 at both level counts, and all L95
+  grids, move from the SPEEDY uniform profile to their ECHAM profile.
 - **Run provenance recorded in every output file** (#591): netCDF global
   attributes (``jcm_prov_*``) carry the git SHA/branch/dirty state of
   every imported editable library, precision flags and devices, the

--- a/jcm/config/diffusion/default.yaml
+++ b/jcm/config/diffusion/default.yaml
@@ -1,14 +1,19 @@
 # Hyperdiffusion configuration.
 #
-# ``kind: auto`` (default) picks a profile from the grid: L47 hybrid grids
-# get the matching ECHAM ``lmidatm`` level-dependent profile
-# (del² at top 4 levels, ..., del⁸ below); everything else gets SPEEDY's
-# uniform-order default.
+# ``kind: auto`` (default) picks a profile from the grid. Hybrid grids at a
+# level count ECHAM tabulates (L47, L95) get the ECHAM ``lmidatm``
+# level-dependent profile for their (truncation, layers): del² near the model
+# top grading to del⁶/del⁸ below, with the ``setdyn.f90`` base timescale
+# (T63 7 h, T127 1.5 h, interpolated in between). Everything else — SPEEDY
+# T31L8, Held-Suarez — gets SPEEDY's uniform-order default, and a hybrid grid
+# that lands there logs a warning, since it is rarely what was intended.
 #
 # Override with ``kind: default`` (SPEEDY uniform, 24h temp / 12h vor_q
-# / 2h div), ``kind: echam_t63_l47`` (T63 lmidatm 7h base), or
-# ``kind: echam_t85_l47`` (T85 lmidatm 3h base). ``scale`` multiplies
-# the chosen profile's timescales.
+# / 2h div), ``kind: echam_lmidatm`` (force the ECHAM profile for this grid),
+# or ``kind: echam_t63_l47`` / ``echam_t85_l47`` to pin a named profile
+# regardless of grid — pinning one whose level count does not match the grid
+# is rejected at build time. ``scale`` multiplies the chosen profile's
+# timescales.
 kind: auto
 scale: 1.0
 

--- a/jcm/diffusion.py
+++ b/jcm/diffusion.py
@@ -9,20 +9,133 @@ suitable for elementwise multiplication against a spectral state of shape
 hyperdiffusion order — del² at TOA, del⁴/⁶/⁸ going down — which keeps the
 stratosphere well-damped without over-smoothing the troposphere.
 
-Known issue: the level-dependent path currently triggers NaN at order >= 4
-under JIT (eager and orders 1-3 are fine). The uniform-order path
-(``level_orders_* = None``) is unaffected. Use the upper sponge layer
-(``jcm.physics.dissipation.UpperSponge``) as an alternative stabiliser
-until the JIT / order=4 interaction is diagnosed.
+:meth:`DiffusionFilter.echam_lmidatm` reproduces those ECHAM ``lmidatm``
+profiles for a ``(truncation, layers)`` grid; see its docstring for how the
+reference tables are indexed and what happens off them.
 """
 
 from __future__ import annotations
 
+import math
 from typing import Optional
 
 import jax.numpy as jnp
 import tree_math
 from jax import tree_util
+
+# ---------------------------------------------------------------------------
+# ECHAM6 lmidatm hyperdiffusion reference tables
+# ---------------------------------------------------------------------------
+#
+# Base damping timescale ``dampth`` in hours, from ECHAM6.3 ``setdyn.f90``.
+# This is the e-folding time applied at the truncation limit: the damping
+# built below reduces exactly to ``exp(-dt/dampth)`` at ``n = nn`` (see
+# :func:`level_dependent_scaling`), so the table is directly comparable with
+# the SPEEDY-style uniform timescales in :meth:`DiffusionFilter.default`.
+_ECHAM_DAMPTH_HOURS = {31: 12.0, 63: 7.0, 127: 1.5, 255: 0.5}
+
+# Per-level hyperdiffusion orders from ECHAM6.3 ``mo_hdiff.f90::sudif``,
+# keyed by ``(truncation, layers)`` and stored top-first as
+# ``(n_levels, order)`` runs — order 1 is del², 2 del⁴, 3 del⁶, 4 del⁸.
+#
+# These are *level-index* tables in the reference, and they transfer verbatim
+# because jcm's hybrid grids ARE ECHAM's: the pressures our L47/L95 tables put
+# at each transition reproduce the ones ECHAM annotates in ``sudif`` (L47
+# jk=4/7/9 → 0.2315/1.2153/2.9571 hPa vs "~0.23/1.22/2.96"; L95 jk=10/20/25 →
+# 0.1503/0.7680/1.5001 hPa vs "~0.15/0.77/1.50"). A pressure-based rule would
+# be *less* faithful, not more — ECHAM does not place these transitions at the
+# same pressures on L47 and L95, so no single pressure rule reproduces both.
+#
+# Note that the profile depends on truncation as well as level count: on L95
+# ECHAM stops at del⁶ for nn >= 127 but goes to del⁸ at nn = 63. Higher
+# horizontal resolution gets the *lower* maximum order.
+_ECHAM_LMIDATM_ORDERS = {
+    (31, 47): ((4, 1), (3, 2), (2, 3), (2, 4), (36, 5)),
+    (63, 47): ((4, 1), (3, 2), (2, 3), (38, 4)),
+    (63, 95): ((10, 1), (10, 2), (5, 3), (70, 4)),
+    (127, 95): ((10, 1), (15, 2), (70, 3)),
+    (255, 95): ((10, 1), (15, 2), (70, 3)),
+}
+
+#: Level counts for which an ECHAM ``lmidatm`` order profile exists.
+ECHAM_LMIDATM_LAYERS = frozenset(nlev for _, nlev in _ECHAM_LMIDATM_ORDERS)
+
+
+def _check_truncation(truncation: int) -> None:
+    """Reject non-positive truncations before they reach ``math.log``.
+
+    Both selection rules are logarithmic in truncation, so a missing or zero
+    ``grid.spectral_truncation`` would otherwise surface as a bare
+    ``math domain error`` with no indication of which config key was empty.
+    """
+    if truncation <= 0:
+        raise ValueError(
+            f"spectral truncation must be positive to select an ECHAM "
+            f"hyperdiffusion profile, got {truncation!r}; check "
+            "grid.spectral_truncation."
+        )
+
+
+def echam_dampth_hours(truncation: int) -> float:
+    """ECHAM ``dampth`` for ``truncation``, in hours.
+
+    Exact for the truncations ECHAM tabulates (T31/T63/T127/T255); otherwise
+    a power law in truncation fitted to the bracketing pair, which is how the
+    reference values themselves scale (T63→T127 is ``τ ∝ nn**-2.20``). Off
+    the ends of the table the nearest segment's slope is extrapolated.
+
+    Deriving rather than hard-coding is deliberate: the previously hard-coded
+    T85 value (3 h) was an eyeballed extrapolation that did not sit on ECHAM's
+    own T63→T127 slope, and there was nothing at all for T106/T119.
+
+    Raises:
+        ValueError: if ``truncation`` is not positive.
+
+    """
+    _check_truncation(truncation)
+    if truncation in _ECHAM_DAMPTH_HOURS:
+        return _ECHAM_DAMPTH_HOURS[truncation]
+    anchors = sorted(_ECHAM_DAMPTH_HOURS)
+    below = [nn for nn in anchors if nn < truncation]
+    above = [nn for nn in anchors if nn > truncation]
+    if not below:                       # below T31: extrapolate the first leg
+        lo, hi = anchors[0], anchors[1]
+    elif not above:                     # above T255: extrapolate the last leg
+        lo, hi = anchors[-2], anchors[-1]
+    else:
+        lo, hi = below[-1], above[0]
+    exponent = (math.log(_ECHAM_DAMPTH_HOURS[hi] / _ECHAM_DAMPTH_HOURS[lo])
+                / math.log(hi / lo))
+    return _ECHAM_DAMPTH_HOURS[lo] * (truncation / lo) ** exponent
+
+
+def echam_lmidatm_orders(truncation: int, layers: int) -> jnp.ndarray:
+    """Per-level hyperdiffusion orders for ``(truncation, layers)``.
+
+    Truncations ECHAM does not tabulate borrow the profile of the nearest
+    tabulated truncation *in log space* — the natural metric when the tables
+    themselves are spaced by factors of two. That rule keeps T85L47 on the
+    T63L47 profile (as before this function existed) and puts T106L95 and
+    T119L95 on the T127L95 profile.
+
+    Raises:
+        ValueError: if ``truncation`` is not positive, or no ECHAM profile
+            exists for ``layers`` at all.
+
+    """
+    _check_truncation(truncation)
+    candidates = [nn for nn, nlev in _ECHAM_LMIDATM_ORDERS if nlev == layers]
+    if not candidates:
+        raise ValueError(
+            f"No ECHAM lmidatm hyperdiffusion profile for {layers} levels; "
+            f"mo_hdiff.f90::sudif defines profiles for "
+            f"{sorted(ECHAM_LMIDATM_LAYERS)} levels only."
+        )
+    nearest = min(candidates, key=lambda nn: abs(math.log(truncation / nn)))
+    orders = []
+    for count, order in _ECHAM_LMIDATM_ORDERS[(nearest, layers)]:
+        orders.extend([order] * count)
+    return jnp.asarray(orders, dtype=jnp.int32)
 
 
 @tree_math.struct
@@ -64,39 +177,45 @@ class DiffusionFilter:
 
     @classmethod
     def echam_t85_l47(cls):
-        """Level-dependent hyperdiffusion profile tuned for T85 x 47 levels.
+        """ECHAM ``lmidatm`` profile for T85 x 47 levels.
 
-        Based on the ECHAM T63L47 order profile (see mo_hdiff.f90::sudif)
-        extrapolated to T85 by shortening the base timescale from 7 h (T63)
-        toward 3 h (T85 sits between T63 and T127). Levels 1-4 use del²,
-        5-7 del⁴, 8-9 del⁶, 10+ del⁸. Applied equally to div/vor_q/temp.
+        Thin wrapper over :meth:`echam_lmidatm` retained for callers that pin
+        a named profile.
         """
-        return cls._echam_l47(base_tau_h=3.0)
+        return cls.echam_lmidatm(truncation=85, layers=47)
 
     @classmethod
     def echam_t63_l47(cls):
-        """Level-dependent hyperdiffusion profile matching ECHAM6.3 T63 lmidatm.
+        """ECHAM ``lmidatm`` profile for T63 x 47 levels — the tuned target.
 
-        Per ``setdyn.f90``: ``dampth = 7 h`` for ``nn = 63`` selects the base
-        vorticity timescale; the level-order profile from ``mo_hdiff.f90::sudif``
-        for ``(nn = 63, nlev = 47)`` is ``[del², del², del², del², del⁴, del⁴,
-        del⁴, del⁶, del⁶, del⁸, ...]`` (levels 1-4 del², 5-7 del⁴, 8-9 del⁶,
-        10+ del⁸). Equivalent to ``echam_t85_l47()`` but with the T63 7-hour
-        base timescale instead of the T85 3-hour value, and so applied at
-        ``physics=echam`` runs on a T63L47 grid.
+        Thin wrapper over :meth:`echam_lmidatm`. This is the one combination
+        the reference tabulates exactly on both axes (``dampth = 7 h``, orders
+        ``[del²]*4 + [del⁴]*3 + [del⁶]*2 + [del⁸]*38``), so it doubles as the
+        fidelity anchor for the derived cases.
         """
-        return cls._echam_l47(base_tau_h=7.0)
+        return cls.echam_lmidatm(truncation=63, layers=47)
 
     @classmethod
-    def _echam_l47(cls, base_tau_h: float):
-        """Shared constructor for ECHAM lmidatm L47 hyperdiffusion profiles.
+    def echam_lmidatm(cls, truncation: int, layers: int):
+        """ECHAM6.3 ``lmidatm`` level-dependent hyperdiffusion for a grid.
 
-        ``base_tau_h`` is the ECHAM ``dampth`` value in hours (T63→7, T85→3,
-        T127→1.5, T255→0.5; see ``setdyn.f90``).
+        Combines the ``setdyn.f90`` base timescale (:func:`echam_dampth_hours`)
+        with the ``mo_hdiff.f90::sudif`` per-level order profile
+        (:func:`echam_lmidatm_orders`) — del² near the model top grading to
+        del⁶/del⁸ below, which damps the stratosphere hard without
+        over-smoothing the troposphere.
+
+        Args:
+            truncation: spectral truncation (``nn``).
+            layers: number of vertical levels (``nlev``). Must be one of
+                :data:`ECHAM_LMIDATM_LAYERS`.
+
+        Raises:
+            ValueError: if ECHAM defines no profile for ``layers``.
+
         """
-        orders = [1] * 4 + [2] * 3 + [3] * 2 + [4] * 38  # 4+3+2+38 = 47
-        level_orders = jnp.asarray(orders, dtype=jnp.int32)
-        base_tau = base_tau_h * 3600.0
+        level_orders = echam_lmidatm_orders(truncation, layers)
+        base_tau = echam_dampth_hours(truncation) * 3600.0
         return cls(
             # Effective timescale for each variable is ``base_tau * factor``;
             # factors match ECHAM's difvo / difd / dift proportions

--- a/jcm/diffusion_test.py
+++ b/jcm/diffusion_test.py
@@ -6,7 +6,13 @@ import jax.numpy as jnp
 import numpy as np
 import numpy.testing as npt
 
-from jcm.diffusion import DiffusionFilter, level_dependent_scaling, uniform_scaling
+from jcm.diffusion import (
+    DiffusionFilter,
+    echam_dampth_hours,
+    echam_lmidatm_orders,
+    level_dependent_scaling,
+    uniform_scaling,
+)
 
 
 # Realistic dimensional Laplacian eigenvalues for a triangular T63 grid in
@@ -105,20 +111,143 @@ class SpmdPaddedEigenvaluesTest(unittest.TestCase):
         )
 
 
-class EchamL47FactoryTest(unittest.TestCase):
+class EchamReferenceTableTest(unittest.TestCase):
+    """Pin the ported ECHAM6.3 ``lmidatm`` tables against the Fortran source.
 
-    def test_t63_uses_7h_base_timescale(self):
+    These are transcriptions, so the test is a transcription check: every
+    ``(nn, nlev)`` pair ``mo_hdiff.f90::sudif`` defines must come back
+    verbatim, and ``setdyn.f90``'s ``dampth`` values must be exact.
+    """
+
+    # mo_hdiff.f90::sudif, lmidatm branch. Top-first, 1 = del², 4 = del⁸.
+    _SUDIF = {
+        (31, 47): [1] * 4 + [2] * 3 + [3] * 2 + [4] * 2 + [5] * 36,
+        (63, 47): [1] * 4 + [2] * 3 + [3] * 2 + [4] * 38,
+        (63, 95): [1] * 10 + [2] * 10 + [3] * 5 + [4] * 70,
+        (127, 95): [1] * 10 + [2] * 15 + [3] * 70,
+        (255, 95): [1] * 10 + [2] * 15 + [3] * 70,
+    }
+
+    def test_order_tables_match_sudif(self):
+        for (nn, nlev), expected in self._SUDIF.items():
+            with self.subTest(truncation=nn, layers=nlev):
+                np.testing.assert_array_equal(
+                    np.asarray(echam_lmidatm_orders(nn, nlev)), expected,
+                )
+
+    def test_dampth_matches_setdyn(self):
+        # setdyn.f90 section 1.5: dampth by truncation, lmidatm.
+        for nn, hours in ((31, 12.0), (63, 7.0), (127, 1.5), (255, 0.5)):
+            with self.subTest(truncation=nn):
+                self.assertAlmostEqual(echam_dampth_hours(nn), hours, places=9)
+
+    def test_grid_levels_sit_at_the_pressures_sudif_annotates(self):
+        """The index tables are transferable only because our grids ARE ECHAM's.
+
+        ``sudif`` places the order transitions by level *index* and annotates
+        each with a pressure. Porting the indices verbatim is therefore only
+        correct while jcm's hybrid tables put those indices at the same
+        pressures — so assert it, and fail loudly if the level definitions
+        ever drift (#579).
+        """
+        from jcm.physics.echam.echam_levels import get_echam_levels
+
+        # (layers, 1-based ECHAM level, hPa quoted in the sudif comment)
+        annotated = [
+            (47, 4, 0.23), (47, 7, 1.22), (47, 9, 2.96),
+            (95, 10, 0.15), (95, 20, 0.77), (95, 25, 1.50),
+        ]
+        for layers, jk, p_ref in annotated:
+            with self.subTest(layers=layers, level=jk):
+                h = get_echam_levels(layers)
+                p_half = (np.asarray(h.a_boundaries)
+                          + np.asarray(h.b_boundaries) * 101325.0)
+                p_full_hpa = 0.5 * (p_half[1:] + p_half[:-1])[jk - 1] / 100.0
+                # sudif quotes two decimals, so match to its rounding.
+                self.assertAlmostEqual(p_full_hpa, p_ref, places=2)
+
+
+class EchamLmidatmFactoryTest(unittest.TestCase):
+
+    def test_t63_l47_is_the_exact_reference_configuration(self):
+        """T63L47 is tabulated on both axes — the fidelity anchor."""
         d = DiffusionFilter.echam_t63_l47()
         self.assertAlmostEqual(d.vor_q_timescale, 7 * 3600.0, places=3)
+        # mo_hdiff.f90: difd = 5*difvo, dift = 0.4*difvo.
         self.assertAlmostEqual(d.div_timescale, 7 * 3600.0 / 5.0, places=3)
         self.assertAlmostEqual(d.temp_timescale, 7 * 3600.0 / 0.4, places=3)
-        # ECHAM lmidatm L47 sudif profile
-        np.testing.assert_array_equal(np.asarray(d.level_orders_temp), [1] * 4 + [2] * 3 + [3] * 2 + [4] * 38)
+        np.testing.assert_array_equal(
+            np.asarray(d.level_orders_temp), [1] * 4 + [2] * 3 + [3] * 2 + [4] * 38,
+        )
 
-    def test_t85_uses_3h_base_timescale(self):
-        d = DiffusionFilter.echam_t85_l47()
-        self.assertAlmostEqual(d.vor_q_timescale, 3 * 3600.0, places=3)
+    def test_profile_length_matches_layers(self):
+        for truncation, layers in ((63, 47), (85, 47), (106, 95), (119, 95)):
+            with self.subTest(truncation=truncation, layers=layers):
+                d = DiffusionFilter.echam_lmidatm(truncation, layers)
+                for orders in (d.level_orders_div, d.level_orders_vor_q,
+                               d.level_orders_temp):
+                    self.assertEqual(len(orders), layers)
+
+    def test_untabulated_truncation_borrows_nearest_in_log_space(self):
+        """T85 sits nearer T63 than T127 in log space; T106/T119 nearer T127.
+
+        This matters on L95, where the two reference profiles genuinely
+        differ: T63L95 grades down to del⁸, T127L95 stops at del⁶.
+        """
+        np.testing.assert_array_equal(
+            np.asarray(echam_lmidatm_orders(85, 47)),
+            np.asarray(echam_lmidatm_orders(63, 47)),
+        )
+        for truncation in (106, 119):
+            with self.subTest(truncation=truncation):
+                np.testing.assert_array_equal(
+                    np.asarray(echam_lmidatm_orders(truncation, 95)),
+                    np.asarray(echam_lmidatm_orders(127, 95)),
+                )
+                # ...and specifically NOT the del⁸ T63L95 profile.
+                self.assertEqual(
+                    int(np.max(np.asarray(echam_lmidatm_orders(truncation, 95)))), 3,
+                )
+
+    def test_dampth_is_monotone_and_bracketed(self):
+        """Derived timescales must decrease with truncation and interpolate."""
+        truncations = [31, 63, 85, 106, 119, 127, 255]
+        taus = [echam_dampth_hours(nn) for nn in truncations]
+        self.assertEqual(taus, sorted(taus, reverse=True))
+        # Each derived value lies strictly between its ECHAM neighbours.
+        for nn in (85, 106, 119):
+            with self.subTest(truncation=nn):
+                self.assertLess(echam_dampth_hours(nn), 7.0)
+                self.assertGreater(echam_dampth_hours(nn), 1.5)
+
+    def test_unsupported_layer_count_raises_a_named_error(self):
+        with self.assertRaisesRegex(ValueError, r"No ECHAM lmidatm .*31 levels"):
+            DiffusionFilter.echam_lmidatm(truncation=63, layers=31)
+
+    def test_missing_truncation_raises_before_reaching_math_log(self):
+        """A zero/absent ``grid.spectral_truncation`` must name the config key.
+
+        Both selection rules take ``log(truncation)``, so without this guard
+        an unset key surfaces as a bare ``math domain error``.
+        """
+        # Label with a string, not the callable: under pytest-xdist the
+        # subTest parameters are serialised across the execnet gateway, which
+        # cannot pickle a function ("DumpError: can't serialize <class
+        # 'function'>") — the test then fails only in the parallel run.
+        entry_points = {
+            "echam_dampth_hours": lambda: echam_dampth_hours(0),
+            "echam_lmidatm_orders": lambda: echam_lmidatm_orders(0, 47),
+            "DiffusionFilter.echam_lmidatm": lambda: DiffusionFilter.echam_lmidatm(0, 47),
+        }
+        for name, call in entry_points.items():
+            with self.subTest(entry_point=name):
+                with self.assertRaisesRegex(ValueError, "grid.spectral_truncation"):
+                    call()
+
+    def test_all_three_slots_share_one_profile(self):
+        d = DiffusionFilter.echam_lmidatm(63, 95)
         np.testing.assert_array_equal(d.level_orders_temp, d.level_orders_div)
+        np.testing.assert_array_equal(d.level_orders_temp, d.level_orders_vor_q)
 
 
 if __name__ == "__main__":

--- a/jcm/runners.py
+++ b/jcm/runners.py
@@ -21,7 +21,7 @@ import jax.numpy as jnp
 from omegaconf import DictConfig
 
 from jcm import provenance
-from jcm.diffusion import DiffusionFilter
+from jcm.diffusion import ECHAM_LMIDATM_LAYERS, DiffusionFilter
 from jcm.model import Model, ModelPredictions
 from jcm.terrain import TerrainData
 from jcm.utils import get_coords
@@ -426,41 +426,53 @@ def build_diffusion(cfg: DictConfig) -> DiffusionFilter:
     """Build a ``DiffusionFilter`` honouring ``cfg.diffusion`` + the grid.
 
     Resolution selector: when ``cfg.diffusion.kind`` is ``"auto"`` (the
-    default) and the grid is an L47 hybrid, return the matching
-    ECHAM ``lmidatm`` level-dependent profile (del² at top 4 levels, del⁴
-    at 5-7, del⁶ at 8-9, del⁸ below) — that's the stability stack the
-    grid was tuned for in ECHAM. T63L47 picks the 7-hour base timescale;
-    T85L47 picks 3 h. Set ``cfg.diffusion.kind: default`` to force the
-    uniform SPEEDY del² profile (24h temp / 12h vor_q / 2h div), or
-    ``cfg.diffusion.kind: echam_t63_l47`` / ``echam_t85_l47`` to pin a
-    specific factory regardless of grid. ``cfg.diffusion.scale`` still
-    multiplies the chosen profile's timescales — keep the existing
-    SPEEDY-tuned configs working unchanged.
+    default) and the grid is a hybrid grid with a level count ECHAM
+    tabulates (L47 or L95), return the ECHAM ``lmidatm`` level-dependent
+    profile for that ``(truncation, layers)`` — del² near the model top
+    grading to del⁶/del⁸ below, with the ``setdyn.f90`` base timescale.
+    That's the stability stack these grids were tuned for in ECHAM, and it
+    is what the L95 middle-atmosphere grids exist to exploit. Any other
+    grid — SPEEDY T31L8, Held-Suarez, a hybrid grid at an untabulated level
+    count — gets the uniform SPEEDY del² profile, with a warning in the
+    hybrid case since that is unlikely to be what was intended (#579).
+
+    Set ``cfg.diffusion.kind: default`` to force the uniform SPEEDY profile
+    (24h temp / 12h vor_q / 2h div), ``echam_lmidatm`` to force the ECHAM
+    profile for the configured grid, or ``echam_t63_l47`` / ``echam_t85_l47``
+    to pin a specific named profile regardless of grid.
+    ``cfg.diffusion.scale`` still multiplies the chosen profile's timescales
+    — keep the existing SPEEDY-tuned configs working unchanged.
     """
     diffusion = cfg.get("diffusion", None)
     kind = "auto" if diffusion is None else str(diffusion.get("kind", "auto"))
     scale = 1.0 if diffusion is None else float(diffusion.get("scale", 1.0))
 
+    grid_cfg = cfg.get("grid", None)
+    layers = int(grid_cfg.get("layers", 0)) if grid_cfg is not None else 0
+    truncation = int(grid_cfg.get("spectral_truncation", 0)) if grid_cfg is not None else 0
+    vertical = str(grid_cfg.get("vertical", "")) if grid_cfg is not None else ""
+
     if kind == "auto":
-        # Pick by grid: ECHAM lmidatm profile for L47 hybrid grids, SPEEDY
-        # default otherwise. Match on the (vertical=hybrid, layers, truncation)
-        # triple so this fires for both echam_t63_l47_hybrid and
-        # echam_t85_l47_hybrid — and stays inert for SPEEDY T31L8 / Held-Suarez.
-        grid_cfg = cfg.get("grid", None)
-        layers = int(grid_cfg.get("layers", 0)) if grid_cfg is not None else 0
-        truncation = int(grid_cfg.get("spectral_truncation", 0)) if grid_cfg is not None else 0
-        vertical = str(grid_cfg.get("vertical", "")) if grid_cfg is not None else ""
-        if vertical == "hybrid" and layers == 47:
-            if truncation == 63:
-                base = DiffusionFilter.echam_t63_l47()
-            elif truncation == 85:
-                base = DiffusionFilter.echam_t85_l47()
-            else:
-                base = DiffusionFilter.default()
+        # Match on the (vertical=hybrid, layers) pair so this fires for every
+        # ECHAM-family grid at any truncation — and stays inert for SPEEDY
+        # T31L8 / Held-Suarez, which have their own tuned uniform damping.
+        if vertical == "hybrid" and layers in ECHAM_LMIDATM_LAYERS:
+            base = DiffusionFilter.echam_lmidatm(truncation, layers)
         else:
+            if vertical == "hybrid":
+                logger.warning(
+                    "diffusion.kind=auto found no ECHAM lmidatm profile for a "
+                    "hybrid grid with %d levels, so this run uses the uniform "
+                    "SPEEDY profile (24h temp / 12h vor_q / 2h div). ECHAM "
+                    "profiles exist for %s levels. Set diffusion.kind "
+                    "explicitly to silence this.",
+                    layers, sorted(ECHAM_LMIDATM_LAYERS),
+                )
             base = DiffusionFilter.default()
     elif kind == "default":
         base = DiffusionFilter.default()
+    elif kind == "echam_lmidatm":
+        base = DiffusionFilter.echam_lmidatm(truncation, layers)
     elif kind == "echam_t63_l47":
         base = DiffusionFilter.echam_t63_l47()
     elif kind == "echam_t85_l47":
@@ -468,7 +480,21 @@ def build_diffusion(cfg: DictConfig) -> DiffusionFilter:
     else:
         raise ValueError(
             f"Unknown diffusion.kind={kind!r}; expected one of "
-            "'auto', 'default', 'echam_t63_l47', 'echam_t85_l47'."
+            "'auto', 'default', 'echam_lmidatm', 'echam_t63_l47', "
+            "'echam_t85_l47'."
+        )
+
+    # A level-dependent profile is a per-level array, so pinning one whose
+    # length does not match the grid fails later inside the spectral filter as
+    # an opaque broadcast error ("(95, 213, 108) vs (47,)"). Catch it here,
+    # where the actual mismatch can be named (#579).
+    n_orders = None if base.level_orders_temp is None else len(base.level_orders_temp)
+    if n_orders is not None and layers and n_orders != layers:
+        raise ValueError(
+            f"diffusion.kind={kind!r} builds a {n_orders}-level hyperdiffusion "
+            f"profile but the grid has {layers} levels. Use "
+            "diffusion.kind=auto (or 'echam_lmidatm') to get the profile "
+            "matching this grid, or 'default' for the uniform SPEEDY profile."
         )
 
     if scale == 1.0:

--- a/jcm/runners_test.py
+++ b/jcm/runners_test.py
@@ -905,27 +905,65 @@ class TestBuilderErrorAndSelectorPaths(unittest.TestCase):
             # unlike the uniform SPEEDY default.
             self.assertIsNotNone(diffusion.level_orders_temp)
 
-    def test_build_diffusion_auto_picks_lmidatm_for_l47_hybrid(self):
+    @staticmethod
+    def _grid_cfg(layers, truncation, kind="auto", vertical="hybrid"):
         from omegaconf import OmegaConf
+        return OmegaConf.create({
+            "diffusion": {"kind": kind},
+            "grid": {"vertical": vertical, "layers": layers,
+                     "spectral_truncation": truncation},
+        })
+
+    def test_build_diffusion_auto_picks_lmidatm_for_every_echam_grid(self):
+        """Every shipped hybrid grid must get its ECHAM lmidatm profile.
+
+        Regression for #579: ``auto`` matched on ``layers == 47``, so the L95
+        middle-atmosphere grids — which exist precisely to resolve the
+        stratosphere — silently received SPEEDY's uniform profile instead.
+        """
         from jcm.diffusion import DiffusionFilter
 
-        for truncation, factory in (
-            (63, DiffusionFilter.echam_t63_l47),
-            (85, DiffusionFilter.echam_t85_l47),
-            # An untuned truncation on the L47 grid falls back to default.
-            (42, DiffusionFilter.default),
-        ):
-            cfg = OmegaConf.create({
-                "diffusion": {"kind": "auto"},
-                "grid": {"vertical": "hybrid", "layers": 47,
-                         "spectral_truncation": truncation},
-            })
-            diffusion = build_diffusion(cfg)
-            expected = factory()
-            self.assertEqual(
-                float(diffusion.temp_timescale), float(expected.temp_timescale),
-                f"T{truncation}L47 selected the wrong diffusion profile",
-            )
+        for layers, truncation in ((47, 63), (47, 85), (47, 106), (47, 119),
+                                   (95, 63), (95, 106), (95, 119)):
+            with self.subTest(layers=layers, truncation=truncation):
+                diffusion = build_diffusion(self._grid_cfg(layers, truncation))
+                expected = DiffusionFilter.echam_lmidatm(truncation, layers)
+                self.assertEqual(float(diffusion.temp_timescale),
+                                 float(expected.temp_timescale))
+                self.assertEqual(len(diffusion.level_orders_temp), layers)
+
+    def test_build_diffusion_auto_warns_when_falling_back_on_a_hybrid_grid(self):
+        """The SPEEDY fallback on an ECHAM-family grid must not be silent."""
+        from jcm.diffusion import DiffusionFilter
+
+        with self.assertLogs("jcm.runners", level="WARNING") as captured:
+            diffusion = build_diffusion(self._grid_cfg(layers=31, truncation=63))
+        self.assertEqual(float(diffusion.temp_timescale),
+                         float(DiffusionFilter.default().temp_timescale))
+        self.assertIn("no ECHAM lmidatm profile", "\n".join(captured.output))
+
+    def test_build_diffusion_auto_stays_silent_for_non_hybrid_grids(self):
+        """SPEEDY/Held-Suarez sigma grids are tuned for the uniform profile."""
+        import logging
+
+        from jcm.diffusion import DiffusionFilter
+
+        with self.assertNoLogs("jcm.runners", level=logging.WARNING):
+            diffusion = build_diffusion(
+                self._grid_cfg(layers=8, truncation=31, vertical="sigma"))
+        self.assertEqual(float(diffusion.temp_timescale),
+                         float(DiffusionFilter.default().temp_timescale))
+
+    def test_build_diffusion_rejects_a_profile_of_the_wrong_length(self):
+        """Pinning an L47 profile on an L95 grid must fail with a clear error.
+
+        Previously this surfaced deep inside the spectral filter as
+        "objects cannot be broadcast to a single shape ... (95, 213, 108)
+        and (47,)", which named neither the config key nor the grid (#579).
+        """
+        cfg = self._grid_cfg(layers=95, truncation=106, kind="echam_t85_l47")
+        with self.assertRaisesRegex(ValueError, r"47-level .* grid has 95 levels"):
+            build_diffusion(cfg)
 
     def test_build_diffusion_unknown_kind_raises(self):
         from omegaconf import OmegaConf


### PR DESCRIPTION
Closes #579.

## What was wrong

`diffusion.kind=auto` matched on `layers == 47`, so **every L95 middle-atmosphere grid silently got SPEEDY's uniform del² profile** — on grids that exist specifically to resolve the stratosphere. Pinning an L47 profile instead failed inside the spectral filter with `objects cannot be broadcast ... (95, 213, 108) and (47,)`, and no truncation above T85 had a base timescale at all.

## The reference already had the answer

ECHAM6.3 `mo_hdiff.f90::sudif` contains an **authoritative T63L95 table that was simply never ported**:

```fortran
ELSE IF (nn == 63) THEN
  IF (nlev == 95) THEN
    ihq63(1:10)=1; ihq63(11:20)=2; ihq63(21:25)=3; ihq63(26:)=4
```

So this PR ports the reference tables in full rather than inventing a generalisation — `(31,47) (63,47) (63,95) (127,95) (255,95)` orders, plus the `setdyn.f90` `dampth` timescales (T31 12 h, T63 7 h, T127 1.5 h, T255 0.5 h).

**The profile depends on truncation as well as level count**: on L95, ECHAM stops at del⁶ for `nn >= 127` but reaches del⁸ at `nn = 63`. Higher horizontal resolution gets the *lower* maximum order. That rules out one-table-per-level-count.

## On the issue's "place transitions by pressure" suggestion — I did not do this, deliberately

It would be **less** faithful, not more. ECHAM places the transitions at *different pressures* on L47 and L95 (del²→del⁴ at 0.23 hPa on L47 but 0.15 hPa on L95), so no single pressure rule reproduces both.

The index tables transfer verbatim because jcm's hybrid grids **are** ECHAM's. A test asserts exactly that, so the transcription fails loudly if the level definitions ever drift:

| `sudif` comment | our grid computes |
|---|---|
| L47 `jk=4 => ~0.23 hPa` | 0.2315 |
| L47 `jk=7 => ~1.22 hPa` | 1.2153 |
| L47 `jk=9 => ~2.96 hPa` | 2.9571 |
| L95 `jk=10 => ~0.15 hPa` | 0.1503 |
| L95 `jk=20 => ~0.77 hPa` | 0.7680 |
| L95 `jk=25 => ~1.50 hPa` | 1.5001 |

## Truncations ECHAM doesn't tabulate

T85/T106/T119 borrow the nearest tabulated profile **in log space** and interpolate `dampth` along ECHAM's own T63→T127 slope (`τ ∝ nn**-2.20`):

| | dampth | order table |
|---|---|---|
| T63 | 7.00 h *(ECHAM)* | own |
| T85 | 3.63 h | T63 |
| T106 | 2.23 h | T63 on L47, **T127 on L95** |
| T119 | 1.73 h | T63 on L47, **T127 on L95** |
| T127 | 1.50 h *(ECHAM)* | own |

The issue proposed extrapolating with an exponent of ~2.8, which gives 1.6 h / 1.2 h. That exponent comes from the repo's own invented T63→T85 pair; ECHAM's real T63→T127 slope is 2.20, so I anchored on the reference instead.

## ⚠️ This changes results on T85L47

Its base timescale was a hard-coded 3 h that did not sit on ECHAM's slope; it is now derived as **3.63 h**, so damping is slightly weaker. Discussed and chosen deliberately over pinning 3 h as an anchor.

**Unchanged (verified):** T63L47 — the tuned and validated target — is bit-identical, as is every SPEEDY and Held-Suarez configuration. T106/T119 at both level counts, and all L95 grids, move from the SPEEDY uniform profile to their ECHAM profile.

## Also

- A hybrid grid that still finds no profile now **warns** instead of falling back silently.
- A length-mismatched pin is **rejected at build time** naming the config key and the grid.
- New `diffusion.kind=echam_lmidatm` forces the ECHAM profile for the configured grid.
- Guards a non-positive `grid.spectral_truncation` so it doesn't surface as a bare `math domain error`.
- Drops a **stale** module note claiming the level-dependent path NaNs at order >= 4 under JIT. That float32 underflow was fixed and is pinned by `test_no_nan_at_high_orders`.

## Validation

| | result |
|---|---|
| Fast gate | 1658 passed, 0 failed, **94.59%** (>= 90) |
| Slow gate | 73 passed, **84.17%** (>= 80) |
| `ruff check .` | clean |
| Docs | build succeeds; no new warnings |
| T63L95 `echam-rrtmgp`, 2 days | both chunks OK, **0/122 NaN vars** |
| T106L95 `echam-rrtmgp`, 1 day | OK, **0/122 NaN vars** — exercises the nearest-truncation rule (borrows T127L95 del⁶) |

Note on scope of the runs: they validate the *mechanism* end-to-end on 95 levels (correct array plumbing, stable integration, no grid-scale noise at the top). The *fidelity* claim rests on the table transcription, which is unit-tested line-by-line against the Fortran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)