### PR TITLE
JAM: finish the cloud-borne cycle behind a population switch + physics-side aerosol vertical transport (#602)

### DIFF
--- a/jcm/config/physics/echam-jam.yaml
+++ b/jcm/config/physics/echam-jam.yaml
@@ -28,6 +28,18 @@ jam_microphysics: mam4_jax  # the MAM4-JAX core (#490); "placeholder" for κ-Kö
 jam_arg_variant: ghosh2025  # or arg2000
 jam_aqueous_scheme: full
 
+# Explicit cloud-borne aerosol phase (#602). true (default) carries and cycles
+# the mc_*/nc_* mirror tracers: ARG activation transfer + resuspension,
+# in-droplet wet removal, dry deposition, and the aqueous sulfate split. false
+# drops the 25 mirrors from the tracer set — they are ~43% of the tracer count
+# and tracers are ~94% of the dycore step at ne30 — and scavenges interstitial
+# aerosol by its activated fraction instead (the implicit M7/TOMAS-style
+# treatment). Flip this one flag for the A/B cost/fidelity comparison.
+# Flipping it changes the transported tracer set, so a restart across the
+# flip fails loudly (checkpoint pytree mismatch); false -> true cold-starts
+# the mirrors at zero (spin-up).
+jam_cloud_borne: true
+
 # Prescribed-emission terms (driven by forcing.emissions_file):
 jam_anthropogenic: true        # bulk SO2/BC/OC → in-model speciation + injection
 jam_prescribed_speciated: true # already-speciated per-tracer fields (CAM-faithful)

--- a/jcm/physics/aerosol/jam/__init__.py
+++ b/jcm/physics/aerosol/jam/__init__.py
@@ -9,6 +9,10 @@ later phases; Phase 0 exposes the population contract and the placeholder
 core.
 """
 
+from jcm.physics.aerosol.jam.cloud_borne import (
+    CloudBorneExchange,
+    CloudBorneExchangeParameters,
+)
 from jcm.physics.aerosol.jam.jam_state import JamAerosolState
 from jcm.physics.aerosol.jam.jam_terms import jam_aerosol_physics
 from jcm.physics.aerosol.jam.microphysics import (
@@ -31,6 +35,8 @@ __all__ = [
     "AerosolMode",
     "AerosolSpecies",
     "ModalAerosolSpec",
+    "CloudBorneExchange",
+    "CloudBorneExchangeParameters",
     "JamAerosolState",
     "jam_aerosol_physics",
     "ModalMicrophysicsTerm",

--- a/jcm/physics/aerosol/jam/activation/arg.py
+++ b/jcm/physics/aerosol/jam/activation/arg.py
@@ -110,10 +110,15 @@ def arg_activation(
 ):
     """ARG closed-form activation.
 
-    Returns ``(activated_cdnc, activated_fraction, s_max)``:
+    Returns ``(activated_cdnc, activated_fraction, s_max, number_frac,
+    mass_frac)``:
       * ``activated_cdnc``  (nlev, ncols) total activated number [m^-3]
       * ``activated_fraction`` (nlev, ncols) number-weighted fraction [-]
       * ``s_max`` (nlev, ncols) maximum supersaturation [-]
+      * ``number_frac`` (M, nlev, ncols) per-mode activated number fraction,
+        zero for non-activatable modes
+      * ``mass_frac`` (M, nlev, ncols) per-mode activated mass fraction
+        (the log-normal number erf shifted by ``3·lnσ/√2``), same masking
     """
     # Floor the modal number at 0: spectral advection of the aerosol-number
     # tracers leaves small NEGATIVE number on the near-zero cold-start field
@@ -167,11 +172,17 @@ def arg_activation(
     inv_smax2 = jnp.sum(can_activate * term / sm ** 2, axis=0)
     s_max = 1.0 / jnp.sqrt(jnp.maximum(inv_smax2, _TINY))
 
-    # Activated fraction per mode and total.
+    # Activated fraction per mode and total. The mass fraction is the same
+    # log-normal integral evaluated against the mass distribution, whose
+    # median is ``exp(3·ln²σ)`` above the number median — the standard ARG
+    # ``u_m = u − 3·lnσ/√2`` shift.
     u = (2.0 * jnp.log(sm / s_max)) / (3.0 * jnp.sqrt(2.0) * ln_sigma)
     f_act = 0.5 * (1.0 - erf(u))
+    f_mass = 0.5 * (1.0 - erf(u - 3.0 * ln_sigma / jnp.sqrt(2.0)))
     n_act = jnp.sum(can_activate * number_vol * f_act, axis=0)
 
     n_total = jnp.sum(can_activate * number_vol, axis=0)
     activated_fraction = n_act / jnp.maximum(n_total, _TINY)
-    return n_act, activated_fraction, s_max
+    return n_act, activated_fraction, s_max, can_activate * f_act, (
+        can_activate * f_mass
+    )

--- a/jcm/physics/aerosol/jam/activation/arg_term.py
+++ b/jcm/physics/aerosol/jam/activation/arg_term.py
@@ -28,6 +28,21 @@ from jcm.physics_interface import PhysicsTendency
 
 
 @tree_math.struct
+class JamActivationData:
+    """Per-mode ARG activated fractions (the ``_jam_activation`` key).
+
+    Written each step for the cloud-borne exchange term (#602): the fraction
+    of each mode's interstitial number and mass that would reside in cloud
+    droplets at the diagnosed maximum supersaturation. Mode axis first,
+    ``(n_aer, nlev, ncols)``, matching ``_jam_state``; zero for modes that
+    cannot activate.
+    """
+
+    number_frac: jnp.ndarray   # activated number fraction [-]
+    mass_frac: jnp.ndarray     # activated mass fraction [-]
+
+
+@tree_math.struct
 class ArgParameters:
     """Tunable knobs for ARG activation (differentiable)."""
 
@@ -53,7 +68,7 @@ class ArgActivation(PhysicsTerm):
         "_jam_state", "pressure_full", "air_density",
     )
     provides: ClassVar[tuple[str, ...]] = (
-        "activated_cdnc", "activated_fraction",
+        "activated_cdnc", "activated_fraction", "_jam_activation",
     )
 
     def __init__(
@@ -101,7 +116,8 @@ class ArgActivation(PhysicsTerm):
 
         updraft = self._updraft(diagnostics, state.temperature.shape, params)
 
-        activated_cdnc, activated_fraction, _ = arg_activation(
+        activated_cdnc, activated_fraction, _, number_frac, mass_frac = (
+            arg_activation(
             r_dry=aer.r_dry,
             kappa=aer.kappa,
             number_vol=number_vol,
@@ -112,11 +128,14 @@ class ArgActivation(PhysicsTerm):
             pressure=diagnostics["pressure_full"],
             sigma_acc=self._sigma_acc,
             variant=self._variant,
-        )
+        ))
 
         tendency = PhysicsTendency.zeros(state.temperature.shape)
         return tendency, {
             **diagnostics,
             "activated_cdnc": activated_cdnc,
             "activated_fraction": activated_fraction,
+            "_jam_activation": JamActivationData(
+                number_frac=number_frac, mass_frac=mass_frac,
+            ),
         }

--- a/jcm/physics/aerosol/jam/activation/arg_test.py
+++ b/jcm/physics/aerosol/jam/activation/arg_test.py
@@ -57,6 +57,61 @@ class ShapeCoefficientTest(unittest.TestCase):
             _shape_coefficients(jnp.asarray(0.0), jnp.asarray(0.5), 1.8, "x")
 
 
+class PerModeFractionTest(unittest.TestCase):
+    def test_per_mode_fractions_physical(self):
+        # Two modes, the second masked non-activatable. Number and mass
+        # fractions must be in [0, 1], the mass fraction at least the number
+        # fraction (large particles activate preferentially), and masked
+        # modes exactly zero in both.
+        two = lambda a, b: jnp.asarray([a, b]).reshape(2, 1, 1)
+        kw = dict(
+            r_dry=two(0.05e-6, 0.05e-6),
+            kappa=two(0.6, 0.6),
+            number_vol=two(1.0e8, 1.0e8),
+            sigma_g=two(1.8, 1.8),
+            can_activate=two(1.0, 0.0),
+        )
+        _, _, _, fn, fm = arg_activation(
+            updraft=jnp.full((1, 1), 0.5),
+            temperature=jnp.full((1, 1), 283.0),
+            pressure=jnp.full((1, 1), 9.0e4),
+            sigma_acc=1.8,
+            variant="arg2000",
+            **kw,
+        )
+        fn0, fm0 = float(fn[0, 0, 0]), float(fm[0, 0, 0])
+        self.assertGreater(fn0, 0.0)
+        self.assertLessEqual(fn0, 1.0)
+        self.assertGreaterEqual(fm0, fn0)
+        self.assertLessEqual(fm0, 1.0)
+        self.assertEqual(float(fn[1, 0, 0]), 0.0)
+        self.assertEqual(float(fm[1, 0, 0]), 0.0)
+
+    def test_mass_fraction_is_the_shifted_number_erf(self):
+        # Pin the exact ARG (2000) relation between the two fractions:
+        # recover u from the returned number fraction (fn = erfc(u)/2) and
+        # require fm == erfc(u − 3·lnσ/√2)/2. A plausible-wrong shift
+        # (3·lnσ/2, 3√2·lnσ, √2·lnσ) fails this; the inequality checks
+        # above would not catch it.
+        from scipy.special import erf, erfinv
+
+        sigma = 1.8
+        _, _, _, fn, fm = arg_activation(
+            updraft=jnp.full((1, 1), 0.5),
+            temperature=jnp.full((1, 1), 283.0),
+            pressure=jnp.full((1, 1), 9.0e4),
+            sigma_acc=sigma,
+            variant="arg2000",
+            **_single_mode(sigma=sigma),
+        )
+        fn0, fm0 = float(fn[0, 0, 0]), float(fm[0, 0, 0])
+        u = erfinv(1.0 - 2.0 * fn0)
+        expected = 0.5 * (
+            1.0 - erf(u - 3.0 * np.log(sigma) / np.sqrt(2.0))
+        )
+        self.assertAlmostEqual(fm0, float(expected), places=5)
+
+
 def _single_mode(r_dry=0.05e-6, kappa=0.6, n_percc=100.0, sigma=1.8):
     """One-mode (M=1, 1 level, 1 col) ARG input set."""
     one = lambda v: jnp.full((1, 1, 1), v)
@@ -76,7 +131,7 @@ def _scalar(x):
 class ArgActivationCoreTest(unittest.TestCase):
     def _run(self, w=0.5, T=283.0, p=9.0e4, variant="arg2000", **over):
         kw = _single_mode(**over)
-        n_act, frac, smax = arg_activation(
+        n_act, frac, smax, _, _ = arg_activation(
             updraft=jnp.full((1, 1), w),
             temperature=jnp.full((1, 1), T),
             pressure=jnp.full((1, 1), p),
@@ -129,7 +184,7 @@ class ArgActivationCoreTest(unittest.TestCase):
 
     def test_grad_through_updraft_finite(self):
         def loss(w):
-            n_act, _, _ = arg_activation(
+            n_act, *_ = arg_activation(
                 updraft=jnp.full((1, 1), w),
                 temperature=jnp.full((1, 1), 283.0),
                 pressure=jnp.full((1, 1), 9.0e4),

--- a/jcm/physics/aerosol/jam/chemistry/aqueous.py
+++ b/jcm/physics/aerosol/jam/chemistry/aqueous.py
@@ -226,17 +226,16 @@ class AqueousSulfur(PhysicsTerm):
         # Fallback destination for sulfate produced where no cloud-borne
         # number exists: the INTERSTITIAL accumulation mode. HAM assigns this
         # droplet sulfate to the cloud-borne coarse mode (Seinfeld & Pandis
-        # 1998) — but HAM also scavenges cloud-borne aerosol. This chain has
-        # neither an activation transfer populating cloud-borne tracers
-        # (``nc_* ≡ 0`` everywhere today) nor cloud-borne wet scavenging
-        # (``wetdep_term`` is interstitial-only), so the HAM fallback made
-        # ``mc_so4_cor`` a sourced, sink-less reservoir: the first online-
-        # emission ne30 year grew it linearly ~0.7 mg/m²/day with no
-        # equilibrium. Producing into interstitial accumulation instead is
-        # the simpler-HAM "immediate detrainment" treatment — transport,
-        # optics and both deposition pathways all act on it. Revisit when
-        # real cloud-borne cycling (activation transfer + cloud-borne
-        # scavenging) exists.
+        # 1998) — but that is only safe alongside cloud-borne cycling. With
+        # ``spec.cloud_borne`` the cycle now exists (#602: the exchange term
+        # populates ``nc_*`` and wet/dry deposition drain ``mc_*``), so the
+        # HAM number-fraction split above is live and this fallback covers
+        # only spin-up cells; before the cycle existed the HAM assignment
+        # made ``mc_so4_cor`` a sourced, sink-less reservoir (the first
+        # online-emission ne30 year grew it linearly ~0.7 mg/m²/day).
+        # Without a prognostic cloud-borne phase the whole production lands
+        # here — the "immediate detrainment" treatment; transport, optics
+        # and both deposition pathways all act on it.
         self._fallback_interstitial = (
             "acc" if "acc" in self._so4_modes else self._so4_modes[0]
         )
@@ -285,33 +284,48 @@ class AqueousSulfur(PhysicsTerm):
 
         # Distribute the cloud-borne sulfate over the sulfate modes by their
         # cloud-borne number fraction (HAM ms4as/ms4cs split). Where a cell
-        # has no cloud-borne number (spin-up, or — today — everywhere, since
-        # no activation transfer populates the cloud-borne tracers yet) the
-        # production goes to INTERSTITIAL accumulation-mode sulfate instead
-        # (see ``_fallback_interstitial`` in ``__init__`` for why this
-        # deviates from HAM's cloud-borne-coarse assignment). The cloud-borne
-        # fractions plus the fallback branch always sum to 1, so the produced
-        # sulfate exactly matches the SO2 sink.
-        nc = {
-            m: jnp.maximum(
-                state.tracers.get(number_name(m, cloud_borne=True), zeros), 0.0
-            )
-            for m in self._so4_modes
-        }
-        nc_sum = sum(nc.values())
-        has_number = nc_sum > _NC_MIN
-        nc_safe = jnp.maximum(nc_sum, _TINY)
-
+        # has no cloud-borne number (spin-up, or a cloud the exchange term
+        # has not yet populated) the production goes to INTERSTITIAL
+        # accumulation-mode sulfate instead (see ``_fallback_interstitial``
+        # in ``__init__`` for why this deviates from HAM's cloud-borne-coarse
+        # assignment). The cloud-borne fractions plus the fallback branch
+        # always sum to 1, so the produced sulfate exactly matches the SO2
+        # sink. Without a prognostic cloud-borne phase (#602) the whole
+        # production is interstitial by construction — the compose-time
+        # branch below, so no dead ``mc_*`` tendencies are emitted.
         tracer_tends: dict[str, jnp.ndarray] = {"g_so2": so2_rate}
-        for m in self._so4_modes:
-            frac = jnp.where(has_number, nc[m] / nc_safe, 0.0)
-            tracer_tends[mass_name("so4", m, cloud_borne=True)] = so4_rate * frac
-        # Interstitial fallback carries the full production where no droplet
-        # population exists (m_so4_* keys are disjoint from the mc_* ones
-        # above, so this is a fresh entry, not an accumulation).
-        tracer_tends[mass_name("so4", self._fallback_interstitial)] = (
-            jnp.where(has_number, 0.0, so4_rate)
-        )
+        if self._spec.cloud_borne:
+            nc = {
+                m: jnp.maximum(
+                    state.tracers.get(
+                        number_name(m, cloud_borne=True), zeros
+                    ), 0.0,
+                )
+                for m in self._so4_modes
+            }
+            nc_sum = sum(nc.values())
+            has_number = nc_sum > _NC_MIN
+            # Floor at _NC_MIN (1 kg⁻¹), not a tiny epsilon: below the floor
+            # the ``where`` selects the fallback branch anyway, and a tiny
+            # floor reopens the squared-underflow VJP window — the division
+            # cotangent forms nc/nc_safe², which underflows to 0/0 for
+            # 0 < nc_sum < ~1e-19 in float32 (the double-where NaN class).
+            nc_safe = jnp.maximum(nc_sum, _NC_MIN)
+            for m in self._so4_modes:
+                frac = jnp.where(has_number, nc[m] / nc_safe, 0.0)
+                tracer_tends[mass_name("so4", m, cloud_borne=True)] = (
+                    so4_rate * frac
+                )
+            # Interstitial fallback carries the full production where no
+            # droplet population exists (m_so4_* keys are disjoint from the
+            # mc_* ones above, so this is a fresh entry, not an accumulation).
+            tracer_tends[mass_name("so4", self._fallback_interstitial)] = (
+                jnp.where(has_number, 0.0, so4_rate)
+            )
+        else:
+            tracer_tends[mass_name("so4", self._fallback_interstitial)] = (
+                so4_rate
+            )
 
         tendency = PhysicsTendency(
             u_wind=jnp.zeros_like(state.u_wind),

--- a/jcm/physics/aerosol/jam/chemistry/aqueous_test.py
+++ b/jcm/physics/aerosol/jam/chemistry/aqueous_test.py
@@ -98,12 +98,12 @@ class AqueousTermTest(unittest.TestCase):
         self.assertTrue(np.all(np.abs(s_rate) < 1.0e-18))
 
     def test_sulfur_conserved_without_cloud_borne_number(self):
-        # No cloud-borne number anywhere (today's reality: no activation
-        # transfer populates the cloud-borne tracers). Production must land in
-        # INTERSTITIAL accumulation-mode sulfate — the HAM cloud-borne-coarse
-        # fallback fed a tracer nothing scavenges (wetdep is interstitial-
-        # only), which grew ~0.7 mg/m²/day without equilibrium in the first
-        # online-emission ne30 year — and must still match the SO2 sink.
+        # No cloud-borne number anywhere (spin-up, before the exchange term
+        # has populated the mirrors). Production must land in INTERSTITIAL
+        # accumulation-mode sulfate — the HAM cloud-borne-coarse fallback fed
+        # a tracer nothing scavenged before #602 closed the cycle, which grew
+        # ~0.7 mg/m²/day without equilibrium in the first online-emission
+        # ne30 year — and must still match the SO2 sink.
         from jcm.physics.aerosol.jam import MAM4_SPEC
         from jcm.physics.aerosol.jam.chemistry.aqueous import _MW_SO2, _MW_SO4
 
@@ -124,6 +124,29 @@ class AqueousTermTest(unittest.TestCase):
         for m in (mm.short for mm in MAM4_SPEC.modes if "so4" in mm.species):
             key = mass_name("so4", m, cloud_borne=True)
             s_rate = s_rate + np.asarray(tend.tracers[key]) / _MW_SO4
+        self.assertTrue(np.all(np.abs(s_rate) < 1.0e-18))
+
+    def test_implicit_population_emits_no_cloud_borne_keys(self):
+        # With ``spec.cloud_borne = False`` (#602) the whole production is
+        # interstitial by construction: no mirror tendencies at all, and the
+        # sulfur budget still closes against the SO2 sink.
+        import dataclasses
+        from jcm.physics.aerosol.jam import MAM4_SPEC
+        from jcm.physics.aerosol.jam.chemistry.aqueous import _MW_SO2, _MW_SO4
+
+        spec = dataclasses.replace(MAM4_SPEC, cloud_borne=False)
+        state, diagnostics = self._setup()
+        tend, _ = AqueousSulfur(spec=spec)(state, diagnostics, None, None)
+        self.assertFalse(
+            any(nm.startswith(("mc_", "nc_")) for nm in tend.tracers)
+        )
+        self.assertGreater(
+            float(tend.tracers[mass_name("so4", "acc")][0, 0]), 0.0,
+        )
+        s_rate = np.asarray(tend.tracers["g_so2"]) / _MW_SO2
+        s_rate = s_rate + np.asarray(
+            tend.tracers[mass_name("so4", "acc")]
+        ) / _MW_SO4
         self.assertTrue(np.all(np.abs(s_rate) < 1.0e-18))
 
     def test_no_clouds_no_production(self):

--- a/jcm/physics/aerosol/jam/cloud_borne.py
+++ b/jcm/physics/aerosol/jam/cloud_borne.py
@@ -1,0 +1,179 @@
+"""``CloudBorneExchange`` — interstitial ↔ cloud-borne aerosol transfer (#602).
+
+Closes the cloud-borne population cycle for MAM-style populations
+(``spec.cloud_borne``): activation is the only physical source of cloud-borne
+aerosol and droplet evaporation its only return path, and before this term
+neither existed — the ``mc_*``/``nc_*`` mirrors were transported at full cost
+while carrying nothing.
+
+The scheme is a bounded relaxation toward the activation-equilibrium
+partition. For each mode and phase pair ``(q_int, q_cb)``, ARG's per-mode
+activated fractions (``_jam_activation``, number and mass separately — large
+particles activate preferentially, so the mass fraction is well above the
+number fraction) define the grid-mean equilibrium cloud-borne amount
+
+    q_cb* = cloud_fraction · f_act · (q_int + q_cb)
+
+and the pair relaxes toward it with a tunable timescale, activation and
+resuspension each getting their own knob. Both directions come out of the one
+expression: a growing or persistent cloud pulls ``q_cb`` up toward the
+activated partition, and a cleared sky (``cloud_fraction → 0``) returns the
+whole reservoir to interstitial. The per-step transfer uses the exponential
+relaxation factor ``1 − exp(−Δt/τ)``, so it is unconditionally bounded by the
+donor phase's content and exactly conserving (the two tendencies are equal
+and opposite).
+
+This is deliberately simpler than CAM's ``dropmixnuc``, which couples the
+transfer to an implicit turbulent-mixing solve; jcm has no physics-side
+aerosol vertical transport yet (#602 item 2), so the relaxation form is the
+honest standalone treatment. Convective processing of cloud-borne aerosol
+(the ``aero_convproc`` analogue) is likewise future work, and cloud-borne
+aerosol does not sediment (it follows the hydrometeors — see
+``sedi_term``). ECHAM-HAM's M7 and sectional schemes like TOMAS never carry
+an explicit cloud-borne phase at all: for those populations
+``spec.cloud_borne = False`` and this term is not composed — the harness
+then scavenges interstitial aerosol by ``cf · activated_fraction``, which
+removes the same mass at exchange equilibrium. The representations still
+differ where the representation itself matters: the explicit phase delays
+rainout by the exchange timescale, and its in-droplet mass is invisible to
+the (interstitial-only) aerosol optics, whereas the implicit treatment
+keeps it in ``m_*`` where the optics see it.
+
+Boundedness: each of this term's two directions is bounded by its donor
+phase in isolation, but jcm's parallel operator splitting sums this
+tendency with wet/dry deposition computed from the same start-of-step
+state, so a decaying, still-precipitating cloud can transiently overdraw
+``mc_*`` below zero. The excursion self-heals (both removal tendencies
+scale with the tracer and flip sign with it) and every consumer floors at
+0 on read; it is the same additivity every pair of bounded sinks in the
+chain already accepts.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import jax.numpy as jnp
+import tree_math
+from flax import nnx
+
+from jcm.physics.aerosol.jam.microphysics.mam4_data import MAM4_SPEC
+from jcm.physics.aerosol.jam.population import ModalAerosolSpec
+from jcm.physics.aerosol.jam.tracer_layout import mass_name, number_name
+from jcm.physics.physics_term import PhysicsTerm
+from jcm.physics_interface import PhysicsTendency
+
+
+@tree_math.struct
+class CloudBorneExchangeParameters:
+    """Tunable exchange timescales (differentiable)."""
+
+    activation_timescale: jnp.ndarray    # τ toward the activated partition [s]
+    resuspension_timescale: jnp.ndarray  # τ back to interstitial [s]
+
+    @classmethod
+    def default(cls) -> "CloudBorneExchangeParameters":
+        # Droplet nucleation and evaporative release are both fast against
+        # the coupling step; 900 s makes the partition track the cloud field
+        # within ~a step at Δt = 1800 s without being a hard swap.
+        return cls(
+            activation_timescale=jnp.asarray(900.0),
+            resuspension_timescale=jnp.asarray(900.0),
+        )
+
+
+class CloudBorneExchange(PhysicsTerm):
+    """Relax the interstitial/cloud-borne partition toward ARG's equilibrium."""
+
+    name: ClassVar[str] = "jam_cloud_borne_exchange"
+    category: ClassVar[str] = "aerosol_cloud_borne"
+    requires: ClassVar[tuple[str, ...]] = ("_jam_activation", "clouds")
+    provides: ClassVar[tuple[str, ...]] = ()
+
+    def __init__(
+        self,
+        params: CloudBorneExchangeParameters | None = None,
+        *,
+        spec: ModalAerosolSpec | None = None,
+    ):
+        """Hold params and the population (which must prognose the phase)."""
+        self.params = nnx.Param(
+            params or CloudBorneExchangeParameters.default()
+        )
+        self._spec = spec or MAM4_SPEC
+        if not self._spec.cloud_borne:
+            # Composed against a population without the mirror tracers, the
+            # ``mc_*``/``nc_*`` tendencies would be silently dropped by the
+            # accumulator while the interstitial side still fires — venting
+            # mass with no error. Fail at compose time instead.
+            raise ValueError(
+                "CloudBorneExchange needs a population with "
+                "spec.cloud_borne=True; this spec prognoses no cloud-borne "
+                "phase (use the implicit activated-fraction scavenging "
+                "instead)."
+            )
+
+    def __call__(self, state, diagnostics, forcing, terrain):
+        params = self.params.get_value()
+        act = diagnostics["_jam_activation"]
+        clouds = diagnostics["clouds"]
+        cf = jnp.clip(clouds.cloud_fraction, 0.0, 1.0)
+        dt = diagnostics.get("_dt_seconds", 1800.0)
+
+        # Gather every (interstitial, cloud-borne) pair with its activated
+        # fraction and run the relaxation once over the whole stack (the
+        # wetdep/sedimentation batching pattern). ``state.tracers`` is empty
+        # during ``Model.get_empty_data``'s structural probe, so fall back to
+        # zeros there. Tracers are floored at 0: spectral advection leaves
+        # small negative mass/number on near-zero fields (Gibbs ringing),
+        # and a negative donor would flip the transfer's sign.
+        zeros = jnp.zeros_like(state.temperature)
+        int_names: list[str] = []
+        cb_names: list[str] = []
+        q_int: list[jnp.ndarray] = []
+        q_cb: list[jnp.ndarray] = []
+        fracs: list[jnp.ndarray] = []
+        for i, mode in enumerate(self._spec.modes):
+            pairs = [(
+                number_name(mode.short),
+                number_name(mode.short, cloud_borne=True),
+                act.number_frac[i],
+            )] + [(
+                mass_name(sp, mode.short),
+                mass_name(sp, mode.short, cloud_borne=True),
+                act.mass_frac[i],
+            ) for sp in mode.species]
+            for int_nm, cb_nm, frac in pairs:
+                int_names.append(int_nm)
+                cb_names.append(cb_nm)
+                q_int.append(
+                    jnp.maximum(state.tracers.get(int_nm, zeros), 0.0)
+                )
+                q_cb.append(jnp.maximum(state.tracers.get(cb_nm, zeros), 0.0))
+                fracs.append(frac)
+
+        q_int_arr = jnp.stack(q_int)
+        q_cb_arr = jnp.stack(q_cb)
+        target = cf * jnp.stack(fracs) * (q_int_arr + q_cb_arr)
+        tau = jnp.where(
+            target > q_cb_arr,
+            params.activation_timescale,
+            params.resuspension_timescale,
+        )
+        # 1 − exp(−Δt/τ) ∈ [0, 1]: the move never overshoots the target, so
+        # neither phase can go negative (|Δ| ≤ |target − q_cb| ≤ donor).
+        phi = -jnp.expm1(-dt / jnp.maximum(tau, 1.0))
+        transfer = (target - q_cb_arr) * phi / dt   # [.../s], + toward cloud-borne
+
+        tracer_tends = {nm: transfer[k] for k, nm in enumerate(cb_names)}
+        for k, nm in enumerate(int_names):
+            tracer_tends[nm] = -transfer[k]
+
+        tendency = PhysicsTendency(
+            u_wind=jnp.zeros_like(state.u_wind),
+            v_wind=jnp.zeros_like(state.v_wind),
+            temperature=jnp.zeros_like(state.temperature),
+            specific_humidity=jnp.zeros_like(state.specific_humidity),
+            tracers=tracer_tends,
+        )
+        return tendency, diagnostics

--- a/jcm/physics/aerosol/jam/cloud_borne_test.py
+++ b/jcm/physics/aerosol/jam/cloud_borne_test.py
@@ -1,0 +1,287 @@
+"""Tests for the cloud-borne aerosol switch and exchange term (#602)."""
+
+import dataclasses
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from jcm.physics.aerosol.jam import (
+    MAM4_SPEC,
+    CloudBorneExchange,
+    CloudBorneExchangeParameters,
+    mass_name,
+    number_name,
+    tracer_specs,
+)
+from jcm.physics.aerosol.jam.activation.arg_term import JamActivationData
+from jcm.physics_interface import PhysicsState
+
+_IMPLICIT_SPEC = dataclasses.replace(MAM4_SPEC, cloud_borne=False)
+
+
+class TracerLayoutSwitchTest(unittest.TestCase):
+    def test_explicit_population_declares_both_phases(self):
+        names = {s.name for s in tracer_specs(MAM4_SPEC)}
+        self.assertIn(number_name("acc"), names)
+        self.assertIn(number_name("acc", cloud_borne=True), names)
+        # One number per mode and one mass per (mode, species), doubled.
+        n_interstitial = MAM4_SPEC.n_modes() + sum(
+            len(m.species) for m in MAM4_SPEC.modes
+        )
+        self.assertEqual(len(names), 2 * n_interstitial)
+
+    def test_implicit_population_declares_interstitial_only(self):
+        names = {s.name for s in tracer_specs(_IMPLICIT_SPEC)}
+        self.assertIn(number_name("acc"), names)
+        self.assertFalse(
+            any(n.startswith(("mc_", "nc_")) for n in names),
+            "implicit population must not declare cloud-borne mirrors",
+        )
+        n_interstitial = MAM4_SPEC.n_modes() + sum(
+            len(m.species) for m in MAM4_SPEC.modes
+        )
+        self.assertEqual(len(names), n_interstitial)
+
+
+class _Clouds:
+    def __init__(self, cloud_fraction):
+        self.cloud_fraction = cloud_fraction
+
+
+class CloudBorneExchangeTest(unittest.TestCase):
+    def _setup(
+        self,
+        nlev=3,
+        ncols=2,
+        cloud_fraction=0.5,
+        number_frac=0.3,
+        mass_frac=0.9,
+        q_int=1.0e-9,
+        n_int=1.0e8,
+        q_cb=0.0,
+        n_cb=0.0,
+    ):
+        shape = (nlev, ncols)
+        tracers = {}
+        for mode in MAM4_SPEC.modes:
+            tracers[number_name(mode.short)] = jnp.full(shape, n_int)
+            tracers[number_name(mode.short, cloud_borne=True)] = jnp.full(
+                shape, n_cb
+            )
+            for sp in mode.species:
+                tracers[mass_name(sp, mode.short)] = jnp.full(shape, q_int)
+                tracers[mass_name(sp, mode.short, cloud_borne=True)] = (
+                    jnp.full(shape, q_cb)
+                )
+        state = PhysicsState.zeros(shape).copy(
+            temperature=jnp.full(shape, 275.0), tracers=tracers,
+        )
+        # Per-mode fractions with the non-activatable pcm mode masked to
+        # zero, as ARG publishes them. Modes get DISTINCT fractions
+        # (base / (1 + i), so acc keeps the base value) so a per-mode
+        # misindexing in the exchange term cannot hide behind uniformity.
+        n_modes = MAM4_SPEC.n_modes()
+        can = jnp.asarray(
+            [float(m.can_activate) for m in MAM4_SPEC.modes]
+        ).reshape(-1, 1, 1)
+        per_mode = can / (1.0 + jnp.arange(n_modes).reshape(-1, 1, 1))
+        act = JamActivationData(
+            number_frac=per_mode * jnp.full((n_modes,) + shape, number_frac),
+            mass_frac=per_mode * jnp.full((n_modes,) + shape, mass_frac),
+        )
+        diagnostics = {
+            "_jam_activation": act,
+            "clouds": _Clouds(jnp.full(shape, cloud_fraction)),
+            "_dt_seconds": 1800.0,
+        }
+        return state, diagnostics
+
+    def test_transfer_conserves_each_pair_exactly(self):
+        state, diagnostics = self._setup(q_cb=2.0e-10, n_cb=1.0e7)
+        tend, _ = CloudBorneExchange()(state, diagnostics, None, None)
+        for mode in MAM4_SPEC.modes:
+            pairs = [(number_name(mode.short),
+                      number_name(mode.short, cloud_borne=True))]
+            pairs += [
+                (mass_name(sp, mode.short),
+                 mass_name(sp, mode.short, cloud_borne=True))
+                for sp in mode.species
+            ]
+            for int_nm, cb_nm in pairs:
+                np.testing.assert_array_equal(
+                    np.asarray(tend.tracers[int_nm] + tend.tracers[cb_nm]),
+                    0.0,
+                    err_msg=f"{int_nm}/{cb_nm} exchange must conserve",
+                )
+
+    def test_activation_transfer_fills_cloud_borne(self):
+        state, diagnostics = self._setup()
+        tend, _ = CloudBorneExchange()(state, diagnostics, None, None)
+        cb = tend.tracers[mass_name("so4", "acc", cloud_borne=True)]
+        self.assertTrue(bool(jnp.all(cb > 0.0)))
+        # The move is the relaxation fraction of the equilibrium target
+        # cf * f_mass * (q_int + q_cb).
+        dt = 1800.0
+        target = 0.5 * 0.9 * 1.0e-9
+        phi = -np.expm1(-dt / 900.0)
+        np.testing.assert_allclose(
+            np.asarray(cb) * dt, target * phi, rtol=1e-6,
+        )
+        # And each mode uses ITS OWN fraction (the fixture halves it for
+        # aitken), so a mode-axis misindexing shows up here.
+        cb_ait = tend.tracers[mass_name("so4", "ait", cloud_borne=True)]
+        np.testing.assert_allclose(
+            np.asarray(cb_ait) * dt, 0.5 * target * phi, rtol=1e-6,
+        )
+
+    def test_mass_and_number_use_their_own_fractions(self):
+        # Large particles activate preferentially: the mass fraction (0.9)
+        # must drive 3x the relative transfer of the number fraction (0.3).
+        state, diagnostics = self._setup(q_int=1.0, n_int=1.0)
+        tend, _ = CloudBorneExchange()(state, diagnostics, None, None)
+        m = float(tend.tracers[mass_name("so4", "acc", cloud_borne=True)][0, 0])
+        n = float(tend.tracers[number_name("acc", cloud_borne=True)][0, 0])
+        self.assertAlmostEqual(m / n, 3.0, places=5)
+
+    def test_clear_sky_resuspends_to_interstitial(self):
+        state, diagnostics = self._setup(
+            cloud_fraction=0.0, q_cb=1.0e-9, n_cb=1.0e8,
+        )
+        tend, _ = CloudBorneExchange()(state, diagnostics, None, None)
+        cb_key = mass_name("so4", "acc", cloud_borne=True)
+        self.assertTrue(bool(jnp.all(tend.tracers[cb_key] < 0.0)))
+        self.assertTrue(
+            bool(jnp.all(tend.tracers[mass_name("so4", "acc")] > 0.0))
+        )
+        # Bounded: the reservoir cannot go negative in one step.
+        q_new = 1.0e-9 + np.asarray(tend.tracers[cb_key]) * 1800.0
+        self.assertGreaterEqual(float(q_new.min()), 0.0)
+
+    def test_non_activatable_mode_only_resuspends(self):
+        # pcm cannot activate (fraction masked to zero), so its cloud-borne
+        # reservoir drains even under full cloud cover.
+        state, diagnostics = self._setup(
+            cloud_fraction=1.0, q_cb=1.0e-10, n_cb=1.0e7,
+        )
+        tend, _ = CloudBorneExchange()(state, diagnostics, None, None)
+        cb = tend.tracers[mass_name("poa", "pcm", cloud_borne=True)]
+        self.assertTrue(bool(jnp.all(cb < 0.0)))
+
+    def test_equilibrium_is_a_fixed_point(self):
+        # cf = 1 and q_cb == f * (q_int + q_cb) → target == q_cb → no flux.
+        # With f = 0.5 that is q_cb == q_int.
+        state, diagnostics = self._setup(
+            cloud_fraction=1.0, number_frac=0.5, mass_frac=0.5,
+            q_int=1.0e-9, q_cb=1.0e-9, n_int=1.0e8, n_cb=1.0e8,
+        )
+        tend, _ = CloudBorneExchange()(state, diagnostics, None, None)
+        for key in (mass_name("so4", "acc", cloud_borne=True),
+                    number_name("acc", cloud_borne=True)):
+            np.testing.assert_allclose(
+                np.asarray(tend.tracers[key]), 0.0, atol=1e-25,
+            )
+
+    def test_positivity_preserved_both_phases(self):
+        state, diagnostics = self._setup(q_cb=5.0e-10, n_cb=5.0e7)
+        tend, _ = CloudBorneExchange()(state, diagnostics, None, None)
+        dt = 1800.0
+        for nm, dq in tend.tracers.items():
+            q_new = np.asarray(state.tracers[nm]) + np.asarray(dq) * dt
+            self.assertGreaterEqual(float(q_new.min()), 0.0, nm)
+
+    def test_empty_probe_state_is_safe(self):
+        # ``Model.get_empty_data`` runs terms with no tracers seeded.
+        state, diagnostics = self._setup()
+        state = state.copy(tracers={})
+        tend, _ = CloudBorneExchange()(state, diagnostics, None, None)
+        for dq in tend.tracers.values():
+            np.testing.assert_array_equal(np.asarray(dq), 0.0)
+
+    def test_implicit_population_rejected_at_compose_time(self):
+        # Composed against a population without the mirrors, the cloud-borne
+        # tendencies would be silently dropped while the interstitial side
+        # still fires — venting mass. Must fail loudly instead.
+        with self.assertRaisesRegex(ValueError, "cloud_borne"):
+            CloudBorneExchange(spec=_IMPLICIT_SPEC)
+
+    def test_grad_through_timescales(self):
+        state, diagnostics = self._setup(q_cb=2.0e-10, n_cb=1.0e7)
+
+        def loss(tau):
+            params = CloudBorneExchangeParameters(
+                activation_timescale=tau,
+                resuspension_timescale=jnp.asarray(900.0),
+            )
+            term = CloudBorneExchange(params=params)
+            tend, _ = term(state, diagnostics, None, None)
+            return sum(jnp.sum(v ** 2) for v in tend.tracers.values())
+
+        g = jax.grad(loss)(jnp.asarray(900.0))
+        self.assertTrue(np.isfinite(float(g)))
+        self.assertNotEqual(float(g), 0.0)
+
+
+class FactorySwitchTest(unittest.TestCase):
+    def test_default_composes_exchange_and_mirrors(self):
+        from jcm.physics.aerosol.jam import jam_aerosol_physics
+
+        terms = jam_aerosol_physics()
+        cats = [t.category for t in terms]
+        self.assertIn("aerosol_cloud_borne", cats)
+        # Exchange sits after drydep and before the aqueous split that
+        # distributes by cloud-borne number.
+        self.assertLess(
+            cats.index("aerosol_drydep"), cats.index("aerosol_cloud_borne"),
+        )
+        self.assertLess(
+            cats.index("aerosol_cloud_borne"),
+            cats.index("aerosol_aqueous_chemistry"),
+        )
+        names = set()
+        for t in terms:
+            names |= {s.name for s in t.required_tracers()}
+        self.assertIn(number_name("acc", cloud_borne=True), names)
+
+    def test_cloud_borne_off_drops_term_and_mirrors(self):
+        from jcm.physics.aerosol.jam import jam_aerosol_physics
+
+        terms = jam_aerosol_physics(cloud_borne=False)
+        self.assertNotIn(
+            "aerosol_cloud_borne", [t.category for t in terms],
+        )
+        names = set()
+        for t in terms:
+            names |= {s.name for s in t.required_tracers()}
+        self.assertFalse(
+            any(n.startswith(("mc_", "nc_")) for n in names),
+            "cloud_borne=False must not declare mirror tracers",
+        )
+        # The A/B cost claim: half the aerosol tracers are gone.
+        on = {
+            s.name
+            for t in jam_aerosol_physics()
+            for s in t.required_tracers()
+        }
+        self.assertEqual(
+            len([n for n in on if n.startswith(("mc_", "nc_"))]),
+            len([n for n in on if n.startswith(("m_", "n_"))]),
+        )
+
+    def test_instance_core_with_conflicting_flag_raises(self):
+        from jcm.physics.aerosol.jam import (
+            PlaceholderMicrophysics,
+            jam_aerosol_physics,
+        )
+
+        core = PlaceholderMicrophysics()
+        with self.assertRaisesRegex(ValueError, "cloud_borne"):
+            jam_aerosol_physics(microphysics=core, cloud_borne=False)
+        # A matching flag merely validates.
+        terms = jam_aerosol_physics(microphysics=core, cloud_borne=True)
+        self.assertIn("aerosol_cloud_borne", [t.category for t in terms])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jcm/physics/aerosol/jam/drydep/drydep_term.py
+++ b/jcm/physics/aerosol/jam/drydep/drydep_term.py
@@ -114,6 +114,16 @@ class SlinnDryDeposition(PhysicsTerm):
             names = [number_name(mode.short)] + [
                 mass_name(sp, mode.short) for sp in mode.species
             ]
+            # A prognostic cloud-borne phase (#602) deposits too — CAM's
+            # ``aero_model_drydep`` treatment, using the mode's interstitial
+            # deposition velocity (droplet-resolved velocities are a
+            # refinement). Small next to wet removal, but it keeps a
+            # surface-layer cloud from becoming a sink-less corner.
+            if self._spec.cloud_borne:
+                names += [number_name(mode.short, cloud_borne=True)] + [
+                    mass_name(sp, mode.short, cloud_borne=True)
+                    for sp in mode.species
+                ]
             for nm in names:
                 q = state.tracers.get(nm, zeros)
                 tracer_tends[nm] = jnp.zeros_like(q).at[-1].set(

--- a/jcm/physics/aerosol/jam/drydep/drydep_test.py
+++ b/jcm/physics/aerosol/jam/drydep/drydep_test.py
@@ -60,9 +60,14 @@ class DryDepTermTest(unittest.TestCase):
         )
         tracers = {}
         for mode in MAM4_SPEC.modes:
-            tracers[number_name(mode.short)] = jnp.full((nlev, ncols), 1.0e8)
-            for sp in mode.species:
-                tracers[mass_name(sp, mode.short)] = jnp.full((nlev, ncols), 1e-9)
+            for cb in (False, True):
+                tracers[number_name(mode.short, cloud_borne=cb)] = jnp.full(
+                    (nlev, ncols), 1.0e8
+                )
+                for sp in mode.species:
+                    tracers[mass_name(sp, mode.short, cloud_borne=cb)] = (
+                        jnp.full((nlev, ncols), 1e-9)
+                    )
         state = PhysicsState.zeros((nlev, ncols)).copy(
             temperature=jnp.full((nlev, ncols), 285.0),
             tracers=tracers,
@@ -84,6 +89,30 @@ class DryDepTermTest(unittest.TestCase):
         # Loss only at the surface layer; aloft is zero.
         self.assertLess(float(dq[-1, 0]), 0.0)
         self.assertTrue(bool(jnp.all(dq[:-1] == 0.0)))
+
+    def test_cloud_borne_deposits_only_with_explicit_phase(self):
+        # With the default (explicit cloud-borne) population the mirror
+        # tracers deposit at the surface too (#602); with the implicit
+        # population no mirror tendencies are emitted at all.
+        import dataclasses
+        from jcm.physics.aerosol.jam import MAM4_SPEC
+
+        state, diagnostics, spec, mass_name = self._setup()
+        tend, _ = SlinnDryDeposition()(state, diagnostics, None, None)
+        cb_key = mass_name(
+            spec.modes[0].species[0], spec.modes[0].short, cloud_borne=True,
+        )
+        dq = tend.tracers[cb_key]
+        self.assertLess(float(dq[-1, 0]), 0.0)
+        self.assertTrue(bool(jnp.all(dq[:-1] == 0.0)))
+
+        implicit = SlinnDryDeposition(
+            spec=dataclasses.replace(MAM4_SPEC, cloud_borne=False)
+        )
+        tend, _ = implicit(state, diagnostics, None, None)
+        self.assertFalse(
+            any(nm.startswith(("mc_", "nc_")) for nm in tend.tracers)
+        )
 
     def test_uses_vertical_diffusion_ustar_when_present(self):
         from jcm.physics.vertical_diffusion.tte_tke.vertical_diffusion_types import (

--- a/jcm/physics/aerosol/jam/jam_integration_test.py
+++ b/jcm/physics/aerosol/jam/jam_integration_test.py
@@ -88,6 +88,38 @@ class JamIntegrationTest(unittest.TestCase):
             bool(jnp.any(jnp.isnan(predictions.dynamics.temperature)))
         )
 
+    def test_cloud_borne_mirrors_carried_finite(self):
+        # Default configuration prognoses the cloud-borne mirrors (#602):
+        # they must be seeded, transported and stay finite end-to-end. (A
+        # 3-step cold start carries near-zero aerosol, so this asserts the
+        # plumbing, not a nonzero reservoir; the transfer/resuspension
+        # mechanics are pinned in cloud_borne_test.)
+        from jcm.physics.aerosol.jam import MAM4_SPEC, mass_name, number_name
+
+        _, predictions = self._run()
+        tracers = predictions.dynamics.tracers
+        for key in (
+            number_name(MAM4_SPEC.modes[0].short, cloud_borne=True),
+            mass_name(MAM4_SPEC.modes[0].species[0],
+                      MAM4_SPEC.modes[0].short, cloud_borne=True),
+        ):
+            self.assertIn(key, tracers)
+            self.assertTrue(np.all(np.isfinite(np.asarray(tracers[key]))))
+
+    def test_cloud_borne_off_drops_mirrors_and_runs(self):
+        # The A/B switch (#602): with jam_cloud_borne=False the mirror
+        # tracers are not declared at all — the transported set halves —
+        # and the model still runs finite with the implicit scavenging.
+        _, predictions = self._run(jam_cloud_borne=False)
+        tracers = predictions.dynamics.tracers
+        self.assertFalse(
+            any(k.startswith(("mc_", "nc_")) for k in tracers),
+            "cloud-borne mirrors must not be transported when off",
+        )
+        self.assertFalse(
+            bool(jnp.any(jnp.isnan(predictions.dynamics.temperature)))
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/jcm/physics/aerosol/jam/jam_terms.py
+++ b/jcm/physics/aerosol/jam/jam_terms.py
@@ -1,7 +1,8 @@
 """``jam_aerosol_physics()`` factory — the ordered JAM harness term list.
 
 Returns the HAMMOZ-style process chain (emissions → microphysics core →
-activation → sedimentation → dry deposition → wet deposition) as a list of
+activation → sedimentation → dry deposition → cloud-borne exchange →
+aqueous chemistry → wet deposition) as a list of
 ``PhysicsTerm``s, ready to splice into ``echam_physics``. The microphysics
 core is the swap point: pass ``"placeholder"`` (default κ-Köhler equilibrium)
 or any ``ModalMicrophysicsTerm`` instance (e.g. a future MAM4-JAX wrapper,
@@ -11,9 +12,15 @@ on mode/species layout.
 
 from __future__ import annotations
 
+import dataclasses
+
 from jcm.physics.aerosol.jam.activation.arg_term import (
     ArgActivation,
     ArgParameters,
+)
+from jcm.physics.aerosol.jam.cloud_borne import (
+    CloudBorneExchange,
+    CloudBorneExchangeParameters,
 )
 from jcm.physics.aerosol.jam.chemistry.aqueous import (
     AqueousSulfur,
@@ -70,32 +77,54 @@ def _load_mam4_jax() -> type[ModalMicrophysicsTerm]:
     return Mam4JaxMicrophysics
 
 
-# Core resolvers. ``placeholder`` is built-in; ``mam4_jax`` is loaded lazily so
-# the optional GPL-3.0 ``mam4-jax`` dependency is only imported when selected.
+# Core resolvers (each takes a spec override, ``None`` for the core default).
+# ``placeholder`` is built-in; ``mam4_jax`` is loaded lazily so the optional
+# GPL-3.0 ``mam4-jax`` dependency is only imported when selected.
 _MICROPHYSICS = {
-    "placeholder": lambda: PlaceholderMicrophysics(),
-    "mam4_jax": lambda: _load_mam4_jax()(),
+    "placeholder": lambda spec: PlaceholderMicrophysics(spec=spec),
+    "mam4_jax": lambda spec: _load_mam4_jax()(spec=spec),
 }
 
 
 def _resolve_microphysics(
     microphysics: ModalMicrophysicsTerm | str,
+    cloud_borne: bool | None = None,
 ) -> ModalMicrophysicsTerm:
     if isinstance(microphysics, ModalMicrophysicsTerm):
+        if (
+            cloud_borne is not None
+            and microphysics.spec.cloud_borne != cloud_borne
+        ):
+            raise ValueError(
+                f"cloud_borne={cloud_borne} conflicts with the supplied "
+                "core's population "
+                f"(spec.cloud_borne={microphysics.spec.cloud_borne}); "
+                "construct the core with a spec carrying the intended flag "
+                "instead."
+            )
         return microphysics
     try:
-        return _MICROPHYSICS[microphysics]()
+        factory = _MICROPHYSICS[microphysics]
     except KeyError:
         raise ValueError(
             f"Unknown aer microphysics {microphysics!r}. "
             f"Choose one of {sorted(_MICROPHYSICS)} or pass a "
             "ModalMicrophysicsTerm instance."
         ) from None
+    core = factory(None)
+    if cloud_borne is not None and core.spec.cloud_borne != cloud_borne:
+        # Rebuild on the same population with the flag flipped; construction
+        # is compose-time only, so the double build costs nothing at run time.
+        core = factory(
+            dataclasses.replace(core.spec, cloud_borne=cloud_borne)
+        )
+    return core
 
 
 def jam_aerosol_physics(
     *,
     microphysics: ModalMicrophysicsTerm | str = "placeholder",
+    cloud_borne: bool | None = None,
     arg_variant: str = "arg2000",
     optics: bool = True,
     optics_diagnostics: bool = False,
@@ -112,6 +141,7 @@ def jam_aerosol_physics(
     ice_scheme: str = "niemand",
     ice_nucleation_params: IceNucleationParameters | None = None,
     activation: ArgParameters | None = None,
+    cloud_borne_exchange: CloudBorneExchangeParameters | None = None,
     sedimentation: SedParameters | None = None,
     drydep: DryDepParameters | None = None,
     wetdep: WetDepParameters | None = None,
@@ -121,6 +151,19 @@ def jam_aerosol_physics(
     Args:
         microphysics: the swappable core — ``"placeholder"`` or a
             ``ModalMicrophysicsTerm`` instance.
+        cloud_borne: prognose an explicit cloud-borne aerosol phase (#602).
+            ``None`` (default) follows the core population's own
+            ``spec.cloud_borne``; ``True``/``False`` override it for a
+            string-named core (and merely validate an instance core). On:
+            the ``mc_*``/``nc_*`` mirrors are declared and cycled —
+            activation transfer + resuspension (``CloudBorneExchange``),
+            in-droplet wet removal, surface dry deposition, and the aqueous
+            sulfate goes to the cloud-borne modes. Off: the mirrors are not
+            declared at all (halving the aerosol transport bill) and the
+            harness scavenges interstitial aerosol by its activated
+            fraction, the implicit M7/TOMAS-style treatment. Both settings
+            are complete physics, so A/B cost/fidelity comparisons are one
+            flag apart.
         arg_variant: ``"arg2000"`` (default) or ``"ghosh2025"`` activation.
         seasalt/dms/dust: optional ``Parameters`` overrides for the natural
             emission schemes (Gong sea salt, Nightingale DMS, Tegen dust).
@@ -138,17 +181,19 @@ def jam_aerosol_physics(
         ice_scheme: heterogeneous freezing scheme — ``"niemand"`` (default,
             singular/active-site) or ``"lohmann_diehl"`` (ECHAM-HAM number-based);
             ``ice_nucleation_params`` overrides the differentiable defaults.
-        activation/sedimentation/drydep/wetdep: optional per-process
-            ``Parameters`` overrides (each ``None`` resolves to its default).
+        activation/cloud_borne_exchange/sedimentation/drydep/wetdep: optional
+            per-process ``Parameters`` overrides (each ``None`` resolves to
+            its default).
 
     Returns:
         The ordered term list: natural emissions, prescribed oxidants and
         gas-phase sulfur chemistry, the microphysics core (optionally followed
-        by online optics), activation, sedimentation, dry deposition, in-cloud
+        by online optics), activation, sedimentation, dry deposition,
+        cloud-borne exchange (when the population prognoses one), in-cloud
         aqueous sulfur chemistry, and wet deposition.
 
     """
-    core = _resolve_microphysics(microphysics)
+    core = _resolve_microphysics(microphysics, cloud_borne)
     spec = core.spec
     emissions = [
         SeaSaltEmissions(params=seasalt, spec=spec),
@@ -196,6 +241,13 @@ def jam_aerosol_physics(
         ),
         StokesSedimentation(params=sedimentation, spec=spec),
         SlinnDryDeposition(params=drydep, spec=spec),
+        # Cloud-borne cycling (#602): activation transfer + resuspension
+        # against the current step's cloud field, so it runs in the
+        # post-cloud block, before the aqueous chemistry that splits its
+        # product by cloud-borne number and the scavenging that drains the
+        # reservoir. Only composed when the population prognoses the phase.
+        *([CloudBorneExchange(params=cloud_borne_exchange, spec=spec)]
+          if spec.cloud_borne else []),
         # In-cloud aqueous SO2 oxidation → cloud-borne sulfate; runs in the
         # post-cloud block (needs current clouds), just before wet scavenging.
         AqueousSulfur(params=aqueous, spec=spec, scheme=aqueous_scheme),

--- a/jcm/physics/aerosol/jam/jam_terms.py
+++ b/jcm/physics/aerosol/jam/jam_terms.py
@@ -66,7 +66,15 @@ from jcm.physics.aerosol.jam.wetdep.wetdep_term import (
     WetScavenging,
     WetDepParameters,
 )
+from jcm.physics.convection.tracer_transport import (
+    ConvectiveTracerTransport,
+    ConvTransportParameters,
+)
 from jcm.physics.physics_term import PhysicsTerm
+from jcm.physics.vertical_diffusion.tracer_diffusion import (
+    TracerDiffusionParameters,
+    TracerVerticalDiffusion,
+)
 
 def _load_mam4_jax() -> type[ModalMicrophysicsTerm]:
     """Import the MAM4-JAX core lazily (optional GPL-3.0 dependency)."""
@@ -145,6 +153,10 @@ def jam_aerosol_physics(
     sedimentation: SedParameters | None = None,
     drydep: DryDepParameters | None = None,
     wetdep: WetDepParameters | None = None,
+    vertical_mixing: bool = True,
+    tracer_diffusion: TracerDiffusionParameters | None = None,
+    convective_transport: bool = True,
+    conv_transport: ConvTransportParameters | None = None,
 ) -> list[PhysicsTerm]:
     """Build the ordered JAM harness term list.
 
@@ -181,9 +193,21 @@ def jam_aerosol_physics(
         ice_scheme: heterogeneous freezing scheme — ``"niemand"`` (default,
             singular/active-site) or ``"lohmann_diehl"`` (ECHAM-HAM number-based);
             ``ice_nucleation_params`` overrides the differentiable defaults.
-        activation/cloud_borne_exchange/sedimentation/drydep/wetdep: optional
-            per-process ``Parameters`` overrides (each ``None`` resolves to
-            its default).
+        activation/cloud_borne_exchange/sedimentation/drydep/wetdep/
+            tracer_diffusion/conv_transport: optional per-process
+            ``Parameters`` overrides (each ``None`` resolves to its
+            default).
+        vertical_mixing: turbulent vertical diffusion of every JAM tracer
+            with the TTE-TKE exchange coefficients (#602 item 2 — ECHAM
+            diffuses all tracers in vdiff; without this the dycore is the
+            sole aerosol transporter). On by default.
+        convective_transport: bulk mass-flux transport of the interstitial
+            aerosol and gas tracers through Tiedtke updrafts with
+            compensating subsidence (ECHAM ``cuxtte`` analogue; #602 item
+            2). Cloud-borne mirrors are deliberately excluded — their
+            updraft processing is entangled with convective scavenging
+            and neither reference model transports a stratiform
+            cloud-borne phase convectively. On by default.
 
     Returns:
         The ordered term list: natural emissions, prescribed oxidants and
@@ -217,12 +241,44 @@ def jam_aerosol_physics(
         from jcm.physics.aerosol.jam.emissions.flux_diagnostic import (
             ResetEmissionFluxes)
         emissions = [ResetEmissionFluxes(), *emissions]
-    pre_core = [
-        *emissions,
+    chemistry = [
         # Sulfur chemistry: oxidants → gas-phase DMS/SO2 oxidation, producing
         # the H2SO4/SOAG gas the core condenses + nucleates this same step.
         PrescribedOxidants(params=oxidants),
         SulfurGasChemistry(params=sulfur_gas),
+    ]
+    # Physics-side vertical transport (#602 item 2). The tracer set is
+    # everything the composed JAM terms declare (aerosol in both phases +
+    # gas precursors); ECHAM's vdiff diffuses all of them. Convection
+    # moves the interstitial + gas tracers only (see the docstring).
+    # Placed right after the emitters so the narrative order matches
+    # ECHAM's physc (vdiff -> convection -> chemistry); under operator
+    # splitting the tendencies sum regardless.
+    transport_names: list[str] = []
+    for _t in [core, *emissions, *chemistry]:
+        for _s in _t.required_tracers():
+            if _s.name not in transport_names:
+                transport_names.append(_s.name)
+    transport_terms: list[PhysicsTerm] = []
+    if vertical_mixing:
+        transport_terms.append(
+            TracerVerticalDiffusion(
+                tuple(transport_names), params=tracer_diffusion,
+            )
+        )
+    if convective_transport:
+        interstitial_names = tuple(
+            n for n in transport_names if not n.startswith(("mc_", "nc_"))
+        )
+        transport_terms.append(
+            ConvectiveTracerTransport(
+                interstitial_names, params=conv_transport,
+            )
+        )
+    pre_core = [
+        *emissions,
+        *transport_terms,
+        *chemistry,
     ]
     # Online aerosol direct radiative effect (#495): placed right after the core
     # (needs ``_jam_state``); overwrites the MACv2-SP ``aerosol`` optics.

--- a/jcm/physics/aerosol/jam/jam_terms_test.py
+++ b/jcm/physics/aerosol/jam/jam_terms_test.py
@@ -34,6 +34,7 @@ class JamFactoryTest(unittest.TestCase):
                 "aerosol_ice_nucleation",
                 "aerosol_sedimentation",
                 "aerosol_drydep",
+                "aerosol_cloud_borne",
                 "aerosol_aqueous_chemistry",
                 "aerosol_wetdep",
             ],

--- a/jcm/physics/aerosol/jam/jam_terms_test.py
+++ b/jcm/physics/aerosol/jam/jam_terms_test.py
@@ -26,6 +26,11 @@ class JamFactoryTest(unittest.TestCase):
         self.assertEqual(
             cats[4:],
             [
+                # Physics-side vertical transport (#602 item 2): turbulent
+                # mixing of every JAM tracer, then convective mass-flux
+                # transport of the interstitial + gas set.
+                "tracer_transport",
+                "tracer_transport",
                 "aerosol_oxidants",
                 "aerosol_gas_chemistry",
                 "aerosol_microphysics",

--- a/jcm/physics/aerosol/jam/microphysics/mam4_jax.py
+++ b/jcm/physics/aerosol/jam/microphysics/mam4_jax.py
@@ -228,12 +228,17 @@ class Mam4JaxMicrophysics(ModalMicrophysicsTerm):
         qqcw_pack: list[tuple[str, int]] = []
         num_pcnst: list[int] = []
         mode_species: list[list[tuple[int, float, float]]] = []
+        # The qqcw side is packed/unpacked only when the population prognoses
+        # a cloud-borne phase (#602); without one the core still receives a
+        # zero qqcw array (its API needs it) but no tendencies are read back.
+        explicit_cb = self.spec.cloud_borne
         for i, mode in enumerate(self.spec.modes):
             q_pack.append((number_name(mode.short), int(data.NUMPTR_AMODE[i])))
-            qqcw_pack.append(
-                (number_name(mode.short, cloud_borne=True),
-                 int(data.NUMPTRCW_AMODE[i]))
-            )
+            if explicit_cb:
+                qqcw_pack.append(
+                    (number_name(mode.short, cloud_borne=True),
+                     int(data.NUMPTRCW_AMODE[i]))
+                )
             num_pcnst.append(int(data.NUMPTR_AMODE[i]))
             types = tuple(data.LSPECTYPE_AMODE[i])
             sp_list: list[tuple[int, float, float]] = []
@@ -242,9 +247,10 @@ class Mam4JaxMicrophysics(ModalMicrophysicsTerm):
                 midx = int(data.LMASSPTR_AMODE[i][slot])
                 mcidx = int(data.LMASSPTRCW_AMODE[i][slot])
                 q_pack.append((mass_name(sp, mode.short), midx))
-                qqcw_pack.append(
-                    (mass_name(sp, mode.short, cloud_borne=True), mcidx)
-                )
+                if explicit_cb:
+                    qqcw_pack.append(
+                        (mass_name(sp, mode.short, cloud_borne=True), mcidx)
+                    )
                 props = self.spec.species_props(sp)
                 sp_list.append((midx, props.density, props.hygroscopicity))
             mode_species.append(sp_list)

--- a/jcm/physics/aerosol/jam/population.py
+++ b/jcm/physics/aerosol/jam/population.py
@@ -133,6 +133,16 @@ class ModalAerosolSpec:
     modes: tuple[AerosolMode, ...]
     species: tuple[AerosolSpecies, ...]
     family: str = "modal"
+    #: Whether the population prognoses an explicit cloud-borne mirror per
+    #: class (MAM-style ``mc_*``/``nc_*`` tracers alongside the interstitial
+    #: set). This is a property of the population *representation*, not of the
+    #: process harness: MAM keeps in-droplet aerosol as separate constituents,
+    #: while M7 (ECHAM-HAM) and sectional schemes like TOMAS represent it
+    #: implicitly, scavenging the interstitial tracers by their activated
+    #: fraction. ``False`` halves the aerosol tracer count (and the dycore
+    #: transport bill with it); the harness terms fall back to the implicit
+    #: treatment, so both settings are complete, comparable physics (#602).
+    cloud_borne: bool = True
     #: Population policy for where freshly-emitted **primary** mass of a species
     #: goes: ``{species: ((mode_short, mass_fraction), ...)}`` with fractions
     #: summing to 1. This centralises the modal (or sectional) assumption with

--- a/jcm/physics/aerosol/jam/tracer_layout.py
+++ b/jcm/physics/aerosol/jam/tracer_layout.py
@@ -56,11 +56,14 @@ def tracer_specs(spec: ModalAerosolSpec) -> tuple[TracerSpec, ...]:
     """All ``TracerSpec``s for a population (interstitial + cloud-borne).
 
     Returns one mass spec per (mode, species) and one number spec per mode,
-    each doubled for the cloud-borne mirror.
+    each doubled for the cloud-borne mirror when the population prognoses
+    one (``spec.cloud_borne``); an implicit-in-droplet population declares
+    only the interstitial keys.
     """
+    phases = (False, True) if spec.cloud_borne else (False,)
     out: list[TracerSpec] = []
     for mode in spec.modes:
-        for cb in (False, True):
+        for cb in phases:
             out.append(
                 TracerSpec(
                     number_name(mode.short, cloud_borne=cb),

--- a/jcm/physics/aerosol/jam/wetdep/__init__.py
+++ b/jcm/physics/aerosol/jam/wetdep/__init__.py
@@ -5,13 +5,13 @@ from jcm.physics.aerosol.jam.wetdep.wetdep_term import (
     WetDepParameters,
     below_cloud_rate,
     in_cloud_rate,
-    precip_formation_rate,
+    reinjection_budget,
 )
 
 __all__ = [
     "WetScavenging",
     "WetDepParameters",
-    "precip_formation_rate",
+    "reinjection_budget",
     "in_cloud_rate",
     "below_cloud_rate",
 ]

--- a/jcm/physics/aerosol/jam/wetdep/wetdep_term.py
+++ b/jcm/physics/aerosol/jam/wetdep/wetdep_term.py
@@ -159,36 +159,43 @@ def conv_in_cloud_rate(
 
 
 def reinjection_budget(
-    scavenged_flux: jnp.ndarray,  # (K, nlev, ncols) removal into precip [kg/m²/s]
-    evap_fraction: jnp.ndarray,   # (nlev, ncols) precip fraction evaporating
+    scavenged_below: jnp.ndarray,   # (K, nlev, ncols) impaction removal [kg/m²/s]
+    scavenged_formed: jnp.ndarray,  # (K, nlev, ncols) in-cloud removal [kg/m²/s]
+    evap_fraction: jnp.ndarray,     # (nlev, ncols) incoming-precip fraction evaporating
 ) -> tuple[jnp.ndarray, jnp.ndarray]:
     """Aerosol-in-precip ledger: re-injected flux per layer + surface flux.
 
-    Integrates the scavenged-aerosol flux top to bottom: entering each layer,
-    the fraction of the carrier precip that evaporates there releases the
-    same fraction of the carried aerosol (``reinjected``); the layer's own
-    scavenging then joins the flux. Returns ``(reinjected, surface_flux)``
-    with ``reinjected`` shaped like ``scavenged_flux`` and ``surface_flux``
-    ``(K, ncols)``, satisfying column conservation
-    ``sum_k(scavenged - reinjected) = surface_flux`` exactly.
+    Integrates the scavenged-aerosol flux top to bottom, honouring the
+    cloud schemes' own flux ordering (evaporation is capped by the
+    INCOMING precip, formation is added after): aerosol impacted out by
+    the falling precip within a layer (``scavenged_below``) joins the
+    incoming carrier BEFORE the release — a fully-evaporating virga layer
+    releases it rather than surface-depositing it through dry air — while
+    aerosol scavenged into precip NEWLY FORMED in the layer
+    (``scavenged_formed``) joins AFTER, because the incoming carrier's
+    evaporation cannot touch precip that is only now forming and heading
+    down. Returns ``(reinjected, surface_flux)`` with ``reinjected``
+    shaped like the inputs and ``surface_flux`` ``(K, ncols)``, satisfying
+    column conservation
+    ``sum_k(scavenged_below + scavenged_formed - reinjected) =
+    surface_flux`` exactly.
     """
     def step(carried, xs):
-        s_k, e_k = xs                       # (K, ncols), (ncols,)
-        # The layer's own scavenging joins the ledger BEFORE the release,
-        # as in HAMMOZ: in a fully-evaporating (virga) layer everything —
-        # including aerosol impacted out within that layer — is released,
-        # so nothing rides a terminated carrier to the surface through dry
-        # air.
-        total = carried + s_k
-        released = total * e_k[jnp.newaxis, :]
-        carried = total - released
+        s_below_k, s_form_k, e_k = xs        # (K, ncols) x2, (ncols,)
+        incoming = carried + s_below_k
+        released = incoming * e_k[jnp.newaxis, :]
+        carried = incoming - released + s_form_k
         return carried, released
 
-    k, _, ncols = scavenged_flux.shape
+    k, _, ncols = scavenged_below.shape
     surface, released = jax.lax.scan(
         step,
-        jnp.zeros((k, ncols), scavenged_flux.dtype),
-        (jnp.moveaxis(scavenged_flux, 1, 0), evap_fraction),
+        jnp.zeros((k, ncols), scavenged_below.dtype),
+        (
+            jnp.moveaxis(scavenged_below, 1, 0),
+            jnp.moveaxis(scavenged_formed, 1, 0),
+            evap_fraction,
+        ),
     )
     return jnp.moveaxis(released, 0, 1), surface
 
@@ -324,7 +331,11 @@ class WetScavenging(PhysicsTerm):
         # to the interstitial phase).
         reinject_to: list[str] = []
         q_list: list[jnp.ndarray] = []
-        rate_strat: list[jnp.ndarray] = []
+        # Stratiform removal splits by carrier relationship (see
+        # ``reinjection_budget``): impaction into the INCOMING precip vs
+        # in-cloud scavenging into precip FORMED here.
+        rate_below_strat: list[jnp.ndarray] = []
+        rate_form_strat: list[jnp.ndarray] = []
         rate_conv: list[jnp.ndarray] = []
         # With a prognostic cloud-borne phase (``spec.cloud_borne``, #602) the
         # stratiform in-cloud (nucleation) pathway belongs to the cloud-borne
@@ -356,27 +367,29 @@ class WetScavenging(PhysicsTerm):
                     frac_mass = jam_act.mass_frac[i]
                 else:
                     frac_num = frac_mass = activated_fraction
-                strat_num = below_strat + frac_num * rate_ic_unit
-                strat_mass = below_strat + frac_mass * rate_ic_unit
+                form_num = frac_num * rate_ic_unit
+                form_mass = frac_mass * rate_ic_unit
                 conv_rate = below_conv + rate_conv_incloud
             elif mode.can_activate:
-                strat_num = strat_mass = below_strat
+                form_num = form_mass = zeros
                 conv_rate = below_conv + rate_conv_incloud
             else:
-                strat_num = strat_mass = below_strat
+                form_num = form_mass = zeros
                 conv_rate = below_conv
             n_nm = number_name(mode.short)
             names.append(n_nm)
             reinject_to.append(n_nm)
             q_list.append(state.tracers.get(n_nm, zeros))
-            rate_strat.append(strat_num)
+            rate_below_strat.append(below_strat)
+            rate_form_strat.append(form_num)
             rate_conv.append(conv_rate)
             for sp in mode.species:
                 nm = mass_name(sp, mode.short)
                 names.append(nm)
                 reinject_to.append(nm)
                 q_list.append(state.tracers.get(nm, zeros))
-                rate_strat.append(strat_mass)
+                rate_below_strat.append(below_strat)
+                rate_form_strat.append(form_mass)
                 rate_conv.append(conv_rate)
             if explicit_cb:
                 # Cloud-borne aerosol is entirely in-droplet: no below-cloud
@@ -392,7 +405,8 @@ class WetScavenging(PhysicsTerm):
                     names.append(nm)
                     reinject_to.append(partner)
                     q_list.append(state.tracers.get(nm, zeros))
-                    rate_strat.append(rate_cb)
+                    rate_below_strat.append(zeros)
+                    rate_form_strat.append(rate_cb)
                     rate_conv.append(zeros)
 
         # Implicit (exponential) scavenging over the step: q(t+dt) = q·exp(-rate·dt).
@@ -409,25 +423,28 @@ class WetScavenging(PhysicsTerm):
         # apply exactly ``q·(exp(-rate·dt) - 1)`` over the step.
         # Clamp the decay rates to ≥0 so the exponential update is always a
         # bounded removal (a scavenging rate is non-negative by construction).
-        strat_arr = jnp.maximum(jnp.stack(rate_strat), 0.0)
+        below_arr = jnp.maximum(jnp.stack(rate_below_strat), 0.0)
+        form_arr = jnp.maximum(jnp.stack(rate_form_strat), 0.0)
         conv_arr = jnp.maximum(jnp.stack(rate_conv), 0.0)
-        rate_arr = strat_arr + conv_arr
+        rate_arr = below_arr + form_arr + conv_arr
         removed_frac = -jnp.expm1(-rate_arr * dt)              # 1 - exp(-rate·dt) ∈ [0, 1]
         dq_stack = -(removed_frac * jnp.stack(q_list)) / dt
 
-        # Re-evaporation re-injection (#499): the stratiform share of each
-        # tracer's removal (proportional attribution between the two rate
-        # families) rides the falling precip; ``reinjection_budget``
-        # releases it where the carrier evaporates. Convectively scavenged
-        # aerosol deposits directly (no convective evap profile yet).
-        strat_share = jnp.where(
-            rate_arr > _RATE_FLOOR,
-            strat_arr / jnp.maximum(rate_arr, _RATE_FLOOR),
-            0.0,
-        )
-        scavenged_flux = -dq_stack * strat_share * dm[jnp.newaxis]
+        # Re-evaporation re-injection (#499): the stratiform shares of each
+        # tracer's removal (proportional attribution among the rate
+        # families) ride the falling precip; ``reinjection_budget``
+        # releases them where the carrier evaporates, with impaction
+        # joining the incoming carrier and in-cloud scavenging the newly
+        # formed one (see its docstring). Convectively scavenged aerosol
+        # deposits directly (no convective evap profile yet).
+        rate_safe = jnp.maximum(rate_arr, _RATE_FLOOR)
+        live = rate_arr > _RATE_FLOOR
+        share_below = jnp.where(live, below_arr / rate_safe, 0.0)
+        share_form = jnp.where(live, form_arr / rate_safe, 0.0)
+        removed_flux = -dq_stack * dm[jnp.newaxis]
         reinjected, _surface = reinjection_budget(
-            scavenged_flux, evap_fraction,
+            removed_flux * share_below, removed_flux * share_form,
+            evap_fraction,
         )
         reinject_tend = reinjected / dm[jnp.newaxis]
 

--- a/jcm/physics/aerosol/jam/wetdep/wetdep_term.py
+++ b/jcm/physics/aerosol/jam/wetdep/wetdep_term.py
@@ -220,9 +220,18 @@ class WetScavenging(PhysicsTerm):
         # cloud-borne representations would disagree at exchange equilibrium
         # for reasons that have nothing to do with the representation (#602).
         cf_clip = jnp.clip(cloud_fraction, 0.0, 1.0)
-        rate_incloud = params.incloud_scale * cf_clip * in_cloud_rate(
-            activated_fraction, p_form, qc,
-        ) + rate_conv_incloud
+        # ``in_cloud_rate`` is linear in the activated fraction, so keep the
+        # unit-fraction base and apply per-mode, per-quantity fractions
+        # below: ARG's number and mass fractions differ a lot (large
+        # particles activate preferentially) and vary by mode, and using
+        # the aggregate number-weighted fraction for everything biases the
+        # implicit representation away from the explicit one at exchange
+        # equilibrium. The aggregate is kept only as a fallback for
+        # standalone composition without the ARG term upstream.
+        rate_ic_unit = params.incloud_scale * cf_clip * in_cloud_rate(
+            jnp.ones_like(state.temperature), p_form, qc,
+        )
+        jam_act = diagnostics.get("_jam_activation")
 
         # Build a per-tracer scavenging rate and stack with the matching
         # tracers, so the elementwise removal runs as one batched op (rather
@@ -257,18 +266,29 @@ class WetScavenging(PhysicsTerm):
             # only implicitly (via the activated fraction) when there is no
             # explicit cloud-borne phase to carry it. Convective processing
             # always acts on interstitial (updrafts ingest environment air).
-            if mode.can_activate:
-                rate = rate_below + (
-                    rate_conv_incloud if explicit_cb else rate_incloud
+            if mode.can_activate and not explicit_cb:
+                if jam_act is not None:
+                    frac_num = jam_act.number_frac[i]
+                    frac_mass = jam_act.mass_frac[i]
+                else:
+                    frac_num = frac_mass = activated_fraction
+                rate_num = rate_below + rate_conv_incloud + (
+                    frac_num * rate_ic_unit
                 )
+                rate_mass = rate_below + rate_conv_incloud + (
+                    frac_mass * rate_ic_unit
+                )
+            elif mode.can_activate:
+                rate_num = rate_mass = rate_below + rate_conv_incloud
             else:
-                rate = rate_below
-            for nm in [number_name(mode.short)] + [
-                mass_name(sp, mode.short) for sp in mode.species
-            ]:
+                rate_num = rate_mass = rate_below
+            names.append(number_name(mode.short))
+            q_list.append(state.tracers.get(number_name(mode.short), zeros))
+            rate_list.append(rate_num)
+            for nm in [mass_name(sp, mode.short) for sp in mode.species]:
                 names.append(nm)
                 q_list.append(state.tracers.get(nm, zeros))
-                rate_list.append(rate)
+                rate_list.append(rate_mass)
             if explicit_cb:
                 # Cloud-borne aerosol is entirely in-droplet: no below-cloud
                 # impaction, no activated-fraction weighting.

--- a/jcm/physics/aerosol/jam/wetdep/wetdep_term.py
+++ b/jcm/physics/aerosol/jam/wetdep/wetdep_term.py
@@ -1,8 +1,13 @@
 """``WetScavenging`` — in-cloud and below-cloud aerosol scavenging.
 
-Two removal pathways for interstitial aerosol, both differentiable and built
+Two removal pathways for aerosol, both differentiable and built
 only from diagnostics the cloud scheme already exposes (so the cloud
-microphysics terms are untouched):
+microphysics terms are untouched). With a prognostic cloud-borne phase
+(``spec.cloud_borne``, #602) the stratiform in-cloud pathway acts on the
+cloud-borne tracers at the full condensate→precip conversion rate and the
+interstitial tracers keep impaction + convective processing; without one,
+the in-cloud pathway acts on interstitial aerosol weighted by its activated
+fraction (the implicit M7/TOMAS-style treatment):
 
 * **In-cloud nucleation scavenging** — the activated fraction of aerosol is in
   cloud droplets and is removed at the rate cloud condensate converts to
@@ -207,7 +212,15 @@ class WetScavenging(PhysicsTerm):
         p_form = precip_formation_rate(
             precip_col, cloud_fraction, qc, air_density, dz,
         )
-        rate_incloud = params.incloud_scale * in_cloud_rate(
+        # The implicit stratiform rate is weighted by the cloudy area
+        # fraction: the grid-mean p_form/qc ratio is the IN-CLOUD conversion
+        # rate (cf cancels between them), but only cf·af of the grid-mean
+        # interstitial tracer is in droplets. Without the cf factor broken
+        # cloud (cf ~ 0.3) over-scavenged ~3x, and the implicit and explicit
+        # cloud-borne representations would disagree at exchange equilibrium
+        # for reasons that have nothing to do with the representation (#602).
+        cf_clip = jnp.clip(cloud_fraction, 0.0, 1.0)
+        rate_incloud = params.incloud_scale * cf_clip * in_cloud_rate(
             activated_fraction, p_form, qc,
         ) + rate_conv_incloud
 
@@ -220,6 +233,18 @@ class WetScavenging(PhysicsTerm):
         names: list[str] = []
         q_list: list[jnp.ndarray] = []
         rate_list: list[jnp.ndarray] = []
+        # With a prognostic cloud-borne phase (``spec.cloud_borne``, #602) the
+        # stratiform in-cloud (nucleation) pathway belongs to the cloud-borne
+        # tracers, which sit in the droplets by definition: they are removed
+        # at the full condensate→precip conversion rate, and the interstitial
+        # tracers keep only impaction and convective processing (activated
+        # aerosol first transfers via ``CloudBorneExchange``, then rains
+        # out). Without it, the current implicit treatment stands — the
+        # interstitial tracers are scavenged by their activated fraction.
+        explicit_cb = self._spec.cloud_borne
+        rate_cb = params.incloud_scale * in_cloud_rate(
+            jnp.ones_like(state.temperature), p_form, qc,
+        )
         for i, mode in enumerate(self._spec.modes):
             # Stratiform washout column-wide (interim, #499); convective
             # only below the convective cloud top.
@@ -228,14 +253,32 @@ class WetScavenging(PhysicsTerm):
             ) + conv_below * below_cloud_rate(
                 conv_precip, cloud_fraction, aer.r_wet[i], params,
             )
-            # In-cloud only removes from activatable (soluble) modes.
-            rate = rate_below + (rate_incloud if mode.can_activate else 0.0)
+            # In-cloud only removes from activatable (soluble) modes — and
+            # only implicitly (via the activated fraction) when there is no
+            # explicit cloud-borne phase to carry it. Convective processing
+            # always acts on interstitial (updrafts ingest environment air).
+            if mode.can_activate:
+                rate = rate_below + (
+                    rate_conv_incloud if explicit_cb else rate_incloud
+                )
+            else:
+                rate = rate_below
             for nm in [number_name(mode.short)] + [
                 mass_name(sp, mode.short) for sp in mode.species
             ]:
                 names.append(nm)
                 q_list.append(state.tracers.get(nm, zeros))
                 rate_list.append(rate)
+            if explicit_cb:
+                # Cloud-borne aerosol is entirely in-droplet: no below-cloud
+                # impaction, no activated-fraction weighting.
+                for nm in [number_name(mode.short, cloud_borne=True)] + [
+                    mass_name(sp, mode.short, cloud_borne=True)
+                    for sp in mode.species
+                ]:
+                    names.append(nm)
+                    q_list.append(state.tracers.get(nm, zeros))
+                    rate_list.append(rate_cb)
 
         # Implicit (exponential) scavenging over the step: q(t+dt) = q·exp(-rate·dt).
         # The first-order-decay rate is unbounded — the in-cloud rate ∝ 1/qc

--- a/jcm/physics/aerosol/jam/wetdep/wetdep_term.py
+++ b/jcm/physics/aerosol/jam/wetdep/wetdep_term.py
@@ -1,38 +1,50 @@
 """``WetScavenging`` — in-cloud and below-cloud aerosol scavenging.
 
-Two removal pathways for aerosol, both differentiable and built
-only from diagnostics the cloud scheme already exposes (so the cloud
-microphysics terms are untouched). With a prognostic cloud-borne phase
-(``spec.cloud_borne``, #602) the stratiform in-cloud pathway acts on the
-cloud-borne tracers at the full condensate→precip conversion rate and the
-interstitial tracers keep impaction + convective processing; without one,
-the in-cloud pathway acts on interstitial aerosol weighted by its activated
-fraction (the implicit M7/TOMAS-style treatment):
+Removal pathways for aerosol, all differentiable, driven by the per-level
+precipitation process rates the cloud microphysics schemes actually
+integrate (``CloudData.precip_formation_rate`` / ``precip_evaporation_rate``,
+#499; the carrier flux is their own cumulative ledger, which deliberately
+excludes the sedimenting cloud-ice flux — see ``__call__``). With a prognostic
+cloud-borne phase (``spec.cloud_borne``, #602) the stratiform in-cloud
+pathway acts on the cloud-borne tracers at the full condensate→precip
+conversion rate and the interstitial tracers keep impaction + convective
+processing; without one, the in-cloud pathway acts on interstitial aerosol
+weighted by its per-mode activated fractions (the implicit M7/TOMAS-style
+treatment):
 
-* **In-cloud nucleation scavenging** — the activated fraction of aerosol is in
-  cloud droplets and is removed at the rate cloud condensate converts to
-  precipitation. As an interim, the per-level precip-formation rate is
-  *reconstructed* by distributing the column surface precip
-  (``CloudData.precip_rain/snow``) across the cloudy column weighted by
-  in-cloud condensate; exposing the true per-level formation (and
-  evaporation) rate from the cloud schemes — and adding re-evaporation
-  re-injection — is tracked in #499.
-* **Below-cloud impaction scavenging** — falling precipitation collects
-  interstitial aerosol in clear air, with a size-dependent (∝ r²) collection
-  efficiency so coarse particles are scavenged far faster than accumulation
-  mode. Driven by stratiform AND convective precipitation — with the
-  convective contribution masked to levels at/below the convective cloud
-  top (diagnosed by pressure from the heating footprint), since rain
-  cannot collect aerosol above where it forms.
+* **In-cloud nucleation scavenging** — aerosol residing in cloud droplets is
+  removed at the local rate cloud condensate converts to precipitation,
+  ``precip_formation_rate / (qc + qi)`` (both grid-mean, so the cloudy-area
+  factor cancels inside the ratio).
+* **Below-cloud impaction scavenging** — precipitation falling through a
+  layer collects aerosol in its clear-air part, with a size-dependent
+  (∝ r²) collection efficiency. The stratiform contribution uses the
+  per-level flux entering each layer, so washout is automatically confined
+  below where precip actually forms; the convective contribution uses the
+  surface convective precip masked to levels at/below the convective cloud
+  top (diagnosed by pressure from the heating footprint).
 * **Convective in-cloud scavenging** — the convective mirror of the
   stratiform pathway: scavenging ratio × (per-layer updraft precip
   formation / in-updraft condensate), from ``ConvectionData``'s
   ``precip_formation`` (ECHAM ``pdmfup``) and ``qc_conv``/``qi_conv``;
-  soluble modes only.
+  activatable modes only.
+* **Re-evaporation re-injection** — aerosol scavenged by the stratiform
+  pathways is carried in the falling precip; where that precip evaporates
+  or sublimates, the same fraction of the carried aerosol returns to the
+  INTERSTITIAL phase (a droplet that evaporates releases its aerosol, so
+  cloud-borne-scavenged material also re-enters as interstitial). The
+  aerosol-in-precip flux is integrated top to bottom per tracer, exactly
+  mirroring HAMMOZ ``mo_ham_wetdep``'s re-evaporation ledger; the flux
+  reaching the bottom is the net surface wet deposition. Convectively
+  scavenged aerosol is deposited directly (the convection scheme exposes no
+  evaporation profile yet).
 
 ``ConvectionData`` is read via ``diagnostics.get("convection")`` with a
 zero-precip fallback so the term still composes without a convection
-scheme.
+scheme. A cloud scheme that does not populate the per-level process rates
+(both ECHAM schemes do) yields zero stratiform scavenging altogether — the
+in-cloud rate, the impaction carrier and the re-injection ledger all derive
+from those two fields.
 
 Mirrors ``mo_hammoz_wetdep``.
 """
@@ -41,6 +53,7 @@ from __future__ import annotations
 
 from typing import ClassVar
 
+import jax
 import jax.numpy as jnp
 import tree_math
 from flax import nnx
@@ -51,6 +64,13 @@ from jcm.physics.aerosol.jam.tracer_layout import mass_name, number_name
 from jcm.physics.physics_term import PhysicsTendency, PhysicsTerm
 
 _EPS = 1.0e-30
+# Physical floors for the re-injection budget's divisions. Values below
+# these are dynamically negligible (a 1e-15 1/s removal rate is a ~30 Myr
+# timescale; 1e-12 kg/m²/s is ~1e-4 mm/day), and a *physical* floor — not a
+# tiny epsilon — keeps the guarded-division VJPs clear of the squared-
+# underflow window in float32 (the double-where NaN class).
+_RATE_FLOOR = 1.0e-15   # [1/s]
+_FLUX_FLOOR = 1.0e-12   # [kg/m²/s]
 
 
 @tree_math.struct
@@ -74,24 +94,12 @@ class WetDepParameters:
         )
 
 
-def precip_formation_rate(
-    precip_col: jnp.ndarray,      # (ncols,) surface precip [kg/m²/s]
-    cloud_fraction: jnp.ndarray,  # (nlev, ncols)
-    qc: jnp.ndarray,              # (nlev, ncols)
-    air_density: jnp.ndarray,
-    layer_thickness: jnp.ndarray,
-) -> jnp.ndarray:
-    """Per-level condensate→precip conversion rate [kg/kg/s].
-
-    Distributes the column surface precip across the cloudy column weighted
-    by in-cloud condensate, converting the surface mass flux to a local
-    mixing-ratio sink rate.
-    """
-    weight = cloud_fraction * jnp.maximum(qc, 0.0)
-    w_sum = jnp.sum(weight, axis=0, keepdims=True)
-    frac = weight / jnp.maximum(w_sum, _EPS)
-    local = precip_col[jnp.newaxis, :] / (air_density * layer_thickness)
-    return local * frac
+#: Physical condensate floor for the in-cloud rate [kg/kg]. A cell with less
+#: than this holds no cloud worth scavenging in; it is also what keeps the
+#: division's VJP clear of the float32 squared-underflow window (a 1e-30
+#: epsilon guard here gave a verified NaN gradient in every clear f32 cell:
+#: the cotangent forms p_form/condensate², and 1e-60 flushes to zero).
+_CONDENSATE_FLOOR = 1.0e-12
 
 
 def in_cloud_rate(
@@ -99,18 +107,24 @@ def in_cloud_rate(
     p_form: jnp.ndarray,
     qc: jnp.ndarray,
 ) -> jnp.ndarray:
-    """In-cloud scavenging rate [1/s] applied to interstitial aerosol."""
-    return activated_fraction * p_form / jnp.maximum(qc, _EPS)
+    """In-cloud scavenging rate [1/s] applied to in-droplet aerosol."""
+    rate = activated_fraction * p_form / jnp.maximum(qc, _CONDENSATE_FLOOR)
+    return jnp.where(qc > _CONDENSATE_FLOOR, rate, 0.0)
 
 
 def below_cloud_rate(
-    precip_col: jnp.ndarray,
-    cloud_fraction: jnp.ndarray,
+    precip_flux: jnp.ndarray,     # (nlev, ncols) precip falling through [kg/m²/s]
+    cloud_fraction: jnp.ndarray,  # (nlev, ncols)
     r_wet: jnp.ndarray,
     params: WetDepParameters,
 ) -> jnp.ndarray:
-    """Below-cloud impaction scavenging rate [1/s], size-dependent (∝ r²)."""
-    rain_mmph = precip_col[jnp.newaxis, :] * 3600.0  # kg/m²/s -> mm/h
+    """Below-cloud impaction scavenging rate [1/s], size-dependent (∝ r²).
+
+    ``precip_flux`` is the local flux falling through each layer (per-level
+    profile for stratiform precip; a broadcast surface value is the interim
+    convective treatment).
+    """
+    rain_mmph = precip_flux * 3600.0  # kg/m²/s -> mm/h
     efficiency = (r_wet / params.below_radius_ref) ** 2
     # Clear-sky (below-cloud) fraction, clipped to [0, 1]. The cloud scheme can
     # return cloud_fraction > 1 (e.g. where RH > 1), which would make this
@@ -144,8 +158,43 @@ def conv_in_cloud_rate(
     return jnp.where(conv_condensate > 1.0e-12, rate, 0.0)
 
 
+def reinjection_budget(
+    scavenged_flux: jnp.ndarray,  # (K, nlev, ncols) removal into precip [kg/m²/s]
+    evap_fraction: jnp.ndarray,   # (nlev, ncols) precip fraction evaporating
+) -> tuple[jnp.ndarray, jnp.ndarray]:
+    """Aerosol-in-precip ledger: re-injected flux per layer + surface flux.
+
+    Integrates the scavenged-aerosol flux top to bottom: entering each layer,
+    the fraction of the carrier precip that evaporates there releases the
+    same fraction of the carried aerosol (``reinjected``); the layer's own
+    scavenging then joins the flux. Returns ``(reinjected, surface_flux)``
+    with ``reinjected`` shaped like ``scavenged_flux`` and ``surface_flux``
+    ``(K, ncols)``, satisfying column conservation
+    ``sum_k(scavenged - reinjected) = surface_flux`` exactly.
+    """
+    def step(carried, xs):
+        s_k, e_k = xs                       # (K, ncols), (ncols,)
+        # The layer's own scavenging joins the ledger BEFORE the release,
+        # as in HAMMOZ: in a fully-evaporating (virga) layer everything —
+        # including aerosol impacted out within that layer — is released,
+        # so nothing rides a terminated carrier to the surface through dry
+        # air.
+        total = carried + s_k
+        released = total * e_k[jnp.newaxis, :]
+        carried = total - released
+        return carried, released
+
+    k, _, ncols = scavenged_flux.shape
+    surface, released = jax.lax.scan(
+        step,
+        jnp.zeros((k, ncols), scavenged_flux.dtype),
+        (jnp.moveaxis(scavenged_flux, 1, 0), evap_fraction),
+    )
+    return jnp.moveaxis(released, 0, 1), surface
+
+
 class WetScavenging(PhysicsTerm):
-    """In-cloud + below-cloud scavenging of interstitial aerosol."""
+    """In-cloud + below-cloud scavenging with re-evaporation re-injection."""
 
     name: ClassVar[str] = "jam_wet_deposition"
     category: ClassVar[str] = "aerosol_wetdep"
@@ -171,19 +220,53 @@ class WetScavenging(PhysicsTerm):
         activated_fraction = diagnostics["activated_fraction"]
         air_density = diagnostics["air_density"]
         dz = diagnostics["layer_thickness"]
+        dm = air_density * dz
         # Timestep for the implicit (exponential) scavenging update below.
         dt = diagnostics.get("_dt_seconds", 1800.0)
 
         clouds = diagnostics["clouds"]
-        precip_col = clouds.precip_rain + clouds.precip_snow
         cloud_fraction = clouds.cloud_fraction
-        qc = clouds.qc
+        # Total cloud condensate: the formation ledger spans both the rain
+        # (from qc) and snow (from qc and qi) pathways, so the in-droplet
+        # residence pool is liquid + ice.
+        condensate = jnp.maximum(clouds.qc, 0.0) + jnp.maximum(clouds.qi, 0.0)
+        # Per-level stratiform process rates from the cloud scheme (#499):
+        # the true local condensate→precip conversion and the falling-precip
+        # evaporation. The carrier flux for impaction and the re-evap ledger
+        # is rebuilt as the cumulative (formation − evaporation) integral of
+        # those same rates rather than read from ``clouds.rain_flux +
+        # snow_flux``: the schemes fold the sedimenting cloud-ice flux into
+        # the frozen profile at interior levels, and that ice is not a
+        # scavenging carrier (its sublimation is likewise excluded from
+        # ``precip_evaporation_rate``), so using the profiles directly would
+        # both drive impaction with a non-carrier flux and dilute the
+        # re-evaporation fraction under cirrus. Melt only moves mass between
+        # rain and snow, so the summed ledger is exact for the actual
+        # precip; the floor guards accumulated round-off. Note the
+        # ice-sedimentation flux that reaches the surface as snow therefore
+        # carries no aerosol removal at all — a real missing sink, accepted
+        # with the non-carrier stance.
+        p_form = jnp.maximum(clouds.precip_formation_rate, 0.0)
+        p_evap = jnp.maximum(clouds.precip_evaporation_rate, 0.0)
+        strat_flux = jnp.maximum(
+            jnp.cumsum((p_form - p_evap) * dm, axis=0), 0.0
+        )
+        flux_in = jnp.concatenate(
+            [jnp.zeros_like(strat_flux[:1]), strat_flux[:-1]], axis=0
+        )
+        # Fraction of the precip entering a layer that evaporates within it,
+        # guarded on a physical flux floor (see _FLUX_FLOOR note above).
+        evap_fraction = jnp.where(
+            flux_in > _FLUX_FLOOR,
+            jnp.clip(p_evap * dm / jnp.maximum(flux_in, _FLUX_FLOOR), 0.0, 1.0),
+            0.0,
+        )
 
         # Convective precipitation (Tiedtke). Zero-precip fallback keeps the
         # term composable without a convection scheme (see module docstring).
         conv = diagnostics.get("convection")
         if conv is None:
-            conv_precip = jnp.zeros_like(precip_col)
+            conv_precip = jnp.zeros_like(state.temperature[0])
             rate_conv_incloud = jnp.zeros_like(state.temperature)
             conv_below = jnp.zeros_like(state.temperature)
         else:
@@ -209,58 +292,59 @@ class WetScavenging(PhysicsTerm):
                 # No pressure diagnostic: column-wide washout, not none.
                 conv_below = jnp.ones_like(state.temperature)
 
-        p_form = precip_formation_rate(
-            precip_col, cloud_fraction, qc, air_density, dz,
-        )
         # The implicit stratiform rate is weighted by the cloudy area
-        # fraction: the grid-mean p_form/qc ratio is the IN-CLOUD conversion
-        # rate (cf cancels between them), but only cf·af of the grid-mean
-        # interstitial tracer is in droplets. Without the cf factor broken
-        # cloud (cf ~ 0.3) over-scavenged ~3x, and the implicit and explicit
-        # cloud-borne representations would disagree at exchange equilibrium
-        # for reasons that have nothing to do with the representation (#602).
+        # fraction: the grid-mean p_form/condensate ratio is the IN-CLOUD
+        # conversion rate (cf cancels between them), but only cf·af of the
+        # grid-mean interstitial tracer is in droplets. ``in_cloud_rate`` is
+        # linear in the activated fraction, so keep the unit-fraction base
+        # and apply per-mode, per-quantity fractions below: ARG's number and
+        # mass fractions differ a lot (large particles activate
+        # preferentially) and vary by mode. The aggregate fraction is kept
+        # only as a fallback for standalone composition without ARG
+        # upstream.
         cf_clip = jnp.clip(cloud_fraction, 0.0, 1.0)
-        # ``in_cloud_rate`` is linear in the activated fraction, so keep the
-        # unit-fraction base and apply per-mode, per-quantity fractions
-        # below: ARG's number and mass fractions differ a lot (large
-        # particles activate preferentially) and vary by mode, and using
-        # the aggregate number-weighted fraction for everything biases the
-        # implicit representation away from the explicit one at exchange
-        # equilibrium. The aggregate is kept only as a fallback for
-        # standalone composition without the ARG term upstream.
         rate_ic_unit = params.incloud_scale * cf_clip * in_cloud_rate(
-            jnp.ones_like(state.temperature), p_form, qc,
+            jnp.ones_like(state.temperature), p_form, condensate,
         )
         jam_act = diagnostics.get("_jam_activation")
 
-        # Build a per-tracer scavenging rate and stack with the matching
+        # Build per-tracer scavenging rates and stack with the matching
         # tracers, so the elementwise removal runs as one batched op (rather
-        # than an unrolled tendency per mode×species). ``state.tracers`` is
-        # empty during ``Model.get_empty_data``'s structural probe, so fall
-        # back to zeros there (real runs have every declared tracer seeded).
+        # than an unrolled tendency per mode×species). Stratiform and
+        # convective rates are kept separate: only stratiform-scavenged
+        # aerosol enters the re-evaporation ledger (its carrier's per-level
+        # evaporation is known). ``state.tracers`` is empty during
+        # ``Model.get_empty_data``'s structural probe, so fall back to zeros
+        # there (real runs have every declared tracer seeded).
         zeros = jnp.zeros_like(state.temperature)
         names: list[str] = []
+        # Interstitial destination for each stacked tracer's re-injected
+        # aerosol: itself for interstitial tracers; the interstitial partner
+        # for cloud-borne ones (an evaporated droplet releases its aerosol
+        # to the interstitial phase).
+        reinject_to: list[str] = []
         q_list: list[jnp.ndarray] = []
-        rate_list: list[jnp.ndarray] = []
+        rate_strat: list[jnp.ndarray] = []
+        rate_conv: list[jnp.ndarray] = []
         # With a prognostic cloud-borne phase (``spec.cloud_borne``, #602) the
         # stratiform in-cloud (nucleation) pathway belongs to the cloud-borne
         # tracers, which sit in the droplets by definition: they are removed
         # at the full condensate→precip conversion rate, and the interstitial
         # tracers keep only impaction and convective processing (activated
         # aerosol first transfers via ``CloudBorneExchange``, then rains
-        # out). Without it, the current implicit treatment stands — the
-        # interstitial tracers are scavenged by their activated fraction.
+        # out). Without it, the implicit treatment stands — the interstitial
+        # tracers are scavenged by their per-mode activated fractions.
         explicit_cb = self._spec.cloud_borne
         rate_cb = params.incloud_scale * in_cloud_rate(
-            jnp.ones_like(state.temperature), p_form, qc,
+            jnp.ones_like(state.temperature), p_form, condensate,
         )
         for i, mode in enumerate(self._spec.modes):
-            # Stratiform washout column-wide (interim, #499); convective
-            # only below the convective cloud top.
-            rate_below = below_cloud_rate(
-                precip_col, cloud_fraction, aer.r_wet[i], params,
-            ) + conv_below * below_cloud_rate(
-                conv_precip, cloud_fraction, aer.r_wet[i], params,
+            below_strat = below_cloud_rate(
+                flux_in, cloud_fraction, aer.r_wet[i], params,
+            )
+            below_conv = conv_below * below_cloud_rate(
+                conv_precip[jnp.newaxis, :], cloud_fraction,
+                aer.r_wet[i], params,
             )
             # In-cloud only removes from activatable (soluble) modes — and
             # only implicitly (via the activated fraction) when there is no
@@ -272,33 +356,44 @@ class WetScavenging(PhysicsTerm):
                     frac_mass = jam_act.mass_frac[i]
                 else:
                     frac_num = frac_mass = activated_fraction
-                rate_num = rate_below + rate_conv_incloud + (
-                    frac_num * rate_ic_unit
-                )
-                rate_mass = rate_below + rate_conv_incloud + (
-                    frac_mass * rate_ic_unit
-                )
+                strat_num = below_strat + frac_num * rate_ic_unit
+                strat_mass = below_strat + frac_mass * rate_ic_unit
+                conv_rate = below_conv + rate_conv_incloud
             elif mode.can_activate:
-                rate_num = rate_mass = rate_below + rate_conv_incloud
+                strat_num = strat_mass = below_strat
+                conv_rate = below_conv + rate_conv_incloud
             else:
-                rate_num = rate_mass = rate_below
-            names.append(number_name(mode.short))
-            q_list.append(state.tracers.get(number_name(mode.short), zeros))
-            rate_list.append(rate_num)
-            for nm in [mass_name(sp, mode.short) for sp in mode.species]:
+                strat_num = strat_mass = below_strat
+                conv_rate = below_conv
+            n_nm = number_name(mode.short)
+            names.append(n_nm)
+            reinject_to.append(n_nm)
+            q_list.append(state.tracers.get(n_nm, zeros))
+            rate_strat.append(strat_num)
+            rate_conv.append(conv_rate)
+            for sp in mode.species:
+                nm = mass_name(sp, mode.short)
                 names.append(nm)
+                reinject_to.append(nm)
                 q_list.append(state.tracers.get(nm, zeros))
-                rate_list.append(rate_mass)
+                rate_strat.append(strat_mass)
+                rate_conv.append(conv_rate)
             if explicit_cb:
                 # Cloud-borne aerosol is entirely in-droplet: no below-cloud
-                # impaction, no activated-fraction weighting.
-                for nm in [number_name(mode.short, cloud_borne=True)] + [
-                    mass_name(sp, mode.short, cloud_borne=True)
+                # impaction, no activated-fraction weighting, and its
+                # re-injected share returns to the interstitial partner.
+                pairs = [(number_name(mode.short, cloud_borne=True),
+                          number_name(mode.short))] + [
+                    (mass_name(sp, mode.short, cloud_borne=True),
+                     mass_name(sp, mode.short))
                     for sp in mode.species
-                ]:
+                ]
+                for nm, partner in pairs:
                     names.append(nm)
+                    reinject_to.append(partner)
                     q_list.append(state.tracers.get(nm, zeros))
-                    rate_list.append(rate_cb)
+                    rate_strat.append(rate_cb)
+                    rate_conv.append(zeros)
 
         # Implicit (exponential) scavenging over the step: q(t+dt) = q·exp(-rate·dt).
         # The first-order-decay rate is unbounded — the in-cloud rate ∝ 1/qc
@@ -312,12 +407,33 @@ class WetScavenging(PhysicsTerm):
         # ``mo_ham_wetdep`` applies the same ``1 - exp(-Λ·Δt)`` removed fraction).
         # Emitted as a per-second tendency so the operator-split sum + dynamics
         # apply exactly ``q·(exp(-rate·dt) - 1)`` over the step.
-        # Clamp the decay rate to ≥0 so the exponential update is always a
+        # Clamp the decay rates to ≥0 so the exponential update is always a
         # bounded removal (a scavenging rate is non-negative by construction).
-        rate_arr = jnp.maximum(jnp.stack(rate_list), 0.0)
+        strat_arr = jnp.maximum(jnp.stack(rate_strat), 0.0)
+        conv_arr = jnp.maximum(jnp.stack(rate_conv), 0.0)
+        rate_arr = strat_arr + conv_arr
         removed_frac = -jnp.expm1(-rate_arr * dt)              # 1 - exp(-rate·dt) ∈ [0, 1]
         dq_stack = -(removed_frac * jnp.stack(q_list)) / dt
+
+        # Re-evaporation re-injection (#499): the stratiform share of each
+        # tracer's removal (proportional attribution between the two rate
+        # families) rides the falling precip; ``reinjection_budget``
+        # releases it where the carrier evaporates. Convectively scavenged
+        # aerosol deposits directly (no convective evap profile yet).
+        strat_share = jnp.where(
+            rate_arr > _RATE_FLOOR,
+            strat_arr / jnp.maximum(rate_arr, _RATE_FLOOR),
+            0.0,
+        )
+        scavenged_flux = -dq_stack * strat_share * dm[jnp.newaxis]
+        reinjected, _surface = reinjection_budget(
+            scavenged_flux, evap_fraction,
+        )
+        reinject_tend = reinjected / dm[jnp.newaxis]
+
         tracer_tends = {nm: dq_stack[k] for k, nm in enumerate(names)}
+        for k, target in enumerate(reinject_to):
+            tracer_tends[target] = tracer_tends[target] + reinject_tend[k]
 
         tendency = PhysicsTendency(
             u_wind=jnp.zeros_like(state.u_wind),
@@ -326,8 +442,9 @@ class WetScavenging(PhysicsTerm):
             specific_humidity=jnp.zeros_like(state.specific_humidity),
             tracers=tracer_tends,
         )
-        # AeroCom deposition fluxes (jax-gcm#581): this term's removal,
-        # column-integrated, accumulated onto the per-step-reset keys.
+        # AeroCom deposition fluxes (jax-gcm#581): this term's NET removal
+        # (scavenging minus re-injection), column-integrated, accumulated
+        # onto the per-step-reset keys.
         from jcm.physics.aerosol.jam.emissions.flux_diagnostic import (
             accumulate_deposition_fluxes)
         diagnostics = accumulate_deposition_fluxes(

--- a/jcm/physics/aerosol/jam/wetdep/wetdep_test.py
+++ b/jcm/physics/aerosol/jam/wetdep/wetdep_test.py
@@ -87,9 +87,14 @@ class WetDepTermTest(unittest.TestCase):
         )
         tracers = {}
         for mode in MAM4_SPEC.modes:
-            tracers[number_name(mode.short)] = jnp.full((nlev, ncols), 1.0e8)
-            for sp in mode.species:
-                tracers[mass_name(sp, mode.short)] = jnp.full((nlev, ncols), 1e-9)
+            for cb in (False, True):
+                tracers[number_name(mode.short, cloud_borne=cb)] = jnp.full(
+                    (nlev, ncols), 1.0e8
+                )
+                for sp in mode.species:
+                    tracers[mass_name(sp, mode.short, cloud_borne=cb)] = (
+                        jnp.full((nlev, ncols), 1e-9)
+                    )
         state = PhysicsState.zeros((nlev, ncols)).copy(
             temperature=jnp.full((nlev, ncols), 275.0),
             tracers=tracers,
@@ -243,6 +248,127 @@ class WetDepTermTest(unittest.TestCase):
         tend, _ = term(state, diagnostics, None, None)
         key = mass_name(spec.modes[0].species[0], spec.modes[0].short)
         self.assertTrue(np.all(np.isfinite(np.asarray(tend.tracers[key]))))
+
+    def test_cloud_borne_removed_at_full_incloud_rate(self):
+        # Cloud-borne aerosol is entirely in-droplet: its stratiform removal
+        # must not scale with the interstitial activated fraction, and must
+        # be a strict sink wherever condensate converts to precip (#602).
+        state, diagnostics, spec, mass_name = self._setup()
+        from jcm.physics.aerosol.jam import number_name
+
+        term = WetScavenging()
+        tend, _ = term(state, diagnostics, None, None)
+        cb_key = mass_name(spec.modes[0].species[0], spec.modes[0].short,
+                           cloud_borne=True)
+        self.assertIn(cb_key, tend.tracers)
+        self.assertIn(number_name(spec.modes[0].short, cloud_borne=True),
+                      tend.tracers)
+        self.assertTrue(bool(jnp.all(tend.tracers[cb_key] < 0.0)))
+        # Independent of the interstitial activated fraction.
+        diagnostics_af0 = dict(diagnostics)
+        diagnostics_af0["activated_fraction"] = jnp.zeros_like(
+            diagnostics["activated_fraction"]
+        )
+        tend_af0, _ = term(state, diagnostics_af0, None, None)
+        np.testing.assert_array_equal(
+            np.asarray(tend_af0.tracers[cb_key]),
+            np.asarray(tend.tracers[cb_key]),
+        )
+
+    def test_incloud_pathway_moves_with_the_representation(self):
+        # Explicit cloud-borne phase (default MAM4 spec): the interstitial
+        # tracers keep only impaction — the activated fraction no longer
+        # scales their removal. Implicit phase (cloud_borne=False): the
+        # activated fraction does scale removal, and no mirror tendencies
+        # are emitted at all.
+        import dataclasses
+        from jcm.physics.aerosol.jam import MAM4_SPEC
+
+        state, diagnostics, spec, mass_name = self._setup()
+        key = mass_name(spec.modes[0].species[0], spec.modes[0].short)
+        lo = dict(diagnostics)
+        lo["activated_fraction"] = jnp.full_like(
+            diagnostics["activated_fraction"], 0.1
+        )
+
+        explicit = WetScavenging()
+        t_hi, _ = explicit(state, diagnostics, None, None)   # af = 0.7
+        t_lo, _ = explicit(state, lo, None, None)
+        np.testing.assert_array_equal(
+            np.asarray(t_hi.tracers[key]), np.asarray(t_lo.tracers[key]),
+        )
+
+        implicit = WetScavenging(
+            spec=dataclasses.replace(MAM4_SPEC, cloud_borne=False)
+        )
+        t_hi, _ = implicit(state, diagnostics, None, None)
+        t_lo, _ = implicit(state, lo, None, None)
+        self.assertLess(
+            float(t_hi.tracers[key].sum()), float(t_lo.tracers[key].sum()),
+            "implicit treatment must scavenge more at higher activation",
+        )
+        self.assertFalse(
+            any(nm.startswith(("mc_", "nc_")) for nm in t_hi.tracers),
+            "implicit population must not emit mirror tendencies",
+        )
+
+    def test_equilibrium_removal_matches_between_representations(self):
+        # At exchange equilibrium (q_cb = cf·af·q_tot) the explicit
+        # representation removes rate_ic·q_cb and the implicit one removes
+        # cf·af·rate_ic·q_tot — the SAME mass. Without the cf factor on the
+        # implicit stratiform rate the two disagree by 1/cf (2x here), which
+        # would poison the #602 A/B comparison with a difference that has
+        # nothing to do with the representation. Below-cloud impaction is
+        # switched off and the precip kept light so the exponential update
+        # stays in its linear regime.
+        import dataclasses
+        from jcm.physics.aerosol.jam import MAM4_SPEC
+
+        state, diagnostics, spec, mass_name = self._setup(precip=1.0e-7)
+        cf, af, q_tot = 0.6, 0.7, 1.0e-9
+        diagnostics = dict(diagnostics)
+        diagnostics["activated_fraction"] = jnp.full_like(
+            diagnostics["activated_fraction"], af
+        )
+        params = WetDepParameters(
+            incloud_scale=jnp.asarray(1.0),
+            below_coeff=jnp.asarray(0.0),
+            below_radius_ref=jnp.asarray(1.0e-7),
+            conv_scav_ratio=jnp.asarray(0.99),
+        )
+        key_int = mass_name(spec.modes[0].species[0], spec.modes[0].short)
+        key_cb = mass_name(spec.modes[0].species[0], spec.modes[0].short,
+                           cloud_borne=True)
+
+        # Explicit: the pair partitioned at the exchange equilibrium.
+        q_cb = cf * af * q_tot
+        tracers = dict(state.tracers)
+        tracers[key_int] = jnp.full_like(tracers[key_int], q_tot - q_cb)
+        tracers[key_cb] = jnp.full_like(tracers[key_cb], q_cb)
+        tend_exp, _ = WetScavenging(params=params)(
+            state.copy(tracers=tracers), diagnostics, None, None,
+        )
+        removed_explicit = -(
+            np.asarray(tend_exp.tracers[key_int])
+            + np.asarray(tend_exp.tracers[key_cb])
+        )
+
+        # Implicit: all of q_tot interstitial, activated-fraction scavenged.
+        tracers = dict(state.tracers)
+        tracers[key_int] = jnp.full_like(tracers[key_int], q_tot)
+        implicit = WetScavenging(
+            params=params,
+            spec=dataclasses.replace(MAM4_SPEC, cloud_borne=False),
+        )
+        tend_imp, _ = implicit(
+            state.copy(tracers=tracers), diagnostics, None, None,
+        )
+        removed_implicit = -np.asarray(tend_imp.tracers[key_int])
+
+        self.assertGreater(float(removed_explicit.max()), 0.0)
+        np.testing.assert_allclose(
+            removed_implicit, removed_explicit, rtol=5e-3,
+        )
 
     def test_grad_through_below_coeff(self):
         state, diagnostics, spec, mass_name = self._setup()

--- a/jcm/physics/aerosol/jam/wetdep/wetdep_test.py
+++ b/jcm/physics/aerosol/jam/wetdep/wetdep_test.py
@@ -12,22 +12,41 @@ from jcm.physics.aerosol.jam.wetdep.wetdep_term import (
     below_cloud_rate,
     conv_in_cloud_rate,
     in_cloud_rate,
-    precip_formation_rate,
+    reinjection_budget,
 )
 
 
 class ScavengingFunctionTest(unittest.TestCase):
-    def test_precip_formation_distributes_over_condensate(self):
-        precip = jnp.asarray([1.0e-4])           # kg/m²/s
-        cf = jnp.array([[0.0], [0.8], [0.0]])
-        qc = jnp.array([[0.0], [1.0e-3], [0.0]])
-        rho = jnp.ones((3, 1))
-        dz = jnp.full((3, 1), 100.0)
-        pf = precip_formation_rate(precip, cf, qc, rho, dz)
-        # All formation in the single cloudy layer.
-        self.assertGreater(float(pf[1, 0]), 0.0)
-        self.assertAlmostEqual(float(pf[0, 0]), 0.0)
-        self.assertAlmostEqual(float(pf[2, 0]), 0.0)
+    def test_reinjection_budget_conserves_the_column(self):
+        # Aerosol scavenged at the top rides the precip down; a 50%-evap
+        # layer releases half, a full-evap layer releases the rest, and
+        # nothing reaches the surface. sum(scavenged - reinjected) must
+        # equal the surface flux EXACTLY at every column.
+        scavenged = jnp.zeros((1, 3, 1)).at[0, 0, 0].set(2.0)
+        evap_frac = jnp.array([[0.0], [0.5], [1.0]])
+        reinjected, surface = reinjection_budget(scavenged, evap_frac)
+        np.testing.assert_allclose(np.asarray(reinjected[0, :, 0]),
+                                   [0.0, 1.0, 1.0])
+        np.testing.assert_allclose(np.asarray(surface), 0.0)
+        # Partial evap: the un-released remainder deposits.
+        evap_frac = jnp.array([[0.0], [0.25], [0.0]])
+        reinjected, surface = reinjection_budget(scavenged, evap_frac)
+        np.testing.assert_allclose(np.asarray(surface[0, 0]), 1.5)
+        np.testing.assert_allclose(
+            float(jnp.sum(scavenged - reinjected)), float(surface[0, 0]),
+        )
+
+    def test_same_layer_scavenge_and_full_evap_releases_everything(self):
+        # Virga: aerosol impacted out within a fully-evaporating layer must
+        # be released there too, not ride a terminated carrier to the
+        # surface through dry air (the layer's scavenging joins the ledger
+        # BEFORE the release, as in HAMMOZ). The pre-fix ordering deposited
+        # it all.
+        scavenged = jnp.zeros((1, 3, 1)).at[0, 2, 0].set(1.0)
+        evap_frac = jnp.zeros((3, 1)).at[2].set(1.0)
+        reinjected, surface = reinjection_budget(scavenged, evap_frac)
+        np.testing.assert_allclose(np.asarray(reinjected[0, 2, 0]), 1.0)
+        np.testing.assert_allclose(np.asarray(surface), 0.0)
 
     def test_in_cloud_rate_scales_with_activation(self):
         pf = jnp.full((1, 1), 1.0e-6)
@@ -37,7 +56,7 @@ class ScavengingFunctionTest(unittest.TestCase):
         self.assertGreater(float(hi[0, 0]), float(lo[0, 0]))
 
     def test_below_cloud_size_dependence(self):
-        precip = jnp.asarray([1.0e-4])
+        precip = jnp.full((1, 1), 1.0e-4)
         cf = jnp.zeros((1, 1))
         params = WetDepParameters.default()
         accum = below_cloud_rate(precip, cf, jnp.full((1, 1), 0.1e-6), params)
@@ -47,7 +66,8 @@ class ScavengingFunctionTest(unittest.TestCase):
     def test_no_precip_no_below_cloud(self):
         params = WetDepParameters.default()
         rate = below_cloud_rate(
-            jnp.zeros((1,)), jnp.zeros((1, 1)), jnp.full((1, 1), 1e-6), params,
+            jnp.zeros((1, 1)), jnp.zeros((1, 1)), jnp.full((1, 1), 1e-6),
+            params,
         )
         self.assertAlmostEqual(float(rate[0, 0]), 0.0)
 
@@ -99,10 +119,19 @@ class WetDepTermTest(unittest.TestCase):
             temperature=jnp.full((nlev, ncols), 275.0),
             tracers=tracers,
         )
+        # Uniform formation through the column whose integral equals the
+        # surface precip (dm = rho * dz = 200 kg/m² per layer here), with
+        # the matching cumulative rain-flux profile — the per-level fields
+        # the cloud schemes now expose (#499).
+        dm = 1.0 * 200.0
+        form = jnp.full((nlev, ncols), precip / (nlev * dm))
+        rain_flux = jnp.cumsum(form * dm, axis=0)
         clouds = CloudData.zeros((ncols,), nlev).copy(
             cloud_fraction=jnp.full((nlev, ncols), 0.6),
             qc=jnp.full((nlev, ncols), 1.0e-3),
             precip_rain=jnp.full((ncols,), precip),
+            precip_formation_rate=form,
+            rain_flux=rain_flux,
         )
         diagnostics = {
             "_jam_state": aer,
@@ -248,6 +277,130 @@ class WetDepTermTest(unittest.TestCase):
         tend, _ = term(state, diagnostics, None, None)
         key = mass_name(spec.modes[0].species[0], spec.modes[0].short)
         self.assertTrue(np.all(np.isfinite(np.asarray(tend.tracers[key]))))
+
+    def test_incloud_driven_by_formation_not_surface_precip(self):
+        # The in-cloud pathway must key off the cloud scheme's per-level
+        # formation rate, not a reconstruction from the surface precip: a
+        # stale surface value with zero formation (and no flux profile)
+        # scavenges NOTHING. This fails on the pre-#499 reconstruction.
+        from jcm.physics.clouds.cloud_data import CloudData
+
+        state, diagnostics, spec, mass_name = self._setup()
+        nlev, ncols = state.temperature.shape
+        diagnostics = dict(diagnostics)
+        diagnostics["clouds"] = CloudData.zeros((ncols,), nlev).copy(
+            cloud_fraction=jnp.full((nlev, ncols), 0.6),
+            qc=jnp.full((nlev, ncols), 1.0e-3),
+            precip_rain=jnp.full((ncols,), 1.0e-3),   # stale, no formation
+        )
+        tend, _ = WetScavenging()(state, diagnostics, None, None)
+        for dq in tend.tracers.values():
+            np.testing.assert_array_equal(np.asarray(dq), 0.0)
+
+    def test_below_cloud_confined_below_formation(self):
+        # Impaction uses the per-level flux entering each layer: levels at
+        # and above the formation level see no falling precip and must not
+        # scavenge; levels below must. Probed with the non-activatable pcm
+        # mode (below-cloud is its only stratiform pathway).
+        from jcm.physics.clouds.cloud_data import CloudData
+
+        state, diagnostics, spec, mass_name = self._setup()
+        nlev, ncols = state.temperature.shape
+        dm = 200.0
+        form = jnp.zeros((nlev, ncols)).at[1].set(1.0e-7)
+        rain_flux = jnp.cumsum(form * dm, axis=0)
+        diagnostics = dict(diagnostics)
+        diagnostics["clouds"] = CloudData.zeros((ncols,), nlev).copy(
+            cloud_fraction=jnp.full((nlev, ncols), 0.6),
+            qc=jnp.full((nlev, ncols), 1.0e-3),
+            precip_rain=rain_flux[-1],
+            precip_formation_rate=form,
+            rain_flux=rain_flux,
+        )
+        tend, _ = WetScavenging()(state, diagnostics, None, None)
+        pcm = spec.mode("pcm")
+        dq = np.asarray(tend.tracers[mass_name(pcm.species[0], "pcm")])
+        np.testing.assert_array_equal(dq[0], 0.0)   # above formation
+        np.testing.assert_array_equal(dq[1], 0.0)   # the forming layer itself
+        self.assertTrue(np.all(dq[2:] < 0.0))       # washed out below
+
+    def test_reinjection_returns_scavenged_aerosol_where_precip_evaporates(self):
+        # Cloud-borne aerosol scavenged in the cloudy upper levels rides
+        # the rain down; a fully-evaporating layer below must re-inject it
+        # into the INTERSTITIAL phase there, and the term's column budget
+        # (removal + re-injection integrated over dm) must equal the
+        # surviving surface flux exactly.
+        from jcm.physics.clouds.cloud_data import CloudData
+        from jcm.physics.aerosol.jam import number_name
+
+        state, diagnostics, spec, mass_name = self._setup()
+        nlev, ncols = state.temperature.shape
+        # LEVEL-DEPENDENT layer mass: the budget's dm weightings cancel on
+        # a uniform grid (budget(x*dm)/dm == budget(x)), so a misplaced dm
+        # would be invisible there — vary it so it isn't.
+        dz = jnp.array([300.0, 250.0, 200.0, 150.0])[:, None] * jnp.ones(
+            (1, ncols)
+        )
+        dm = 1.0 * dz
+        diagnostics = dict(diagnostics)
+        diagnostics["layer_thickness"] = dz
+        # Rain forms at levels 0-1; level 2's evaporation consumes the
+        # whole accumulated carrier (evap*dm2 == form*(dm0+dm1)); none
+        # below.
+        form = jnp.zeros((nlev, ncols)).at[0].set(1.0e-7).at[1].set(1.0e-7)
+        evap_rate = 1.0e-7 * (300.0 + 250.0) / 200.0
+        evap = jnp.zeros((nlev, ncols)).at[2].set(evap_rate)
+        cf = jnp.zeros((nlev, ncols)).at[0:2].set(0.6)
+        diagnostics["clouds"] = CloudData.zeros((ncols,), nlev).copy(
+            cloud_fraction=cf,
+            qc=jnp.zeros((nlev, ncols)).at[0:2].set(1.0e-3),
+            precip_formation_rate=form,
+            precip_evaporation_rate=evap,
+        )
+        # Isolate the in-cloud pathway: no impaction.
+        params = WetDepParameters(
+            incloud_scale=jnp.asarray(1.0),
+            below_coeff=jnp.asarray(0.0),
+            below_radius_ref=jnp.asarray(1.0e-7),
+            conv_scav_ratio=jnp.asarray(0.99),
+        )
+        term = WetScavenging(params=params)
+        tend, _ = term(state, diagnostics, None, None)
+
+        mode = spec.modes[0]
+        cb = np.asarray(
+            tend.tracers[mass_name(mode.species[0], mode.short,
+                                   cloud_borne=True)]
+        )
+        it = np.asarray(tend.tracers[mass_name(mode.species[0], mode.short)])
+        # Removal only where condensate converts (levels 0-1), from the
+        # cloud-borne tracer.
+        self.assertTrue(np.all(cb[0:2] < 0.0))
+        np.testing.assert_array_equal(cb[2:], 0.0)
+        # Re-injection lands in the INTERSTITIAL tracer in the evap layer.
+        self.assertTrue(np.all(it[2] > 0.0))
+        np.testing.assert_array_equal(it[[0, 1, 3]], 0.0)
+        # Column budget: everything scavenged was re-released (full evap),
+        # for mass and number alike.
+        dm_np = np.asarray(dm)
+        for pair in (
+            (mass_name(mode.species[0], mode.short, cloud_borne=True),
+             mass_name(mode.species[0], mode.short)),
+            (number_name(mode.short, cloud_borne=True),
+             number_name(mode.short)),
+        ):
+            net = sum(np.asarray(tend.tracers[nm]) * dm_np for nm in pair)
+            # Tolerance relative to the gross removal: the evap fraction
+            # carries f32 round-off from the cumsum/divide, so "everything
+            # re-released" holds to ~1e-6 of what was scavenged, not to
+            # absolute zero on 1e8-scale number tracers.
+            gross = float(
+                np.sum(np.abs(np.asarray(tend.tracers[pair[0]])) * dm_np)
+            )
+            np.testing.assert_allclose(
+                np.sum(net, axis=0), 0.0, atol=max(1e-5 * gross, 1e-20),
+                err_msg=str(pair),
+            )
 
     def test_cloud_borne_removed_at_full_incloud_rate(self):
         # Cloud-borne aerosol is entirely in-droplet: its stratiform removal

--- a/jcm/physics/aerosol/jam/wetdep/wetdep_test.py
+++ b/jcm/physics/aerosol/jam/wetdep/wetdep_test.py
@@ -324,38 +324,64 @@ class WetDepTermTest(unittest.TestCase):
         import dataclasses
         from jcm.physics.aerosol.jam import MAM4_SPEC
 
-        state, diagnostics, spec, mass_name = self._setup(precip=1.0e-7)
-        cf, af, q_tot = 0.6, 0.7, 1.0e-9
-        diagnostics = dict(diagnostics)
-        diagnostics["activated_fraction"] = jnp.full_like(
-            diagnostics["activated_fraction"], af
+        from jcm.physics.aerosol.jam import MAM4_SPEC as SPEC, number_name
+        from jcm.physics.aerosol.jam.activation.arg_term import (
+            JamActivationData,
         )
+
+        state, diagnostics, spec, mass_name = self._setup(precip=1.0e-7)
+        cf, q_tot, n_tot = 0.6, 1.0e-9, 1.0e8
+        shape = state.temperature.shape
+        # Distinct per-mode AND per-quantity fractions, so using the
+        # aggregate (or the wrong one of the pair, or the wrong mode's)
+        # anywhere breaks the match.
+        n_modes = SPEC.n_modes()
+        can = jnp.asarray(
+            [float(m.can_activate) for m in SPEC.modes]
+        ).reshape(-1, 1, 1)
+        per_mode = can / (1.0 + jnp.arange(n_modes).reshape(-1, 1, 1))
+        act = JamActivationData(
+            number_frac=per_mode * jnp.full((n_modes,) + shape, 0.4),
+            mass_frac=per_mode * jnp.full((n_modes,) + shape, 0.8),
+        )
+        diagnostics = dict(diagnostics)
+        diagnostics["_jam_activation"] = act
         params = WetDepParameters(
             incloud_scale=jnp.asarray(1.0),
             below_coeff=jnp.asarray(0.0),
             below_radius_ref=jnp.asarray(1.0e-7),
             conv_scav_ratio=jnp.asarray(0.99),
         )
-        key_int = mass_name(spec.modes[0].species[0], spec.modes[0].short)
-        key_cb = mass_name(spec.modes[0].species[0], spec.modes[0].short,
-                           cloud_borne=True)
 
-        # Explicit: the pair partitioned at the exchange equilibrium.
-        q_cb = cf * af * q_tot
+        # The (interstitial key, cloud-borne key, total, fraction) tuples
+        # under test: mass and number of the first two activatable modes.
+        cases = []
+        for i in (0, 1):
+            mode = SPEC.modes[i]
+            fn = float(act.number_frac[i, 0, 0])
+            fm = float(act.mass_frac[i, 0, 0])
+            cases.append((number_name(mode.short),
+                          number_name(mode.short, cloud_borne=True),
+                          n_tot, fn))
+            cases.append((mass_name(mode.species[0], mode.short),
+                          mass_name(mode.species[0], mode.short,
+                                    cloud_borne=True),
+                          q_tot, fm))
+
+        # Explicit: each pair partitioned at its own exchange equilibrium.
         tracers = dict(state.tracers)
-        tracers[key_int] = jnp.full_like(tracers[key_int], q_tot - q_cb)
-        tracers[key_cb] = jnp.full_like(tracers[key_cb], q_cb)
+        for key_int, key_cb, tot, frac in cases:
+            q_cb = cf * frac * tot
+            tracers[key_int] = jnp.full_like(tracers[key_int], tot - q_cb)
+            tracers[key_cb] = jnp.full_like(tracers[key_cb], q_cb)
         tend_exp, _ = WetScavenging(params=params)(
             state.copy(tracers=tracers), diagnostics, None, None,
         )
-        removed_explicit = -(
-            np.asarray(tend_exp.tracers[key_int])
-            + np.asarray(tend_exp.tracers[key_cb])
-        )
 
-        # Implicit: all of q_tot interstitial, activated-fraction scavenged.
+        # Implicit: everything interstitial, per-mode-fraction scavenged.
         tracers = dict(state.tracers)
-        tracers[key_int] = jnp.full_like(tracers[key_int], q_tot)
+        for key_int, _, tot, _ in cases:
+            tracers[key_int] = jnp.full_like(tracers[key_int], tot)
         implicit = WetScavenging(
             params=params,
             spec=dataclasses.replace(MAM4_SPEC, cloud_borne=False),
@@ -363,12 +389,18 @@ class WetDepTermTest(unittest.TestCase):
         tend_imp, _ = implicit(
             state.copy(tracers=tracers), diagnostics, None, None,
         )
-        removed_implicit = -np.asarray(tend_imp.tracers[key_int])
 
-        self.assertGreater(float(removed_explicit.max()), 0.0)
-        np.testing.assert_allclose(
-            removed_implicit, removed_explicit, rtol=5e-3,
-        )
+        for key_int, key_cb, tot, frac in cases:
+            removed_explicit = -(
+                np.asarray(tend_exp.tracers[key_int])
+                + np.asarray(tend_exp.tracers[key_cb])
+            )
+            removed_implicit = -np.asarray(tend_imp.tracers[key_int])
+            self.assertGreater(float(removed_explicit.max()), 0.0, key_int)
+            np.testing.assert_allclose(
+                removed_implicit, removed_explicit, rtol=5e-3,
+                err_msg=key_int,
+            )
 
     def test_grad_through_below_coeff(self):
         state, diagnostics, spec, mass_name = self._setup()

--- a/jcm/physics/aerosol/jam/wetdep/wetdep_test.py
+++ b/jcm/physics/aerosol/jam/wetdep/wetdep_test.py
@@ -22,31 +22,45 @@ class ScavengingFunctionTest(unittest.TestCase):
         # layer releases half, a full-evap layer releases the rest, and
         # nothing reaches the surface. sum(scavenged - reinjected) must
         # equal the surface flux EXACTLY at every column.
-        scavenged = jnp.zeros((1, 3, 1)).at[0, 0, 0].set(2.0)
+        none = jnp.zeros((1, 3, 1))
+        scavenged = none.at[0, 0, 0].set(2.0)
         evap_frac = jnp.array([[0.0], [0.5], [1.0]])
-        reinjected, surface = reinjection_budget(scavenged, evap_frac)
+        reinjected, surface = reinjection_budget(none, scavenged, evap_frac)
         np.testing.assert_allclose(np.asarray(reinjected[0, :, 0]),
                                    [0.0, 1.0, 1.0])
         np.testing.assert_allclose(np.asarray(surface), 0.0)
         # Partial evap: the un-released remainder deposits.
         evap_frac = jnp.array([[0.0], [0.25], [0.0]])
-        reinjected, surface = reinjection_budget(scavenged, evap_frac)
+        reinjected, surface = reinjection_budget(none, scavenged, evap_frac)
         np.testing.assert_allclose(np.asarray(surface[0, 0]), 1.5)
         np.testing.assert_allclose(
             float(jnp.sum(scavenged - reinjected)), float(surface[0, 0]),
         )
 
-    def test_same_layer_scavenge_and_full_evap_releases_everything(self):
-        # Virga: aerosol impacted out within a fully-evaporating layer must
-        # be released there too, not ride a terminated carrier to the
-        # surface through dry air (the layer's scavenging joins the ledger
-        # BEFORE the release, as in HAMMOZ). The pre-fix ordering deposited
-        # it all.
-        scavenged = jnp.zeros((1, 3, 1)).at[0, 2, 0].set(1.0)
+    def test_virga_releases_same_layer_impaction(self):
+        # Aerosol impacted out of the INCOMING precip within a fully-
+        # evaporating layer must be released there too, not ride a
+        # terminated carrier to the surface through dry air (impaction
+        # joins the ledger before the release, as in HAMMOZ).
+        none = jnp.zeros((1, 3, 1))
+        impacted = none.at[0, 2, 0].set(1.0)
         evap_frac = jnp.zeros((3, 1)).at[2].set(1.0)
-        reinjected, surface = reinjection_budget(scavenged, evap_frac)
+        reinjected, surface = reinjection_budget(impacted, none, evap_frac)
         np.testing.assert_allclose(np.asarray(reinjected[0, 2, 0]), 1.0)
         np.testing.assert_allclose(np.asarray(surface), 0.0)
+
+    def test_formation_in_full_evap_layer_still_deposits(self):
+        # Codex P1 on #612: the incoming carrier's evaporation cannot touch
+        # precip NEWLY FORMED in the same layer — both cloud schemes cap
+        # evaporation by the incoming flux and add formation after. Aerosol
+        # scavenged into that new precip must continue downward, not be
+        # released by an evap fraction that belongs to the old carrier.
+        none = jnp.zeros((1, 3, 1))
+        formed = none.at[0, 1, 0].set(1.0)
+        evap_frac = jnp.zeros((3, 1)).at[1].set(1.0)
+        reinjected, surface = reinjection_budget(none, formed, evap_frac)
+        np.testing.assert_allclose(np.asarray(reinjected), 0.0)
+        np.testing.assert_allclose(np.asarray(surface[0, 0]), 1.0)
 
     def test_in_cloud_rate_scales_with_activation(self):
         pf = jnp.full((1, 1), 1.0e-6)

--- a/jcm/physics/clouds/cloud_data.py
+++ b/jcm/physics/clouds/cloud_data.py
@@ -40,6 +40,20 @@ class CloudData:
     # bottom level.
     rain_flux: jnp.ndarray           # LS rain flux [kg/m²/s] (nlev, ncols)
     snow_flux: jnp.ndarray           # LS snow(+ice) flux [kg/m²/s] (nlev, ncols)
+    # Per-level precipitation process rates (#499), grid-mean [kg/kg/s]:
+    # the condensate→precip conversion (rain: autoconversion + accretion;
+    # frozen: ice autoconversion + aggregation + riming) and the
+    # evaporation/sublimation of the falling stratiform precip (rain
+    # evaporation + snow sublimation; the sedimenting cloud-ice flux's own
+    # sublimation is not included — it is not a scavenging carrier, which
+    # also means the cirrus ice that reaches the surface as snow removes no
+    # aerosol). These
+    # are the rates the schemes actually integrate, exposed for JAM wet
+    # scavenging (in-cloud nucleation removal at the true local formation
+    # rate; re-injection of scavenged aerosol where precip re-evaporates)
+    # instead of a column reconstruction from the surface fluxes.
+    precip_formation_rate: jnp.ndarray    # (nlev, ncols)
+    precip_evaporation_rate: jnp.ndarray  # (nlev, ncols)
     # Column-integrated rain-source split [kg/m²/s], written by the 2M
     # scheme (zero under 1M, which does not separate the pathways): rain
     # formed by the warm chain (autoconversion + accretion of liquid) and
@@ -90,6 +104,8 @@ class CloudData:
             precip_snow=jnp.zeros(nodal_shape),
             rain_flux=jnp.zeros((nlev,) + nodal_shape),
             snow_flux=jnp.zeros((nlev,) + nodal_shape),
+            precip_formation_rate=jnp.zeros((nlev,) + nodal_shape),
+            precip_evaporation_rate=jnp.zeros((nlev,) + nodal_shape),
             rain_formation_warm=jnp.zeros(nodal_shape),
             rain_from_melt=jnp.zeros(nodal_shape),
             droplet_number=jnp.zeros((nlev,) + nodal_shape),
@@ -112,6 +128,8 @@ class CloudData:
             'precip_snow': self.precip_snow,
             'rain_flux': self.rain_flux,
             'snow_flux': self.snow_flux,
+            'precip_formation_rate': self.precip_formation_rate,
+            'precip_evaporation_rate': self.precip_evaporation_rate,
             'rain_formation_warm': self.rain_formation_warm,
             'rain_from_melt': self.rain_from_melt,
             'droplet_number': self.droplet_number,

--- a/jcm/physics/clouds/echam_1m.py
+++ b/jcm/physics/clouds/echam_1m.py
@@ -194,6 +194,7 @@ class MicrophysicsState(NamedTuple):
     snow_flux: jnp.ndarray      # Snow(+falling-ice) flux leaving each level
     rain_source: jnp.ndarray    # Per-layer rain production (kg/m²/s)
     snow_source: jnp.ndarray    # Per-layer snow production (kg/m²/s)
+    rain_evap_flux: jnp.ndarray  # Per-layer rain evaporation (kg/m²/s, #499)
 
     # In-cloud values
     qc_in_cloud: jnp.ndarray    # In-cloud liquid water (kg/kg)
@@ -1110,6 +1111,12 @@ def cloud_microphysics_column_sweep(
             dTdt, dqdt, dqcdt, dqidt, rain_source, snow_source,
             autoconv_rate_diag, accretion_rate_diag,
             zrfl_out, zsfl_out + zxiflux_out,
+            # Per-layer rain evaporation flux (#499): the depletion the
+            # flux ledger above already applied, exposed for the JAM
+            # wet-scavenging re-injection budget. The 1M scheme has no
+            # snow sublimation, so this is the whole stratiform
+            # evaporation term.
+            rain_evap_flux,
         )
         return (zrfl_out, zsfl_out, zclcpre_out, zxiflux_out), out
 
@@ -1126,7 +1133,7 @@ def cloud_microphysics_column_sweep(
         level_inputs,
     )
     (dtedt, dqdt, dqcdt, dqidt, rain_source, snow_source, autoconv_rate,
-     accretion_rate, rain_flux, snow_flux) = per_level_out
+     accretion_rate, rain_flux, snow_flux, rain_evap_flux) = per_level_out
 
     tendencies = MicrophysicsTendencies(
         dtedt=dtedt, dqdt=dqdt, dqcdt=dqcdt, dqidt=dqidt,
@@ -1147,6 +1154,7 @@ def cloud_microphysics_column_sweep(
     state = MicrophysicsState(
         rain_flux=rain_flux, snow_flux=snow_flux,
         rain_source=rain_source, snow_source=snow_source,
+        rain_evap_flux=rain_evap_flux,
         qc_in_cloud=qc_in_cloud, qi_in_cloud=qi_in_cloud,
         autoconv_rate=autoconv_rate, accretion_rate=accretion_rate,
         melting_rate=jnp.zeros(nlev), freezing_rate=jnp.zeros(nlev),
@@ -1319,6 +1327,17 @@ class Echam1MMicrophysics(PhysicsTerm):
             # CloudData layout, same as the tendency fields above.
             rain_flux=micro_state.rain_flux.T,
             snow_flux=micro_state.snow_flux.T,
+            # Per-level process rates for JAM wet scavenging (#499),
+            # converted from the sweep's per-layer fluxes [kg/m²/s] to
+            # grid-mean mixing-ratio rates [kg/kg/s] with the layer mass.
+            # Formation is the full condensate→precip ledger (rain: autoconv
+            # + accretion; snow: ice autoconv + aggregation + riming);
+            # evaporation is Rotstayn rain evap (the 1M scheme has no snow
+            # sublimation).
+            precip_formation_rate=(
+                micro_state.rain_source + micro_state.snow_source
+            ).T / dm_col.T,
+            precip_evaporation_rate=micro_state.rain_evap_flux.T / dm_col.T,
             droplet_number=cdnc_m3,
         )
 

--- a/jcm/physics/clouds/echam_1m_test.py
+++ b/jcm/physics/clouds/echam_1m_test.py
@@ -417,6 +417,52 @@ class TestColumnSweepMicrophysics:
         assert rain_source_total > 0.0, "autoconv didn't fire — adjust q profile"
         assert float(state.precip_rain) < rain_source_total
 
+    def test_rain_evap_flux_closes_the_warm_flux_ledger(self):
+        """The exposed per-level rain evaporation closes the rain-flux ledger.
+
+        On an all-warm column (no snow, no melt) the sweep's flux update is
+        exactly ``rain_flux[k] = rain_flux[k-1] + rain_source[k] -
+        rain_evap_flux[k]``, so the new #499 diagnostic must satisfy that
+        identity level by level, with evaporation active (nonzero) in the
+        sub-saturated layers below the cloud and never exceeding the
+        available flux.
+        """
+        import numpy as np
+        from jcm.physics.clouds.sundqvist import saturation_specific_humidity
+        cfg = MicrophysicsParameters.default()
+        nlev = 20
+        T = jnp.linspace(280.0, 300.0, nlev)
+        p = jnp.linspace(20000.0, 100000.0, nlev)
+        qsw = jax.vmap(saturation_specific_humidity)(p, T)
+        # Moist enough below cloud that evap never zeroes the flux (the
+        # ledger clamp stays slack), dry enough that evap is nonzero.
+        cloud_level = 5
+        q = jnp.where(
+            jnp.arange(nlev) == cloud_level, 0.95 * qsw, 0.6 * qsw,
+        )
+        qc = jnp.zeros(nlev).at[cloud_level].set(2e-3)
+        qi = jnp.zeros(nlev)
+        cf = jnp.where(qc > 0, 0.7, 0.0)
+        rho = p / (287.0 * T)
+        dz = jnp.full(nlev, 500.0)
+        ndrop = jnp.full(nlev, 1e8)
+        _, state = cloud_microphysics_column_sweep(
+            T, q, p, qc, qi, cf, rho, dz, ndrop, dt=1800.0, config=cfg,
+        )
+        assert float(jnp.sum(state.snow_source)) == 0.0
+        assert float(jnp.max(state.rain_evap_flux)) > 0.0
+        assert float(jnp.min(state.rain_evap_flux)) >= 0.0
+        rain_in = jnp.concatenate([jnp.zeros(1), state.rain_flux[:-1]])
+        # atol covers f32 round-off relative to the ~1e-4 kg/m²/s flux
+        # scale (observed residual ~2.5e-13 where evap consumes ~all of
+        # the inflow).
+        np.testing.assert_allclose(
+            np.asarray(state.rain_flux),
+            np.asarray(rain_in + state.rain_source - state.rain_evap_flux),
+            rtol=1e-6, atol=1e-10,
+        )
+        assert float(state.rain_flux.min()) >= 0.0
+
     def test_snow_above_warm_layer_melts_to_rain(self):
         """Snow flux generated aloft melts as it falls into T>273K layers."""
         cfg = MicrophysicsParameters.default()

--- a/jcm/physics/clouds/lohmann_2m/scheme.py
+++ b/jcm/physics/clouds/lohmann_2m/scheme.py
@@ -772,12 +772,25 @@ def cloud_microphysics_2m(
     # stacked from the scan ys) go last so existing ``tend, rain, snow,
     # *_`` call sites keep working; their bottom row equals the surface
     # fluxes by construction (same carry values).
+    # Per-level precip process rates for JAM wet scavenging (#499), grid
+    # mean [kg/kg/s]. Formation is the full condensate→precip ledger the
+    # flux update integrates: the warm chain (KK2000 autoconversion +
+    # accretion, ``qr_gain_warm``), riming (``psacl``) and the cold snow
+    # formation. Evaporation is rain evap + snow sublimation; the falling
+    # cloud-ice sublimation (``ice_sublim``) is deliberately excluded — the
+    # sedimenting ice flux is not a scavenging carrier.
+    precip_formation_rate = (
+        qr_gain_warm + psacl + snow_formation_gridmean
+    ) / dt
+    precip_evaporation_rate = (rain_evap + snow_sublim) / dt
+
     # NOTE the (nlev,) rain / frozen flux profiles stay LAST: call sites and
     # tests unpack them positionally from the end (``*_, rain_b, snow_b``),
-    # so new scalars are inserted before them, not appended.
+    # so new outputs are inserted before them, not appended.
     return tendencies, surface_rain_flux, surface_snow_flux, \
         liq_eff_radius, ice_eff_radius, rain_formation_warm, rain_from_melt, \
         autoconv_rate_col, accretion_rate_col, wbf_rate_col, \
+        precip_formation_rate, precip_evaporation_rate, \
         rain_flux_profile, snow_flux_profile
 
 
@@ -942,10 +955,11 @@ class Lohmann2MMicrophysics(PhysicsTerm):
         (tend_all, surface_rain_flux, surface_snow_flux,
          r_eff_liq_all, r_eff_ice_all, rain_formation_warm, rain_from_melt,
          autoconv_all, accretion_all, wbf_all,
+         precip_form_all, precip_evap_all,
          rain_flux_all, snow_flux_all) = jax.vmap(
             cloud_microphysics_2m,
             in_axes=(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, None, None),
-            out_axes=(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+            out_axes=(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
         )(
             temperature_in, specific_humidity_in, pressure_full,
             qc_interim, qi_interim, qnc, qni, qr, qs,
@@ -1001,6 +1015,10 @@ class Lohmann2MMicrophysics(PhysicsTerm):
             # CloudData layout, same as the effective radii below.
             rain_flux=rain_flux_all.T,
             snow_flux=snow_flux_all.T,
+            # Per-level precip formation / evaporation rates [kg/kg/s] for
+            # JAM wet scavenging (#499); see cloud_microphysics_2m.
+            precip_formation_rate=precip_form_all.T,
+            precip_evaporation_rate=precip_evap_all.T,
             # Microphysical effective radii (um) for the radiation term
             # (ECHAM preffl/preffi; consumed next step via the carry —
             # same lag as every cross-term diagnostic).

--- a/jcm/physics/clouds/lohmann_2m_test.py
+++ b/jcm/physics/clouds/lohmann_2m_test.py
@@ -1452,6 +1452,111 @@ class TestColumnWaterConservation2M:
             f"(gross movement {gross:.3e}, precip {P:.3e})"
         )
 
+    def test_precip_process_rates_close_the_warm_ledger(self):
+        """The #499 per-level formation/evaporation rates are the true ledger.
+
+        On an all-warm liquid column (no ice, snow or melt) every kg of
+        surface rain was formed minus evaporated on the way down, so the
+        new grid-mean [kg/kg/s] outputs must satisfy
+        ``rain_sfc == sum((formation - evaporation) * rho * dz)`` — a
+        units-and-sign check that also fails if a pathway (accretion,
+        riming) is missing from the formation sum.
+        """
+        import numpy as np
+        from jcm.physics.clouds.lohmann_2m import cloud_microphysics_2m
+        from jcm.physics.clouds.lohmann_2m_params import CloudParams2M
+        from jcm.physics.clouds.sundqvist import saturation_specific_humidity
+
+        nlev = 20
+        T = jnp.linspace(280.0, 300.0, nlev)
+        p = jnp.linspace(2e4, 1e5, nlev)
+        rho = p / (287.0 * T)
+        qsw = jax.vmap(saturation_specific_humidity)(p, T)
+        q = jnp.where(
+            (jnp.arange(nlev) >= 10) & (jnp.arange(nlev) < 16),
+            0.95 * qsw, 0.7 * qsw,
+        )
+        qc = jnp.zeros(nlev).at[10:16].set(1e-3)
+        cf = jnp.where(qc > 0, 0.7, 0.0)
+        dz = jnp.full(nlev, 500.0)
+        qnc = jnp.where(qc > 0, 5e7, 0.0)
+        params = CloudParams2M.default()
+
+        (tend, rain_sfc, snow_sfc, _rl, _ri, _rfw, _rfm, _au, _ac, _wbf,
+         form, evap, rain_prof, snow_prof) = cloud_microphysics_2m(
+            T, q, p, qc, jnp.zeros(nlev), qnc, jnp.zeros(nlev),
+            jnp.zeros(nlev), jnp.zeros(nlev), cf, rho, dz,
+            jnp.full(nlev, 0.1), jnp.full(nlev, 5e7),
+            jnp.zeros(nlev), jnp.zeros(nlev),
+            1800.0, params,
+        )
+        assert form.shape == (nlev,) and evap.shape == (nlev,)
+        assert float(jnp.min(form)) >= 0.0
+        assert float(jnp.min(evap)) >= 0.0
+        assert float(snow_sfc) == 0.0
+        assert float(rain_sfc) > 0.0, "no rain formed — fixture too dry"
+        assert float(jnp.max(evap)) > 0.0, "no evap — fixture too moist"
+        mref = np.asarray(rho * dz)
+        np.testing.assert_allclose(
+            float(rain_sfc),
+            float(np.sum((np.asarray(form) - np.asarray(evap)) * mref)),
+            rtol=1e-5,
+        )
+
+    def test_precip_process_rates_cover_the_cold_chain(self):
+        """The #499 formation rate must use the GRID-MEAN snow-side terms.
+
+        An all-cold ice column (no liquid, no melt) with numerous small
+        crystals (high ICNC → slow sedimentation, so the folded cloud-ice
+        flux is a small correction) forms snow through the cold chain
+        alone. The surface snow must then be bracketed by the
+        (formation − evaporation) column ledger: equal up to the small
+        sedimenting-ice contribution. An implementation that grabbed the
+        IN-CLOUD cold-formation variants instead of the grid-mean ones
+        overshoots by 1/cf ≈ 1.4x and breaks the upper bracket.
+        """
+        import numpy as np
+        from jcm.physics.clouds.lohmann_2m import cloud_microphysics_2m
+        from jcm.physics.clouds.lohmann_2m_params import CloudParams2M
+        from jcm.physics.clouds.sundqvist import saturation_specific_humidity
+
+        nlev = 20
+        T = jnp.linspace(215.0, 262.0, nlev)          # never melts
+        p = jnp.linspace(2e4, 7e5 / 10.0, nlev)
+        rho = p / (287.0 * T)
+        qsw = jax.vmap(saturation_specific_humidity)(p, T)
+        q = 0.9 * qsw
+        qi = jnp.zeros(nlev).at[8:14].set(3e-4)
+        qni = jnp.where(qi > 0, 1e6, 0.0)             # many small crystals
+        cf = jnp.where(qi > 0, 0.7, 0.0)
+        dz = jnp.full(nlev, 500.0)
+        params = CloudParams2M.default()
+
+        (tend, rain_sfc, snow_sfc, _rl, _ri, _rfw, _rfm, _au, _ac, _wbf,
+         form, evap, _rp, _sp) = cloud_microphysics_2m(
+            T, q, p, jnp.zeros(nlev), qi, jnp.zeros(nlev), qni,
+            jnp.zeros(nlev), jnp.zeros(nlev), cf, rho, dz,
+            jnp.full(nlev, 0.1), jnp.full(nlev, 5e7),
+            jnp.zeros(nlev), jnp.zeros(nlev),
+            1800.0, params,
+        )
+        mref = np.asarray(rho * dz)
+        ledger = float(np.sum((np.asarray(form) - np.asarray(evap)) * mref))
+        total_sfc = float(rain_sfc + snow_sfc)
+        assert total_sfc > 0.0, "cold chain made no precip — fixture off"
+        assert ledger > 0.0
+        # Ledger ≤ surface (the sedimenting-ice fold adds mass the ledger
+        # deliberately excludes), and covers at least 60% of it (the
+        # crystals are small and slow, so the fold is a minor term). An
+        # in-cloud/grid-mean mixup (~1.4x) breaks the first bound.
+        assert ledger <= total_sfc * (1.0 + 1e-5), (
+            f"ledger {ledger:.3e} exceeds surface {total_sfc:.3e}"
+        )
+        assert ledger >= 0.6 * total_sfc, (
+            f"ledger {ledger:.3e} vs surface {total_sfc:.3e} — cold-chain "
+            "formation missing from the #499 rate"
+        )
+
     def test_cold_supersaturation_is_consumed(self):
         """Sub-cthomi supersaturation must deposit onto diagnosed ICNC.
 

--- a/jcm/physics/composable_physics.py
+++ b/jcm/physics/composable_physics.py
@@ -456,6 +456,10 @@ class ComposablePhysics(nnx.Module, Physics):
         "_echam_params",
         "_echam_coords",
         "_speedy_coords",
+        # Per-mode ARG activated fractions — inter-term plumbing for the
+        # cloud-borne exchange (#602), not an output field (the totals a
+        # user wants are ``activated_cdnc``/``activated_fraction``).
+        "_jam_activation",
         # Running tendency view for diagnostics (see the term loop); an
         # intermediate, not a field anyone wants in the netCDF.
         "_tendency_run",

--- a/jcm/physics/convection/tiedtke_nordeng/tiedtke_nordeng.py
+++ b/jcm/physics/convection/tiedtke_nordeng/tiedtke_nordeng.py
@@ -106,7 +106,7 @@ def initialize_convection(temperature: jnp.ndarray,
     return ConvectionState(
         tu=tu, qu=qu, lu=lu, uu=uu, vu=vu,
         td=td, qd=qd, ud=ud, vd=vd,
-        mfu=mfu, mfd=mfd,
+        mfu=mfu, mfd=mfd, entr=jnp.zeros_like(temperature),
         ktype=ktype, kbase=kbase, ktop=ktop,
         prate=prate
     )
@@ -878,6 +878,10 @@ def tiedtke_nordeng_convection(
             td=downdraft_state.td, qd=downdraft_state.qd,
             ud=u_wind, vd=v_wind,  # Simplified
             mfu=updraft_state.mfu, mfd=downdraft_state.mfd,
+            # Fractional entrainment (1/m) is rescale-invariant (a rate,
+            # not a flux); the transport term rebuilds the absolute
+            # entrainment flux against the rescaled mfu.
+            entr=updraft_state.entr,
             ktype=jnp.asarray(conv_type, dtype=jnp.int32),
             kbase=jnp.array(cloud_base),
             ktop=actual_ktop, prate=enhanced_tendencies.precip_conv,
@@ -1147,17 +1151,41 @@ class TiedtkeConvection(PhysicsTerm):
             },
         )
 
-        # Mass-flux / cloud-base/top / CAPE diagnostics aren't populated
-        # by the wrapper today (the scheme returns the per-column state
-        # but we don't reduce or surface it yet) — they stay as zeros
-        # for back-compat with existing xarray field names. The heating /
+        # Cloud-base/top / CAPE diagnostics aren't populated by the
+        # wrapper today (the scheme returns the per-column state but we
+        # don't reduce or surface it yet) — they stay as zeros for
+        # back-compat with existing xarray field names. The heating /
         # moistening rates, by contrast, are the *applied* (post-cap)
         # tendencies returned above, surfaced so downstream analysis (e.g.
         # an RCE convective-vs-radiative heating balance) reads them straight
         # off the trajectory instead of re-running the term.
+        #
+        # Mass fluxes and the absolute entrainment flux (#602) carry the
+        # SAME per-column cap scaling as the tendency ledger, so the
+        # tracer transport they drive stays proportional to the heat and
+        # moisture transport actually applied. ``entr`` is the fractional
+        # rate (1/m); the absolute per-layer entrainment flux is
+        # ``entr_k · mfu_{k+1} · dz_k`` (the plume entrains against the
+        # flux ENTERING the layer from below — updraft.py's ``dmf_entr``).
+        # Custom/test schemes may return no state — zeros then (like
+        # ktype), meaning no convective tracer transport.
+        if _state_all is not None:
+            _mfu = (_state_all.mfu * cap_scale).T          # (nlev, ncols)
+            _mfd = (_state_all.mfd * cap_scale).T
+            _mfu_below = jnp.concatenate(
+                [_mfu[1:], jnp.zeros_like(_mfu[:1])], axis=0
+            )
+            _entrain = (
+                _state_all.entr.T * _mfu_below * layer_thickness
+            )
+        else:
+            _mfu = jnp.zeros_like(pressure_full)
+            _mfd = jnp.zeros_like(pressure_full)
+            _entrain = jnp.zeros_like(pressure_full)
         convection = ConvectionData(
-            mass_flux_up=jnp.zeros_like(pressure_full),
-            mass_flux_down=jnp.zeros_like(pressure_full),
+            mass_flux_up=_mfu,
+            mass_flux_down=_mfd,
+            entrain_up=_entrain,
             cloud_base=jnp.zeros(ncols, dtype=int),
             cloud_top=jnp.zeros(ncols, dtype=int),
             cape=jnp.zeros(ncols),

--- a/jcm/physics/convection/tiedtke_nordeng/tiedtke_nordeng_test.py
+++ b/jcm/physics/convection/tiedtke_nordeng/tiedtke_nordeng_test.py
@@ -330,6 +330,70 @@ def test_wrapper_surfaces_applied_convective_heating_and_moistening(monkeypatch)
     )
 
 
+def test_wrapper_publishes_mass_flux_ledger_for_tracer_transport():
+    """The convection diagnostic carries the updraft ledger (#602 item 2).
+
+    ``mass_flux_up`` / ``entrain_up`` were zero-filled before the
+    convective tracer transport landed; a real convecting column must now
+    publish a physical ledger: non-negative fluxes, nonzero where deep
+    convection is active, and no entrainment where there is no carrying
+    flux entering from below (``entrain_up = entr·mfu_below·dz`` by
+    construction, so the cloud-base supply appears via plume continuity,
+    not as entrainment).
+    """
+    import numpy as np
+    from jcm.physics.convection.saturation import (
+        saturation_specific_humidity,
+    )
+    from jcm.constants import grav, rd
+
+    nlev, ncols = 8, 1
+    # Top-first unstable moist column (the SPEEDY-style moist-adiabat
+    # fixture, reversed to the physics-internal orientation).
+    T = jnp.array([210., 230., 250., 265., 275., 285., 295., 300.])[:, None]
+    p = (jnp.array(
+        [0.025, 0.095, 0.2, 0.34, 0.51, 0.685, 0.835, 0.95]
+    ) * 1e5)[:, None]
+    qs = jax.vmap(
+        lambda pp, tt: saturation_specific_humidity(tt, pp)
+    )(p[:, 0], T[:, 0])[:, None]
+    rh = jnp.array([0.5, 0.7, 0.75, 0.7, 0.65, 0.6, 0.8, 0.85])[:, None]
+    rho = p / (rd * T)
+    dz = jnp.abs(jnp.diff(
+        -rd * T[:, 0] / grav * jnp.log(p[:, 0] / 1e5), append=0.0,
+    ))[:, None] + 500.0
+    state = PhysicsState.zeros(
+        (nlev, ncols), temperature=T, specific_humidity=rh * qs,
+        tracers={"qc": jnp.zeros((nlev, ncols)),
+                 "qi": jnp.zeros((nlev, ncols))},
+    )
+    diagnostics = {
+        "_dt_seconds": 900.0,
+        "pressure_full": p,
+        "layer_thickness": dz,
+        "air_density": rho,
+        "clouds": CloudData.zeros((ncols,), nlev),
+    }
+    terrain = SimpleNamespace(fmask=jnp.zeros(ncols))
+
+    _, diagnostics_out = TiedtkeConvection()(
+        state, diagnostics, forcing=None, terrain=terrain,
+    )
+    conv = diagnostics_out["convection"]
+    mfu = np.asarray(conv.mass_flux_up[:, 0])
+    entrain = np.asarray(conv.entrain_up[:, 0])
+
+    assert int(conv.ktype[0]) == 1, "fixture no longer triggers deep conv"
+    assert float(conv.precip_conv[0]) > 0.0
+    assert mfu.min() >= 0.0 and entrain.min() >= 0.0
+    assert mfu.max() > 0.0, "mass_flux_up still zero-filled"
+    # No entrainment without a carrying flux entering from below.
+    mfu_below = np.concatenate([mfu[1:], [0.0]])
+    np.testing.assert_array_equal(entrain[mfu_below == 0.0], 0.0)
+    # Entrainment fires somewhere the plume is active.
+    assert entrain.max() > 0.0
+
+
 class TestMassFluxCFLCap:
     """The cloud-base mass flux must respect the layer-mass / dt CFL cap
     that ECHAM enforces in ``mo_cumastr.f90:582-583``::

--- a/jcm/physics/convection/tiedtke_nordeng/types.py
+++ b/jcm/physics/convection/tiedtke_nordeng/types.py
@@ -138,7 +138,8 @@ class ConvectionState(NamedTuple):
     # Mass fluxes
     mfu: jnp.ndarray         # Updraft mass flux (kg/m²/s)
     mfd: jnp.ndarray         # Downdraft mass flux (kg/m²/s)
-    
+    entr: jnp.ndarray        # Fractional updraft entrainment rate (1/m)
+
     # Convection diagnostics
     ktype: jnp.ndarray       # Convection type (0=none, 1=deep, 2=shallow, 3=mid)
     kbase: jnp.ndarray       # Cloud base level index
@@ -176,13 +177,20 @@ class ConvectionData:
 
     Stored in the diagnostics dict under the ``"convection"`` key (no
     leading underscore — flows to user-facing xarray output as
-    ``convection.<field>``). The ``mass_flux_*`` / ``cloud_base`` /
-    ``cloud_top`` / ``cape`` fields are reserved for the future port of
-    the equivalent ECHAM diagnostics; they are zero-filled today.
+    ``convection.<field>``). The ``cloud_base`` / ``cloud_top`` / ``cape``
+    fields are reserved for the future port of the equivalent ECHAM
+    diagnostics; they are zero-filled today. ``mass_flux_up``/``down`` and
+    ``entrain_up`` are populated (post-rescale, post-cap — the same ledger
+    scaling as the tendencies) for the convective tracer transport
+    (#602): the updraft flux at each layer's TOP interface, and the
+    absolute per-layer entrainment flux; per-layer detrainment follows
+    from plume continuity, so it is not stored separately.
     """
 
     mass_flux_up: jnp.ndarray        # Updraft mass flux [kg/m²/s] (nlev, ncols)
     mass_flux_down: jnp.ndarray      # Downdraft mass flux [kg/m²/s] (nlev, ncols)
+    entrain_up: jnp.ndarray          # Updraft entrainment flux per layer
+                                     # [kg/m²/s] (nlev, ncols)
     cloud_base: jnp.ndarray          # Cloud base level index (ncols,)
     cloud_top: jnp.ndarray           # Cloud top level index (ncols,)
     cape: jnp.ndarray                # CAPE [J/kg] (ncols,)
@@ -212,6 +220,7 @@ class ConvectionData:
         return cls(
             mass_flux_up=jnp.zeros((nlev,) + nodal_shape),
             mass_flux_down=jnp.zeros((nlev,) + nodal_shape),
+            entrain_up=jnp.zeros((nlev,) + nodal_shape),
             cloud_base=jnp.zeros(nodal_shape, dtype=int),
             cloud_top=jnp.zeros(nodal_shape, dtype=int),
             cape=jnp.zeros(nodal_shape),

--- a/jcm/physics/convection/tracer_transport.py
+++ b/jcm/physics/convection/tracer_transport.py
@@ -1,0 +1,215 @@
+"""``ConvectiveTracerTransport`` — bulk mass-flux tracer transport.
+
+ECHAM transports every tracer through Tiedtke convection (the
+``cuxtte``/``mo_cuascn`` xt budgeting) and CAM's ``convtran`` does the
+same for constituents; jcm applied the convective mass fluxes only to
+heat, moisture and momentum (#602 item 2). This term closes that gap for
+an explicit tracer list using the profiles the Tiedtke term now publishes
+in ``ConvectionData``: the updraft mass flux at each layer's top
+interface (``mass_flux_up``) and the absolute per-layer entrainment flux
+(``entrain_up``), both carrying the scheme's rescale + cap ledger
+scaling, so tracer transport is proportional to the heat and moisture
+transport actually applied.
+
+The scheme is a bulk entraining/detraining plume with compensating
+subsidence:
+
+* Per-layer detrainment is derived from plume continuity,
+  ``D_k = max(E_raw_k − (M_k − M_{k+1}), 0)`` with the effective
+  entrainment ``E_k = D_k + (M_k − M_{k+1})`` — this absorbs everything
+  the mass-flux profile actually did (survival cuts, cloud-base supply:
+  at cloud base the mass-flux jump appears as entrainment of that
+  layer's air, which is exactly the physical picture).
+* Updraft tracer concentration from an upward scan:
+  ``q_up_k = (M_{k+1}·q_up_{k+1} + E_k·q_k) / (M_{k+1} + E_k)`` — a
+  convex mix, so the plume concentration is bounded by the environment
+  profile it entrained.
+* Environment tendency in flux form: detrainment source, entrainment
+  sink, and compensating subsidence between (downward advection of
+  environment air at the interface updraft flux). Column tracer mass is
+  conserved exactly (the subsidence fluxes telescope; the plume's own
+  budget closes by construction).
+
+Downdraft tracer transport is not included yet (``mass_flux_down`` is
+published for it; the downdraft entrainment ledger is not) — the
+documented follow-up, typically a ~30% correction on the updraft
+circulation. Likewise not included: in-plume scavenging of soluble
+aerosol (ECHAM ``cuscav`` removes a large fraction of what the updraft
+carries before it detrains; here the plume is conservative and the
+convective wet removal lives separately in the JAM wetdep term), so
+expect a high bias in upper-tropospheric soluble aerosol in deep
+convective regions until that lands. Explicit stability: the per-column ledger is scaled so the
+subsidence Courant number stays ≤ 1 (the scheme's own cloud-base CFL cap
+makes this a no-op in practice).
+
+Like the other cross-step consumers (``vertical_diffusion``), the
+``convection`` diagnostic is read from the previous step's carry with a
+no-op fallback when absent.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import jax
+import jax.numpy as jnp
+import tree_math
+from flax import nnx
+
+from jcm.physics.physics_term import PhysicsTerm
+from jcm.physics_interface import PhysicsTendency
+
+#: Physical floor on plume mass flux [kg/m²/s] in divisions: below this
+#: the plume carries nothing worth budgeting (~1e-4 mm/day of air), and a
+#: physical floor keeps the guarded-division VJPs out of the float32
+#: squared-underflow window.
+_MF_FLOOR = 1.0e-10
+
+
+@tree_math.struct
+class ConvTransportParameters:
+    """Tunable knob for convective tracer transport (differentiable)."""
+
+    transport_scale: jnp.ndarray   # multiplies the mass-flux ledger
+
+    @classmethod
+    def default(cls) -> "ConvTransportParameters":
+        return cls(transport_scale=jnp.asarray(1.0))
+
+
+def convective_tracer_tendency(
+    q: jnp.ndarray,        # (K, nlev, ncols) tracer stack
+    mfu: jnp.ndarray,      # (nlev, ncols) updraft flux at layer TOP [kg/m²/s]
+    entrain: jnp.ndarray,  # (nlev, ncols) per-layer entrainment flux [kg/m²/s]
+    air_density: jnp.ndarray,
+    layer_thickness: jnp.ndarray,
+    dt: jnp.ndarray,
+) -> jnp.ndarray:
+    """Bulk-plume + compensating-subsidence tracer tendency [.../s]."""
+    dm = air_density * layer_thickness
+    mfu = jnp.maximum(mfu, 0.0)
+    # No flux through the model top: a residual plume reaching the top
+    # layer detrains there (via the continuity-derived D below), which is
+    # what makes the column budget close EXACTLY rather than only when
+    # the plume happens to terminate lower down.
+    mfu = mfu.at[0].set(0.0)
+    entrain = jnp.maximum(entrain, 0.0)
+
+    # Continuity-derived detrainment and effective entrainment (see
+    # module docstring). ``mfu_below`` is the flux entering the layer
+    # from below (zero under the surface). Derived BEFORE the CFL guard:
+    # the environment sink coefficient is (E_eff + mfu_below)·Δt/Δm, and
+    # in a net-detrainment layer that references the flux from the layer
+    # BELOW over this layer's OWN mass — a cross-level ratio a guard on
+    # (mfu + E) per layer never forms. With thin layers aloft (generic in
+    # hybrid coordinates) the wrong guard let the sink exceed 1 and drove
+    # detrainment-layer tracers negative (adversarial review, confirmed
+    # repro). All four ledger arrays are positively homogeneous in
+    # (mfu, entrain), so scaling AFTER the derivation is exactly linear
+    # and preserves continuity and column conservation.
+    mfu_below = jnp.concatenate(
+        [mfu[1:], jnp.zeros_like(mfu[:1])], axis=0
+    )
+    delta = mfu - mfu_below
+    detrain = jnp.maximum(entrain - delta, 0.0)
+    entrain_eff = detrain + delta                     # >= 0 by construction
+
+    courant = jnp.max(
+        (entrain_eff + mfu_below) * dt / dm, axis=0, keepdims=True,
+    )
+    scale = jnp.minimum(1.0, 1.0 / jnp.maximum(courant, 1.0))
+    mfu = mfu * scale
+    mfu_below = mfu_below * scale
+    detrain = detrain * scale
+    entrain_eff = entrain_eff * scale
+
+    # Upward plume scan for the in-plume concentration (surface -> top).
+    def ascend(q_up_below, xs):
+        m_below_k, e_k, q_k = xs                      # (ncols,), (ncols,), (K, ncols)
+        denom = m_below_k + e_k
+        q_mix = jnp.where(
+            (denom > _MF_FLOOR)[jnp.newaxis],
+            (m_below_k[jnp.newaxis] * q_up_below + e_k[jnp.newaxis] * q_k)
+            / jnp.maximum(denom, _MF_FLOOR)[jnp.newaxis],
+            q_k,
+        )
+        return q_mix, q_mix
+
+    q_lev = jnp.moveaxis(q, 1, 0)                     # (nlev, K, ncols)
+    _, q_up_rev = jax.lax.scan(
+        ascend,
+        q_lev[-1],                                    # seeded, overwritten at base
+        (mfu_below, entrain_eff, q_lev),
+        reverse=True,
+    )
+    q_up = jnp.moveaxis(q_up_rev, 0, 1)               # (K, nlev, ncols)
+
+    # Compensating subsidence: environment air enters each layer from
+    # above at the layer-top updraft flux and leaves to the layer below
+    # at the layer-bottom flux. The top layer's "from above" is itself
+    # (no flux through the model top), which keeps the telescoping sum —
+    # and hence column conservation — exact.
+    q_above = jnp.concatenate([q[:, :1], q[:, :-1]], axis=1)
+    dq = (
+        detrain[jnp.newaxis] * q_up
+        - entrain_eff[jnp.newaxis] * q
+        + mfu[jnp.newaxis] * q_above
+        - mfu_below[jnp.newaxis] * q
+    ) / dm[jnp.newaxis]
+    return dq
+
+
+class ConvectiveTracerTransport(PhysicsTerm):
+    """Updraft + compensating-subsidence transport of an explicit tracer list."""
+
+    name: ClassVar[str] = "convective_tracer_transport"
+    category: ClassVar[str] = "tracer_transport"
+    requires: ClassVar[tuple[str, ...]] = (
+        "air_density", "layer_thickness",
+    )
+    provides: ClassVar[tuple[str, ...]] = ()
+
+    def __init__(
+        self,
+        tracer_names: tuple[str, ...],
+        params: ConvTransportParameters | None = None,
+    ):
+        """Hold the tracer list and params."""
+        if not tracer_names:
+            raise ValueError(
+                "ConvectiveTracerTransport needs a non-empty tracer list."
+            )
+        self._tracer_names = tuple(tracer_names)
+        self.params = nnx.Param(params or ConvTransportParameters.default())
+
+    def __call__(self, state, diagnostics, forcing, terrain):
+        params = self.params.get_value()
+        conv = diagnostics.get("convection")
+        zeros = jnp.zeros_like(state.temperature)
+        if conv is None:
+            tracer_tends = {nm: zeros for nm in self._tracer_names}
+        else:
+            dt = diagnostics.get("_dt_seconds", 1800.0)
+            q = jnp.stack([
+                state.tracers.get(nm, zeros) for nm in self._tracer_names
+            ])
+            dq = convective_tracer_tendency(
+                q,
+                params.transport_scale * conv.mass_flux_up,
+                params.transport_scale * conv.entrain_up,
+                diagnostics["air_density"],
+                diagnostics["layer_thickness"],
+                dt,
+            )
+            tracer_tends = {
+                nm: dq[k] for k, nm in enumerate(self._tracer_names)
+            }
+
+        tendency = PhysicsTendency(
+            u_wind=jnp.zeros_like(state.u_wind),
+            v_wind=jnp.zeros_like(state.v_wind),
+            temperature=jnp.zeros_like(state.temperature),
+            specific_humidity=jnp.zeros_like(state.specific_humidity),
+            tracers=tracer_tends,
+        )
+        return tendency, diagnostics

--- a/jcm/physics/convection/tracer_transport_test.py
+++ b/jcm/physics/convection/tracer_transport_test.py
@@ -1,0 +1,228 @@
+"""Tests for the convective bulk-plume tracer transport (#602 item 2)."""
+
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from jcm.physics.convection.tracer_transport import (
+    ConvTransportParameters,
+    ConvectiveTracerTransport,
+    convective_tracer_tendency,
+)
+from jcm.physics_interface import PhysicsState
+
+
+def _plume(nlev=10, ncols=1, base=8, top=3, mf=0.05):
+    """Synthetic updraft: base supply at ``base``, detrainment near ``top``.
+
+    ``mfu[k]`` is the flux at each layer's TOP interface: constant ``mf``
+    from the base layer up to (and including) ``top``, zero above.
+    Entrainment: the base supply plus a small lateral pickup per layer.
+    """
+    mfu = jnp.zeros((nlev, ncols))
+    lev = jnp.arange(nlev)[:, None]
+    inside = (lev >= top) & (lev <= base)
+    mfu = jnp.where(inside, mf, 0.0) * jnp.ones((1, ncols))
+    entrain = jnp.zeros((nlev, ncols))
+    entrain = entrain.at[base].set(mf)          # cloud-base supply
+    return mfu, entrain
+
+
+class ConvectiveTendencyTest(unittest.TestCase):
+    def _grid(self, nlev=10, ncols=1):
+        rho = jnp.linspace(0.4, 1.2, nlev)[:, None] * jnp.ones((1, ncols))
+        dz = jnp.full((nlev, ncols), 400.0)
+        return rho, dz
+
+    def test_conserves_column_mass_exactly(self):
+        rho, dz = self._grid()
+        mfu, entrain = _plume()
+        q = jnp.stack([
+            jnp.linspace(2.0, 0.1, 10)[:, None] ** 2 * 1e-9
+            * jnp.ones((1, 1)),
+        ])
+        dq = convective_tracer_tendency(q, mfu, entrain, rho, dz, 1800.0)
+        dm = rho * dz
+        net = float(jnp.sum(dq * dm[jnp.newaxis]))
+        gross = float(jnp.sum(jnp.abs(dq) * dm[jnp.newaxis]))
+        self.assertGreater(gross, 0.0, "plume did nothing — fixture off")
+        self.assertLessEqual(abs(net), 1e-6 * gross)
+
+    def test_lofts_boundary_layer_tracer(self):
+        # A surface-concentrated tracer entrained at cloud base must be
+        # deposited at the detrainment levels aloft and reduced below.
+        rho, dz = self._grid()
+        mfu, entrain = _plume(base=8, top=3)
+        q = jnp.zeros((1, 10, 1)).at[0, 8:].set(1.0e-9)
+        dq = convective_tracer_tendency(q, mfu, entrain, rho, dz, 1800.0)
+        # Detrainment lands in the layer ABOVE the last carrying interface
+        # (mfu is the layer-TOP flux, so the plume dies inside level top-1).
+        self.assertGreater(float(dq[0, 2, 0]), 0.0)
+        # The base layer loses to the updraft.
+        self.assertLess(float(dq[0, 8, 0]), 0.0)
+
+    def test_plume_concentration_bounded_by_environment(self):
+        # The plume is a convex mix of what it entrained, and subsidence
+        # advects environment values — no new extrema can appear.
+        rho, dz = self._grid()
+        mfu, entrain = _plume()
+        q0 = jnp.linspace(0.0, 1.0e-9, 10)[:, None][jnp.newaxis]
+        dq = convective_tracer_tendency(q0, mfu, entrain, rho, dz, 1800.0)
+        q1 = q0 + 1800.0 * dq
+        self.assertGreaterEqual(float(q1.min()), -1e-25)
+        self.assertLessEqual(float(q1.max()), 1.0e-9 * (1.0 + 1e-6))
+
+    def test_plume_through_model_top_still_conserves(self):
+        # A pathological mass-flux profile that reaches the top layer must
+        # detrain there (no flux through the model top), not leak tracer.
+        rho, dz = self._grid()
+        mfu = jnp.full((10, 1), 0.05)
+        entrain = jnp.zeros((10, 1)).at[9].set(0.05)
+        q = jnp.stack([jnp.linspace(1.0, 0.1, 10)[:, None] * 1e-9])
+        dq = convective_tracer_tendency(q, mfu, entrain, rho, dz, 1800.0)
+        dm = rho * dz
+        net = float(jnp.sum(dq * dm[jnp.newaxis]))
+        gross = float(jnp.sum(jnp.abs(dq) * dm[jnp.newaxis]))
+        self.assertLessEqual(abs(net), 1e-6 * max(gross, 1e-30))
+
+    def test_thin_detrainment_layer_stays_bounded(self):
+        # Adversarial-review repro: the environment sink in a
+        # net-detrainment layer is (E_eff + mfu_below)·dt/dm — the flux
+        # from the layer BELOW over this layer's OWN mass. With thin
+        # layers aloft (hybrid-coordinate dm shrinking with height) and a
+        # near-CFL base flux, a guard formed per layer from (mfu + E)
+        # missed that cross-level ratio: the sink reached 1.556 and a
+        # bounded tracer went to -0.556. The guard must bound the DERIVED
+        # sink, keeping the update positivity-preserving here.
+        nlev = 6
+        dm_prof = jnp.array([60.0, 90.0, 300.0, 700.0, 1000.0, 1300.0])
+        rho = jnp.ones((nlev, 1))
+        dz = dm_prof[:, None]                     # rho = 1 → dm = dz
+        lev = jnp.arange(nlev)[:, None]
+        mfu = jnp.where((lev >= 1) & (lev <= 5), 0.55, 0.0) * jnp.ones((1, 1))
+        entrain = jnp.zeros((nlev, 1)).at[5].set(0.55)
+        dt = 1800.0
+        # Tracer concentrated in the detrainment layer (level 0): the
+        # over-drained case.
+        q = jnp.zeros((1, nlev, 1)).at[0, 0].set(1.0)
+        dq = convective_tracer_tendency(q, mfu, entrain, rho, dz, dt)
+        q1 = q + dt * dq
+        self.assertGreaterEqual(float(q1.min()), -1e-9)
+        # Bounded-in-[0,1] tracer cannot exceed 1 either.
+        q = jnp.ones((1, nlev, 1))
+        dq = convective_tracer_tendency(q, mfu, entrain, rho, dz, dt)
+        q1 = q + dt * dq
+        self.assertLessEqual(float(q1.max()), 1.0 + 1e-9)
+        self.assertGreaterEqual(float(q1.min()), -1e-9)
+
+    def test_conserves_with_distinct_tracers_and_columns(self):
+        # K=2 tracers x 2 distinct columns: a transposed (K, ncols) carry
+        # in the plume scan mixes them and breaks the per-tracer,
+        # per-column budgets.
+        nlev = 10
+        rho = jnp.linspace(0.4, 1.2, nlev)[:, None] * jnp.ones((1, 2))
+        dz = jnp.full((nlev, 2), 400.0)
+        mfu, entrain = _plume(ncols=2)
+        mfu = mfu * jnp.asarray([1.0, 0.5])[None, :]
+        entrain = entrain * jnp.asarray([1.0, 0.5])[None, :]
+        q = jnp.stack([
+            jnp.zeros((nlev, 2)).at[8:].set(1.0e-9),
+            jnp.linspace(1.0, 0.2, nlev)[:, None] * jnp.ones((1, 2)) * 1e-8,
+        ])
+        dq = convective_tracer_tendency(q, mfu, entrain, rho, dz, 1800.0)
+        dm = rho * dz
+        for k in range(2):
+            for col in range(2):
+                net = float(jnp.sum(dq[k, :, col] * dm[:, col]))
+                gross = float(jnp.sum(jnp.abs(dq[k, :, col]) * dm[:, col]))
+                self.assertLessEqual(
+                    abs(net), 1e-6 * max(gross, 1e-30), (k, col),
+                )
+
+    def test_huge_mass_flux_stays_positive(self):
+        # The per-column CFL rescale bounds the explicit update: even a
+        # mass flux that would empty a layer many times over cannot drive
+        # a tracer negative.
+        rho, dz = self._grid()
+        mfu, entrain = _plume(mf=50.0)
+        q = jnp.zeros((1, 10, 1)).at[0, 8:].set(1.0e-9)
+        dq = convective_tracer_tendency(q, mfu, entrain, rho, dz, 1800.0)
+        q1 = q + 1800.0 * dq
+        self.assertGreaterEqual(float(q1.min()), -1e-25)
+        self.assertTrue(bool(jnp.all(jnp.isfinite(dq))))
+
+    def test_no_mass_flux_no_tendency(self):
+        rho, dz = self._grid()
+        q = jnp.ones((1, 10, 1)) * 1e-9
+        dq = convective_tracer_tendency(
+            q, jnp.zeros((10, 1)), jnp.zeros((10, 1)), rho, dz, 1800.0,
+        )
+        np.testing.assert_array_equal(np.asarray(dq), 0.0)
+
+
+class _Conv:
+    def __init__(self, mfu, entrain):
+        self.mass_flux_up = mfu
+        self.entrain_up = entrain
+
+
+class ConvectiveTracerTransportTermTest(unittest.TestCase):
+    def _setup(self, with_conv=True, nlev=10, ncols=1):
+        shape = (nlev, ncols)
+        tracers = {"m_so4_acc": jnp.zeros(shape).at[8:].set(1.0e-9)}
+        state = PhysicsState.zeros(shape).copy(
+            temperature=jnp.full(shape, 280.0), tracers=tracers,
+        )
+        diagnostics = {
+            "air_density": jnp.full(shape, 1.0),
+            "layer_thickness": jnp.full(shape, 400.0),
+            "_dt_seconds": 1800.0,
+        }
+        if with_conv:
+            mfu, entrain = _plume(nlev=nlev, ncols=ncols)
+            diagnostics["convection"] = _Conv(mfu, entrain)
+        return state, diagnostics
+
+    def test_transports_and_conserves(self):
+        state, diagnostics = self._setup()
+        term = ConvectiveTracerTransport(("m_so4_acc",))
+        tend, _ = term(state, diagnostics, None, None)
+        dq = np.asarray(tend.tracers["m_so4_acc"])
+        self.assertGreater(float(dq[2, 0]), 0.0)
+        self.assertLess(float(dq[8, 0]), 0.0)
+        net = float(np.sum(dq) * 400.0)
+        gross = float(np.sum(np.abs(dq)) * 400.0)
+        self.assertLessEqual(abs(net), 1e-6 * gross)
+
+    def test_noop_without_convection_diagnostic(self):
+        state, diagnostics = self._setup(with_conv=False)
+        term = ConvectiveTracerTransport(("m_so4_acc",))
+        tend, _ = term(state, diagnostics, None, None)
+        np.testing.assert_array_equal(
+            np.asarray(tend.tracers["m_so4_acc"]), 0.0,
+        )
+
+    def test_grad_through_transport_scale(self):
+        state, diagnostics = self._setup()
+
+        def loss(scale):
+            term = ConvectiveTracerTransport(
+                ("m_so4_acc",),
+                params=ConvTransportParameters(transport_scale=scale),
+            )
+            tend, _ = term(state, diagnostics, None, None)
+            return jnp.sum(tend.tracers["m_so4_acc"] ** 2)
+
+        g = jax.grad(loss)(jnp.asarray(1.0))
+        self.assertTrue(np.isfinite(float(g)))
+        self.assertNotEqual(float(g), 0.0)
+
+    def test_empty_tracer_list_rejected(self):
+        with self.assertRaises(ValueError):
+            ConvectiveTracerTransport(())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jcm/physics/echam/echam_terms.py
+++ b/jcm/physics/echam/echam_terms.py
@@ -73,6 +73,7 @@ def echam_physics(
     cloud_scheme: str = "1m",
     aerosol_module: str = "macv2sp",
     jam_microphysics: str = "placeholder",
+    jam_cloud_borne: bool = True,
     jam_arg_variant: str = "arg2000",
     jam_aqueous_scheme: str = "full",
     jam_ice_scheme: str = "niemand",
@@ -143,6 +144,14 @@ def echam_physics(
             would let JAM fully replace MACv2-SP optics is tracked in #495.
         jam_microphysics: JAM core when ``aerosol_module="jam"`` —
             ``"placeholder"`` (κ-Köhler equilibrium) today; MAM4-JAX is #490.
+        jam_cloud_borne: prognose the explicit cloud-borne aerosol phase
+            (#602). ``True`` (default) declares and cycles the ``mc_*`` /
+            ``nc_*`` mirror tracers (activation transfer, resuspension,
+            in-droplet wet removal, dry deposition); ``False`` drops them
+            entirely — about half the aerosol tracer count and most of the
+            dycore tracer-transport bill — and scavenges interstitial
+            aerosol by its activated fraction instead. The A/B
+            cost/fidelity switch.
         jam_arg_variant: ``"arg2000"`` (default) or ``"ghosh2025"`` activation.
         jam_ice_scheme: heterogeneous ice nucleation scheme — ``"niemand"``
             (default) or ``"lohmann_diehl"`` (drives the 2M ICNC).
@@ -304,7 +313,8 @@ def echam_physics(
     elif aerosol_module == "jam":
         from jcm.physics.aerosol.jam.jam_terms import jam_aerosol_physics
         jam_terms = jam_aerosol_physics(
-            microphysics=jam_microphysics, arg_variant=jam_arg_variant,
+            microphysics=jam_microphysics, cloud_borne=jam_cloud_borne,
+            arg_variant=jam_arg_variant,
             aqueous_scheme=jam_aqueous_scheme,
             ice_scheme=jam_ice_scheme,
             anthropogenic=jam_anthropogenic,
@@ -322,7 +332,13 @@ def echam_physics(
         # Aqueous chemistry + wet deposition need the current step's clouds, so
         # they run after the cloud microphysics term; the rest of the JAM chain
         # is the pre-cloud aerosol block.
-        _post_cloud = ("aerosol_wetdep", "aerosol_aqueous_chemistry")
+        # Cloud-borne exchange sits with the other cloud-consuming terms:
+        # it needs the current step's cloud fraction, and must precede the
+        # aqueous split and wet scavenging (order preserved from jam_terms).
+        _post_cloud = (
+            "aerosol_cloud_borne", "aerosol_aqueous_chemistry",
+            "aerosol_wetdep",
+        )
         jam_post_cloud_terms = [
             t for t in jam_terms if t.category in _post_cloud
         ]

--- a/jcm/physics/vertical_diffusion/tracer_diffusion.py
+++ b/jcm/physics/vertical_diffusion/tracer_diffusion.py
@@ -1,0 +1,176 @@
+"""``TracerVerticalDiffusion`` — implicit turbulent mixing of tracers.
+
+ECHAM's vdiff diffuses every tracer with the heat exchange coefficient
+(``cfh``, the ``pxtte`` update in ``mo_vdiff_solver``) and CAM likewise
+diffuses all constituents; jcm's TTE-TKE term solves only its fixed
+8-variable block (u, v, T, q, qc, qi, TKE, TTE), so until now nothing in
+the physics mixed aerosol or gas tracers vertically at all — the dycore
+was the sole transporter (#602 item 2). This term closes that gap
+generically: an unconditionally stable backward-Euler diffusion of an
+explicit tracer list, using the ``kh`` exchange-coefficient profile the
+TTE-TKE term publishes in the ``vertical_diffusion`` diagnostic.
+
+Like the other consumers of that diagnostic (ARG's updraft, dry
+deposition's u*), the profile comes from the previous step's carry
+because the vdiff term runs after the aerosol block in the ECHAM
+ordering; on the very first step the diagnostic is absent and the term is
+a no-op. Boundaries are zero-flux: the surface exchange is dry
+deposition's job, and emission injection is the emission terms' job, so
+this term is pure interior mixing and conserves each tracer's column mass
+exactly.
+
+The solve is one batched Thomas algorithm over the stacked tracers (two
+``lax.scan`` sweeps over levels), so cost is independent of how many
+tracers ride along.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import jax
+import jax.numpy as jnp
+import tree_math
+from flax import nnx
+
+from jcm.physics.physics_term import PhysicsTerm
+from jcm.physics_interface import PhysicsTendency
+
+#: Physical floor on the layer mass [kg/m²] in divisions (a 1e-3 kg/m²
+#: layer is far thinner than any real grid); keeps the guarded-division
+#: VJPs clear of the float32 squared-underflow window.
+_DM_FLOOR = 1.0e-3
+
+
+@tree_math.struct
+class TracerDiffusionParameters:
+    """Tunable knob for tracer turbulent mixing (differentiable)."""
+
+    diffusion_scale: jnp.ndarray   # multiplies the exchange coefficient
+
+    @classmethod
+    def default(cls) -> "TracerDiffusionParameters":
+        return cls(diffusion_scale=jnp.asarray(1.0))
+
+
+def diffuse_tracers_implicit(
+    q: jnp.ndarray,             # (K, nlev, ncols) tracer stack
+    kh: jnp.ndarray,            # (nlev, ncols) exchange coefficient [m²/s]
+    air_density: jnp.ndarray,   # (nlev, ncols)
+    layer_thickness: jnp.ndarray,  # (nlev, ncols) [m]
+    dt: jnp.ndarray,
+) -> jnp.ndarray:
+    """Backward-Euler vertical diffusion of a tracer stack.
+
+    Interface conductances ``g = ρ·K/Δz`` [kg/m²/s] from arithmetic
+    means of the layer values; zero-flux at top and bottom. The implicit
+    operator is in flux form, so each tracer's column integral
+    ``Σ q·ρ·Δz`` is conserved to solver round-off for ANY ``K·Δt``, and
+    the solution is positivity-preserving (an M-matrix). Returns the
+    post-diffusion stack.
+    """
+    dm = air_density * layer_thickness
+    k_int = 0.5 * (kh[:-1] + kh[1:])
+    rho_int = 0.5 * (air_density[:-1] + air_density[1:])
+    dz_int = 0.5 * (layer_thickness[:-1] + layer_thickness[1:])
+    g_int = rho_int * k_int / dz_int                     # (nlev-1, ncols)
+
+    zero_row = jnp.zeros_like(g_int[:1])
+    g_up = jnp.concatenate([zero_row, g_int], axis=0)    # g_{k-1/2}
+    g_dn = jnp.concatenate([g_int, zero_row], axis=0)    # g_{k+1/2}
+    dm_safe = jnp.maximum(dm, _DM_FLOOR)
+    alpha = dt * g_up / dm_safe
+    gamma = dt * g_dn / dm_safe
+
+    a = -alpha                       # sub-diagonal (coupling to k-1)
+    b = 1.0 + alpha + gamma          # diagonal
+    c = -gamma                       # super-diagonal (coupling to k+1)
+
+    # Thomas forward sweep over levels; carries are the modified
+    # super-diagonal (ncols,) and RHS (K, ncols).
+    def forward(carry, xs):
+        c_prev, d_prev = carry
+        a_k, b_k, c_k, d_k = xs
+        denom = b_k - a_k * c_prev
+        c_new = c_k / denom
+        d_new = (d_k - a_k[jnp.newaxis] * d_prev) / denom[jnp.newaxis]
+        return (c_new, d_new), (c_new, d_new)
+
+    d0 = jnp.moveaxis(q, 1, 0)                            # (nlev, K, ncols)
+    (_, _), (c_mod, d_mod) = jax.lax.scan(
+        forward,
+        (jnp.zeros_like(a[0]), jnp.zeros_like(d0[0])),
+        (a, b, c, d0),
+    )
+
+    def backward(x_next, xs):
+        c_k, d_k = xs
+        x_k = d_k - c_k[jnp.newaxis] * x_next
+        return x_k, x_k
+
+    _, x_rev = jax.lax.scan(
+        backward,
+        jnp.zeros_like(d0[0]),
+        (c_mod, d_mod),
+        reverse=True,
+    )
+    return jnp.moveaxis(x_rev, 0, 1)                      # (K, nlev, ncols)
+
+
+class TracerVerticalDiffusion(PhysicsTerm):
+    """Implicit turbulent vertical mixing of an explicit tracer list."""
+
+    name: ClassVar[str] = "tracer_vertical_diffusion"
+    category: ClassVar[str] = "tracer_transport"
+    requires: ClassVar[tuple[str, ...]] = (
+        "air_density", "layer_thickness",
+    )
+    provides: ClassVar[tuple[str, ...]] = ()
+
+    def __init__(
+        self,
+        tracer_names: tuple[str, ...],
+        params: TracerDiffusionParameters | None = None,
+    ):
+        """Hold the tracer list and params."""
+        if not tracer_names:
+            raise ValueError(
+                "TracerVerticalDiffusion needs a non-empty tracer list."
+            )
+        self._tracer_names = tuple(tracer_names)
+        self.params = nnx.Param(
+            params or TracerDiffusionParameters.default()
+        )
+
+    def __call__(self, state, diagnostics, forcing, terrain):
+        params = self.params.get_value()
+        vd = diagnostics.get("vertical_diffusion")
+        zeros = jnp.zeros_like(state.temperature)
+        if vd is None:
+            # First step / no vdiff scheme composed: nothing to mix with.
+            tracer_tends = {nm: zeros for nm in self._tracer_names}
+        else:
+            dt = diagnostics.get("_dt_seconds", 1800.0)
+            q = jnp.stack([
+                state.tracers.get(nm, zeros) for nm in self._tracer_names
+            ])
+            q_new = diffuse_tracers_implicit(
+                q,
+                params.diffusion_scale * jnp.maximum(vd.kh, 0.0),
+                diagnostics["air_density"],
+                diagnostics["layer_thickness"],
+                dt,
+            )
+            dq = (q_new - q) / dt
+            tracer_tends = {
+                nm: dq[k] for k, nm in enumerate(self._tracer_names)
+            }
+
+        tendency = PhysicsTendency(
+            u_wind=jnp.zeros_like(state.u_wind),
+            v_wind=jnp.zeros_like(state.v_wind),
+            temperature=jnp.zeros_like(state.temperature),
+            specific_humidity=jnp.zeros_like(state.specific_humidity),
+            tracers=tracer_tends,
+        )
+        return tendency, diagnostics

--- a/jcm/physics/vertical_diffusion/tracer_diffusion_test.py
+++ b/jcm/physics/vertical_diffusion/tracer_diffusion_test.py
@@ -1,0 +1,165 @@
+"""Tests for the implicit tracer vertical diffusion (#602 item 2)."""
+
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from jcm.physics.vertical_diffusion.tracer_diffusion import (
+    TracerDiffusionParameters,
+    TracerVerticalDiffusion,
+    diffuse_tracers_implicit,
+)
+from jcm.physics_interface import PhysicsState
+
+
+class DiffuseImplicitTest(unittest.TestCase):
+    def _grid(self, nlev=12, ncols=2):
+        rho = jnp.linspace(0.3, 1.2, nlev)[:, None] * jnp.ones((1, ncols))
+        dz = jnp.linspace(900.0, 150.0, nlev)[:, None] * jnp.ones((1, ncols))
+        kh = jnp.linspace(1.0, 40.0, nlev)[:, None] * jnp.ones((1, ncols))
+        return rho, dz, kh
+
+    def test_conserves_column_mass_exactly(self):
+        rho, dz, kh = self._grid()
+        q = jnp.stack([
+            jnp.linspace(0.0, 1.0e-8, 12)[:, None] * jnp.ones((1, 2)),
+            jnp.zeros((12, 2)).at[-1].set(5.0e-9),
+        ])
+        q_new = diffuse_tracers_implicit(q, kh, rho, dz, 1800.0)
+        dm = rho * dz
+        before = jnp.sum(q * dm[jnp.newaxis], axis=1)
+        after = jnp.sum(q_new * dm[jnp.newaxis], axis=1)
+        np.testing.assert_allclose(
+            np.asarray(after), np.asarray(before), rtol=1e-6,
+        )
+
+    def test_mixes_surface_load_upward(self):
+        rho, dz, kh = self._grid()
+        q = jnp.zeros((1, 12, 2)).at[0, -1].set(1.0e-8)
+        q_new = diffuse_tracers_implicit(q, kh, rho, dz, 1800.0)
+        # The layer above the loaded one gains; the loaded one loses.
+        self.assertGreater(float(q_new[0, -2, 0]), 0.0)
+        self.assertLess(float(q_new[0, -1, 0]), 1.0e-8)
+
+    def test_unconditionally_stable_and_bounded(self):
+        # Backward Euler with an M-matrix obeys the maximum principle for
+        # ANY K·dt: no overshoot, no negatives, even at K·dt/dz² >> 1.
+        rho, dz, kh = self._grid()
+        q = jnp.zeros((1, 12, 2)).at[0, 5].set(1.0e-6)
+        q_new = diffuse_tracers_implicit(
+            q, 1.0e5 * kh, rho, dz, 36000.0,
+        )
+        self.assertGreaterEqual(float(q_new.min()), 0.0)
+        self.assertLessEqual(float(q_new.max()), 1.0e-6 * (1.0 + 1e-6))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(q_new))))
+
+    def test_two_layer_exchange_matches_closed_form(self):
+        # Analytic pin (a magnitude error in the conductance — dropped
+        # rho_int, dz_int or dm — is invisible to conservation and
+        # direction checks). Two equal layers exchanging through one
+        # interface, backward Euler:
+        #   d' = d / (1 + 2·dt·g/dm),  g = rho_int·K_int/dz_int.
+        rho = jnp.full((2, 1), 0.8)
+        dz = jnp.full((2, 1), 250.0)
+        kh = jnp.array([[10.0], [30.0]])
+        q = jnp.array([[[4.0e-9], [1.0e-9]]])
+        dt = 900.0
+        g = 0.8 * 20.0 / 250.0
+        dm = 0.8 * 250.0
+        expected_diff = (4.0e-9 - 1.0e-9) / (1.0 + 2.0 * dt * g / dm)
+        q_new = diffuse_tracers_implicit(q, kh, rho, dz, dt)
+        got_diff = float(q_new[0, 0, 0] - q_new[0, 1, 0])
+        np.testing.assert_allclose(got_diff, expected_diff, rtol=1e-6)
+        np.testing.assert_allclose(
+            float(jnp.sum(q_new)), 5.0e-9, rtol=1e-6,
+        )
+
+    def test_zero_k_is_identity(self):
+        rho, dz, _ = self._grid()
+        q = jnp.ones((1, 12, 2)) * 3.0e-9
+        q_new = diffuse_tracers_implicit(
+            q, jnp.zeros((12, 2)), rho, dz, 1800.0,
+        )
+        np.testing.assert_allclose(np.asarray(q_new), np.asarray(q))
+
+
+class _VDiff:
+    def __init__(self, kh):
+        self.kh = kh
+
+
+class TracerVerticalDiffusionTermTest(unittest.TestCase):
+    def _setup(self, nlev=8, ncols=2, with_vdiff=True):
+        shape = (nlev, ncols)
+        tracers = {
+            "m_so4_acc": jnp.zeros(shape).at[-1].set(1.0e-9),
+            "n_acc": jnp.zeros(shape).at[-1].set(1.0e7),
+        }
+        state = PhysicsState.zeros(shape).copy(
+            temperature=jnp.full(shape, 280.0), tracers=tracers,
+        )
+        diagnostics = {
+            "air_density": jnp.full(shape, 1.0),
+            "layer_thickness": jnp.full(shape, 300.0),
+            "_dt_seconds": 1800.0,
+        }
+        if with_vdiff:
+            diagnostics["vertical_diffusion"] = _VDiff(
+                jnp.full(shape, 30.0)
+            )
+        return state, diagnostics
+
+    def test_mixes_and_conserves(self):
+        state, diagnostics = self._setup()
+        term = TracerVerticalDiffusion(("m_so4_acc", "n_acc"))
+        tend, _ = term(state, diagnostics, None, None)
+        dm = 300.0
+        for nm in ("m_so4_acc", "n_acc"):
+            dq = np.asarray(tend.tracers[nm])
+            self.assertLess(dq[-1, 0], 0.0)          # surface layer loses
+            self.assertGreater(dq[-2, 0], 0.0)       # layer above gains
+            total = float(np.sum(dq) * dm)
+            scale = float(np.sum(np.abs(dq)) * dm)
+            self.assertLessEqual(abs(total), 1e-6 * max(scale, 1e-30), nm)
+
+    def test_noop_without_vdiff_diagnostic(self):
+        state, diagnostics = self._setup(with_vdiff=False)
+        term = TracerVerticalDiffusion(("m_so4_acc",))
+        tend, _ = term(state, diagnostics, None, None)
+        np.testing.assert_array_equal(
+            np.asarray(tend.tracers["m_so4_acc"]), 0.0,
+        )
+
+    def test_empty_probe_state_is_safe(self):
+        state, diagnostics = self._setup()
+        state = state.copy(tracers={})
+        term = TracerVerticalDiffusion(("m_so4_acc",))
+        tend, _ = term(state, diagnostics, None, None)
+        np.testing.assert_array_equal(
+            np.asarray(tend.tracers["m_so4_acc"]), 0.0,
+        )
+
+    def test_grad_through_diffusion_scale(self):
+        state, diagnostics = self._setup()
+
+        def loss(scale):
+            term = TracerVerticalDiffusion(
+                ("m_so4_acc",),
+                params=TracerDiffusionParameters(diffusion_scale=scale),
+            )
+            tend, _ = term(state, diagnostics, None, None)
+            return jnp.sum(tend.tracers["m_so4_acc"] ** 2)
+
+        g = jax.grad(loss)(jnp.asarray(1.0))
+        self.assertTrue(np.isfinite(float(g)))
+        self.assertNotEqual(float(g), 0.0)
+
+    def test_empty_tracer_list_rejected(self):
+        with self.assertRaises(ValueError):
+            TracerVerticalDiffusion(())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #602 (both items): the cloud-borne aerosol population is now *finished* — activation transfer, resuspension, wet and dry removal, and the aqueous split all live — **and** it is a single switch, so the "stop transporting 25 empty fields" cost win is one flag away and the two configurations are a clean A/B pair (same removal physics at exchange equilibrium, different representation). The PR also closes the issue's item 2: **physics-side aerosol vertical transport now exists** — turbulent diffusion of every JAM tracer and convective mass-flux transport, active in both switch states (see the last section), so the dycore is no longer the sole aerosol transporter.

## The switch

`ModalAerosolSpec.cloud_borne: bool = True`, a property of the population *representation*, not the harness: MAM keeps in-droplet aerosol as separate constituents; M7 (ECHAM-HAM) and sectional schemes like TOMAS represent it implicitly and scavenge interstitial aerosol by its activated fraction. That placement matters for where the microphysics roadmap is going: an M7 or TOMAS core (#491) publishes a spec with `cloud_borne=False` and the whole harness — tracer layout, deposition, aqueous, exchange composition — does the right thing with no further per-scheme code. Plumbed as `jam_aerosol_physics(cloud_borne=...)` (None = follow the core's spec; overriding a string core rebuilds it on a `dataclasses.replace`d spec; a conflicting instance core is rejected loudly), `echam_physics(jam_cloud_borne=...)`, and `jam_cloud_borne` in `echam-jam.yaml`.

**Off**: `tracer_specs` emits no `mc_*`/`nc_*` mirrors at all — 25 of the 58 `echam-jam` tracers gone, which at ne30 is most of the dycore step (#595: tracers are ~94% of its FLOPs). Every mirror producer is compose-time gated (aqueous, wetdep, drydep, the MAM4-JAX qqcw pack/unpack, the exchange term is not composed), so nothing emits tendencies the accumulator would silently drop. The physics is the pre-change implicit treatment, not a degraded one.

**On** (default): the cycle the mirrors were always meant to carry.

## Closing the cycle

* **Activation transfer + resuspension** — new `CloudBorneExchange` term (post-cloud block, before the aqueous split and wet scavenging): each (interstitial, cloud-borne) pair relaxes toward the activation-equilibrium partition `q_cb* = cf · f_act · (q_int + q_cb)` with separate differentiable activation/resuspension timescales (default 900 s). Both directions come from the one expression — a cleared sky returns the whole reservoir — and the `1 − exp(−Δt/τ)` move is bounded by the donor and exactly conserving per pair. ARG now returns per-mode number **and mass** activated fractions (the `u_m = u − 3·lnσ/√2` shift; large particles activate preferentially, so mass transfers much faster than number), published as the internal `_jam_activation` diagnostic. Deliberately simpler than CAM's `dropmixnuc`, which is inseparable from a turbulent-mixing solve jcm doesn't have yet (#602 item 2); crucially, the mirrors **stay dycore-transported tracers** — nothing moves to the physics carry, so the "column-local frozen aerosol" trap in the issue is structurally avoided.
* **Wet removal** — the stratiform in-cloud (nucleation) pathway moves to where the physics says it belongs: cloud-borne tracers are removed at the full condensate→precip conversion rate (no activated-fraction weighting, no below-cloud impaction); interstitial tracers keep impaction + convective processing. Without the explicit phase, the implicit activated-fraction pathway stands — now weighted by cloud fraction, fixing a pre-existing ~1/cf over-scavenge in broken cloud that would otherwise have poisoned the A/B with a difference that has nothing to do with representation. A regression test pins the two representations to remove the *same mass at exchange equilibrium* (verified to fail on the unweighted code by file-copy swap).
* **Dry removal** — cloud-borne deposits in the bottom layer too (CAM's `aero_model_drydep` treatment, interstitial velocities), so a surface-layer cloud is not a sink-less corner.
* **Aqueous sulfate** — with the reservoir now cycled, HAM's cloud-borne number-fraction split (`ms4as`/`ms4cs`) is live; the interstitial-accumulation fallback covers only spin-up cells (it exists because the HAM assignment without cycling grew `mc_so4_cor` ~0.7 mg/m²/day without equilibrium — see the term's history). Sulfur conservation holds in both switch states.

Known, documented asymmetries of the explicit representation: rainout lags by the exchange timescale, in-droplet mass is invisible to the (interstitial-only) optics, and cloud-borne aerosol has no convective processing or sedimentation yet.

## Review hardening (local adversarial pass)

Six findings fixed before this PR: the cf weighting above (M); a compose-time guard on `CloudBorneExchange` against implicit specs, where the dropped-tendency mechanism would otherwise silently vent mass (S); the aqueous nc-split floor raised from 1e-30 to `_NC_MIN` to close a float32 squared-underflow VJP window (the #602-adjacent double-where NaN class); `_jam_activation` added to the internal diagnostic keys so pure plumbing doesn't inflate every saved output; a pinned-value test for the ARG mass-fraction shift (the inequality checks alone could not catch a wrong coefficient); distinct per-mode fractions in the exchange fixture so mode-axis misindexing cannot hide.

## Tests

Exchange: exact per-pair conservation, pinned transfer bookkeeping per mode, mass/number fraction independence, clear-sky resuspension, non-activatable modes drain, equilibrium fixed point, positivity, empty-probe safety, nonzero finite gradients through both timescales. Switch: tracer-set halving, no mirror producers when off (aqueous/wetdep/drydep), factory composition and ordering, instance-core conflict, representation-equivalence at equilibrium. End-to-end T21L20 (slow): mirrors carried finite when on; mirrors absent and model finite when off. AeroCom burdens (`m_* + mc_*` sum) and the wet/dry deposition flux diagnostics pick up the cloud-borne removals with no changes (`_species_of` already parsed `mc_`).

Local gates per `jcm-local-ci`: ruff clean, fast + slow suites at CI dependency parity (numbers in checks).


## Also in this branch: #499 (merged via #612)

The stacked PR #612 — per-level precip formation/evaporation rates from both cloud schemes and the wet-scavenging rework onto the true ledger (with re-evaporation re-injection) — was reviewed and merged into this branch, so this PR delivers it to `dev` as well; see #612 for its review record.

## Physics-side vertical transport (#602 item 2)

Both reference models move tracers in the physics — ECHAM diffuses every tracer in vdiff (`pxtte`) and transports them through Tiedtke updrafts (`cuxtte`), CAM diffuses constituents and runs `convtran` — while jcm moved aerosol only by dycore advection. Two new generic terms close that, composed by the JAM factory in both switch states:

* **`TracerVerticalDiffusion`** (jcm/physics/vertical_diffusion/tracer_diffusion.py): unconditionally stable backward-Euler diffusion of an explicit tracer list with the TTE-TKE `kh` exchange-coefficient profile (previous-step carry, like every cross-term consumer of that diagnostic; no-op on the first step). One batched Thomas solve over the stacked tracers, zero-flux boundaries (surface exchange stays dry deposition's job), exactly conservative and positivity-preserving for any K·Δt — pinned by an analytic two-layer closed form plus conservation/boundedness tests on asymmetric grids. Mixes all 54 JAM tracers (29 with the mirrors off).
* **`ConvectiveTracerTransport`** (jcm/physics/convection/tracer_transport.py): bulk entraining/detraining plume with compensating subsidence, driven by the updraft ledger the Tiedtke term now publishes in `ConvectionData` (`mass_flux_up`, `entrain_up`, post-rescale and post-cap so tracer transport is proportional to the heat/moisture transport actually applied). Detrainment derives from plume continuity — which automatically absorbs the survival cuts and turns the cloud-base mass supply into entrainment of cloud-base air — and the plume concentration is a convex mix, so no new extrema. Column conservation is exact by construction (telescoping subsidence, forced top detrainment). Transports the 29 interstitial + gas tracers; cloud-borne mirrors are excluded (their updraft processing is entangled with convective scavenging).

The local adversarial review caught one real bug before this landed: the explicit-update CFL guard originally bounded `(mfu + E)·Δt/Δm` per layer, but a net-detrainment layer's true sink references the flux from the layer *below* over its *own* mass — with thin layers aloft (generic in hybrid coordinates) the sink exceeded 1 and drove detrainment-layer tracers negative (numerically reproduced). The guard now bounds the derived sink `(E_eff + M_below)·Δt/Δm`, scaling the whole ledger after derivation (homogeneous, so conservation is untouched); the thin-layer repro is the regression test, proven discriminating by file-copy swap.

Documented follow-ups, in the term docstrings: downdraft tracer transport (`mass_flux_down` is published for it) and in-plume scavenging of soluble aerosol (ECHAM's `cuscav`; without it expect a high bias in upper-tropospheric soluble aerosol under deep convection — the plume is conservative and convective wet removal lives separately in the JAM wetdep term).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aqshaa5nDrxcDWgg1FYw8Z
