### PR TITLE
docs: land the fix-campaign plan and JCM/AIDE convergence roadmap on dev

### DIFF
--- a/docs/aide_jcm_convergence_roadmap.md
+++ b/docs/aide_jcm_convergence_roadmap.md
@@ -1,0 +1,193 @@
+# JCM ↔ AIDE convergence roadmap
+
+**Status:** proposal, 2026-08-11.
+**Scope:** phased development plan for `climate-analytics-lab/jax-gcm` (JCM) and
+`reflective-org/aide_sai_core` (AIDE, with `reflective-org/tomas-jax`), starting
+from separate tracks and converging on a shared-library end state ("Option D"),
+with AIDE persisting long-term as a research harness for plugins and wrappers
+that don't belong in JCM.
+
+This follows a full comparative read of both codebases (AIDE @ 7b837a7,
+JCM `dev` @ f47ff5a including the JAM aerosol harness). The analysis it rests
+on: both projects already share `jax-rrtmgp` and feed it aerosol through the
+identical `aerosol_optics_sw/lw` kwargs; JAM was explicitly architected for
+interchangeable microphysics cores with a sectional family anticipated (#491);
+AIDE's kernels are pure JAX but its orchestration (env-vars-at-import,
+monkeypatch composition, host-side numpy loop with per-hour netCDF reads) is
+non-differentiable and non-importable as a library.
+
+## End state (the target picture)
+
+- **JCM is the library**: dycore protocol (prognostic, prescribed-met, learned),
+  the JAM process harness with swappable aerosol cores (placeholder / MAM4-JAX /
+  TOMAS-JAX / trained emulators), radiation backends (grey / RRTMGP / NN),
+  calibration machinery.
+- **AIDE is the research harness**: campaign configs, host-model readers
+  (CESM h1, …), experimental plugins and wrappers, emulator training and
+  validation studies — an incubator whose stable pieces graduate into JCM or
+  tomas-jax.
+- **tomas-jax stays a separate installable package** (LGPL-3.0), consumed by
+  JCM through the same lazy-load pattern already used for GPL-3.0 mam4-jax.
+- **Physics lives in JCM or tomas-jax, never in AIDE** except while
+  experimental. One implementation of every seam.
+
+Each convergence seam is also an **emulator swap point** — this is what makes
+the roadmap serve the linked-emulator goal rather than compete with it:
+
+| component | physical backend | emulator backend | seam |
+|---|---|---|---|
+| dynamics | Dinosaur (or prescribed CESM met) | learned dycore | `DynamicalCore` protocol |
+| aerosol microphysics | TOMAS-JAX / MAM4-JAX | trained NN core | JAM microphysics-core contract |
+| radiation | jax-rrtmgp | GRU emulator (exists) | radiation scheme signature + `aerosol_optics` kwargs |
+
+---
+
+## Phase 0 — hygiene and contracts (weeks; unblocks everything)
+
+Parallel, low-risk, mostly each org in its own tree.
+
+**JCM**
+- Merge JAM to `dev`; land the in-flight physics-review PRs (PR1/PR2 branches).
+- Re-verify the MACv2-SP review findings against post-JAM `dev`
+  (`macv2_sp.py` was heavily reworked; some findings may already be fixed).
+
+**Shared (`jax-rrtmgp`)**
+- Make it pip-installable with version tags and CI.
+- Write down the `aerosol_optics_sw/lw = {optical_depth, ssa,
+  asymmetry_factor}` kwarg contract as the stable seam, with a contract test
+  both downstreams run against pinned versions.
+
+**AIDE / tomas-jax**
+- Fix tomas-jax license metadata (`pyproject.toml` says MIT; LICENSE/README say
+  LGPL-3.0 — decide and make them agree).
+- Merge/publish the `gpu-fast` branch (`tomas_jax.fast`) into tomas-jax main;
+  it is currently AIDE's production engine but lives on an unmerged branch.
+- AIDE replaces the `sys.path` sibling-repo hacks with pip installs of
+  jax-rrtmgp and tomas-jax.
+
+**Gate:** both models consume the same pinned, installable jax-rrtmgp; the
+optics contract test passes in both CIs.
+
+---
+
+## Phase 1 — interface convergence (1–2 months)
+
+**JCM**
+- Implement the sectional population family (#491): `SectionalAerosolSpec` as
+  the sibling of `ModalAerosolSpec`, exposing the same geometry interface so
+  the harness terms (emissions, sedimentation, drydep, wetdep, activation,
+  optics) stay family-invariant as designed.
+- Extend the microphysics-core contract (`ModalMicrophysicsTerm` →
+  a family-neutral base) to cover per-bin number+mass tracer layouts.
+- Port AIDE's composition-resolved sulfate optics into JAM: Tabazadeh (1997)
+  equilibrium wt%, Palmer & Williams RI at tabulated solution strengths,
+  wt%-interpolated Mie tables. Benefits JCM's own stratospheric-aerosol
+  fidelity independent of any merge (AIDE measured ~47% 550 nm extinction
+  error from dry-size/fixed-composition optics).
+
+**AIDE**
+- Untangle config from import: env vars resolved once at the entry point into
+  a config object passed down (keep the env interface as a shim; the
+  self-describing run-header discipline is worth keeping verbatim).
+- Move the global `jax_enable_x64` flag from `settling.py` import time to the
+  entry points.
+- Extract the CESM h1 reader into a standalone module with a documented
+  interface (it becomes the first "host-model reader" plugin).
+
+**tomas-jax**
+- Adopt `wet_size` / `tang_density` upstream (currently duplicated in AIDE's
+  `settling.py` with a documented workaround for the empty-bin density guard —
+  fix the guard upstream instead).
+
+**Gate:** TOMAS-JAX runs as a JAM core in a JCM single-column / prescribed-state
+test, with a first performance number for the coupling budget.
+
+---
+
+## Phase 2 — components cross the boundary (2–4 months)
+
+**Into JCM**
+- `TomasJaxMicrophysics` core, lazy-loaded like mam4-jax (LGPL boundary
+  respected). Decisions to make explicitly at the wrapper: f64↔f32 casting
+  policy; substep count per physics dt; ICOMP=2 (sulfate-only fast engine)
+  vs full-species core.
+- Optional implicit (backward-Euler upwind) solver in JAM sedimentation for
+  long-substep configurations, following AIDE's `settle_step`.
+- AIDE's budget-audit discipline as a JCM diagnostic utility: staged
+  per-process burden closure ("if a change breaks that closure, the change is
+  wrong") — valuable for every JCM tracer, not just aerosol.
+
+**Into AIDE (as plugins/deps, replacing local code)**
+- `jax_solar` for solar geometry (replaces the hand-rolled zenith formula).
+- JAM wet scavenging — closes AIDE's own standing caveat ("no wet removal
+  anywhere; settling and transport out of the band are the only sinks").
+- JAM's differentiable Gaussian injection profile — replaces the
+  zero-gradient nearest-level snap (`INJ_HPA`), directly serving SAI
+  injection-height calibration.
+
+**Gate:** A/B validation of the TOMAS-in-JAM core against AIDE's box/production
+references (sulfur closure, size-distribution error bounds from their
+`docs/gpu_fast.md` calibration tables).
+
+---
+
+## Phase 3 — PrescribedMetDycore: AIDE as a JCM configuration (3–6 months)
+
+The structural unification step. AIDE's mode of operation — evolve tracers on
+prescribed 3-D meteorology — is a missing middle in JCM (between
+`prescribed_state_model`, which has no tracer evolution, and the full GCM).
+
+**JCM**
+- A `PrescribedMetDycore` backend implementing the `DynamicalCore` protocol:
+  - pluggable offline met source (CESM h1 first; the Phase-1 reader);
+  - tracer transport by AIDE's Lin-Rood flux-form scheme (`fct_lr`), ported as
+    the backend's advection operator. This is the right operator to own
+    regardless: conservative to roundoff for winds that don't satisfy discrete
+    continuity, which AIDE's docs correctly note "matters MORE for emulator
+    winds". It also sidesteps the open question of spectral advection of ~82
+    positive-definite sectional tracers through Dinosaur;
+  - subdomain/band support (e.g. 1–150 hPa) and polar-cap handling;
+  - `u/v/T` overwritten from files each step; anomaly-mode `dT_rad` carried by
+    a physics term (mirrors AIDE's `RAD_MODE=anomaly`).
+- Config for the SAI setup: `jam_aerosol_physics(microphysics="tomas_jax")`
+  + RRTMGP + injection, on the prescribed dycore.
+
+**AIDE**
+- Reproduce the production scenario (10 Tg/yr equatorial ring, 90 d) through
+  the JCM path; side-by-side vs the legacy driver on burdens, AOD550, ARF
+  within documented tolerances.
+- Freeze the legacy driver (tag) for reproducing published runs; new science
+  moves to the JCM path.
+
+**Gate (the payoff demo):** a differentiable SAI experiment neither codebase
+can do today — gradients of AOD/forcing metrics w.r.t. injection height, rate,
+nucleation scale, accommodation coefficient, through the full coupled band
+model.
+
+---
+
+## Phase 4 — Option D steady state (6–12 months)
+
+- JCM releases carry the prescribed dycore, sectional core support, and the
+  calibration workflow; AIDE's repo shrinks to readers + campaign configs +
+  experimental plugins + analysis.
+- Graduation rule, to keep the boundary honest: a component moves from AIDE to
+  JCM (or tomas-jax) when it has tests, a stable interface, and a second use
+  case; it stays in AIDE while it is a single-campaign instrument.
+- Emulator program runs on the stabilized seams: train aerosol/radiation
+  emulators in AIDE against the JAM-core and radiation contracts, deploy them
+  in JCM by construction. Speed-vs-fidelity sweeps (the original AIDE goal)
+  become configuration matrices, not code forks.
+
+---
+
+## Standing risks and decision points
+
+| risk | phase | mitigation / decision |
+|---|---|---|
+| Spectral advection of sectional tracers (Gibbs → negative number) | 1–2 | Prescribed/flux-form path first; decide whether prognostic-dynamics sectional runs wait for a finite-volume dycore backend |
+| TOMAS f64 vs JCM f32 | 2 | Explicit casting policy at the core wrapper; measure accuracy cost |
+| Microphysics cost in a GCM loop (94% of AIDE runtime) | 1 gate | Early perf number; chunking/stiffness-sort strategies port from `tomas_jax.fast` |
+| AIDE campaign reproducibility | 3 | Legacy driver frozen and tagged; published runs never re-run through new code silently |
+| Cross-org drift | all | Pinned versions + contract tests in both CIs; physics-single-home rule |
+| tomas-jax license metadata inconsistency | 0 | Resolve before anything depends on it contractually |

--- a/docs/echam_rrtmgp_fix_plan.md
+++ b/docs/echam_rrtmgp_fix_plan.md
@@ -1,0 +1,242 @@
+# ECHAM+RRTMGP fix campaign — plan and PR sequencing
+
+**Date:** 2026-07-02 · **Base:** `dev` @ `b41076a`. · **Status updated:**
+2026-08-12 (PRs 1–2 merged; PR 3 in review; see the table below).
+
+Companion documents — the two point-in-time review reports
+(`echam_rrtmgp_physics_review.md`: scientific correctness, findings numbered
+PR-1.x criticals / PR-2.x majors / PR-3.x minors, referenced below;
+`echam_rrtmgp_maintainability_review.md`: comments Part A, gradient
+smoothness Part B, refactoring/dead code Part C) were written against
+`dev` @ `b41076a` and live on the archived review branch
+(`claude/echam-rrtmgp-physics-review-zcof6u`), not in `dev` — their cited
+line numbers drift with the code, so the durable tracking for still-open
+findings is GitHub issues, converted per scheme as each PR below is picked
+up.
+
+## Strategy
+
+Physics first, with a thin structural pre-pass. Rationale:
+
+- The physics defects are leading-order (convection violates energy/water
+  conservation at the precipitation rate; SW insolation scales as cos²θ;
+  Twomey factor ~100×) — tuning/validation done while they persist is
+  wasted and gets redone.
+- But three structural items de-risk the physics campaign and go first:
+  mechanical dead-code deletion (shrinks review surface in the 1400-3800
+  line cloud modules), the thermodynamics module (it *is* the fix for
+  three saturation bugs), and the NaN-gradient fix + parameter-gradient
+  tests (a regression gate for everything after).
+- Big refactors (lohmann_2m package split, vmap hoisting) and the
+  smoothing work (Part B) come last: they churn the same lines the
+  physics fixes touch, and smoothing changes physics by design, so the
+  faithful baseline must be validated first (otherwise calibration drift
+  and bug fixes are indistinguishable).
+
+## PR sequence
+
+| # | Branch / PR | Type | Status |
+|---|---|---|---|
+| 1 | `claude/pr1-dead-code-cleanup` | structural, zero behavior change | **merged** (landed via #569, `chore/dead-code`) |
+| 2 | `claude/pr2-thermodynamics` | structural+physics | **merged** (branch fully contained in `dev`) |
+| 3 | `claude/pr3-radiation-quick-wins` | physics | **implemented, in review** (insolation µ0², surface BC, halo, gas-optics water, Twomey) |
+| 4 | convection ledger | physics | not started |
+| 5 | 1M/2M microphysics ledgers | physics | not started |
+| 6 | MACv2-SP fidelity + 2M param threading | physics+structural | not started |
+| 7 | module splits, vmap hoisting, smoothing (Part B) | structural | not started |
+
+Related but outside this sequence: `claude/echam-surface-faithful-wiring`
+(surface wiring + T21L16 reference-snapshot regeneration via CI) is in
+flight and touches the same ECHAM test references — coordinate merges.
+The JAM/AIDE convergence programme (issue #609,
+`docs/aide_jcm_convergence_roadmap.md`) runs alongside; PR 6's MACv2-SP
+work should be re-scoped against post-JAM `macv2_sp.py` before starting,
+as parts of the review may already be addressed.
+
+All branches base on `dev`. Working conventions: `ruff check .`;
+`JAX_PLATFORMS=cpu pytest -n 12 -m "not slow" -q` must be green; **test-pin
+discipline** — a changed numeric pin must be justified against the corrected
+physics (old→new in the commit body), never tolerance-loosened; PRs 3-6 add
+per-scheme column conservation checks (water: Σdp/g·(dq+dqc+dqi+…) + precip
+= 0; energy: cp·dT + L·dq closure) and parameter-gradient finiteness tests
+as they touch each scheme.
+
+## PR 1 — dead-code deletion (zero behavior change)
+
+Scope implemented (from maintainability review Part C.1, each deletion
+re-verified by caller grep):
+
+- Delete: `tracer_transport.py` (+`__init__` exports, test class);
+  `echam/unit_conversions.py` + `UNIT_CONVERSIONS.md` (3 radiation tests get
+  local helpers); `REMAINING_ISSUES.md`; grey_two_stream
+  `ICON_FULL_IMPLEMENTATION_ROADMAP.md`; `sucloud`; lohmann_2m dead symbols
+  (`cloud_micro_interface`, `lookup_1d/2d_interp`, `sat_spec_hum`,
+  `MicrophysicsState_2M`, `…_2m_minimal` alias, ~110-line commented-out
+  struct, commented blocks, `# ...existing code...`); `moist_static_energy`;
+  in-module test scaffolding (adjustment.py, planck.py, cloud_optics.py) +
+  `__main__` blocks; `radiation_scheme_rrtmgp_fn`; `RadiationFluxes`,
+  `SpectralBands`; test-only radiation helpers with their tests;
+  jam `species_tuple`/`mass_names_for_mode`; macv2_sp dead `total_aod`.
+- Doc fixes riding along: `docs/source/echam_physics.rst` factual fix (the
+  column sweep IS the wired path), CLAUDE.md `icon/`→`echam/` structure
+  update, accurate MACv2-SP README rewrite.
+- **Deliberately deferred**: legacy `cloud_microphysics` in echam_1m (needs
+  the ice-sedimentation port first — PR 5); sundqvist `shallow_cloud_scheme`
+  (carries the stratospheric condensation gate — PR 5); surface test-only
+  orchestrators (coverage risk); flux_tendencies `conv_levels` block (PR 4
+  rewrites that function anyway).
+
+**Status: merged** (via #569). The deliberately-deferred items above remain
+live and are still owned by PRs 4–5 as noted.
+
+## PR 2 — thermodynamics module + saturation fixes + NaN gradients
+
+Scope implemented:
+
+- New `jcm/physics/thermodynamics.py` (ECHAM 6.3 constants c1es=610.78,
+  c3les=17.269/c4les=35.86, c3ies=21.875/c4ies=7.66): es(T, phase),
+  qs(T, p, phase), (qs, dqs/dT), `mixed_phase_weight`,
+  `grid_mean_to_in_cloud`. + `thermodynamics_test.py` (value pins vs
+  Murphy-Koop, FD-checked derivative, grad finiteness, broadcasting).
+- Physics fixes (review refs): **PR-1.3** convection ice saturation
+  (A_ICE 35.86 → c3ies 21.875; convection was ~3× low at −20 °C, ~60× at
+  −60 °C) via delegation to the shared module; **PR-2.20** lohmann_2m
+  `es_water` used ice coefficients below 0 °C (degenerate Bergeron
+  variable) → water coefficients at all T; **PR-3.1** frozen-surface
+  saturation (sea_ice.py, land.py) used over-water es with sublimation
+  latent heat → ice formula.
+- **B.0** NaN-gradient fix: double-where on fractional-power bases in the
+  1M sweep (`zxrp1`, `zxsp1`, rain-evap 0.61 power) + a parameter-gradient
+  regression test (fails on dev with NaN, passes with fix).
+
+**Status: merged.** The remaining-item sweep for other
+fractional-power-at-zero sites (grep `power(jnp.maximum` / `** 0.` patterns
+in echam scope) is not confirmed done — carry it into PR 5/7 review unless
+it landed with the merge.
+
+## PR 3 — radiation quick wins (small isolated diffs, biggest W/m² per line)
+
+From the physics review §4 (RRTMGP glue):
+
+1. **PR-1.5 µ0² double-cosine**: `rrtmgp.py:452` passes
+   `radiation_flux(...)` (already ×sinα) as `irrad` while the library
+   multiplies by µ again. Fix: `irrad = direct_solar_irradiance(orbital
+   phase)` (normal-incidence, distance-corrected), keep `zenith`. ~110 W/m²
+   global-mean insolation deficit today.
+2. **PR-1.6 surface albedo/emissivity**: `sfc_alb=0.07`/`sfc_emis=0.98`
+   hardcoded in `AtmosphericStateCfg` (rrtmgp.py:96-98); per-column values
+   from the surface scheme only reach diagnostics. Needs a jax-rrtmgp API
+   hook (like the vmr_fields/cloud-path hooks) or per-column
+   dataclasses.replace. Restores ice-albedo feedback + atmosphere/surface
+   energy consistency.
+3. **PR-2.39 pressure halo**: `_to_3d_with_filled_halo` edge-fill halves
+   the effective Δp of top/bottom layers under the library's centered
+   difference → exactly 2× heating there. Fix: linear extrapolation
+   (`2p[0]−p[1]`).
+4. **PR-2.40 condensate-as-vapor**: `total_water = h2o + in-cloud
+   condensate` (rrtmgp.py:222) survives while q_liq/q_ice/q_c are zeroed
+   (:559-562) → gas optics sees condensate as vapor everywhere incl.
+   clear-sky CRE. Fix: q_t = vapor only after the zeroing.
+5. **PR-1.4 Twomey**: replace `get_CDNC(aod)/get_CDNC(0)` (≈137 at
+   AOD 0.43) with Stevens et al. (2017) `dNovrN = ln(1000·(aod_sp+aod_bg)+1)
+   / ln(1000·aod_bg+1)` (≈1.0-1.6), aod_bg from the background AOD.
+   Touches macv2_sp.py:100-110 + consumers (echam_1m base_cdnc,
+   cloud_optics r_eff) stay as-is.
+6. Ride-alongs if cheap: **PR-2.36** liquid/ice r_eff overhaul (Martin
+   1994 from LWC/Nd; Sun-Rikus-style rei(IWC,T); fix the degenerate
+   `cip/max(1.0, cwp+cip)` argument and hard-wired `land_fraction=0.5`) —
+   or split to its own PR if it balloons.
+
+## PR 4 — convection ledger (the deep one)
+
+Physics review §2 (Tiedtke-Nordeng), reference mo_cufluxdts/cuascent:
+
+1. **PR-1.1 cudtdq form**: flux_tendencies.py:186-209 — latent-heat term
+   sign (+L·Δ(lu·mfu) should be −L·(Δpmful − plude − (pdmfup+pdmfdp)));
+   add the missing plude/pdmfup/pdmfdp sinks to both T and q tendencies.
+   Today: water created at the precipitation rate; column heating 454 vs
+   L·P=140 W/m².
+2. **PR-1.2 cprcon units**: updraft.py:358-363 — ECHAM's CPRCON=1.1e-3/g
+   multiplies g·dz; code multiplies per-metre 1.4e-3 by g·dz (~12×).
+   Fix: cprcon·dz (or cprcon/g·g·dz), default 1.1e-3.
+3. **PR-2.1 remove the grid-mean saturation adjustment**
+   (`convective_adjustment` call, tiedtke_nordeng.py:922) — no ECHAM
+   counterpart; double-counts stratiform condensation; ~2/3 of current
+   column heating.
+4. **PR-2.2 downdraft evaporation**: replace the `cevapcu`-scaled pseudo-
+   evaporation with the existing faithful `cuadjtq(kcall=2)` at every
+   downdraft level; restore cevapcu to its Kessler sub-cloud-rain-evap
+   meaning.
+5. **PR-2.3 precip budget**: sub-cloud rain evaporation (CEVAPCU1/2),
+   downdraft `pdmfdp`, rain/snow partition + `alf·pdpmel` melting term.
+6. **PR-2.4 magic-number qc/qi tendencies** (`lu*0.1`/`lu*0.05`,
+   `flux*0.1*0.001`) → proper `plude` detrainment.
+7. Smaller: **PR-2.5** deep-closure form (Nordeng zheat), **PR-2.6**
+   momentum transport (cududv), **PR-2.7** cuadjtq Ls/Lv phase pairing,
+   entrscv value, turbulent detrainment δ=ε, cmfctop at cloud top,
+   cloud-base condensate discard, surface-layer tendency, `_DTDT_MAX`
+   T/q asymmetry, `energy_conservation_check` fix.
+   (#530 half-level restagger stays a separate tracked issue — do after.)
+   Gate: new column energy/water conservation tests; RCE testbed (#523)
+   comparison; 3D T63L47 revalidation like #529.
+
+## PR 5 — microphysics ledgers
+
+1M (physics review §2.9-2.16): port ice sedimentation into the column sweep
+(from the legacy path, then delete legacy per Part C); replace ad-hoc
+`ice_autoconversion` with ECHAM zsaut (Levkov); snow-melt cooling extra /dt;
+rain-evap `zbst` missing Rv; inverted `sqrt(rho/1.3)` in zxrp1; snow-kernel
+riming/aggregation constants (cn0s/crhosno/ccsacl/colleffi — un-deads those
+params); warm-ice melt (`zimlt`); clear-cell force-evaporation; 1M
+`thermo_run` consumption (post-convection T/q like the 2M term); KK2000
+unit fix; `zrac2` dt.
+
+2M (§2.17-2.26, after/with PR-1 ledger items): qr/qs dual accounting (add
+fallout sinks or drop the tracers to ECHAM's flux form); per-level ice-flux
+dumping (kk==klev gate); dqsdt Boltzmann-constant fix (`c.ak`→Tetens
+coefficient — value fix beyond PR 2's scope); `_qsat` missing ε; WBF
+vertical-velocity gate; melting mass/number decoupling; scalar `snow_melt`
+broadcast; KK2000 in-cloud scaling + double saturation adjustment (#539
+interaction); activation dead zone (`ll2` only at the floor).
+Sundqvist ride-alongs: inversion off-by-one (+land/sea-ice/ktype guards),
+cptop 100→10 hPa, ice-presence-conditional saturation switch.
+
+## PR 6 — MACv2-SP fidelity + 2M parameter threading
+
+- MACv2-SP (§2.30-2.35): dz-weighted vertical-profile normalization;
+  per-feature annual cycle inside the spatial sum; AOD-weighted (not
+  Gaussian-weighted) SSA/ASY; orography truncation; real
+  MACv2.0-SP_v1.nc parameter loader (fix `aerosol_parameters_from_macv2`
+  TypeError) + wire year_weight/ann_cycle defaults; 3000 nm cutoff;
+  background-AOD handling documented as a deviation.
+- `CloudParams2M` threading: replace the import-time module-global bake
+  (lohmann_2m_params.py:434-499) with the threaded params struct —
+  prerequisite for any 2M calibration; prune the ~40 dead parameter
+  fields across all Parameters structs (Part C.2); un-sever the SPA-knob
+  gradient path (`float()` casts in echam_terms.py:183-186).
+
+## PR 7 — structure + smoothing (after answers stop changing)
+
+- lohmann_2m package split (Part C.4), tiedtke types split, vmap hoisting
+  (perf-plan Step 2), thermodynamics migration of the remaining inline
+  qsat copies (lohmann_2m orchestrator, moist_air_state, runners).
+- Smoothing per Part B priorities: sigmoid trigger/type blend for Tiedtke
+  (w≈20-50 J/kg, annealable), tapered updraft termination, learnable
+  zdnoprc, Sundqvist soft-clip + softmax inversion, KK2000 ccraut ramp,
+  smooth floors/STE for positivity clips, deterministic-key McICA for
+  calibration, log-parameterization of tunables.
+- Comment-hygiene sweep for whatever Part A items didn't ride along with
+  their code fixes.
+
+## How to resume
+
+PRs 1–2 are merged; the working branch for the campaign is now
+`claude/pr3-radiation-quick-wins` (open a PR against `dev` if one is not
+already up), then PRs 4–7 in sequence, each freshly branched from `dev`.
+Standard gates throughout: `ruff check .` and
+`JAX_PLATFORMS=cpu pytest -n 12 -m "not slow" -q` green; test-pin
+discipline (changed pins justified old→new against the corrected physics);
+per-scheme conservation + parameter-gradient tests added as each scheme is
+touched (see "Working conventions" above). Before starting PR 4+, convert
+that PR's still-open review findings into GitHub issues so tracking
+survives the review branch's retirement.

--- a/docs/echam_rrtmgp_fix_plan.md
+++ b/docs/echam_rrtmgp_fix_plan.md
@@ -47,12 +47,16 @@ Physics first, with a thin structural pre-pass. Rationale:
 
 Housekeeping: the `claude/pr3-radiation-quick-wins` and
 `claude/echam-surface-faithful-wiring` branches were merged via rebase
-(#548 → `1e8808f`, #532 → `748413a`) but each still carries a small
-unmerged residual diff vs `dev` (pr3: ~+308 lines incl. rrtmgp/macv2
-tests; surface: ~+369/−298 in tte_tke + reference regeneration) — triage
-those diffs for leftover value before deleting the branches. The JAM/AIDE
-convergence programme (issue #609, `docs/aide_jcm_convergence_roadmap.md`)
-runs alongside this campaign.
+(#548 → `1e8808f`, #532 → `748413a`), so `git log dev..branch` still shows
+their commits. Both residual diffs were triaged (2026-08-13): every
+addition — code fixes, regression tests, the `rce.py` solar-constant
+recalibration, the `jax-rrtmgp>=0.2.1` bump, the T21L16 reference
+snapshot, the normalized-RMS comparison — is present in `dev`, and the
+branch-only lines are older superseded versions of code `dev` has since
+evolved. **Both branches are fully harvested and safe to delete**, as are
+`claude/pr1-dead-code-cleanup` and `claude/pr2-thermodynamics` (fully
+contained in `dev`). The JAM/AIDE convergence programme (issue #609,
+`docs/aide_jcm_convergence_roadmap.md`) runs alongside this campaign.
 
 All branches base on `dev`. Working conventions: `ruff check .`;
 `JAX_PLATFORMS=cpu pytest -n 12 -m "not slow" -q` must be green; **test-pin

--- a/docs/echam_rrtmgp_fix_plan.md
+++ b/docs/echam_rrtmgp_fix_plan.md
@@ -39,19 +39,20 @@ Physics first, with a thin structural pre-pass. Rationale:
 |---|---|---|---|
 | 1 | `claude/pr1-dead-code-cleanup` | structural, zero behavior change | **merged** (landed via #569, `chore/dead-code`) |
 | 2 | `claude/pr2-thermodynamics` | structural+physics | **merged** (branch fully contained in `dev`) |
-| 3 | `claude/pr3-radiation-quick-wins` | physics | **implemented, in review** (insolation µ0², surface BC, halo, gas-optics water, Twomey) |
-| 4 | convection ledger | physics | not started |
-| 5 | 1M/2M microphysics ledgers | physics | not started |
-| 6 | MACv2-SP fidelity + 2M param threading | physics+structural | not started |
-| 7 | module splits, vmap hoisting, smoothing (Part B) | structural | not started |
+| 3 | `claude/pr3-radiation-quick-wins` | physics | **merged** (#548, landed as `1e8808f`: insolation µ0², surface BC, halo, gas-optics water, Twomey) |
+| 4 | convection ledger | physics | not started as a unit — but later merges already fixed parts of its scope; **re-scope against current `dev` first** |
+| 5 | 1M/2M microphysics ledgers | physics | not started; re-scope first (#558 NaN hardening overlaps) |
+| 6 | MACv2-SP fidelity + 2M param threading | physics+structural | not started; re-scope against post-JAM `macv2_sp.py` (Twomey dNovrN already landed with PR 3) |
+| 7 | module splits, vmap hoisting, smoothing (Part B) | structural | partially landed via #556 (differentiable smoothing, term ordering, structural splits); re-scope the remainder |
 
-Related but outside this sequence: `claude/echam-surface-faithful-wiring`
-(surface wiring + T21L16 reference-snapshot regeneration via CI) is in
-flight and touches the same ECHAM test references — coordinate merges.
-The JAM/AIDE convergence programme (issue #609,
-`docs/aide_jcm_convergence_roadmap.md`) runs alongside; PR 6's MACv2-SP
-work should be re-scoped against post-JAM `macv2_sp.py` before starting,
-as parts of the review may already be addressed.
+Housekeeping: the `claude/pr3-radiation-quick-wins` and
+`claude/echam-surface-faithful-wiring` branches were merged via rebase
+(#548 → `1e8808f`, #532 → `748413a`) but each still carries a small
+unmerged residual diff vs `dev` (pr3: ~+308 lines incl. rrtmgp/macv2
+tests; surface: ~+369/−298 in tte_tke + reference regeneration) — triage
+those diffs for leftover value before deleting the branches. The JAM/AIDE
+convergence programme (issue #609, `docs/aide_jcm_convergence_roadmap.md`)
+runs alongside this campaign.
 
 All branches base on `dev`. Working conventions: `ruff check .`;
 `JAX_PLATFORMS=cpu pytest -n 12 -m "not slow" -q` must be green; **test-pin
@@ -230,13 +231,14 @@ cptop 100→10 hPa, ice-presence-conditional saturation switch.
 
 ## How to resume
 
-PRs 1–2 are merged; the working branch for the campaign is now
-`claude/pr3-radiation-quick-wins` (open a PR against `dev` if one is not
-already up), then PRs 4–7 in sequence, each freshly branched from `dev`.
-Standard gates throughout: `ruff check .` and
+PRs 1–3 are merged. Before picking up any of PRs 4–7: **re-audit that PR's
+finding list against current `dev`** — substantial overlapping work has
+merged since the review (e.g. #548 radiation, #556 smoothing/splits, #558
+NaN hardening, the coupled surface-flux solve, JAM) — and convert the
+findings that are still open into GitHub issues so tracking survives the
+review branch's retirement. Each PR branches fresh from `dev`. Standard
+gates throughout: `ruff check .` and
 `JAX_PLATFORMS=cpu pytest -n 12 -m "not slow" -q` green; test-pin
 discipline (changed pins justified old→new against the corrected physics);
 per-scheme conservation + parameter-gradient tests added as each scheme is
-touched (see "Working conventions" above). Before starting PR 4+, convert
-that PR's still-open review findings into GitHub issues so tracking
-survives the review branch's retirement.
+touched (see "Working conventions" above).


### PR DESCRIPTION
## Describe your changes

Salvages the two still-current planning documents from the review branch `claude/echam-rrtmgp-physics-review-zcof6u` so that branch can be retired:

- **`docs/echam_rrtmgp_fix_plan.md`** — the ECHAM+RRTMGP fix-campaign plan (7-PR sequence), with statuses corrected to reality: PRs 1–2 **merged** (dead code landed via #569; the thermodynamics branch is fully contained in `dev`), PR 3 **in review** on `claude/pr3-radiation-quick-wins`, PRs 4–7 pending. The resume section is rewritten for the current state, and PR 6 (MACv2-SP) gets a note to re-scope against the post-JAM `macv2_sp.py` before starting. The two point-in-time review reports (physics + maintainability) deliberately stay on the archived branch — their line numbers rot with the code, so still-open findings get converted to per-scheme GitHub issues as PRs 4–7 are picked up.
- **`docs/aide_jcm_convergence_roadmap.md`** — the phased JCM ↔ AIDE convergence plan (interfaces → component exchange → `PrescribedMetDycore` → shared-library steady state). Issue #609 (milestone v2.2) tracks the Phase 1–3 development and links to this file at its `dev` path, so the link goes live when this merges.

Docs-only; no code changes.

## Issue ticket number and link

#609 (JAM/AIDE convergence, Phases 1–3)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas (n/a — docs only)
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works (n/a — docs only)
- [ ] New and existing unit tests pass locally with my changes (n/a — docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADJidn7kEkemMmjCYZbpQJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ADJidn7kEkemMmjCYZbpQJ)_