### PR TITLE
feat(scm): first-class ColumnCoordinates replacing the SimpleNamespace stub

### DIFF
--- a/jcm/column_coordinates.py
+++ b/jcm/column_coordinates.py
@@ -1,0 +1,143 @@
+"""A first-class coordinate system for single-column configurations.
+
+The single-column model previously built its coordinates as a
+``SimpleNamespace`` duck-typing the parts of dinosaur's
+``CoordinateSystem`` that physics packages happen to read. That worked,
+but it had the classic stub problems: the contract lived in a comment
+rather than a type, an attribute the stub lacked surfaced as a bare
+``AttributeError`` deep inside a physics term, and there was nothing to
+test against.
+
+``ColumnCoordinates`` is the explicit version. It carries a real
+vertical coordinate object (``SigmaCoordinates`` or
+``HybridCoordinates``) over an ``(nlon, nlat) = (1, 1)`` horizontal
+"grid" pinned at one geographic location, and implements exactly the
+surface the physics packages consume:
+
+- ``coords.vertical`` — the vertical coordinate object, unchanged;
+- ``coords.nodal_shape`` — ``(nlev, 1, 1)``, matching the grid model's
+  ``(nlev, nlon, nlat)`` convention that e.g. ``EchamTermBase.cache_coords``
+  assumes;
+- ``coords.horizontal.nodal_shape`` — ``(1, 1)``;
+- ``coords.horizontal.latitudes`` / ``longitudes`` — 1-element arrays in
+  **radians** (the convention of dinosaur's grids);
+- ``coords.horizontal.nodal_axes`` — ``(longitudes, sin(latitudes))``,
+  the pair ``utils`` and ``predictions`` unpack.
+
+Spectral attributes (``longitude_wavenumbers`` etc.) are deliberately
+absent — a single column has no spectral truncation — but they fail
+with an explanatory error instead of a bare ``AttributeError``, so a
+spectral-only physics package (e.g. speedy's horizontal diffusion)
+reports *why* it cannot run in column mode.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import jax.numpy as jnp
+import numpy as np
+
+__all__ = ["ColumnCoordinates", "ColumnHorizontalGrid"]
+
+
+_SPECTRAL_ATTRS = frozenset({
+    "longitude_wavenumbers",
+    "total_wavenumbers",
+    "modal_shape",
+    "modal_axes",
+    "mask",
+})
+
+
+@dataclasses.dataclass(frozen=True)
+class ColumnHorizontalGrid:
+    """The ``(1, 1)`` horizontal "grid" of a single column.
+
+    Attributes:
+        latitudes: 1-element array, radians.
+        longitudes: 1-element array, radians.
+
+    """
+
+    latitudes: jnp.ndarray
+    longitudes: jnp.ndarray
+
+    @classmethod
+    def at_degrees(cls, lat_deg: float, lon_deg: float) -> "ColumnHorizontalGrid":
+        return cls(
+            latitudes=jnp.asarray([float(np.deg2rad(lat_deg))]),
+            longitudes=jnp.asarray([float(np.deg2rad(lon_deg))]),
+        )
+
+    @property
+    def nodal_shape(self) -> tuple[int, int]:
+        return (1, 1)
+
+    @property
+    def nodal_axes(self) -> tuple[jnp.ndarray, jnp.ndarray]:
+        """``(longitudes, sin(latitudes))`` — dinosaur's nodal-axes convention."""
+        return (self.longitudes, jnp.sin(self.latitudes))
+
+    def __getattr__(self, name: str):
+        """Turn spectral-attribute access into an explanatory error."""
+        if name in _SPECTRAL_ATTRS:
+            raise AttributeError(
+                f"ColumnHorizontalGrid has no spectral attribute {name!r}: a "
+                "single column has no spectral truncation. The physics "
+                "package requesting it cannot run in single-column mode."
+            )
+        raise AttributeError(
+            f"{type(self).__name__!r} object has no attribute {name!r}"
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class ColumnCoordinates:
+    """Coordinate system for one atmospheric column at a fixed location.
+
+    A drop-in for the places the SCM hands coordinates to physics: it
+    implements the consumed subset of dinosaur's ``CoordinateSystem``
+    with the same shapes and conventions as the full grid model, so a
+    ``PhysicsTerm`` cannot tell the difference (and a term that needs
+    what a column cannot provide gets an explanatory error).
+
+    Attributes:
+        vertical: A ``SigmaCoordinates``/``HybridCoordinates`` instance.
+        horizontal: The single-point horizontal grid.
+
+    """
+
+    vertical: object
+    horizontal: ColumnHorizontalGrid
+
+    @classmethod
+    def at_location(
+        cls, vertical, lat_deg: float, lon_deg: float
+    ) -> "ColumnCoordinates":
+        """Build column coordinates at ``(lat_deg, lon_deg)`` in degrees."""
+        return cls(
+            vertical=vertical,
+            horizontal=ColumnHorizontalGrid.at_degrees(lat_deg, lon_deg),
+        )
+
+    @property
+    def nlev(self) -> int:
+        return _vertical_nlev(self.vertical)
+
+    @property
+    def nodal_shape(self) -> tuple[int, int, int]:
+        """``(nlev, nlon, nlat)`` — the grid model's convention."""
+        return (self.nlev, 1, 1)
+
+
+def _vertical_nlev(vertical) -> int:
+    """Layer count of a Sigma/Hybrid vertical coordinate object."""
+    if hasattr(vertical, "centers"):
+        return int(np.asarray(vertical.centers).shape[0])
+    if hasattr(vertical, "a_boundaries"):
+        return int(np.asarray(vertical.a_boundaries).shape[0]) - 1
+    raise TypeError(
+        f"Unsupported vertical coordinate type {type(vertical).__name__!r}; "
+        "expected SigmaCoordinates or HybridCoordinates."
+    )

--- a/jcm/column_coordinates_test.py
+++ b/jcm/column_coordinates_test.py
@@ -1,0 +1,85 @@
+"""Tests for ``jcm.column_coordinates.ColumnCoordinates``."""
+
+import dataclasses
+import unittest
+
+import numpy as np
+from dinosaur.sigma_coordinates import SigmaCoordinates
+
+from jcm.column_coordinates import ColumnCoordinates
+from jcm.single_column_model import _make_single_column_coords
+
+
+class ColumnCoordinatesTest(unittest.TestCase):
+
+    def setUp(self):
+        self.vertical = SigmaCoordinates.equidistant(12)
+        self.coords = ColumnCoordinates.at_location(
+            self.vertical, lat_deg=15.5, lon_deg=-140.625
+        )
+
+    def test_nodal_shape_follows_grid_convention(self):
+        """(nlev, nlon, nlat), as EchamTermBase.cache_coords assumes."""
+        self.assertEqual(self.coords.nodal_shape, (12, 1, 1))
+        self.assertEqual(self.coords.horizontal.nodal_shape, (1, 1))
+
+    def test_location_is_stored_in_radians(self):
+        np.testing.assert_allclose(
+            np.asarray(self.coords.horizontal.latitudes),
+            [np.deg2rad(15.5)], rtol=1e-6,
+        )
+        np.testing.assert_allclose(
+            np.asarray(self.coords.horizontal.longitudes),
+            [np.deg2rad(-140.625)], rtol=1e-6,
+        )
+
+    def test_nodal_axes_convention(self):
+        """(longitudes, sin(latitudes)) — the pair predictions unpacks."""
+        lon, sin_lat = self.coords.horizontal.nodal_axes
+        np.testing.assert_allclose(
+            np.asarray(lon), np.asarray(self.coords.horizontal.longitudes)
+        )
+        np.testing.assert_allclose(
+            np.asarray(sin_lat),
+            np.sin(np.asarray(self.coords.horizontal.latitudes)),
+        )
+
+    def test_vertical_passes_through_unchanged(self):
+        self.assertIs(self.coords.vertical, self.vertical)
+
+    def test_spectral_attributes_fail_with_explanation(self):
+        """A spectral-only physics package must learn WHY it cannot run.
+
+        The SimpleNamespace stub raised a bare AttributeError from deep
+        inside the requesting term; the class names the actual problem.
+        """
+        with self.assertRaisesRegex(
+            AttributeError, "no spectral truncation"
+        ):
+            _ = self.coords.horizontal.longitude_wavenumbers
+
+    def test_unknown_attributes_still_raise_attribute_error(self):
+        """hasattr()-probing (used across jcm) must keep working."""
+        self.assertFalse(hasattr(self.coords.horizontal, "no_such_attr"))
+
+    def test_scm_helper_returns_the_class(self):
+        made = _make_single_column_coords(self.vertical, 15.5, -140.625)
+        self.assertIsInstance(made, ColumnCoordinates)
+        self.assertEqual(made.nodal_shape, self.coords.nodal_shape)
+
+    def test_physics_term_shape_contract(self):
+        """The exact reads PhysicsTerm.initial_carry_state performs."""
+        ncols = (
+            self.coords.horizontal.nodal_shape[0]
+            * self.coords.horizontal.nodal_shape[1]
+        )
+        nlev = self.coords.nodal_shape[0]
+        self.assertEqual((nlev, ncols), (12, 1))
+
+    def test_is_a_frozen_value_type(self):
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            self.coords.vertical = None
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jcm/single_column_model.py
+++ b/jcm/single_column_model.py
@@ -24,12 +24,12 @@ and computes tendencies for every cell with ``vmap``.
 
 from __future__ import annotations
 
-from types import SimpleNamespace
 from typing import Any, Callable
 
 import jax
 import jax.numpy as jnp
-import numpy as np
+
+from jcm import column_coordinates
 import tree_math
 from jax import lax
 from jax.tree_util import tree_map
@@ -75,46 +75,23 @@ class SCMPredictions:
 
 
 def _vertical_nlev(vertical) -> int:
-    if hasattr(vertical, "centers"):
-        return int(np.asarray(vertical.centers).shape[0])
-    if hasattr(vertical, "a_boundaries"):
-        return int(np.asarray(vertical.a_boundaries).shape[0]) - 1
-    raise TypeError(
-        f"Unsupported vertical coordinate type {type(vertical).__name__!r}; "
-        "expected SigmaCoordinates or HybridCoordinates."
-    )
+    # Retained as an alias: the implementation moved to
+    # ``column_coordinates`` with the first-class coordinate type.
+    return column_coordinates._vertical_nlev(vertical)
 
 
 def _make_single_column_coords(vertical, lat_deg: float, lon_deg: float):
-    """Duck-typed ``CoordinateSystem`` analogue at the user's column.
+    """Column coordinates at the user's location.
 
-    The SCM's physics packages only read ``coords.vertical``,
-    ``coords.horizontal.{latitudes, longitudes, nodal_shape}`` and
-    ``coords.nodal_shape`` from whatever they're handed, so a
-    ``SimpleNamespace`` with those attributes is enough — no real
-    horizontal grid needed.
-
-    The horizontal shape is ``(1, 1)``: a single column at the requested
-    ``(lat_deg, lon_deg)``. ICON's term setup (e.g.
-    ``EchamTermBase.cache_coords``) assumes a 3-tuple ``(nlev, nlon, nlat)``
-    nodal shape, so we keep that convention rather than collapsing to
-    ``(nlev, 1)``.
+    Previously a duck-typed ``SimpleNamespace``; now the first-class
+    :class:`jcm.column_coordinates.ColumnCoordinates`, which implements
+    the same consumed surface (``vertical``, ``nodal_shape``,
+    ``horizontal.{latitudes, longitudes, nodal_shape, nodal_axes}``)
+    with a type to test against and explanatory errors for spectral
+    attributes a column cannot provide.
     """
-    nlev = _vertical_nlev(vertical)
-    lat_rad = jnp.asarray([float(np.deg2rad(lat_deg))])
-    lon_rad = jnp.asarray([float(np.deg2rad(lon_deg))])
-    horizontal = SimpleNamespace(
-        nodal_shape=(1, 1),
-        latitudes=lat_rad,
-        longitudes=lon_rad,
-        # ``nodal_axes`` returns (lon, sin(lat)) by convention; included so
-        # any helper that touches it on a stub coord still works.
-        nodal_axes=(lon_rad, jnp.sin(lat_rad)),
-    )
-    return SimpleNamespace(
-        horizontal=horizontal,
-        vertical=vertical,
-        nodal_shape=(nlev, 1, 1),
+    return column_coordinates.ColumnCoordinates.at_location(
+        vertical, lat_deg, lon_deg
     )
 
 


### PR DESCRIPTION
Replaces the SCM's duck-typed `SimpleNamespace` coordinates with a first-class `ColumnCoordinates` type. Refs the jax-les Phase-4 roadmap item (its GCM column harness is the first external consumer of the SCM contract).

## What changed

- **`jcm/column_coordinates.py` (new)**: `ColumnCoordinates` + `ColumnHorizontalGrid`, frozen dataclasses implementing exactly the coordinate surface physics packages consume — `vertical` (the real Sigma/Hybrid object), `nodal_shape` in the grid model's `(nlev, nlon, nlat)` convention, `horizontal.{latitudes, longitudes, nodal_shape, nodal_axes}` with radians and the `(lon, sin(lat))` axes convention `predictions`/`utils` unpack.
- **`_make_single_column_coords` now returns the class.** Same signature, same consumed surface: no physics package changes.
- **Behavioural improvement**: spectral attributes (`longitude_wavenumbers`, `modal_shape`, …) fail with an error explaining that a column has no spectral truncation, instead of a bare `AttributeError` from deep inside the requesting term (which is how e.g. speedy's spectral diffusion would previously have surfaced). Unknown attributes still raise plain `AttributeError`, so `hasattr()` probing keeps working — there's a test for both behaviours.

## Why this approach

The alternative was to keep the stub and document it harder. But the contract already had three consumers reading five attributes and a comment as its only spec; a type makes drift visible at review time and gives the SCM's external consumers (jax-les) something to program against. `_vertical_nlev` moved with it; the old name stays as an alias.

## Verified

- 8 new tests pin the contract (shape conventions, radians, `nodal_axes` unpack, the exact `PhysicsTerm.initial_carry_state` reads, frozen-ness, both error behaviours).
- Full fast suite: 1747 passed, 14 skipped, `ruff check .` clean.
- Existing SCM tests pass untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqAzi7a3jCXuyk7KTBQTk7