### PR TITLE
Per-level precip formation/evaporation from cloud microphysics; wet scavenging on the true ledger (#499)

### DIFF
--- a/jcm/physics/aerosol/jam/wetdep/__init__.py
+++ b/jcm/physics/aerosol/jam/wetdep/__init__.py
@@ -5,13 +5,13 @@ from jcm.physics.aerosol.jam.wetdep.wetdep_term import (
     WetDepParameters,
     below_cloud_rate,
     in_cloud_rate,
-    precip_formation_rate,
+    reinjection_budget,
 )
 
 __all__ = [
     "WetScavenging",
     "WetDepParameters",
-    "precip_formation_rate",
+    "reinjection_budget",
     "in_cloud_rate",
     "below_cloud_rate",
 ]

--- a/jcm/physics/aerosol/jam/wetdep/wetdep_term.py
+++ b/jcm/physics/aerosol/jam/wetdep/wetdep_term.py
@@ -159,36 +159,43 @@ def conv_in_cloud_rate(
 
 
 def reinjection_budget(
-    scavenged_flux: jnp.ndarray,  # (K, nlev, ncols) removal into precip [kg/m²/s]
-    evap_fraction: jnp.ndarray,   # (nlev, ncols) precip fraction evaporating
+    scavenged_below: jnp.ndarray,   # (K, nlev, ncols) impaction removal [kg/m²/s]
+    scavenged_formed: jnp.ndarray,  # (K, nlev, ncols) in-cloud removal [kg/m²/s]
+    evap_fraction: jnp.ndarray,     # (nlev, ncols) incoming-precip fraction evaporating
 ) -> tuple[jnp.ndarray, jnp.ndarray]:
     """Aerosol-in-precip ledger: re-injected flux per layer + surface flux.
 
-    Integrates the scavenged-aerosol flux top to bottom: entering each layer,
-    the fraction of the carrier precip that evaporates there releases the
-    same fraction of the carried aerosol (``reinjected``); the layer's own
-    scavenging then joins the flux. Returns ``(reinjected, surface_flux)``
-    with ``reinjected`` shaped like ``scavenged_flux`` and ``surface_flux``
-    ``(K, ncols)``, satisfying column conservation
-    ``sum_k(scavenged - reinjected) = surface_flux`` exactly.
+    Integrates the scavenged-aerosol flux top to bottom, honouring the
+    cloud schemes' own flux ordering (evaporation is capped by the
+    INCOMING precip, formation is added after): aerosol impacted out by
+    the falling precip within a layer (``scavenged_below``) joins the
+    incoming carrier BEFORE the release — a fully-evaporating virga layer
+    releases it rather than surface-depositing it through dry air — while
+    aerosol scavenged into precip NEWLY FORMED in the layer
+    (``scavenged_formed``) joins AFTER, because the incoming carrier's
+    evaporation cannot touch precip that is only now forming and heading
+    down. Returns ``(reinjected, surface_flux)`` with ``reinjected``
+    shaped like the inputs and ``surface_flux`` ``(K, ncols)``, satisfying
+    column conservation
+    ``sum_k(scavenged_below + scavenged_formed - reinjected) =
+    surface_flux`` exactly.
     """
     def step(carried, xs):
-        s_k, e_k = xs                       # (K, ncols), (ncols,)
-        # The layer's own scavenging joins the ledger BEFORE the release,
-        # as in HAMMOZ: in a fully-evaporating (virga) layer everything —
-        # including aerosol impacted out within that layer — is released,
-        # so nothing rides a terminated carrier to the surface through dry
-        # air.
-        total = carried + s_k
-        released = total * e_k[jnp.newaxis, :]
-        carried = total - released
+        s_below_k, s_form_k, e_k = xs        # (K, ncols) x2, (ncols,)
+        incoming = carried + s_below_k
+        released = incoming * e_k[jnp.newaxis, :]
+        carried = incoming - released + s_form_k
         return carried, released
 
-    k, _, ncols = scavenged_flux.shape
+    k, _, ncols = scavenged_below.shape
     surface, released = jax.lax.scan(
         step,
-        jnp.zeros((k, ncols), scavenged_flux.dtype),
-        (jnp.moveaxis(scavenged_flux, 1, 0), evap_fraction),
+        jnp.zeros((k, ncols), scavenged_below.dtype),
+        (
+            jnp.moveaxis(scavenged_below, 1, 0),
+            jnp.moveaxis(scavenged_formed, 1, 0),
+            evap_fraction,
+        ),
     )
     return jnp.moveaxis(released, 0, 1), surface
 
@@ -324,7 +331,11 @@ class WetScavenging(PhysicsTerm):
         # to the interstitial phase).
         reinject_to: list[str] = []
         q_list: list[jnp.ndarray] = []
-        rate_strat: list[jnp.ndarray] = []
+        # Stratiform removal splits by carrier relationship (see
+        # ``reinjection_budget``): impaction into the INCOMING precip vs
+        # in-cloud scavenging into precip FORMED here.
+        rate_below_strat: list[jnp.ndarray] = []
+        rate_form_strat: list[jnp.ndarray] = []
         rate_conv: list[jnp.ndarray] = []
         # With a prognostic cloud-borne phase (``spec.cloud_borne``, #602) the
         # stratiform in-cloud (nucleation) pathway belongs to the cloud-borne
@@ -356,27 +367,29 @@ class WetScavenging(PhysicsTerm):
                     frac_mass = jam_act.mass_frac[i]
                 else:
                     frac_num = frac_mass = activated_fraction
-                strat_num = below_strat + frac_num * rate_ic_unit
-                strat_mass = below_strat + frac_mass * rate_ic_unit
+                form_num = frac_num * rate_ic_unit
+                form_mass = frac_mass * rate_ic_unit
                 conv_rate = below_conv + rate_conv_incloud
             elif mode.can_activate:
-                strat_num = strat_mass = below_strat
+                form_num = form_mass = zeros
                 conv_rate = below_conv + rate_conv_incloud
             else:
-                strat_num = strat_mass = below_strat
+                form_num = form_mass = zeros
                 conv_rate = below_conv
             n_nm = number_name(mode.short)
             names.append(n_nm)
             reinject_to.append(n_nm)
             q_list.append(state.tracers.get(n_nm, zeros))
-            rate_strat.append(strat_num)
+            rate_below_strat.append(below_strat)
+            rate_form_strat.append(form_num)
             rate_conv.append(conv_rate)
             for sp in mode.species:
                 nm = mass_name(sp, mode.short)
                 names.append(nm)
                 reinject_to.append(nm)
                 q_list.append(state.tracers.get(nm, zeros))
-                rate_strat.append(strat_mass)
+                rate_below_strat.append(below_strat)
+                rate_form_strat.append(form_mass)
                 rate_conv.append(conv_rate)
             if explicit_cb:
                 # Cloud-borne aerosol is entirely in-droplet: no below-cloud
@@ -392,7 +405,8 @@ class WetScavenging(PhysicsTerm):
                     names.append(nm)
                     reinject_to.append(partner)
                     q_list.append(state.tracers.get(nm, zeros))
-                    rate_strat.append(rate_cb)
+                    rate_below_strat.append(zeros)
+                    rate_form_strat.append(rate_cb)
                     rate_conv.append(zeros)
 
         # Implicit (exponential) scavenging over the step: q(t+dt) = q·exp(-rate·dt).
@@ -409,25 +423,28 @@ class WetScavenging(PhysicsTerm):
         # apply exactly ``q·(exp(-rate·dt) - 1)`` over the step.
         # Clamp the decay rates to ≥0 so the exponential update is always a
         # bounded removal (a scavenging rate is non-negative by construction).
-        strat_arr = jnp.maximum(jnp.stack(rate_strat), 0.0)
+        below_arr = jnp.maximum(jnp.stack(rate_below_strat), 0.0)
+        form_arr = jnp.maximum(jnp.stack(rate_form_strat), 0.0)
         conv_arr = jnp.maximum(jnp.stack(rate_conv), 0.0)
-        rate_arr = strat_arr + conv_arr
+        rate_arr = below_arr + form_arr + conv_arr
         removed_frac = -jnp.expm1(-rate_arr * dt)              # 1 - exp(-rate·dt) ∈ [0, 1]
         dq_stack = -(removed_frac * jnp.stack(q_list)) / dt
 
-        # Re-evaporation re-injection (#499): the stratiform share of each
-        # tracer's removal (proportional attribution between the two rate
-        # families) rides the falling precip; ``reinjection_budget``
-        # releases it where the carrier evaporates. Convectively scavenged
-        # aerosol deposits directly (no convective evap profile yet).
-        strat_share = jnp.where(
-            rate_arr > _RATE_FLOOR,
-            strat_arr / jnp.maximum(rate_arr, _RATE_FLOOR),
-            0.0,
-        )
-        scavenged_flux = -dq_stack * strat_share * dm[jnp.newaxis]
+        # Re-evaporation re-injection (#499): the stratiform shares of each
+        # tracer's removal (proportional attribution among the rate
+        # families) ride the falling precip; ``reinjection_budget``
+        # releases them where the carrier evaporates, with impaction
+        # joining the incoming carrier and in-cloud scavenging the newly
+        # formed one (see its docstring). Convectively scavenged aerosol
+        # deposits directly (no convective evap profile yet).
+        rate_safe = jnp.maximum(rate_arr, _RATE_FLOOR)
+        live = rate_arr > _RATE_FLOOR
+        share_below = jnp.where(live, below_arr / rate_safe, 0.0)
+        share_form = jnp.where(live, form_arr / rate_safe, 0.0)
+        removed_flux = -dq_stack * dm[jnp.newaxis]
         reinjected, _surface = reinjection_budget(
-            scavenged_flux, evap_fraction,
+            removed_flux * share_below, removed_flux * share_form,
+            evap_fraction,
         )
         reinject_tend = reinjected / dm[jnp.newaxis]
 

--- a/jcm/physics/aerosol/jam/wetdep/wetdep_term.py
+++ b/jcm/physics/aerosol/jam/wetdep/wetdep_term.py
@@ -1,38 +1,50 @@
 """``WetScavenging`` — in-cloud and below-cloud aerosol scavenging.
 
-Two removal pathways for aerosol, both differentiable and built
-only from diagnostics the cloud scheme already exposes (so the cloud
-microphysics terms are untouched). With a prognostic cloud-borne phase
-(``spec.cloud_borne``, #602) the stratiform in-cloud pathway acts on the
-cloud-borne tracers at the full condensate→precip conversion rate and the
-interstitial tracers keep impaction + convective processing; without one,
-the in-cloud pathway acts on interstitial aerosol weighted by its activated
-fraction (the implicit M7/TOMAS-style treatment):
+Removal pathways for aerosol, all differentiable, driven by the per-level
+precipitation process rates the cloud microphysics schemes actually
+integrate (``CloudData.precip_formation_rate`` / ``precip_evaporation_rate``,
+#499; the carrier flux is their own cumulative ledger, which deliberately
+excludes the sedimenting cloud-ice flux — see ``__call__``). With a prognostic
+cloud-borne phase (``spec.cloud_borne``, #602) the stratiform in-cloud
+pathway acts on the cloud-borne tracers at the full condensate→precip
+conversion rate and the interstitial tracers keep impaction + convective
+processing; without one, the in-cloud pathway acts on interstitial aerosol
+weighted by its per-mode activated fractions (the implicit M7/TOMAS-style
+treatment):
 
-* **In-cloud nucleation scavenging** — the activated fraction of aerosol is in
-  cloud droplets and is removed at the rate cloud condensate converts to
-  precipitation. As an interim, the per-level precip-formation rate is
-  *reconstructed* by distributing the column surface precip
-  (``CloudData.precip_rain/snow``) across the cloudy column weighted by
-  in-cloud condensate; exposing the true per-level formation (and
-  evaporation) rate from the cloud schemes — and adding re-evaporation
-  re-injection — is tracked in #499.
-* **Below-cloud impaction scavenging** — falling precipitation collects
-  interstitial aerosol in clear air, with a size-dependent (∝ r²) collection
-  efficiency so coarse particles are scavenged far faster than accumulation
-  mode. Driven by stratiform AND convective precipitation — with the
-  convective contribution masked to levels at/below the convective cloud
-  top (diagnosed by pressure from the heating footprint), since rain
-  cannot collect aerosol above where it forms.
+* **In-cloud nucleation scavenging** — aerosol residing in cloud droplets is
+  removed at the local rate cloud condensate converts to precipitation,
+  ``precip_formation_rate / (qc + qi)`` (both grid-mean, so the cloudy-area
+  factor cancels inside the ratio).
+* **Below-cloud impaction scavenging** — precipitation falling through a
+  layer collects aerosol in its clear-air part, with a size-dependent
+  (∝ r²) collection efficiency. The stratiform contribution uses the
+  per-level flux entering each layer, so washout is automatically confined
+  below where precip actually forms; the convective contribution uses the
+  surface convective precip masked to levels at/below the convective cloud
+  top (diagnosed by pressure from the heating footprint).
 * **Convective in-cloud scavenging** — the convective mirror of the
   stratiform pathway: scavenging ratio × (per-layer updraft precip
   formation / in-updraft condensate), from ``ConvectionData``'s
   ``precip_formation`` (ECHAM ``pdmfup``) and ``qc_conv``/``qi_conv``;
-  soluble modes only.
+  activatable modes only.
+* **Re-evaporation re-injection** — aerosol scavenged by the stratiform
+  pathways is carried in the falling precip; where that precip evaporates
+  or sublimates, the same fraction of the carried aerosol returns to the
+  INTERSTITIAL phase (a droplet that evaporates releases its aerosol, so
+  cloud-borne-scavenged material also re-enters as interstitial). The
+  aerosol-in-precip flux is integrated top to bottom per tracer, exactly
+  mirroring HAMMOZ ``mo_ham_wetdep``'s re-evaporation ledger; the flux
+  reaching the bottom is the net surface wet deposition. Convectively
+  scavenged aerosol is deposited directly (the convection scheme exposes no
+  evaporation profile yet).
 
 ``ConvectionData`` is read via ``diagnostics.get("convection")`` with a
 zero-precip fallback so the term still composes without a convection
-scheme.
+scheme. A cloud scheme that does not populate the per-level process rates
+(both ECHAM schemes do) yields zero stratiform scavenging altogether — the
+in-cloud rate, the impaction carrier and the re-injection ledger all derive
+from those two fields.
 
 Mirrors ``mo_hammoz_wetdep``.
 """
@@ -41,6 +53,7 @@ from __future__ import annotations
 
 from typing import ClassVar
 
+import jax
 import jax.numpy as jnp
 import tree_math
 from flax import nnx
@@ -51,6 +64,13 @@ from jcm.physics.aerosol.jam.tracer_layout import mass_name, number_name
 from jcm.physics.physics_term import PhysicsTendency, PhysicsTerm
 
 _EPS = 1.0e-30
+# Physical floors for the re-injection budget's divisions. Values below
+# these are dynamically negligible (a 1e-15 1/s removal rate is a ~30 Myr
+# timescale; 1e-12 kg/m²/s is ~1e-4 mm/day), and a *physical* floor — not a
+# tiny epsilon — keeps the guarded-division VJPs clear of the squared-
+# underflow window in float32 (the double-where NaN class).
+_RATE_FLOOR = 1.0e-15   # [1/s]
+_FLUX_FLOOR = 1.0e-12   # [kg/m²/s]
 
 
 @tree_math.struct
@@ -74,24 +94,12 @@ class WetDepParameters:
         )
 
 
-def precip_formation_rate(
-    precip_col: jnp.ndarray,      # (ncols,) surface precip [kg/m²/s]
-    cloud_fraction: jnp.ndarray,  # (nlev, ncols)
-    qc: jnp.ndarray,              # (nlev, ncols)
-    air_density: jnp.ndarray,
-    layer_thickness: jnp.ndarray,
-) -> jnp.ndarray:
-    """Per-level condensate→precip conversion rate [kg/kg/s].
-
-    Distributes the column surface precip across the cloudy column weighted
-    by in-cloud condensate, converting the surface mass flux to a local
-    mixing-ratio sink rate.
-    """
-    weight = cloud_fraction * jnp.maximum(qc, 0.0)
-    w_sum = jnp.sum(weight, axis=0, keepdims=True)
-    frac = weight / jnp.maximum(w_sum, _EPS)
-    local = precip_col[jnp.newaxis, :] / (air_density * layer_thickness)
-    return local * frac
+#: Physical condensate floor for the in-cloud rate [kg/kg]. A cell with less
+#: than this holds no cloud worth scavenging in; it is also what keeps the
+#: division's VJP clear of the float32 squared-underflow window (a 1e-30
+#: epsilon guard here gave a verified NaN gradient in every clear f32 cell:
+#: the cotangent forms p_form/condensate², and 1e-60 flushes to zero).
+_CONDENSATE_FLOOR = 1.0e-12
 
 
 def in_cloud_rate(
@@ -99,18 +107,24 @@ def in_cloud_rate(
     p_form: jnp.ndarray,
     qc: jnp.ndarray,
 ) -> jnp.ndarray:
-    """In-cloud scavenging rate [1/s] applied to interstitial aerosol."""
-    return activated_fraction * p_form / jnp.maximum(qc, _EPS)
+    """In-cloud scavenging rate [1/s] applied to in-droplet aerosol."""
+    rate = activated_fraction * p_form / jnp.maximum(qc, _CONDENSATE_FLOOR)
+    return jnp.where(qc > _CONDENSATE_FLOOR, rate, 0.0)
 
 
 def below_cloud_rate(
-    precip_col: jnp.ndarray,
-    cloud_fraction: jnp.ndarray,
+    precip_flux: jnp.ndarray,     # (nlev, ncols) precip falling through [kg/m²/s]
+    cloud_fraction: jnp.ndarray,  # (nlev, ncols)
     r_wet: jnp.ndarray,
     params: WetDepParameters,
 ) -> jnp.ndarray:
-    """Below-cloud impaction scavenging rate [1/s], size-dependent (∝ r²)."""
-    rain_mmph = precip_col[jnp.newaxis, :] * 3600.0  # kg/m²/s -> mm/h
+    """Below-cloud impaction scavenging rate [1/s], size-dependent (∝ r²).
+
+    ``precip_flux`` is the local flux falling through each layer (per-level
+    profile for stratiform precip; a broadcast surface value is the interim
+    convective treatment).
+    """
+    rain_mmph = precip_flux * 3600.0  # kg/m²/s -> mm/h
     efficiency = (r_wet / params.below_radius_ref) ** 2
     # Clear-sky (below-cloud) fraction, clipped to [0, 1]. The cloud scheme can
     # return cloud_fraction > 1 (e.g. where RH > 1), which would make this
@@ -144,8 +158,43 @@ def conv_in_cloud_rate(
     return jnp.where(conv_condensate > 1.0e-12, rate, 0.0)
 
 
+def reinjection_budget(
+    scavenged_flux: jnp.ndarray,  # (K, nlev, ncols) removal into precip [kg/m²/s]
+    evap_fraction: jnp.ndarray,   # (nlev, ncols) precip fraction evaporating
+) -> tuple[jnp.ndarray, jnp.ndarray]:
+    """Aerosol-in-precip ledger: re-injected flux per layer + surface flux.
+
+    Integrates the scavenged-aerosol flux top to bottom: entering each layer,
+    the fraction of the carrier precip that evaporates there releases the
+    same fraction of the carried aerosol (``reinjected``); the layer's own
+    scavenging then joins the flux. Returns ``(reinjected, surface_flux)``
+    with ``reinjected`` shaped like ``scavenged_flux`` and ``surface_flux``
+    ``(K, ncols)``, satisfying column conservation
+    ``sum_k(scavenged - reinjected) = surface_flux`` exactly.
+    """
+    def step(carried, xs):
+        s_k, e_k = xs                       # (K, ncols), (ncols,)
+        # The layer's own scavenging joins the ledger BEFORE the release,
+        # as in HAMMOZ: in a fully-evaporating (virga) layer everything —
+        # including aerosol impacted out within that layer — is released,
+        # so nothing rides a terminated carrier to the surface through dry
+        # air.
+        total = carried + s_k
+        released = total * e_k[jnp.newaxis, :]
+        carried = total - released
+        return carried, released
+
+    k, _, ncols = scavenged_flux.shape
+    surface, released = jax.lax.scan(
+        step,
+        jnp.zeros((k, ncols), scavenged_flux.dtype),
+        (jnp.moveaxis(scavenged_flux, 1, 0), evap_fraction),
+    )
+    return jnp.moveaxis(released, 0, 1), surface
+
+
 class WetScavenging(PhysicsTerm):
-    """In-cloud + below-cloud scavenging of interstitial aerosol."""
+    """In-cloud + below-cloud scavenging with re-evaporation re-injection."""
 
     name: ClassVar[str] = "jam_wet_deposition"
     category: ClassVar[str] = "aerosol_wetdep"
@@ -171,19 +220,53 @@ class WetScavenging(PhysicsTerm):
         activated_fraction = diagnostics["activated_fraction"]
         air_density = diagnostics["air_density"]
         dz = diagnostics["layer_thickness"]
+        dm = air_density * dz
         # Timestep for the implicit (exponential) scavenging update below.
         dt = diagnostics.get("_dt_seconds", 1800.0)
 
         clouds = diagnostics["clouds"]
-        precip_col = clouds.precip_rain + clouds.precip_snow
         cloud_fraction = clouds.cloud_fraction
-        qc = clouds.qc
+        # Total cloud condensate: the formation ledger spans both the rain
+        # (from qc) and snow (from qc and qi) pathways, so the in-droplet
+        # residence pool is liquid + ice.
+        condensate = jnp.maximum(clouds.qc, 0.0) + jnp.maximum(clouds.qi, 0.0)
+        # Per-level stratiform process rates from the cloud scheme (#499):
+        # the true local condensate→precip conversion and the falling-precip
+        # evaporation. The carrier flux for impaction and the re-evap ledger
+        # is rebuilt as the cumulative (formation − evaporation) integral of
+        # those same rates rather than read from ``clouds.rain_flux +
+        # snow_flux``: the schemes fold the sedimenting cloud-ice flux into
+        # the frozen profile at interior levels, and that ice is not a
+        # scavenging carrier (its sublimation is likewise excluded from
+        # ``precip_evaporation_rate``), so using the profiles directly would
+        # both drive impaction with a non-carrier flux and dilute the
+        # re-evaporation fraction under cirrus. Melt only moves mass between
+        # rain and snow, so the summed ledger is exact for the actual
+        # precip; the floor guards accumulated round-off. Note the
+        # ice-sedimentation flux that reaches the surface as snow therefore
+        # carries no aerosol removal at all — a real missing sink, accepted
+        # with the non-carrier stance.
+        p_form = jnp.maximum(clouds.precip_formation_rate, 0.0)
+        p_evap = jnp.maximum(clouds.precip_evaporation_rate, 0.0)
+        strat_flux = jnp.maximum(
+            jnp.cumsum((p_form - p_evap) * dm, axis=0), 0.0
+        )
+        flux_in = jnp.concatenate(
+            [jnp.zeros_like(strat_flux[:1]), strat_flux[:-1]], axis=0
+        )
+        # Fraction of the precip entering a layer that evaporates within it,
+        # guarded on a physical flux floor (see _FLUX_FLOOR note above).
+        evap_fraction = jnp.where(
+            flux_in > _FLUX_FLOOR,
+            jnp.clip(p_evap * dm / jnp.maximum(flux_in, _FLUX_FLOOR), 0.0, 1.0),
+            0.0,
+        )
 
         # Convective precipitation (Tiedtke). Zero-precip fallback keeps the
         # term composable without a convection scheme (see module docstring).
         conv = diagnostics.get("convection")
         if conv is None:
-            conv_precip = jnp.zeros_like(precip_col)
+            conv_precip = jnp.zeros_like(state.temperature[0])
             rate_conv_incloud = jnp.zeros_like(state.temperature)
             conv_below = jnp.zeros_like(state.temperature)
         else:
@@ -209,58 +292,59 @@ class WetScavenging(PhysicsTerm):
                 # No pressure diagnostic: column-wide washout, not none.
                 conv_below = jnp.ones_like(state.temperature)
 
-        p_form = precip_formation_rate(
-            precip_col, cloud_fraction, qc, air_density, dz,
-        )
         # The implicit stratiform rate is weighted by the cloudy area
-        # fraction: the grid-mean p_form/qc ratio is the IN-CLOUD conversion
-        # rate (cf cancels between them), but only cf·af of the grid-mean
-        # interstitial tracer is in droplets. Without the cf factor broken
-        # cloud (cf ~ 0.3) over-scavenged ~3x, and the implicit and explicit
-        # cloud-borne representations would disagree at exchange equilibrium
-        # for reasons that have nothing to do with the representation (#602).
+        # fraction: the grid-mean p_form/condensate ratio is the IN-CLOUD
+        # conversion rate (cf cancels between them), but only cf·af of the
+        # grid-mean interstitial tracer is in droplets. ``in_cloud_rate`` is
+        # linear in the activated fraction, so keep the unit-fraction base
+        # and apply per-mode, per-quantity fractions below: ARG's number and
+        # mass fractions differ a lot (large particles activate
+        # preferentially) and vary by mode. The aggregate fraction is kept
+        # only as a fallback for standalone composition without ARG
+        # upstream.
         cf_clip = jnp.clip(cloud_fraction, 0.0, 1.0)
-        # ``in_cloud_rate`` is linear in the activated fraction, so keep the
-        # unit-fraction base and apply per-mode, per-quantity fractions
-        # below: ARG's number and mass fractions differ a lot (large
-        # particles activate preferentially) and vary by mode, and using
-        # the aggregate number-weighted fraction for everything biases the
-        # implicit representation away from the explicit one at exchange
-        # equilibrium. The aggregate is kept only as a fallback for
-        # standalone composition without the ARG term upstream.
         rate_ic_unit = params.incloud_scale * cf_clip * in_cloud_rate(
-            jnp.ones_like(state.temperature), p_form, qc,
+            jnp.ones_like(state.temperature), p_form, condensate,
         )
         jam_act = diagnostics.get("_jam_activation")
 
-        # Build a per-tracer scavenging rate and stack with the matching
+        # Build per-tracer scavenging rates and stack with the matching
         # tracers, so the elementwise removal runs as one batched op (rather
-        # than an unrolled tendency per mode×species). ``state.tracers`` is
-        # empty during ``Model.get_empty_data``'s structural probe, so fall
-        # back to zeros there (real runs have every declared tracer seeded).
+        # than an unrolled tendency per mode×species). Stratiform and
+        # convective rates are kept separate: only stratiform-scavenged
+        # aerosol enters the re-evaporation ledger (its carrier's per-level
+        # evaporation is known). ``state.tracers`` is empty during
+        # ``Model.get_empty_data``'s structural probe, so fall back to zeros
+        # there (real runs have every declared tracer seeded).
         zeros = jnp.zeros_like(state.temperature)
         names: list[str] = []
+        # Interstitial destination for each stacked tracer's re-injected
+        # aerosol: itself for interstitial tracers; the interstitial partner
+        # for cloud-borne ones (an evaporated droplet releases its aerosol
+        # to the interstitial phase).
+        reinject_to: list[str] = []
         q_list: list[jnp.ndarray] = []
-        rate_list: list[jnp.ndarray] = []
+        rate_strat: list[jnp.ndarray] = []
+        rate_conv: list[jnp.ndarray] = []
         # With a prognostic cloud-borne phase (``spec.cloud_borne``, #602) the
         # stratiform in-cloud (nucleation) pathway belongs to the cloud-borne
         # tracers, which sit in the droplets by definition: they are removed
         # at the full condensate→precip conversion rate, and the interstitial
         # tracers keep only impaction and convective processing (activated
         # aerosol first transfers via ``CloudBorneExchange``, then rains
-        # out). Without it, the current implicit treatment stands — the
-        # interstitial tracers are scavenged by their activated fraction.
+        # out). Without it, the implicit treatment stands — the interstitial
+        # tracers are scavenged by their per-mode activated fractions.
         explicit_cb = self._spec.cloud_borne
         rate_cb = params.incloud_scale * in_cloud_rate(
-            jnp.ones_like(state.temperature), p_form, qc,
+            jnp.ones_like(state.temperature), p_form, condensate,
         )
         for i, mode in enumerate(self._spec.modes):
-            # Stratiform washout column-wide (interim, #499); convective
-            # only below the convective cloud top.
-            rate_below = below_cloud_rate(
-                precip_col, cloud_fraction, aer.r_wet[i], params,
-            ) + conv_below * below_cloud_rate(
-                conv_precip, cloud_fraction, aer.r_wet[i], params,
+            below_strat = below_cloud_rate(
+                flux_in, cloud_fraction, aer.r_wet[i], params,
+            )
+            below_conv = conv_below * below_cloud_rate(
+                conv_precip[jnp.newaxis, :], cloud_fraction,
+                aer.r_wet[i], params,
             )
             # In-cloud only removes from activatable (soluble) modes — and
             # only implicitly (via the activated fraction) when there is no
@@ -272,33 +356,44 @@ class WetScavenging(PhysicsTerm):
                     frac_mass = jam_act.mass_frac[i]
                 else:
                     frac_num = frac_mass = activated_fraction
-                rate_num = rate_below + rate_conv_incloud + (
-                    frac_num * rate_ic_unit
-                )
-                rate_mass = rate_below + rate_conv_incloud + (
-                    frac_mass * rate_ic_unit
-                )
+                strat_num = below_strat + frac_num * rate_ic_unit
+                strat_mass = below_strat + frac_mass * rate_ic_unit
+                conv_rate = below_conv + rate_conv_incloud
             elif mode.can_activate:
-                rate_num = rate_mass = rate_below + rate_conv_incloud
+                strat_num = strat_mass = below_strat
+                conv_rate = below_conv + rate_conv_incloud
             else:
-                rate_num = rate_mass = rate_below
-            names.append(number_name(mode.short))
-            q_list.append(state.tracers.get(number_name(mode.short), zeros))
-            rate_list.append(rate_num)
-            for nm in [mass_name(sp, mode.short) for sp in mode.species]:
+                strat_num = strat_mass = below_strat
+                conv_rate = below_conv
+            n_nm = number_name(mode.short)
+            names.append(n_nm)
+            reinject_to.append(n_nm)
+            q_list.append(state.tracers.get(n_nm, zeros))
+            rate_strat.append(strat_num)
+            rate_conv.append(conv_rate)
+            for sp in mode.species:
+                nm = mass_name(sp, mode.short)
                 names.append(nm)
+                reinject_to.append(nm)
                 q_list.append(state.tracers.get(nm, zeros))
-                rate_list.append(rate_mass)
+                rate_strat.append(strat_mass)
+                rate_conv.append(conv_rate)
             if explicit_cb:
                 # Cloud-borne aerosol is entirely in-droplet: no below-cloud
-                # impaction, no activated-fraction weighting.
-                for nm in [number_name(mode.short, cloud_borne=True)] + [
-                    mass_name(sp, mode.short, cloud_borne=True)
+                # impaction, no activated-fraction weighting, and its
+                # re-injected share returns to the interstitial partner.
+                pairs = [(number_name(mode.short, cloud_borne=True),
+                          number_name(mode.short))] + [
+                    (mass_name(sp, mode.short, cloud_borne=True),
+                     mass_name(sp, mode.short))
                     for sp in mode.species
-                ]:
+                ]
+                for nm, partner in pairs:
                     names.append(nm)
+                    reinject_to.append(partner)
                     q_list.append(state.tracers.get(nm, zeros))
-                    rate_list.append(rate_cb)
+                    rate_strat.append(rate_cb)
+                    rate_conv.append(zeros)
 
         # Implicit (exponential) scavenging over the step: q(t+dt) = q·exp(-rate·dt).
         # The first-order-decay rate is unbounded — the in-cloud rate ∝ 1/qc
@@ -312,12 +407,33 @@ class WetScavenging(PhysicsTerm):
         # ``mo_ham_wetdep`` applies the same ``1 - exp(-Λ·Δt)`` removed fraction).
         # Emitted as a per-second tendency so the operator-split sum + dynamics
         # apply exactly ``q·(exp(-rate·dt) - 1)`` over the step.
-        # Clamp the decay rate to ≥0 so the exponential update is always a
+        # Clamp the decay rates to ≥0 so the exponential update is always a
         # bounded removal (a scavenging rate is non-negative by construction).
-        rate_arr = jnp.maximum(jnp.stack(rate_list), 0.0)
+        strat_arr = jnp.maximum(jnp.stack(rate_strat), 0.0)
+        conv_arr = jnp.maximum(jnp.stack(rate_conv), 0.0)
+        rate_arr = strat_arr + conv_arr
         removed_frac = -jnp.expm1(-rate_arr * dt)              # 1 - exp(-rate·dt) ∈ [0, 1]
         dq_stack = -(removed_frac * jnp.stack(q_list)) / dt
+
+        # Re-evaporation re-injection (#499): the stratiform share of each
+        # tracer's removal (proportional attribution between the two rate
+        # families) rides the falling precip; ``reinjection_budget``
+        # releases it where the carrier evaporates. Convectively scavenged
+        # aerosol deposits directly (no convective evap profile yet).
+        strat_share = jnp.where(
+            rate_arr > _RATE_FLOOR,
+            strat_arr / jnp.maximum(rate_arr, _RATE_FLOOR),
+            0.0,
+        )
+        scavenged_flux = -dq_stack * strat_share * dm[jnp.newaxis]
+        reinjected, _surface = reinjection_budget(
+            scavenged_flux, evap_fraction,
+        )
+        reinject_tend = reinjected / dm[jnp.newaxis]
+
         tracer_tends = {nm: dq_stack[k] for k, nm in enumerate(names)}
+        for k, target in enumerate(reinject_to):
+            tracer_tends[target] = tracer_tends[target] + reinject_tend[k]
 
         tendency = PhysicsTendency(
             u_wind=jnp.zeros_like(state.u_wind),
@@ -326,8 +442,9 @@ class WetScavenging(PhysicsTerm):
             specific_humidity=jnp.zeros_like(state.specific_humidity),
             tracers=tracer_tends,
         )
-        # AeroCom deposition fluxes (jax-gcm#581): this term's removal,
-        # column-integrated, accumulated onto the per-step-reset keys.
+        # AeroCom deposition fluxes (jax-gcm#581): this term's NET removal
+        # (scavenging minus re-injection), column-integrated, accumulated
+        # onto the per-step-reset keys.
         from jcm.physics.aerosol.jam.emissions.flux_diagnostic import (
             accumulate_deposition_fluxes)
         diagnostics = accumulate_deposition_fluxes(

--- a/jcm/physics/aerosol/jam/wetdep/wetdep_test.py
+++ b/jcm/physics/aerosol/jam/wetdep/wetdep_test.py
@@ -12,22 +12,41 @@ from jcm.physics.aerosol.jam.wetdep.wetdep_term import (
     below_cloud_rate,
     conv_in_cloud_rate,
     in_cloud_rate,
-    precip_formation_rate,
+    reinjection_budget,
 )
 
 
 class ScavengingFunctionTest(unittest.TestCase):
-    def test_precip_formation_distributes_over_condensate(self):
-        precip = jnp.asarray([1.0e-4])           # kg/m²/s
-        cf = jnp.array([[0.0], [0.8], [0.0]])
-        qc = jnp.array([[0.0], [1.0e-3], [0.0]])
-        rho = jnp.ones((3, 1))
-        dz = jnp.full((3, 1), 100.0)
-        pf = precip_formation_rate(precip, cf, qc, rho, dz)
-        # All formation in the single cloudy layer.
-        self.assertGreater(float(pf[1, 0]), 0.0)
-        self.assertAlmostEqual(float(pf[0, 0]), 0.0)
-        self.assertAlmostEqual(float(pf[2, 0]), 0.0)
+    def test_reinjection_budget_conserves_the_column(self):
+        # Aerosol scavenged at the top rides the precip down; a 50%-evap
+        # layer releases half, a full-evap layer releases the rest, and
+        # nothing reaches the surface. sum(scavenged - reinjected) must
+        # equal the surface flux EXACTLY at every column.
+        scavenged = jnp.zeros((1, 3, 1)).at[0, 0, 0].set(2.0)
+        evap_frac = jnp.array([[0.0], [0.5], [1.0]])
+        reinjected, surface = reinjection_budget(scavenged, evap_frac)
+        np.testing.assert_allclose(np.asarray(reinjected[0, :, 0]),
+                                   [0.0, 1.0, 1.0])
+        np.testing.assert_allclose(np.asarray(surface), 0.0)
+        # Partial evap: the un-released remainder deposits.
+        evap_frac = jnp.array([[0.0], [0.25], [0.0]])
+        reinjected, surface = reinjection_budget(scavenged, evap_frac)
+        np.testing.assert_allclose(np.asarray(surface[0, 0]), 1.5)
+        np.testing.assert_allclose(
+            float(jnp.sum(scavenged - reinjected)), float(surface[0, 0]),
+        )
+
+    def test_same_layer_scavenge_and_full_evap_releases_everything(self):
+        # Virga: aerosol impacted out within a fully-evaporating layer must
+        # be released there too, not ride a terminated carrier to the
+        # surface through dry air (the layer's scavenging joins the ledger
+        # BEFORE the release, as in HAMMOZ). The pre-fix ordering deposited
+        # it all.
+        scavenged = jnp.zeros((1, 3, 1)).at[0, 2, 0].set(1.0)
+        evap_frac = jnp.zeros((3, 1)).at[2].set(1.0)
+        reinjected, surface = reinjection_budget(scavenged, evap_frac)
+        np.testing.assert_allclose(np.asarray(reinjected[0, 2, 0]), 1.0)
+        np.testing.assert_allclose(np.asarray(surface), 0.0)
 
     def test_in_cloud_rate_scales_with_activation(self):
         pf = jnp.full((1, 1), 1.0e-6)
@@ -37,7 +56,7 @@ class ScavengingFunctionTest(unittest.TestCase):
         self.assertGreater(float(hi[0, 0]), float(lo[0, 0]))
 
     def test_below_cloud_size_dependence(self):
-        precip = jnp.asarray([1.0e-4])
+        precip = jnp.full((1, 1), 1.0e-4)
         cf = jnp.zeros((1, 1))
         params = WetDepParameters.default()
         accum = below_cloud_rate(precip, cf, jnp.full((1, 1), 0.1e-6), params)
@@ -47,7 +66,8 @@ class ScavengingFunctionTest(unittest.TestCase):
     def test_no_precip_no_below_cloud(self):
         params = WetDepParameters.default()
         rate = below_cloud_rate(
-            jnp.zeros((1,)), jnp.zeros((1, 1)), jnp.full((1, 1), 1e-6), params,
+            jnp.zeros((1, 1)), jnp.zeros((1, 1)), jnp.full((1, 1), 1e-6),
+            params,
         )
         self.assertAlmostEqual(float(rate[0, 0]), 0.0)
 
@@ -99,10 +119,19 @@ class WetDepTermTest(unittest.TestCase):
             temperature=jnp.full((nlev, ncols), 275.0),
             tracers=tracers,
         )
+        # Uniform formation through the column whose integral equals the
+        # surface precip (dm = rho * dz = 200 kg/m² per layer here), with
+        # the matching cumulative rain-flux profile — the per-level fields
+        # the cloud schemes now expose (#499).
+        dm = 1.0 * 200.0
+        form = jnp.full((nlev, ncols), precip / (nlev * dm))
+        rain_flux = jnp.cumsum(form * dm, axis=0)
         clouds = CloudData.zeros((ncols,), nlev).copy(
             cloud_fraction=jnp.full((nlev, ncols), 0.6),
             qc=jnp.full((nlev, ncols), 1.0e-3),
             precip_rain=jnp.full((ncols,), precip),
+            precip_formation_rate=form,
+            rain_flux=rain_flux,
         )
         diagnostics = {
             "_jam_state": aer,
@@ -248,6 +277,130 @@ class WetDepTermTest(unittest.TestCase):
         tend, _ = term(state, diagnostics, None, None)
         key = mass_name(spec.modes[0].species[0], spec.modes[0].short)
         self.assertTrue(np.all(np.isfinite(np.asarray(tend.tracers[key]))))
+
+    def test_incloud_driven_by_formation_not_surface_precip(self):
+        # The in-cloud pathway must key off the cloud scheme's per-level
+        # formation rate, not a reconstruction from the surface precip: a
+        # stale surface value with zero formation (and no flux profile)
+        # scavenges NOTHING. This fails on the pre-#499 reconstruction.
+        from jcm.physics.clouds.cloud_data import CloudData
+
+        state, diagnostics, spec, mass_name = self._setup()
+        nlev, ncols = state.temperature.shape
+        diagnostics = dict(diagnostics)
+        diagnostics["clouds"] = CloudData.zeros((ncols,), nlev).copy(
+            cloud_fraction=jnp.full((nlev, ncols), 0.6),
+            qc=jnp.full((nlev, ncols), 1.0e-3),
+            precip_rain=jnp.full((ncols,), 1.0e-3),   # stale, no formation
+        )
+        tend, _ = WetScavenging()(state, diagnostics, None, None)
+        for dq in tend.tracers.values():
+            np.testing.assert_array_equal(np.asarray(dq), 0.0)
+
+    def test_below_cloud_confined_below_formation(self):
+        # Impaction uses the per-level flux entering each layer: levels at
+        # and above the formation level see no falling precip and must not
+        # scavenge; levels below must. Probed with the non-activatable pcm
+        # mode (below-cloud is its only stratiform pathway).
+        from jcm.physics.clouds.cloud_data import CloudData
+
+        state, diagnostics, spec, mass_name = self._setup()
+        nlev, ncols = state.temperature.shape
+        dm = 200.0
+        form = jnp.zeros((nlev, ncols)).at[1].set(1.0e-7)
+        rain_flux = jnp.cumsum(form * dm, axis=0)
+        diagnostics = dict(diagnostics)
+        diagnostics["clouds"] = CloudData.zeros((ncols,), nlev).copy(
+            cloud_fraction=jnp.full((nlev, ncols), 0.6),
+            qc=jnp.full((nlev, ncols), 1.0e-3),
+            precip_rain=rain_flux[-1],
+            precip_formation_rate=form,
+            rain_flux=rain_flux,
+        )
+        tend, _ = WetScavenging()(state, diagnostics, None, None)
+        pcm = spec.mode("pcm")
+        dq = np.asarray(tend.tracers[mass_name(pcm.species[0], "pcm")])
+        np.testing.assert_array_equal(dq[0], 0.0)   # above formation
+        np.testing.assert_array_equal(dq[1], 0.0)   # the forming layer itself
+        self.assertTrue(np.all(dq[2:] < 0.0))       # washed out below
+
+    def test_reinjection_returns_scavenged_aerosol_where_precip_evaporates(self):
+        # Cloud-borne aerosol scavenged in the cloudy upper levels rides
+        # the rain down; a fully-evaporating layer below must re-inject it
+        # into the INTERSTITIAL phase there, and the term's column budget
+        # (removal + re-injection integrated over dm) must equal the
+        # surviving surface flux exactly.
+        from jcm.physics.clouds.cloud_data import CloudData
+        from jcm.physics.aerosol.jam import number_name
+
+        state, diagnostics, spec, mass_name = self._setup()
+        nlev, ncols = state.temperature.shape
+        # LEVEL-DEPENDENT layer mass: the budget's dm weightings cancel on
+        # a uniform grid (budget(x*dm)/dm == budget(x)), so a misplaced dm
+        # would be invisible there — vary it so it isn't.
+        dz = jnp.array([300.0, 250.0, 200.0, 150.0])[:, None] * jnp.ones(
+            (1, ncols)
+        )
+        dm = 1.0 * dz
+        diagnostics = dict(diagnostics)
+        diagnostics["layer_thickness"] = dz
+        # Rain forms at levels 0-1; level 2's evaporation consumes the
+        # whole accumulated carrier (evap*dm2 == form*(dm0+dm1)); none
+        # below.
+        form = jnp.zeros((nlev, ncols)).at[0].set(1.0e-7).at[1].set(1.0e-7)
+        evap_rate = 1.0e-7 * (300.0 + 250.0) / 200.0
+        evap = jnp.zeros((nlev, ncols)).at[2].set(evap_rate)
+        cf = jnp.zeros((nlev, ncols)).at[0:2].set(0.6)
+        diagnostics["clouds"] = CloudData.zeros((ncols,), nlev).copy(
+            cloud_fraction=cf,
+            qc=jnp.zeros((nlev, ncols)).at[0:2].set(1.0e-3),
+            precip_formation_rate=form,
+            precip_evaporation_rate=evap,
+        )
+        # Isolate the in-cloud pathway: no impaction.
+        params = WetDepParameters(
+            incloud_scale=jnp.asarray(1.0),
+            below_coeff=jnp.asarray(0.0),
+            below_radius_ref=jnp.asarray(1.0e-7),
+            conv_scav_ratio=jnp.asarray(0.99),
+        )
+        term = WetScavenging(params=params)
+        tend, _ = term(state, diagnostics, None, None)
+
+        mode = spec.modes[0]
+        cb = np.asarray(
+            tend.tracers[mass_name(mode.species[0], mode.short,
+                                   cloud_borne=True)]
+        )
+        it = np.asarray(tend.tracers[mass_name(mode.species[0], mode.short)])
+        # Removal only where condensate converts (levels 0-1), from the
+        # cloud-borne tracer.
+        self.assertTrue(np.all(cb[0:2] < 0.0))
+        np.testing.assert_array_equal(cb[2:], 0.0)
+        # Re-injection lands in the INTERSTITIAL tracer in the evap layer.
+        self.assertTrue(np.all(it[2] > 0.0))
+        np.testing.assert_array_equal(it[[0, 1, 3]], 0.0)
+        # Column budget: everything scavenged was re-released (full evap),
+        # for mass and number alike.
+        dm_np = np.asarray(dm)
+        for pair in (
+            (mass_name(mode.species[0], mode.short, cloud_borne=True),
+             mass_name(mode.species[0], mode.short)),
+            (number_name(mode.short, cloud_borne=True),
+             number_name(mode.short)),
+        ):
+            net = sum(np.asarray(tend.tracers[nm]) * dm_np for nm in pair)
+            # Tolerance relative to the gross removal: the evap fraction
+            # carries f32 round-off from the cumsum/divide, so "everything
+            # re-released" holds to ~1e-6 of what was scavenged, not to
+            # absolute zero on 1e8-scale number tracers.
+            gross = float(
+                np.sum(np.abs(np.asarray(tend.tracers[pair[0]])) * dm_np)
+            )
+            np.testing.assert_allclose(
+                np.sum(net, axis=0), 0.0, atol=max(1e-5 * gross, 1e-20),
+                err_msg=str(pair),
+            )
 
     def test_cloud_borne_removed_at_full_incloud_rate(self):
         # Cloud-borne aerosol is entirely in-droplet: its stratiform removal

--- a/jcm/physics/aerosol/jam/wetdep/wetdep_test.py
+++ b/jcm/physics/aerosol/jam/wetdep/wetdep_test.py
@@ -22,31 +22,45 @@ class ScavengingFunctionTest(unittest.TestCase):
         # layer releases half, a full-evap layer releases the rest, and
         # nothing reaches the surface. sum(scavenged - reinjected) must
         # equal the surface flux EXACTLY at every column.
-        scavenged = jnp.zeros((1, 3, 1)).at[0, 0, 0].set(2.0)
+        none = jnp.zeros((1, 3, 1))
+        scavenged = none.at[0, 0, 0].set(2.0)
         evap_frac = jnp.array([[0.0], [0.5], [1.0]])
-        reinjected, surface = reinjection_budget(scavenged, evap_frac)
+        reinjected, surface = reinjection_budget(none, scavenged, evap_frac)
         np.testing.assert_allclose(np.asarray(reinjected[0, :, 0]),
                                    [0.0, 1.0, 1.0])
         np.testing.assert_allclose(np.asarray(surface), 0.0)
         # Partial evap: the un-released remainder deposits.
         evap_frac = jnp.array([[0.0], [0.25], [0.0]])
-        reinjected, surface = reinjection_budget(scavenged, evap_frac)
+        reinjected, surface = reinjection_budget(none, scavenged, evap_frac)
         np.testing.assert_allclose(np.asarray(surface[0, 0]), 1.5)
         np.testing.assert_allclose(
             float(jnp.sum(scavenged - reinjected)), float(surface[0, 0]),
         )
 
-    def test_same_layer_scavenge_and_full_evap_releases_everything(self):
-        # Virga: aerosol impacted out within a fully-evaporating layer must
-        # be released there too, not ride a terminated carrier to the
-        # surface through dry air (the layer's scavenging joins the ledger
-        # BEFORE the release, as in HAMMOZ). The pre-fix ordering deposited
-        # it all.
-        scavenged = jnp.zeros((1, 3, 1)).at[0, 2, 0].set(1.0)
+    def test_virga_releases_same_layer_impaction(self):
+        # Aerosol impacted out of the INCOMING precip within a fully-
+        # evaporating layer must be released there too, not ride a
+        # terminated carrier to the surface through dry air (impaction
+        # joins the ledger before the release, as in HAMMOZ).
+        none = jnp.zeros((1, 3, 1))
+        impacted = none.at[0, 2, 0].set(1.0)
         evap_frac = jnp.zeros((3, 1)).at[2].set(1.0)
-        reinjected, surface = reinjection_budget(scavenged, evap_frac)
+        reinjected, surface = reinjection_budget(impacted, none, evap_frac)
         np.testing.assert_allclose(np.asarray(reinjected[0, 2, 0]), 1.0)
         np.testing.assert_allclose(np.asarray(surface), 0.0)
+
+    def test_formation_in_full_evap_layer_still_deposits(self):
+        # Codex P1 on #612: the incoming carrier's evaporation cannot touch
+        # precip NEWLY FORMED in the same layer — both cloud schemes cap
+        # evaporation by the incoming flux and add formation after. Aerosol
+        # scavenged into that new precip must continue downward, not be
+        # released by an evap fraction that belongs to the old carrier.
+        none = jnp.zeros((1, 3, 1))
+        formed = none.at[0, 1, 0].set(1.0)
+        evap_frac = jnp.zeros((3, 1)).at[1].set(1.0)
+        reinjected, surface = reinjection_budget(none, formed, evap_frac)
+        np.testing.assert_allclose(np.asarray(reinjected), 0.0)
+        np.testing.assert_allclose(np.asarray(surface[0, 0]), 1.0)
 
     def test_in_cloud_rate_scales_with_activation(self):
         pf = jnp.full((1, 1), 1.0e-6)

--- a/jcm/physics/clouds/cloud_data.py
+++ b/jcm/physics/clouds/cloud_data.py
@@ -40,6 +40,20 @@ class CloudData:
     # bottom level.
     rain_flux: jnp.ndarray           # LS rain flux [kg/m²/s] (nlev, ncols)
     snow_flux: jnp.ndarray           # LS snow(+ice) flux [kg/m²/s] (nlev, ncols)
+    # Per-level precipitation process rates (#499), grid-mean [kg/kg/s]:
+    # the condensate→precip conversion (rain: autoconversion + accretion;
+    # frozen: ice autoconversion + aggregation + riming) and the
+    # evaporation/sublimation of the falling stratiform precip (rain
+    # evaporation + snow sublimation; the sedimenting cloud-ice flux's own
+    # sublimation is not included — it is not a scavenging carrier, which
+    # also means the cirrus ice that reaches the surface as snow removes no
+    # aerosol). These
+    # are the rates the schemes actually integrate, exposed for JAM wet
+    # scavenging (in-cloud nucleation removal at the true local formation
+    # rate; re-injection of scavenged aerosol where precip re-evaporates)
+    # instead of a column reconstruction from the surface fluxes.
+    precip_formation_rate: jnp.ndarray    # (nlev, ncols)
+    precip_evaporation_rate: jnp.ndarray  # (nlev, ncols)
     # Column-integrated rain-source split [kg/m²/s], written by the 2M
     # scheme (zero under 1M, which does not separate the pathways): rain
     # formed by the warm chain (autoconversion + accretion of liquid) and
@@ -90,6 +104,8 @@ class CloudData:
             precip_snow=jnp.zeros(nodal_shape),
             rain_flux=jnp.zeros((nlev,) + nodal_shape),
             snow_flux=jnp.zeros((nlev,) + nodal_shape),
+            precip_formation_rate=jnp.zeros((nlev,) + nodal_shape),
+            precip_evaporation_rate=jnp.zeros((nlev,) + nodal_shape),
             rain_formation_warm=jnp.zeros(nodal_shape),
             rain_from_melt=jnp.zeros(nodal_shape),
             droplet_number=jnp.zeros((nlev,) + nodal_shape),
@@ -112,6 +128,8 @@ class CloudData:
             'precip_snow': self.precip_snow,
             'rain_flux': self.rain_flux,
             'snow_flux': self.snow_flux,
+            'precip_formation_rate': self.precip_formation_rate,
+            'precip_evaporation_rate': self.precip_evaporation_rate,
             'rain_formation_warm': self.rain_formation_warm,
             'rain_from_melt': self.rain_from_melt,
             'droplet_number': self.droplet_number,

--- a/jcm/physics/clouds/echam_1m.py
+++ b/jcm/physics/clouds/echam_1m.py
@@ -194,6 +194,7 @@ class MicrophysicsState(NamedTuple):
     snow_flux: jnp.ndarray      # Snow(+falling-ice) flux leaving each level
     rain_source: jnp.ndarray    # Per-layer rain production (kg/m²/s)
     snow_source: jnp.ndarray    # Per-layer snow production (kg/m²/s)
+    rain_evap_flux: jnp.ndarray  # Per-layer rain evaporation (kg/m²/s, #499)
 
     # In-cloud values
     qc_in_cloud: jnp.ndarray    # In-cloud liquid water (kg/kg)
@@ -1110,6 +1111,12 @@ def cloud_microphysics_column_sweep(
             dTdt, dqdt, dqcdt, dqidt, rain_source, snow_source,
             autoconv_rate_diag, accretion_rate_diag,
             zrfl_out, zsfl_out + zxiflux_out,
+            # Per-layer rain evaporation flux (#499): the depletion the
+            # flux ledger above already applied, exposed for the JAM
+            # wet-scavenging re-injection budget. The 1M scheme has no
+            # snow sublimation, so this is the whole stratiform
+            # evaporation term.
+            rain_evap_flux,
         )
         return (zrfl_out, zsfl_out, zclcpre_out, zxiflux_out), out
 
@@ -1126,7 +1133,7 @@ def cloud_microphysics_column_sweep(
         level_inputs,
     )
     (dtedt, dqdt, dqcdt, dqidt, rain_source, snow_source, autoconv_rate,
-     accretion_rate, rain_flux, snow_flux) = per_level_out
+     accretion_rate, rain_flux, snow_flux, rain_evap_flux) = per_level_out
 
     tendencies = MicrophysicsTendencies(
         dtedt=dtedt, dqdt=dqdt, dqcdt=dqcdt, dqidt=dqidt,
@@ -1147,6 +1154,7 @@ def cloud_microphysics_column_sweep(
     state = MicrophysicsState(
         rain_flux=rain_flux, snow_flux=snow_flux,
         rain_source=rain_source, snow_source=snow_source,
+        rain_evap_flux=rain_evap_flux,
         qc_in_cloud=qc_in_cloud, qi_in_cloud=qi_in_cloud,
         autoconv_rate=autoconv_rate, accretion_rate=accretion_rate,
         melting_rate=jnp.zeros(nlev), freezing_rate=jnp.zeros(nlev),
@@ -1319,6 +1327,17 @@ class Echam1MMicrophysics(PhysicsTerm):
             # CloudData layout, same as the tendency fields above.
             rain_flux=micro_state.rain_flux.T,
             snow_flux=micro_state.snow_flux.T,
+            # Per-level process rates for JAM wet scavenging (#499),
+            # converted from the sweep's per-layer fluxes [kg/m²/s] to
+            # grid-mean mixing-ratio rates [kg/kg/s] with the layer mass.
+            # Formation is the full condensate→precip ledger (rain: autoconv
+            # + accretion; snow: ice autoconv + aggregation + riming);
+            # evaporation is Rotstayn rain evap (the 1M scheme has no snow
+            # sublimation).
+            precip_formation_rate=(
+                micro_state.rain_source + micro_state.snow_source
+            ).T / dm_col.T,
+            precip_evaporation_rate=micro_state.rain_evap_flux.T / dm_col.T,
             droplet_number=cdnc_m3,
         )
 

--- a/jcm/physics/clouds/echam_1m_test.py
+++ b/jcm/physics/clouds/echam_1m_test.py
@@ -417,6 +417,52 @@ class TestColumnSweepMicrophysics:
         assert rain_source_total > 0.0, "autoconv didn't fire — adjust q profile"
         assert float(state.precip_rain) < rain_source_total
 
+    def test_rain_evap_flux_closes_the_warm_flux_ledger(self):
+        """The exposed per-level rain evaporation closes the rain-flux ledger.
+
+        On an all-warm column (no snow, no melt) the sweep's flux update is
+        exactly ``rain_flux[k] = rain_flux[k-1] + rain_source[k] -
+        rain_evap_flux[k]``, so the new #499 diagnostic must satisfy that
+        identity level by level, with evaporation active (nonzero) in the
+        sub-saturated layers below the cloud and never exceeding the
+        available flux.
+        """
+        import numpy as np
+        from jcm.physics.clouds.sundqvist import saturation_specific_humidity
+        cfg = MicrophysicsParameters.default()
+        nlev = 20
+        T = jnp.linspace(280.0, 300.0, nlev)
+        p = jnp.linspace(20000.0, 100000.0, nlev)
+        qsw = jax.vmap(saturation_specific_humidity)(p, T)
+        # Moist enough below cloud that evap never zeroes the flux (the
+        # ledger clamp stays slack), dry enough that evap is nonzero.
+        cloud_level = 5
+        q = jnp.where(
+            jnp.arange(nlev) == cloud_level, 0.95 * qsw, 0.6 * qsw,
+        )
+        qc = jnp.zeros(nlev).at[cloud_level].set(2e-3)
+        qi = jnp.zeros(nlev)
+        cf = jnp.where(qc > 0, 0.7, 0.0)
+        rho = p / (287.0 * T)
+        dz = jnp.full(nlev, 500.0)
+        ndrop = jnp.full(nlev, 1e8)
+        _, state = cloud_microphysics_column_sweep(
+            T, q, p, qc, qi, cf, rho, dz, ndrop, dt=1800.0, config=cfg,
+        )
+        assert float(jnp.sum(state.snow_source)) == 0.0
+        assert float(jnp.max(state.rain_evap_flux)) > 0.0
+        assert float(jnp.min(state.rain_evap_flux)) >= 0.0
+        rain_in = jnp.concatenate([jnp.zeros(1), state.rain_flux[:-1]])
+        # atol covers f32 round-off relative to the ~1e-4 kg/m²/s flux
+        # scale (observed residual ~2.5e-13 where evap consumes ~all of
+        # the inflow).
+        np.testing.assert_allclose(
+            np.asarray(state.rain_flux),
+            np.asarray(rain_in + state.rain_source - state.rain_evap_flux),
+            rtol=1e-6, atol=1e-10,
+        )
+        assert float(state.rain_flux.min()) >= 0.0
+
     def test_snow_above_warm_layer_melts_to_rain(self):
         """Snow flux generated aloft melts as it falls into T>273K layers."""
         cfg = MicrophysicsParameters.default()

--- a/jcm/physics/clouds/lohmann_2m/scheme.py
+++ b/jcm/physics/clouds/lohmann_2m/scheme.py
@@ -772,12 +772,25 @@ def cloud_microphysics_2m(
     # stacked from the scan ys) go last so existing ``tend, rain, snow,
     # *_`` call sites keep working; their bottom row equals the surface
     # fluxes by construction (same carry values).
+    # Per-level precip process rates for JAM wet scavenging (#499), grid
+    # mean [kg/kg/s]. Formation is the full condensate→precip ledger the
+    # flux update integrates: the warm chain (KK2000 autoconversion +
+    # accretion, ``qr_gain_warm``), riming (``psacl``) and the cold snow
+    # formation. Evaporation is rain evap + snow sublimation; the falling
+    # cloud-ice sublimation (``ice_sublim``) is deliberately excluded — the
+    # sedimenting ice flux is not a scavenging carrier.
+    precip_formation_rate = (
+        qr_gain_warm + psacl + snow_formation_gridmean
+    ) / dt
+    precip_evaporation_rate = (rain_evap + snow_sublim) / dt
+
     # NOTE the (nlev,) rain / frozen flux profiles stay LAST: call sites and
     # tests unpack them positionally from the end (``*_, rain_b, snow_b``),
-    # so new scalars are inserted before them, not appended.
+    # so new outputs are inserted before them, not appended.
     return tendencies, surface_rain_flux, surface_snow_flux, \
         liq_eff_radius, ice_eff_radius, rain_formation_warm, rain_from_melt, \
         autoconv_rate_col, accretion_rate_col, wbf_rate_col, \
+        precip_formation_rate, precip_evaporation_rate, \
         rain_flux_profile, snow_flux_profile
 
 
@@ -942,10 +955,11 @@ class Lohmann2MMicrophysics(PhysicsTerm):
         (tend_all, surface_rain_flux, surface_snow_flux,
          r_eff_liq_all, r_eff_ice_all, rain_formation_warm, rain_from_melt,
          autoconv_all, accretion_all, wbf_all,
+         precip_form_all, precip_evap_all,
          rain_flux_all, snow_flux_all) = jax.vmap(
             cloud_microphysics_2m,
             in_axes=(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, None, None),
-            out_axes=(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+            out_axes=(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
         )(
             temperature_in, specific_humidity_in, pressure_full,
             qc_interim, qi_interim, qnc, qni, qr, qs,
@@ -1001,6 +1015,10 @@ class Lohmann2MMicrophysics(PhysicsTerm):
             # CloudData layout, same as the effective radii below.
             rain_flux=rain_flux_all.T,
             snow_flux=snow_flux_all.T,
+            # Per-level precip formation / evaporation rates [kg/kg/s] for
+            # JAM wet scavenging (#499); see cloud_microphysics_2m.
+            precip_formation_rate=precip_form_all.T,
+            precip_evaporation_rate=precip_evap_all.T,
             # Microphysical effective radii (um) for the radiation term
             # (ECHAM preffl/preffi; consumed next step via the carry —
             # same lag as every cross-term diagnostic).

--- a/jcm/physics/clouds/lohmann_2m_test.py
+++ b/jcm/physics/clouds/lohmann_2m_test.py
@@ -1452,6 +1452,111 @@ class TestColumnWaterConservation2M:
             f"(gross movement {gross:.3e}, precip {P:.3e})"
         )
 
+    def test_precip_process_rates_close_the_warm_ledger(self):
+        """The #499 per-level formation/evaporation rates are the true ledger.
+
+        On an all-warm liquid column (no ice, snow or melt) every kg of
+        surface rain was formed minus evaporated on the way down, so the
+        new grid-mean [kg/kg/s] outputs must satisfy
+        ``rain_sfc == sum((formation - evaporation) * rho * dz)`` — a
+        units-and-sign check that also fails if a pathway (accretion,
+        riming) is missing from the formation sum.
+        """
+        import numpy as np
+        from jcm.physics.clouds.lohmann_2m import cloud_microphysics_2m
+        from jcm.physics.clouds.lohmann_2m_params import CloudParams2M
+        from jcm.physics.clouds.sundqvist import saturation_specific_humidity
+
+        nlev = 20
+        T = jnp.linspace(280.0, 300.0, nlev)
+        p = jnp.linspace(2e4, 1e5, nlev)
+        rho = p / (287.0 * T)
+        qsw = jax.vmap(saturation_specific_humidity)(p, T)
+        q = jnp.where(
+            (jnp.arange(nlev) >= 10) & (jnp.arange(nlev) < 16),
+            0.95 * qsw, 0.7 * qsw,
+        )
+        qc = jnp.zeros(nlev).at[10:16].set(1e-3)
+        cf = jnp.where(qc > 0, 0.7, 0.0)
+        dz = jnp.full(nlev, 500.0)
+        qnc = jnp.where(qc > 0, 5e7, 0.0)
+        params = CloudParams2M.default()
+
+        (tend, rain_sfc, snow_sfc, _rl, _ri, _rfw, _rfm, _au, _ac, _wbf,
+         form, evap, rain_prof, snow_prof) = cloud_microphysics_2m(
+            T, q, p, qc, jnp.zeros(nlev), qnc, jnp.zeros(nlev),
+            jnp.zeros(nlev), jnp.zeros(nlev), cf, rho, dz,
+            jnp.full(nlev, 0.1), jnp.full(nlev, 5e7),
+            jnp.zeros(nlev), jnp.zeros(nlev),
+            1800.0, params,
+        )
+        assert form.shape == (nlev,) and evap.shape == (nlev,)
+        assert float(jnp.min(form)) >= 0.0
+        assert float(jnp.min(evap)) >= 0.0
+        assert float(snow_sfc) == 0.0
+        assert float(rain_sfc) > 0.0, "no rain formed — fixture too dry"
+        assert float(jnp.max(evap)) > 0.0, "no evap — fixture too moist"
+        mref = np.asarray(rho * dz)
+        np.testing.assert_allclose(
+            float(rain_sfc),
+            float(np.sum((np.asarray(form) - np.asarray(evap)) * mref)),
+            rtol=1e-5,
+        )
+
+    def test_precip_process_rates_cover_the_cold_chain(self):
+        """The #499 formation rate must use the GRID-MEAN snow-side terms.
+
+        An all-cold ice column (no liquid, no melt) with numerous small
+        crystals (high ICNC → slow sedimentation, so the folded cloud-ice
+        flux is a small correction) forms snow through the cold chain
+        alone. The surface snow must then be bracketed by the
+        (formation − evaporation) column ledger: equal up to the small
+        sedimenting-ice contribution. An implementation that grabbed the
+        IN-CLOUD cold-formation variants instead of the grid-mean ones
+        overshoots by 1/cf ≈ 1.4x and breaks the upper bracket.
+        """
+        import numpy as np
+        from jcm.physics.clouds.lohmann_2m import cloud_microphysics_2m
+        from jcm.physics.clouds.lohmann_2m_params import CloudParams2M
+        from jcm.physics.clouds.sundqvist import saturation_specific_humidity
+
+        nlev = 20
+        T = jnp.linspace(215.0, 262.0, nlev)          # never melts
+        p = jnp.linspace(2e4, 7e5 / 10.0, nlev)
+        rho = p / (287.0 * T)
+        qsw = jax.vmap(saturation_specific_humidity)(p, T)
+        q = 0.9 * qsw
+        qi = jnp.zeros(nlev).at[8:14].set(3e-4)
+        qni = jnp.where(qi > 0, 1e6, 0.0)             # many small crystals
+        cf = jnp.where(qi > 0, 0.7, 0.0)
+        dz = jnp.full(nlev, 500.0)
+        params = CloudParams2M.default()
+
+        (tend, rain_sfc, snow_sfc, _rl, _ri, _rfw, _rfm, _au, _ac, _wbf,
+         form, evap, _rp, _sp) = cloud_microphysics_2m(
+            T, q, p, jnp.zeros(nlev), qi, jnp.zeros(nlev), qni,
+            jnp.zeros(nlev), jnp.zeros(nlev), cf, rho, dz,
+            jnp.full(nlev, 0.1), jnp.full(nlev, 5e7),
+            jnp.zeros(nlev), jnp.zeros(nlev),
+            1800.0, params,
+        )
+        mref = np.asarray(rho * dz)
+        ledger = float(np.sum((np.asarray(form) - np.asarray(evap)) * mref))
+        total_sfc = float(rain_sfc + snow_sfc)
+        assert total_sfc > 0.0, "cold chain made no precip — fixture off"
+        assert ledger > 0.0
+        # Ledger ≤ surface (the sedimenting-ice fold adds mass the ledger
+        # deliberately excludes), and covers at least 60% of it (the
+        # crystals are small and slow, so the fold is a minor term). An
+        # in-cloud/grid-mean mixup (~1.4x) breaks the first bound.
+        assert ledger <= total_sfc * (1.0 + 1e-5), (
+            f"ledger {ledger:.3e} exceeds surface {total_sfc:.3e}"
+        )
+        assert ledger >= 0.6 * total_sfc, (
+            f"ledger {ledger:.3e} vs surface {total_sfc:.3e} — cold-chain "
+            "formation missing from the #499 rate"
+        )
+
     def test_cold_supersaturation_is_consumed(self):
         """Sub-cthomi supersaturation must deposit onto diagnosed ICNC.
 


### PR DESCRIPTION
Closes #499. Wet scavenging now runs on the per-level precipitation process rates the cloud schemes actually integrate, instead of a reconstruction from the surface fluxes, and gains the re-evaporation re-injection pathway the reconstruction could never support. Stacks on #608 (the branch point; the diff to review is the last commit).

## Why this matters for calibration

Wet deposition is the dominant aerosol sink and a primary calibration target. The old interim treatment distributed the *surface* precip across the cloudy column by condensate weight, which (a) put removal at the wrong levels whenever formation and condensate profiles disagree, (b) washed out aerosol column-wide even above where precip forms, and (c) had no way to return scavenged aerosol where rain evaporates before landing — a large systematic bias in exactly the sub-cloud regions (subtropical marine boundary layer, continental virga) where aerosol–cloud interaction matters. All three are now gone, and every knob in the pathway stays differentiable.

## Cloud-scheme side (tendencies untouched)

`CloudData` gains `precip_formation_rate` and `precip_evaporation_rate` (grid-mean kg/kg/s, per level). Both ECHAM schemes populate them from quantities they already compute:

- **1M**: the sweep's per-layer `rain_source + snow_source` ledger (autoconversion + accretion; ice autoconversion + aggregation + riming, with their exact ECHAM area weights) over ρΔz; the Rotstayn rain-evaporation flux is now threaded out of the `lax.scan` (a new `MicrophysicsState.rain_evap_flux` field; the 1M scheme has no snow sublimation). A new test pins the level-by-level ledger identity `rain_flux[k] = rain_flux[k-1] + source[k] − evap[k]` on a warm column.
- **2M**: `qr_gain_warm + psacl + snow_formation_gridmean` and `rain_evap + snow_sublim`, returned per level from the column function (inserted before the trailing flux profiles, per the positional-unpack contract). Warm-column and cold-column ledger tests bracket the outputs against the surface fluxes, discriminating grid-mean vs in-cloud weight mixups and missing pathways.

Falling cloud-ice sublimation is deliberately excluded (the sedimenting ice flux is not a scavenging carrier), which also means cirrus ice reaching the surface as snow removes no aerosol — documented as the accepted gap of that stance.

## Wet-scavenging side

- **In-cloud nucleation removal** now uses `formation_rate / (qc + qi)` — the true local conversion rate (the grid-mean ratio equals the in-cloud one; the cloudy-fraction weighting on the implicit interstitial pathway from #608 is unchanged). The old reconstruction helper is deleted; a regression test proves a stale surface-precip value with zero formation scavenges nothing.
- **Below-cloud impaction** is driven by the precip flux actually entering each layer, so washout is confined below formation levels automatically. The carrier flux is rebuilt as the cumulative `(formation − evaporation)` integral of the exposed rates rather than read from `rain_flux + snow_flux`: the schemes fold the sedimenting cloud-ice flux into the frozen profiles at interior levels, and using them directly would drive impaction with a non-carrier flux and dilute the re-evaporation fraction under cirrus (local adversarial review finding).
- **Re-evaporation re-injection**: a per-tracer aerosol-in-precip flux is integrated top to bottom (`reinjection_budget`); each layer releases the fraction of the carried aerosol equal to the fraction of the carrier that evaporates there, into the INTERSTITIAL phase — cloud-borne-scavenged aerosol re-enters as interstitial (an evaporated droplet releases its core), closing cleanly against the #602/#608 cloud-borne machinery. The layer's own scavenging joins the ledger before its release (HAMMOZ ordering), so aerosol impacted out inside a fully-evaporating virga layer is released there rather than riding a terminated carrier to the surface (adversarial review finding, regression-tested and proven discriminating by file-copy swap). `sum(scavenged − reinjected) = surface flux` holds exactly by construction and is asserted. Stratiform vs convective removal is attributed proportionally; convectively scavenged aerosol still deposits directly (no convective evaporation profile exists yet — noted follow-up).
- The in-cloud rate's denominator guard moved from a 1e-30 epsilon to a physical condensate floor with a double-where: the epsilon guard produced verified NaN gradients in every clear float32 cell (the squared-underflow VJP class).

## Tests

Beyond the ledger tests above: re-injection budget unit tests (column conservation exact; the virga same-layer case), a level-dependent-Δm term test (uniform grids cancel the mass weightings, hiding misplacement), below-formation washout confinement, formation-driven (not surface-precip-driven) in-cloud removal, and the #608 representation-equivalence and cloud-borne tests all passing unchanged on the new rates. Full fast + slow suites at CI dependency parity (numbers in checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aqshaa5nDrxcDWgg1FYw8Z
