### PR TITLE
Remove the advected-tracer cloud-borne path; standing rule to file issues for deferred findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,21 @@ tedious (implicit balances, conservation, edge cases) — not just the easy 80%.
    (per "Think Before Coding" above) — surface it and ask. Effort or tedium is not such a
    reason.
 
+## File an issue for everything you find but don't fix
+Any bug, fidelity gap, missing pathway, or future development option encountered during a
+piece of work that will NOT be dealt with in the current PR must become a GitHub issue
+before that PR merges — a docstring note or PR-body mention is not enough, because nothing
+ever comes back to those. This includes findings from adversarial reviews that are
+triaged as "documented follow-up", pathways deliberately excluded from a term's first
+version, and capability regressions accepted as trade-offs.
+
+ - One issue per independent piece of work, titled by the gap (not the PR that found it),
+   with enough context to start cold: what is missing, where the hooks already are, and
+   what reference formulation applies.
+ - Cross-link it from the code comment or docstring that notes the gap, and from the PR.
+ - Deliberately parked/rejected directions don't get an issue — record the decision and
+   its evidence where the decision was made instead.
+
 ## No bespoke run scripts — new configurations go through Hydra
 Every runnable configuration must be expressible as ``python -m jcm.main``
 with Hydra groups/overrides — never as a standalone driver script:

--- a/jcm/config/physics/echam-jam.yaml
+++ b/jcm/config/physics/echam-jam.yaml
@@ -39,14 +39,14 @@ jam_aqueous_scheme: full
 # flip fails loudly (checkpoint pytree mismatch); false -> true cold-starts
 # the mirrors at zero (spin-up).
 #
-# The explicit phase lives in the physics CARRY by default (#602 item 3):
-# the 30-day T21 A/B measured the dycore-advected mc_*/nc_* mirrors going
-# ~90%-of-cells NEGATIVE from spectral ringing on these episodic fields
-# while costing 2.2x the carry run. Deliberately NOT set here — the
-# factory default is the single source of truth. The advected mode
-# remains reachable (jam_cloud_borne_storage: tracers, forwarded to
-# echam_physics like any factory kwarg) for FV-dycore re-evaluation
-# only; do not use it on spectral grids.
+# The explicit phase lives in the physics CARRY (#602 item 3) — there is
+# no advected-tracer alternative. The 30-day T21 A/B measured the
+# dycore-advected mc_*/nc_* mirrors going ~90%-of-cells NEGATIVE from
+# spectral ringing at 2.2x the carry cost (and 2.1x even under
+# semi-Lagrangian transport, with 0.997 pattern agreement); the FV-dycore
+# re-check was parked because pySES is the CAM-SE dycore, CAM itself
+# keeps qqcw in pbuf, and pySES is the most tracer-cost-sensitive
+# configuration (#595). Evidence figures on #602.
 jam_cloud_borne: true
 
 # Prescribed-emission terms (driven by forcing.emissions_file):

--- a/jcm/physics/aerosol/jam/chemistry/aqueous_test.py
+++ b/jcm/physics/aerosol/jam/chemistry/aqueous_test.py
@@ -13,6 +13,7 @@ from jcm.physics.aerosol.jam.chemistry.aqueous import (
     _CONV_SO2_SO4_MASS,
 )
 from jcm.physics.aerosol.jam.chemistry.oxidants import OxidantField
+from jcm.physics.aerosol.jam.cloud_borne_store import CARRY_KEY
 from jcm.physics.aerosol.jam.tracer_layout import mass_name, number_name
 from jcm.physics_interface import PhysicsState
 
@@ -53,10 +54,13 @@ class AqueousTermTest(unittest.TestCase):
 
         shape = (nlev, ncols)
         tracers = {"g_so2": jnp.full(shape, 1.0e-10)}
+        carry = {}
         for m in (mm.short for mm in MAM4_SPEC.modes if "so4" in mm.species):
             tracers[mass_name("so4", m)] = jnp.full(shape, 1.0e-11)
-            tracers[mass_name("so4", m, cloud_borne=True)] = jnp.full(shape, 1.0e-12)
-            tracers[number_name(m, cloud_borne=True)] = jnp.full(shape, nc)
+            carry[mass_name("so4", m, cloud_borne=True)] = jnp.full(
+                shape, 1.0e-12
+            )
+            carry[number_name(m, cloud_borne=True)] = jnp.full(shape, nc)
         state = PhysicsState.zeros(shape).copy(
             temperature=jnp.full(shape, 275.0), tracers=tracers,
         )
@@ -65,6 +69,7 @@ class AqueousTermTest(unittest.TestCase):
             o3=jnp.full(shape, 1.0e12), h2o2=jnp.full(shape, 1.0e10),
         )
         diagnostics = {
+            CARRY_KEY: carry,
             "oxidants": ox,
             "clouds": types.SimpleNamespace(
                 cloud_fraction=jnp.full(shape, cloud_fraction),
@@ -75,14 +80,22 @@ class AqueousTermTest(unittest.TestCase):
         }
         return state, diagnostics
 
+    @staticmethod
+    def _cb_rate(diag_in, diag_out, nm, dt=1800.0):
+        """Effective cloud-borne production rate from the carry update."""
+        import numpy as _np
+        return (
+            _np.asarray(diag_out[CARRY_KEY][nm])
+            - _np.asarray(diag_in[CARRY_KEY][nm])
+        ) / dt
+
     def test_produces_cloud_borne_sulfate_and_consumes_so2(self):
         state, diagnostics = self._setup()
-        tend, _ = AqueousSulfur()(state, diagnostics, None, None)
-        self.assertIn(mass_name("so4", "acc", cloud_borne=True), tend.tracers)
-        self.assertGreater(
-            float(tend.tracers[mass_name("so4", "acc", cloud_borne=True)][0, 0]),
-            0.0,
+        tend, out = AqueousSulfur()(state, diagnostics, None, None)
+        cb = self._cb_rate(
+            diagnostics, out, mass_name("so4", "acc", cloud_borne=True),
         )
+        self.assertGreater(float(cb[0, 0]), 0.0)
         self.assertLess(float(tend.tracers["g_so2"][0, 0]), 0.0)
 
     def test_sulfur_conserved(self):
@@ -90,11 +103,11 @@ class AqueousTermTest(unittest.TestCase):
         from jcm.physics.aerosol.jam.chemistry.aqueous import _MW_SO2, _MW_SO4
 
         state, diagnostics = self._setup()
-        tend, _ = AqueousSulfur()(state, diagnostics, None, None)
+        tend, out = AqueousSulfur()(state, diagnostics, None, None)
         s_rate = np.asarray(tend.tracers["g_so2"]) / _MW_SO2
         for m in (mm.short for mm in MAM4_SPEC.modes if "so4" in mm.species):
             key = mass_name("so4", m, cloud_borne=True)
-            s_rate = s_rate + np.asarray(tend.tracers[key]) / _MW_SO4
+            s_rate = s_rate + self._cb_rate(diagnostics, out, key) / _MW_SO4
         self.assertTrue(np.all(np.abs(s_rate) < 1.0e-18))
 
     def test_sulfur_conserved_without_cloud_borne_number(self):
@@ -108,22 +121,19 @@ class AqueousTermTest(unittest.TestCase):
         from jcm.physics.aerosol.jam.chemistry.aqueous import _MW_SO2, _MW_SO4
 
         state, diagnostics = self._setup(nc=0.0)
-        tend, _ = AqueousSulfur()(state, diagnostics, None, None)
+        tend, out = AqueousSulfur()(state, diagnostics, None, None)
         # All produced sulfate lands in interstitial accumulation mode…
         self.assertGreater(
             float(tend.tracers[mass_name("so4", "acc")][0, 0]), 0.0,
         )
-        # …and none in any cloud-borne tracer.
-        for m in (mm.short for mm in MAM4_SPEC.modes if "so4" in mm.species):
-            np.testing.assert_allclose(
-                np.asarray(tend.tracers[mass_name("so4", m, cloud_borne=True)]),
-                0.0,
-            )
+        # …and none in any cloud-borne field.
         s_rate = np.asarray(tend.tracers["g_so2"]) / _MW_SO2
         s_rate = s_rate + np.asarray(tend.tracers[mass_name("so4", "acc")]) / _MW_SO4
         for m in (mm.short for mm in MAM4_SPEC.modes if "so4" in mm.species):
             key = mass_name("so4", m, cloud_borne=True)
-            s_rate = s_rate + np.asarray(tend.tracers[key]) / _MW_SO4
+            cb = self._cb_rate(diagnostics, out, key)
+            np.testing.assert_allclose(cb, 0.0)
+            s_rate = s_rate + cb / _MW_SO4
         self.assertTrue(np.all(np.abs(s_rate) < 1.0e-18))
 
     def test_implicit_population_emits_no_cloud_borne_keys(self):
@@ -151,11 +161,11 @@ class AqueousTermTest(unittest.TestCase):
 
     def test_no_clouds_no_production(self):
         state, diagnostics = self._setup(cloud_fraction=0.0)
-        tend, _ = AqueousSulfur()(state, diagnostics, None, None)
-        self.assertAlmostEqual(
-            float(tend.tracers[mass_name("so4", "acc", cloud_borne=True)][0, 0]),
-            0.0,
+        _, out = AqueousSulfur()(state, diagnostics, None, None)
+        cb = self._cb_rate(
+            diagnostics, out, mass_name("so4", "acc", cloud_borne=True),
         )
+        self.assertAlmostEqual(float(cb[0, 0]), 0.0)
 
     def test_grad_through_rate_scale_finite(self):
         from jcm.physics.aerosol.jam.chemistry.aqueous import (
@@ -181,10 +191,13 @@ class SimpleAqueousSchemeTest(unittest.TestCase):
 
         shape = (nlev, ncols)
         tracers = {"g_so2": jnp.full(shape, so2)}
+        carry = {}
         for m in (mm.short for mm in MAM4_SPEC.modes if "so4" in mm.species):
             tracers[mass_name("so4", m)] = jnp.full(shape, 1.0e-11)
-            tracers[mass_name("so4", m, cloud_borne=True)] = jnp.full(shape, 1.0e-12)
-            tracers[number_name(m, cloud_borne=True)] = jnp.full(shape, 1.0e7)
+            carry[mass_name("so4", m, cloud_borne=True)] = jnp.full(
+                shape, 1.0e-12
+            )
+            carry[number_name(m, cloud_borne=True)] = jnp.full(shape, 1.0e7)
         state = PhysicsState.zeros(shape).copy(
             temperature=jnp.full(shape, 275.0), tracers=tracers,
         )
@@ -193,6 +206,7 @@ class SimpleAqueousSchemeTest(unittest.TestCase):
             o3=jnp.full(shape, 1.0e12), h2o2=jnp.full(shape, h2o2),
         )
         diagnostics = {
+            CARRY_KEY: carry,
             "oxidants": ox,
             "clouds": types.SimpleNamespace(
                 cloud_fraction=jnp.full(shape, 0.6), qc=jnp.full(shape, 2.0e-4),
@@ -211,25 +225,30 @@ class SimpleAqueousSchemeTest(unittest.TestCase):
         from jcm.physics.aerosol.jam.chemistry.aqueous import _MW_SO2, _MW_SO4
 
         state, diagnostics = self._setup()
-        tend, _ = AqueousSulfur(scheme="simple")(state, diagnostics, None, None)
-        self.assertGreater(
-            float(tend.tracers[mass_name("so4", "acc", cloud_borne=True)][0, 0]),
-            0.0,
+        tend, out = AqueousSulfur(scheme="simple")(
+            state, diagnostics, None, None,
         )
+        cb_acc = AqueousTermTest._cb_rate(
+            diagnostics, out, mass_name("so4", "acc", cloud_borne=True),
+        )
+        self.assertGreater(float(cb_acc[0, 0]), 0.0)
         s_rate = np.asarray(tend.tracers["g_so2"]) / _MW_SO2
         for m in (mm.short for mm in MAM4_SPEC.modes if "so4" in mm.species):
-            s_rate = s_rate + np.asarray(
-                tend.tracers[mass_name("so4", m, cloud_borne=True)]
+            s_rate = s_rate + AqueousTermTest._cb_rate(
+                diagnostics, out, mass_name("so4", m, cloud_borne=True),
             ) / _MW_SO4
         self.assertTrue(np.all(np.abs(s_rate) < 1.0e-18))
 
     def test_simple_is_h2o2_limited(self):
         # Scarce H2O2 caps the sulfate produced below the abundant-H2O2 case.
-        lo, _ = AqueousSulfur(scheme="simple")(*self._setup(h2o2=1.0e7)[:2], None, None)
-        hi, _ = AqueousSulfur(scheme="simple")(*self._setup(h2o2=1.0e11)[:2], None, None)
         key = mass_name("so4", "acc", cloud_borne=True)
+        s_lo, d_lo = self._setup(h2o2=1.0e7)
+        _, out_lo = AqueousSulfur(scheme="simple")(s_lo, d_lo, None, None)
+        s_hi, d_hi = self._setup(h2o2=1.0e11)
+        _, out_hi = AqueousSulfur(scheme="simple")(s_hi, d_hi, None, None)
         self.assertLess(
-            float(lo.tracers[key][0, 0]), float(hi.tracers[key][0, 0])
+            float(AqueousTermTest._cb_rate(d_lo, out_lo, key)[0, 0]),
+            float(AqueousTermTest._cb_rate(d_hi, out_hi, key)[0, 0]),
         )
 
 

--- a/jcm/physics/aerosol/jam/cloud_borne_store.py
+++ b/jcm/physics/aerosol/jam/cloud_borne_store.py
@@ -1,50 +1,46 @@
-"""Cloud-borne aerosol storage: dycore tracers or the physics carry.
+"""The cloud-borne aerosol phase: physics-carry fields (CAM's pbuf pattern).
 
-#602 item 3 (CAM's ``pbuf`` pattern): with the cloud-borne cycle closed
-(#602 item 1) and physics-side vertical transport in place (item 2), the
-``mc_*``/``nc_*`` mirrors no longer *need* to be dycore-advected tracers —
-they can live in the cross-step physics carry, skipping the spectral
-transforms and advection entirely (the dominant tracer cost at ne30, #595)
-while the exchange/wet/dry/aqueous cycle runs on them unchanged in physics
-space. What carry storage gives up is resolved-scale advection of
-in-droplet aerosol; CAM accepts exactly that trade for ``qqcw``.
+#602: with the cloud-borne cycle closed (item 1) and physics-side
+vertical transport in place (item 2), the ``mc_*``/``nc_*`` phase lives
+in the cross-step physics carry — never in dycore tracers. The 30-day
+controlled A/B (2026-08-13, figures on #602) settled it: Eulerian-spectral
+advection rang the episodic mirrors ~90%-of-cells negative (global-mean
+mass net-negative) at 2.2x the carry cost, and even against the fair
+semi-Lagrangian baseline (quasi-monotone nodal transport, unreleased
+dinosaur#135) the carry agreed to 3-8% with r(zonal)=0.997 at 2.1x less
+cost. A tracers-storage escape hatch was initially retained for an
+FV-dycore re-check and then REMOVED by decision: pySES is the CAM-SE
+dycore, CAM itself keeps ``qqcw`` in pbuf rather than advecting it, and
+pySES is the configuration most sensitive to tracer count (#595) — there
+is no configuration left where advected mirrors could win.
 
-``ModalAerosolSpec.cloud_borne_storage`` selects the mode ("tracers" |
-"carry"; only meaningful with an explicit cloud-borne phase). Carry is
-the factory default: the 30-day controlled A/B (2026-08-13) measured the
-dycore-advected mirrors being rung ~90%-of-cells negative by spectral
-advection of these episodic fields, at 2.2x the carry cost, while carry
-storage stayed positive-definite and recovered ~85% of the implicit
-mode's saving. "tracers" remains reachable (spec field, factory kwarg,
-``echam_physics(jam_cloud_borne_storage=...)``) for FV-dycore
-re-evaluation, where nothing rings and resolved advection of in-droplet
-aerosol could be measured cleanly.
+What the carry gives up is resolved-scale advection of in-droplet
+aerosol (CAM accepts the same trade); what it keeps is the full explicit
+cycle at ~19% over the implicit treatment instead of ~165%.
 
 One semantic nuance of the sequential carry updates: aerosol the
 exchange transfers into the carry can be scavenged by wetdep within the
-SAME step (the tracers mode only exposes it next step) — an O(dt·rate)
-difference that slightly strengthens wet removal in carry mode.
+SAME step (a tracer-mode accumulator only exposed it next step) — an
+O(dt·rate) strengthening of wet removal.
 
-The two access helpers keep the per-term diffs small:
+The access helpers keep per-term code uniform:
 
-* :func:`tracer_view` — a read view merging ``state.tracers`` with the
-  carry, so every consumer reads mirrors the same way in both modes. In
-  carry mode reads are SEQUENTIAL within the step (each term sees the
-  previous term's update), which bounds each removal by the current
-  content — stronger positivity than the parallel tracer accumulator.
-* :func:`apply_updates` — the write path: in tracers mode the updates are
-  handed back for the ordinary tendency accumulator; in carry mode they
-  are integrated into the carry immediately (backward-compatible
-  ``rate·dt`` semantics, so terms emit rates in both modes).
+* :func:`tracer_view` — read view merging ``state.tracers`` with the
+  carry (identity for implicit populations). Reads are SEQUENTIAL within
+  the step: each term sees the previous term's update, which bounds every
+  removal by current content.
+* :func:`apply_updates` — integrates cloud-borne rate updates into the
+  carry (``rate·dt``).
 
 :class:`CloudBorneCarryStore` owns the carry slot: it declares the
 ``initial_carry_state`` seed, guarantees the key exists with identical
 structure on every step (including the ``get_empty_data`` probe, which
 keeps the scan-carry pytree stable), and applies the turbulent vertical
 mixing of the carry with the same TTE-TKE exchange coefficients and
-implicit solve the tracer-mode mirrors get from
-``TracerVerticalDiffusion`` — without it, carry storage would be exactly
-the column-local frozen reservoir #602 warned about.
+implicit solve ``TracerVerticalDiffusion`` gives the interstitial
+tracers — without it, carry storage would be exactly the column-local
+frozen reservoir #602 warned about. Carry-resident state is not threaded
+by ``PrescribedStateModel`` (#623).
 """
 
 from __future__ import annotations
@@ -80,17 +76,17 @@ def mirror_names(spec: ModalAerosolSpec) -> tuple[str, ...]:
 
 
 def carry_mode(spec: ModalAerosolSpec) -> bool:
-    """Whether this population keeps its cloud-borne phase in the carry."""
-    return spec.cloud_borne and spec.cloud_borne_storage == "carry"
+    """Whether this population carries an explicit cloud-borne phase."""
+    return spec.cloud_borne
 
 
 def tracer_view(spec, state, diagnostics) -> dict:
     """Read view over interstitial tracers plus the cloud-borne store.
 
-    In tracers mode this is just ``state.tracers``; in carry mode the
-    carry entries (when present — the probe may run before the store
-    term) overlay it. Mirrors are absent from ``state.tracers`` in carry
-    mode, so the merge cannot shadow a live tracer.
+    For an implicit population this is just ``state.tracers``; with an
+    explicit phase the carry entries (when present — the probe may run
+    before the store term) overlay it. Cloud-borne names are never dycore
+    tracers, so the merge cannot shadow a live tracer.
     """
     if not carry_mode(spec):
         return state.tracers
@@ -103,13 +99,13 @@ def tracer_view(spec, state, diagnostics) -> dict:
 def apply_updates(
     spec, diagnostics, updates: dict, dt,
 ) -> tuple[dict, dict]:
-    """Route cloud-borne rate updates [.../s] to the active store.
+    """Integrate cloud-borne rate updates [.../s] into the carry.
 
-    Returns ``(diagnostics, passthrough)``: in tracers mode the updates
-    come back as ``passthrough`` for the term's ordinary tendency dict;
-    in carry mode they are integrated into the carry now (sequential
-    semantics) and ``passthrough`` is empty. Callers must use both
-    returns.
+    Returns ``(diagnostics, passthrough)`` where ``passthrough`` is
+    always empty for an explicit population (kept in the signature so
+    call sites read uniformly) and echoes ``updates`` for an implicit
+    one, where no store exists and the caller decides the fate of any
+    stray cloud-borne update (there should be none).
     """
     if not carry_mode(spec):
         return diagnostics, updates
@@ -145,8 +141,8 @@ class CloudBorneCarryStore(PhysicsTerm):
         self._spec = spec or MAM4_SPEC
         if not carry_mode(self._spec):
             raise ValueError(
-                "CloudBorneCarryStore needs spec.cloud_borne_storage='carry' "
-                "(and an explicit cloud-borne phase)."
+                "CloudBorneCarryStore needs a population with an explicit "
+                "cloud-borne phase (spec.cloud_borne=True)."
             )
         self._names = mirror_names(self._spec)
         self._vertical_mixing = bool(vertical_mixing)

--- a/jcm/physics/aerosol/jam/cloud_borne_store_test.py
+++ b/jcm/physics/aerosol/jam/cloud_borne_store_test.py
@@ -24,7 +24,7 @@ from jcm.physics.aerosol.jam.cloud_borne_store import (
 )
 from jcm.physics_interface import PhysicsState
 
-_CARRY_SPEC = dataclasses.replace(MAM4_SPEC, cloud_borne_storage="carry")
+_IMPLICIT_SPEC = dataclasses.replace(MAM4_SPEC, cloud_borne=False)
 
 
 class _VDiff:
@@ -33,23 +33,23 @@ class _VDiff:
 
 
 class StoreBasicsTest(unittest.TestCase):
-    def test_carry_spec_declares_no_mirror_tracers(self):
-        names = {s.name for s in tracer_specs(_CARRY_SPEC)}
-        self.assertFalse(any(n.startswith(("mc_", "nc_")) for n in names))
-        # Same interstitial set as the tracers-mode spec.
-        interstitial = {
-            s.name for s in tracer_specs(MAM4_SPEC)
-            if not s.name.startswith(("mc_", "nc_"))
-        }
-        self.assertEqual(names, interstitial)
+    def test_no_mirror_tracers_declared_ever(self):
+        # The cloud-borne phase is carry-only: tracer_specs is the
+        # interstitial set regardless of cloud_borne (the #602 A/B verdict
+        # plus the parked pySES check — CAM-SE keeps qqcw in pbuf too).
+        for spec in (MAM4_SPEC, _IMPLICIT_SPEC):
+            names = {s.name for s in tracer_specs(spec)}
+            self.assertFalse(
+                any(n.startswith(("mc_", "nc_")) for n in names)
+            )
+        n_interstitial = MAM4_SPEC.n_modes() + sum(
+            len(m.species) for m in MAM4_SPEC.modes
+        )
+        self.assertEqual(len(list(tracer_specs(MAM4_SPEC))), n_interstitial)
 
-    def test_invalid_storage_rejected(self):
-        with self.assertRaisesRegex(ValueError, "cloud_borne_storage"):
-            dataclasses.replace(MAM4_SPEC, cloud_borne_storage="pbuf")
-
-    def test_store_term_rejects_tracer_mode_spec(self):
-        with self.assertRaisesRegex(ValueError, "carry"):
-            CloudBorneCarryStore(spec=MAM4_SPEC)
+    def test_store_term_rejects_implicit_spec(self):
+        with self.assertRaisesRegex(ValueError, "cloud_borne"):
+            CloudBorneCarryStore(spec=_IMPLICIT_SPEC)
 
     def test_view_and_apply_roundtrip(self):
         shape = (3, 2)
@@ -59,20 +59,22 @@ class StoreBasicsTest(unittest.TestCase):
         )
         nm = mass_name("so4", "acc", cloud_borne=True)
         diagnostics = {CARRY_KEY: {nm: jnp.full(shape, 2.0e-10)}}
-        view = tracer_view(_CARRY_SPEC, state, diagnostics)
+        view = tracer_view(MAM4_SPEC, state, diagnostics)
         np.testing.assert_allclose(float(view[nm][0, 0]), 2.0e-10)
         np.testing.assert_allclose(float(view["m_so4_acc"][0, 0]), 1.0e-9)
 
         # Carry mode integrates rate·dt now; tracers mode passes through.
         diagnostics2, passthrough = apply_updates(
-            _CARRY_SPEC, diagnostics, {nm: jnp.full(shape, 1.0e-13)}, 1000.0,
+            MAM4_SPEC, diagnostics, {nm: jnp.full(shape, 1.0e-13)}, 1000.0,
         )
         self.assertEqual(passthrough, {})
         np.testing.assert_allclose(
             float(diagnostics2[CARRY_KEY][nm][0, 0]), 3.0e-10, rtol=1e-6,
         )
+        # An implicit population has no store: updates echo back.
         _, passthrough = apply_updates(
-            MAM4_SPEC, diagnostics, {nm: jnp.full(shape, 1.0e-13)}, 1000.0,
+            _IMPLICIT_SPEC, diagnostics,
+            {nm: jnp.full(shape, 1.0e-13)}, 1000.0,
         )
         self.assertIn(nm, passthrough)
 
@@ -85,10 +87,10 @@ class StoreBasicsTest(unittest.TestCase):
             "air_density": jnp.full(shape, 1.0),
             "layer_thickness": jnp.full(shape, 300.0),
         }
-        term = CloudBorneCarryStore(spec=_CARRY_SPEC)
+        term = CloudBorneCarryStore(spec=MAM4_SPEC)
         _, out = term(state, diagnostics, None, None)
         carry = out[CARRY_KEY]
-        self.assertEqual(set(carry), set(mirror_names(_CARRY_SPEC)))
+        self.assertEqual(set(carry), set(mirror_names(MAM4_SPEC)))
         for v in carry.values():
             np.testing.assert_array_equal(np.asarray(v), 0.0)
 
@@ -99,7 +101,7 @@ class StoreBasicsTest(unittest.TestCase):
         )
         nm = mass_name("so4", "acc", cloud_borne=True)
         carry = {
-            n: jnp.zeros(shape) for n in mirror_names(_CARRY_SPEC)
+            n: jnp.zeros(shape) for n in mirror_names(MAM4_SPEC)
         }
         carry[nm] = jnp.zeros(shape).at[2].set(1.0e-9)
         diagnostics = {
@@ -109,7 +111,7 @@ class StoreBasicsTest(unittest.TestCase):
             "vertical_diffusion": _VDiff(jnp.full(shape, 30.0)),
             "_dt_seconds": 1800.0,
         }
-        term = CloudBorneCarryStore(spec=_CARRY_SPEC)
+        term = CloudBorneCarryStore(spec=MAM4_SPEC)
         _, out = term(state, diagnostics, None, None)
         mixed = np.asarray(out[CARRY_KEY][nm])
         self.assertGreater(float(mixed[1, 0]), 0.0)   # spread upward
@@ -139,7 +141,7 @@ class CarryPersistenceTest(unittest.TestCase):
         physics = ComposablePhysics(
             terms=[
                 MoistAirColumnState(),
-                CloudBorneCarryStore(spec=_CARRY_SPEC),
+                CloudBorneCarryStore(spec=MAM4_SPEC),
             ],
             vectorize_columns=True,
         )
@@ -184,16 +186,16 @@ class CarryModeExchangeTest(unittest.TestCase):
     def _setup(self, nlev=3, ncols=2, cf=0.5):
         shape = (nlev, ncols)
         tracers = {}
-        for mode in _CARRY_SPEC.modes:
+        for mode in MAM4_SPEC.modes:
             tracers[number_name(mode.short)] = jnp.full(shape, 1.0e8)
             for sp in mode.species:
                 tracers[mass_name(sp, mode.short)] = jnp.full(shape, 1.0e-9)
         state = PhysicsState.zeros(shape).copy(
             temperature=jnp.full(shape, 275.0), tracers=tracers,
         )
-        n_modes = _CARRY_SPEC.n_modes()
+        n_modes = MAM4_SPEC.n_modes()
         can = jnp.asarray(
-            [float(m.can_activate) for m in _CARRY_SPEC.modes]
+            [float(m.can_activate) for m in MAM4_SPEC.modes]
         ).reshape(-1, 1, 1)
         act = JamActivationData(
             number_frac=can * jnp.full((n_modes,) + shape, 0.3),
@@ -205,7 +207,7 @@ class CarryModeExchangeTest(unittest.TestCase):
 
         diagnostics = {
             CARRY_KEY: {
-                n: jnp.zeros(shape) for n in mirror_names(_CARRY_SPEC)
+                n: jnp.zeros(shape) for n in mirror_names(MAM4_SPEC)
             },
             "_jam_activation": act,
             "clouds": _Clouds(),
@@ -215,7 +217,7 @@ class CarryModeExchangeTest(unittest.TestCase):
 
     def test_transfer_fills_carry_and_conserves_with_tendency(self):
         state, diagnostics = self._setup()
-        term = CloudBorneExchange(spec=_CARRY_SPEC)
+        term = CloudBorneExchange(spec=MAM4_SPEC)
         tend, out = term(state, diagnostics, None, None)
         nm_int = mass_name("so4", "acc")
         nm_cb = mass_name("so4", "acc", cloud_borne=True)
@@ -235,7 +237,7 @@ class CarryModeExchangeTest(unittest.TestCase):
         diagnostics[CARRY_KEY][nm_cb] = jnp.full(
             state.temperature.shape, 1.0e-9,
         )
-        term = CloudBorneExchange(spec=_CARRY_SPEC)
+        term = CloudBorneExchange(spec=MAM4_SPEC)
         tend, out = term(state, diagnostics, None, None)
         self.assertLess(
             float(np.asarray(out[CARRY_KEY][nm_cb]).max()), 1.0e-9,
@@ -245,21 +247,15 @@ class CarryModeExchangeTest(unittest.TestCase):
         )
 
     def test_mode_flag_helpers(self):
-        self.assertTrue(carry_mode(_CARRY_SPEC))
-        self.assertFalse(carry_mode(MAM4_SPEC))
-        self.assertFalse(
-            carry_mode(dataclasses.replace(
-                MAM4_SPEC, cloud_borne=False,
-                cloud_borne_storage="carry",
-            ))
-        )
+        self.assertTrue(carry_mode(MAM4_SPEC))
+        self.assertFalse(carry_mode(_IMPLICIT_SPEC))
 
 
 class CarryModeFactoryTest(unittest.TestCase):
     def test_factory_composes_store_first_and_drops_mirrors(self):
         from jcm.physics.aerosol.jam import jam_aerosol_physics
 
-        terms = jam_aerosol_physics(cloud_borne_storage="carry")
+        terms = jam_aerosol_physics()
         self.assertEqual(terms[0].name, "jam_cloud_borne_store")
         names = set()
         for t in terms:
@@ -270,17 +266,15 @@ class CarryModeFactoryTest(unittest.TestCase):
             "jam_cloud_borne_exchange", [t.name for t in terms],
         )
 
-    def test_tracers_mode_composes_no_store(self):
+    def test_implicit_composes_no_store(self):
         from jcm.physics.aerosol.jam import jam_aerosol_physics
 
         self.assertNotIn(
             "jam_cloud_borne_store",
-            [t.name for t in jam_aerosol_physics(
-                cloud_borne_storage="tracers",
-            )],
+            [t.name for t in jam_aerosol_physics(cloud_borne=False)],
         )
 
-    def test_default_storage_is_carry(self):
+    def test_default_composes_store_first(self):
         from jcm.physics.aerosol.jam import jam_aerosol_physics
 
         terms = jam_aerosol_physics()

--- a/jcm/physics/aerosol/jam/cloud_borne_test.py
+++ b/jcm/physics/aerosol/jam/cloud_borne_test.py
@@ -16,22 +16,13 @@ from jcm.physics.aerosol.jam import (
     tracer_specs,
 )
 from jcm.physics.aerosol.jam.activation.arg_term import JamActivationData
+from jcm.physics.aerosol.jam.cloud_borne_store import CARRY_KEY
 from jcm.physics_interface import PhysicsState
 
 _IMPLICIT_SPEC = dataclasses.replace(MAM4_SPEC, cloud_borne=False)
 
 
 class TracerLayoutSwitchTest(unittest.TestCase):
-    def test_explicit_population_declares_both_phases(self):
-        names = {s.name for s in tracer_specs(MAM4_SPEC)}
-        self.assertIn(number_name("acc"), names)
-        self.assertIn(number_name("acc", cloud_borne=True), names)
-        # One number per mode and one mass per (mode, species), doubled.
-        n_interstitial = MAM4_SPEC.n_modes() + sum(
-            len(m.species) for m in MAM4_SPEC.modes
-        )
-        self.assertEqual(len(names), 2 * n_interstitial)
-
     def test_implicit_population_declares_interstitial_only(self):
         names = {s.name for s in tracer_specs(_IMPLICIT_SPEC)}
         self.assertIn(number_name("acc"), names)
@@ -65,14 +56,15 @@ class CloudBorneExchangeTest(unittest.TestCase):
     ):
         shape = (nlev, ncols)
         tracers = {}
+        carry = {}
         for mode in MAM4_SPEC.modes:
             tracers[number_name(mode.short)] = jnp.full(shape, n_int)
-            tracers[number_name(mode.short, cloud_borne=True)] = jnp.full(
+            carry[number_name(mode.short, cloud_borne=True)] = jnp.full(
                 shape, n_cb
             )
             for sp in mode.species:
                 tracers[mass_name(sp, mode.short)] = jnp.full(shape, q_int)
-                tracers[mass_name(sp, mode.short, cloud_borne=True)] = (
+                carry[mass_name(sp, mode.short, cloud_borne=True)] = (
                     jnp.full(shape, q_cb)
                 )
         state = PhysicsState.zeros(shape).copy(
@@ -92,15 +84,24 @@ class CloudBorneExchangeTest(unittest.TestCase):
             mass_frac=per_mode * jnp.full((n_modes,) + shape, mass_frac),
         )
         diagnostics = {
+            CARRY_KEY: carry,
             "_jam_activation": act,
             "clouds": _Clouds(jnp.full(shape, cloud_fraction)),
             "_dt_seconds": 1800.0,
         }
         return state, diagnostics
 
+    @staticmethod
+    def _cb_rate(diagnostics_in, diagnostics_out, nm, dt=1800.0):
+        """Effective cloud-borne rate from the sequential carry update."""
+        return (
+            np.asarray(diagnostics_out[CARRY_KEY][nm])
+            - np.asarray(diagnostics_in[CARRY_KEY][nm])
+        ) / dt
+
     def test_transfer_conserves_each_pair_exactly(self):
         state, diagnostics = self._setup(q_cb=2.0e-10, n_cb=1.0e7)
-        tend, _ = CloudBorneExchange()(state, diagnostics, None, None)
+        tend, out = CloudBorneExchange()(state, diagnostics, None, None)
         for mode in MAM4_SPEC.modes:
             pairs = [(number_name(mode.short),
                       number_name(mode.short, cloud_borne=True))]
@@ -110,17 +111,25 @@ class CloudBorneExchangeTest(unittest.TestCase):
                 for sp in mode.species
             ]
             for int_nm, cb_nm in pairs:
-                np.testing.assert_array_equal(
-                    np.asarray(tend.tracers[int_nm] + tend.tracers[cb_nm]),
-                    0.0,
+                cb_rate = self._cb_rate(diagnostics, out, cb_nm)
+                dq_int = np.asarray(tend.tracers[int_nm])
+                # Tolerance covers the f32 loss in the test's own
+                # (new - old)/dt reconstruction of the carry rate; the
+                # update itself is a single fused add.
+                scale = float(np.abs(dq_int).max())
+                np.testing.assert_allclose(
+                    dq_int + cb_rate, 0.0,
+                    atol=max(1e-4 * scale, 1e-22),
                     err_msg=f"{int_nm}/{cb_nm} exchange must conserve",
                 )
 
     def test_activation_transfer_fills_cloud_borne(self):
         state, diagnostics = self._setup()
-        tend, _ = CloudBorneExchange()(state, diagnostics, None, None)
-        cb = tend.tracers[mass_name("so4", "acc", cloud_borne=True)]
-        self.assertTrue(bool(jnp.all(cb > 0.0)))
+        tend, out = CloudBorneExchange()(state, diagnostics, None, None)
+        cb = self._cb_rate(
+            diagnostics, out, mass_name("so4", "acc", cloud_borne=True),
+        )
+        self.assertTrue(bool((cb > 0.0).all()))
         # The move is the relaxation fraction of the equilibrium target
         # cf * f_mass * (q_int + q_cb).
         dt = 1800.0
@@ -131,7 +140,9 @@ class CloudBorneExchangeTest(unittest.TestCase):
         )
         # And each mode uses ITS OWN fraction (the fixture halves it for
         # aitken), so a mode-axis misindexing shows up here.
-        cb_ait = tend.tracers[mass_name("so4", "ait", cloud_borne=True)]
+        cb_ait = self._cb_rate(
+            diagnostics, out, mass_name("so4", "ait", cloud_borne=True),
+        )
         np.testing.assert_allclose(
             np.asarray(cb_ait) * dt, 0.5 * target * phi, rtol=1e-6,
         )
@@ -140,24 +151,31 @@ class CloudBorneExchangeTest(unittest.TestCase):
         # Large particles activate preferentially: the mass fraction (0.9)
         # must drive 3x the relative transfer of the number fraction (0.3).
         state, diagnostics = self._setup(q_int=1.0, n_int=1.0)
-        tend, _ = CloudBorneExchange()(state, diagnostics, None, None)
-        m = float(tend.tracers[mass_name("so4", "acc", cloud_borne=True)][0, 0])
-        n = float(tend.tracers[number_name("acc", cloud_borne=True)][0, 0])
+        _, out = CloudBorneExchange()(state, diagnostics, None, None)
+        m = float(self._cb_rate(
+            diagnostics, out, mass_name("so4", "acc", cloud_borne=True),
+        )[0, 0])
+        n = float(self._cb_rate(
+            diagnostics, out, number_name("acc", cloud_borne=True),
+        )[0, 0])
         self.assertAlmostEqual(m / n, 3.0, places=5)
 
     def test_clear_sky_resuspends_to_interstitial(self):
         state, diagnostics = self._setup(
             cloud_fraction=0.0, q_cb=1.0e-9, n_cb=1.0e8,
         )
-        tend, _ = CloudBorneExchange()(state, diagnostics, None, None)
+        tend, out = CloudBorneExchange()(state, diagnostics, None, None)
         cb_key = mass_name("so4", "acc", cloud_borne=True)
-        self.assertTrue(bool(jnp.all(tend.tracers[cb_key] < 0.0)))
+        self.assertTrue(
+            bool((self._cb_rate(diagnostics, out, cb_key) < 0.0).all())
+        )
         self.assertTrue(
             bool(jnp.all(tend.tracers[mass_name("so4", "acc")] > 0.0))
         )
-        # Bounded: the reservoir cannot go negative in one step.
-        q_new = 1.0e-9 + np.asarray(tend.tracers[cb_key]) * 1800.0
-        self.assertGreaterEqual(float(q_new.min()), 0.0)
+        # Bounded: the (sequentially updated) reservoir stays non-negative.
+        self.assertGreaterEqual(
+            float(np.asarray(out[CARRY_KEY][cb_key]).min()), 0.0,
+        )
 
     def test_non_activatable_mode_only_resuspends(self):
         # pcm cannot activate (fraction masked to zero), so its cloud-borne
@@ -165,9 +183,11 @@ class CloudBorneExchangeTest(unittest.TestCase):
         state, diagnostics = self._setup(
             cloud_fraction=1.0, q_cb=1.0e-10, n_cb=1.0e7,
         )
-        tend, _ = CloudBorneExchange()(state, diagnostics, None, None)
-        cb = tend.tracers[mass_name("poa", "pcm", cloud_borne=True)]
-        self.assertTrue(bool(jnp.all(cb < 0.0)))
+        _, out = CloudBorneExchange()(state, diagnostics, None, None)
+        cb = self._cb_rate(
+            diagnostics, out, mass_name("poa", "pcm", cloud_borne=True),
+        )
+        self.assertTrue(bool((cb < 0.0).all()))
 
     def test_equilibrium_is_a_fixed_point(self):
         # cf = 1 and q_cb == f * (q_int + q_cb) → target == q_cb → no flux.
@@ -176,24 +196,28 @@ class CloudBorneExchangeTest(unittest.TestCase):
             cloud_fraction=1.0, number_frac=0.5, mass_frac=0.5,
             q_int=1.0e-9, q_cb=1.0e-9, n_int=1.0e8, n_cb=1.0e8,
         )
-        tend, _ = CloudBorneExchange()(state, diagnostics, None, None)
+        _, out = CloudBorneExchange()(state, diagnostics, None, None)
         for key in (mass_name("so4", "acc", cloud_borne=True),
                     number_name("acc", cloud_borne=True)):
             np.testing.assert_allclose(
-                np.asarray(tend.tracers[key]), 0.0, atol=1e-25,
+                self._cb_rate(diagnostics, out, key), 0.0, atol=1e-25,
             )
 
     def test_positivity_preserved_both_phases(self):
         state, diagnostics = self._setup(q_cb=5.0e-10, n_cb=5.0e7)
-        tend, _ = CloudBorneExchange()(state, diagnostics, None, None)
+        tend, out = CloudBorneExchange()(state, diagnostics, None, None)
         dt = 1800.0
         for nm, dq in tend.tracers.items():
             q_new = np.asarray(state.tracers[nm]) + np.asarray(dq) * dt
             self.assertGreaterEqual(float(q_new.min()), 0.0, nm)
+        for nm, v in out[CARRY_KEY].items():
+            self.assertGreaterEqual(float(np.asarray(v).min()), 0.0, nm)
 
     def test_empty_probe_state_is_safe(self):
-        # ``Model.get_empty_data`` runs terms with no tracers seeded.
-        state, diagnostics = self._setup()
+        # ``Model.get_empty_data`` runs terms with no tracers seeded (the
+        # store term guarantees the carry exists, so it stays in the
+        # fixture).
+        state, diagnostics = self._setup(q_cb=0.0, n_cb=0.0)
         state = state.copy(tracers={})
         tend, _ = CloudBorneExchange()(state, diagnostics, None, None)
         for dq in tend.tracers.values():
@@ -224,12 +248,13 @@ class CloudBorneExchangeTest(unittest.TestCase):
 
 
 class FactorySwitchTest(unittest.TestCase):
-    def test_default_composes_exchange_and_mirrors(self):
+    def test_default_composes_exchange_and_store(self):
         from jcm.physics.aerosol.jam import jam_aerosol_physics
 
-        terms = jam_aerosol_physics(cloud_borne_storage="tracers")
+        terms = jam_aerosol_physics()
         cats = [t.category for t in terms]
         self.assertIn("aerosol_cloud_borne", cats)
+        self.assertIn("aerosol_cloud_borne_store", cats)
         # Exchange sits after drydep and before the aqueous split that
         # distributes by cloud-borne number.
         self.assertLess(
@@ -239,35 +264,19 @@ class FactorySwitchTest(unittest.TestCase):
             cats.index("aerosol_cloud_borne"),
             cats.index("aerosol_aqueous_chemistry"),
         )
+        # Cloud-borne names are never dycore tracers.
         names = set()
         for t in terms:
             names |= {s.name for s in t.required_tracers()}
-        self.assertIn(number_name("acc", cloud_borne=True), names)
+        self.assertNotIn(number_name("acc", cloud_borne=True), names)
 
-    def test_cloud_borne_off_drops_term_and_mirrors(self):
+    def test_cloud_borne_off_drops_terms(self):
         from jcm.physics.aerosol.jam import jam_aerosol_physics
 
         terms = jam_aerosol_physics(cloud_borne=False)
-        self.assertNotIn(
-            "aerosol_cloud_borne", [t.category for t in terms],
-        )
-        names = set()
-        for t in terms:
-            names |= {s.name for s in t.required_tracers()}
-        self.assertFalse(
-            any(n.startswith(("mc_", "nc_")) for n in names),
-            "cloud_borne=False must not declare mirror tracers",
-        )
-        # The A/B cost claim: half the aerosol tracers are gone.
-        on = {
-            s.name
-            for t in jam_aerosol_physics(cloud_borne_storage="tracers")
-            for s in t.required_tracers()
-        }
-        self.assertEqual(
-            len([n for n in on if n.startswith(("mc_", "nc_"))]),
-            len([n for n in on if n.startswith(("m_", "n_"))]),
-        )
+        cats = [t.category for t in terms]
+        self.assertNotIn("aerosol_cloud_borne", cats)
+        self.assertNotIn("aerosol_cloud_borne_store", cats)
 
     def test_instance_core_with_conflicting_flag_raises(self):
         from jcm.physics.aerosol.jam import (
@@ -278,11 +287,10 @@ class FactorySwitchTest(unittest.TestCase):
         core = PlaceholderMicrophysics()
         with self.assertRaisesRegex(ValueError, "cloud_borne"):
             jam_aerosol_physics(microphysics=core, cloud_borne=False)
-        # A matching flag merely validates (instance cores follow their
-        # own spec's storage: tracers here).
+        # A matching flag merely validates.
         terms = jam_aerosol_physics(microphysics=core, cloud_borne=True)
         self.assertIn("aerosol_cloud_borne", [t.category for t in terms])
-        self.assertNotIn(
+        self.assertIn(
             "jam_cloud_borne_store", [t.name for t in terms],
         )
 

--- a/jcm/physics/aerosol/jam/drydep/drydep_test.py
+++ b/jcm/physics/aerosol/jam/drydep/drydep_test.py
@@ -58,21 +58,28 @@ class DryDepTermTest(unittest.TestCase):
             mass=jnp.full(shape, 1e-9),
             number=jnp.full(shape, 1.0e8),
         )
+        from jcm.physics.aerosol.jam.cloud_borne_store import CARRY_KEY
+
         tracers = {}
+        carry = {}
         for mode in MAM4_SPEC.modes:
-            for cb in (False, True):
-                tracers[number_name(mode.short, cloud_borne=cb)] = jnp.full(
-                    (nlev, ncols), 1.0e8
+            tracers[number_name(mode.short)] = jnp.full((nlev, ncols), 1.0e8)
+            carry[number_name(mode.short, cloud_borne=True)] = jnp.full(
+                (nlev, ncols), 1.0e8
+            )
+            for sp in mode.species:
+                tracers[mass_name(sp, mode.short)] = jnp.full(
+                    (nlev, ncols), 1e-9
                 )
-                for sp in mode.species:
-                    tracers[mass_name(sp, mode.short, cloud_borne=cb)] = (
-                        jnp.full((nlev, ncols), 1e-9)
-                    )
+                carry[mass_name(sp, mode.short, cloud_borne=True)] = (
+                    jnp.full((nlev, ncols), 1e-9)
+                )
         state = PhysicsState.zeros((nlev, ncols)).copy(
             temperature=jnp.full((nlev, ncols), 285.0),
             tracers=tracers,
         )
         diagnostics = {
+            CARRY_KEY: carry,
             "_jam_state": aer,
             "air_density": jnp.full((nlev, ncols), 1.2),
             "layer_thickness": jnp.full((nlev, ncols), 100.0),
@@ -91,27 +98,36 @@ class DryDepTermTest(unittest.TestCase):
         self.assertTrue(bool(jnp.all(dq[:-1] == 0.0)))
 
     def test_cloud_borne_deposits_only_with_explicit_phase(self):
-        # With the default (explicit cloud-borne) population the mirror
-        # tracers deposit at the surface too (#602); with the implicit
-        # population no mirror tendencies are emitted at all.
+        # With the default (explicit cloud-borne) population the carry
+        # fields deposit at the surface too (#602); with the implicit
+        # population the carry is untouched and no cloud-borne tendencies
+        # are emitted at all.
         import dataclasses
         from jcm.physics.aerosol.jam import MAM4_SPEC
+        from jcm.physics.aerosol.jam.cloud_borne_store import CARRY_KEY
 
         state, diagnostics, spec, mass_name = self._setup()
-        tend, _ = SlinnDryDeposition()(state, diagnostics, None, None)
+        _, out = SlinnDryDeposition()(state, diagnostics, None, None)
         cb_key = mass_name(
             spec.modes[0].species[0], spec.modes[0].short, cloud_borne=True,
         )
-        dq = tend.tracers[cb_key]
-        self.assertLess(float(dq[-1, 0]), 0.0)
-        self.assertTrue(bool(jnp.all(dq[:-1] == 0.0)))
+        delta = (
+            np.asarray(out[CARRY_KEY][cb_key])
+            - np.asarray(diagnostics[CARRY_KEY][cb_key])
+        )
+        self.assertLess(float(delta[-1, 0]), 0.0)
+        self.assertTrue(bool(jnp.all(delta[:-1] == 0.0)))
 
         implicit = SlinnDryDeposition(
             spec=dataclasses.replace(MAM4_SPEC, cloud_borne=False)
         )
-        tend, _ = implicit(state, diagnostics, None, None)
+        tend, out = implicit(state, diagnostics, None, None)
         self.assertFalse(
             any(nm.startswith(("mc_", "nc_")) for nm in tend.tracers)
+        )
+        np.testing.assert_array_equal(
+            np.asarray(out[CARRY_KEY][cb_key]),
+            np.asarray(diagnostics[CARRY_KEY][cb_key]),
         )
 
     def test_uses_vertical_diffusion_ustar_when_present(self):

--- a/jcm/physics/aerosol/jam/jam_integration_test.py
+++ b/jcm/physics/aerosol/jam/jam_integration_test.py
@@ -88,30 +88,11 @@ class JamIntegrationTest(unittest.TestCase):
             bool(jnp.any(jnp.isnan(predictions.dynamics.temperature)))
         )
 
-    def test_cloud_borne_mirrors_carried_finite(self):
-        # Explicit TRACERS storage prognoses the advected mirrors (#602):
-        # they must be seeded, transported and stay finite end-to-end. (A
-        # 3-step cold start carries near-zero aerosol, so this asserts the
-        # plumbing, not a nonzero reservoir; the transfer/resuspension
-        # mechanics are pinned in cloud_borne_test.)
-        from jcm.physics.aerosol.jam import MAM4_SPEC, mass_name, number_name
-
-        _, predictions = self._run(jam_cloud_borne_storage="tracers")
-        tracers = predictions.dynamics.tracers
-        for key in (
-            number_name(MAM4_SPEC.modes[0].short, cloud_borne=True),
-            mass_name(MAM4_SPEC.modes[0].species[0],
-                      MAM4_SPEC.modes[0].short, cloud_borne=True),
-        ):
-            self.assertIn(key, tracers)
-            self.assertTrue(np.all(np.isfinite(np.asarray(tracers[key]))))
-
     def test_carry_stored_cloud_borne_runs_and_cycles(self):
-        # EXPERIMENTAL carry storage (#602 item 3): the mirrors leave the
-        # dycore tracer set entirely, live in the physics carry, and the
-        # model still runs finite with the carry fields reaching saved
-        # output through the dict flattener.
-        _, predictions = self._run(jam_cloud_borne_storage="carry")
+        # The default (and only) storage (#602 item 3): cloud-borne lives
+        # in the physics carry, never the dycore tracer set, and the model
+        # runs finite with the carry fields reaching saved output.
+        _, predictions = self._run()
         tracers = predictions.dynamics.tracers
         self.assertFalse(
             any(k.startswith(("mc_", "nc_")) for k in tracers),

--- a/jcm/physics/aerosol/jam/jam_phase0_test.py
+++ b/jcm/physics/aerosol/jam/jam_phase0_test.py
@@ -57,8 +57,9 @@ class PopulationTest(unittest.TestCase):
 class TracerLayoutTest(unittest.TestCase):
     def test_spec_count_and_uniqueness(self):
         specs = tracer_specs(MAM4_SPEC)
-        # per mode: (1 number + nspec mass) * 2 (interstitial + cloud-borne)
-        expected = sum(2 * (1 + len(m.species)) for m in MAM4_SPEC.modes)
+        # per mode: 1 number + nspec mass — INTERSTITIAL only (the
+        # cloud-borne phase lives in the physics carry, #602).
+        expected = sum(1 + len(m.species) for m in MAM4_SPEC.modes)
         self.assertEqual(len(specs), expected)
         names = [s.name for s in specs]
         self.assertEqual(len(names), len(set(names)))
@@ -67,9 +68,9 @@ class TracerLayoutTest(unittest.TestCase):
         specs = {s.name: s for s in tracer_specs(MAM4_SPEC)}
         self.assertFalse(specs[number_name("acc")].nondimensionalize)
         self.assertTrue(specs[mass_name("so4", "acc")].nondimensionalize)
-        # cloud-borne mirror present
-        self.assertIn(mass_name("so4", "acc", cloud_borne=True), specs)
-        self.assertIn(number_name("acc", cloud_borne=True), specs)
+        # Cloud-borne names key the carry store, never dycore tracers.
+        self.assertNotIn(mass_name("so4", "acc", cloud_borne=True), specs)
+        self.assertNotIn(number_name("acc", cloud_borne=True), specs)
 
 
 def _uniform_population(nlev=3, ncols=2, mass=1.0e-9, number=1.0e8):

--- a/jcm/physics/aerosol/jam/jam_terms.py
+++ b/jcm/physics/aerosol/jam/jam_terms.py
@@ -101,26 +101,18 @@ _MICROPHYSICS = {
 def _resolve_microphysics(
     microphysics: ModalMicrophysicsTerm | str,
     cloud_borne: bool | None = None,
-    cloud_borne_storage: str | None = None,
 ) -> ModalMicrophysicsTerm:
     if isinstance(microphysics, ModalMicrophysicsTerm):
-        spec = microphysics.spec
-        if cloud_borne is not None and spec.cloud_borne != cloud_borne:
+        if (
+            cloud_borne is not None
+            and microphysics.spec.cloud_borne != cloud_borne
+        ):
             raise ValueError(
                 f"cloud_borne={cloud_borne} conflicts with the supplied "
                 "core's population "
-                f"(spec.cloud_borne={spec.cloud_borne}); "
+                f"(spec.cloud_borne={microphysics.spec.cloud_borne}); "
                 "construct the core with a spec carrying the intended flag "
                 "instead."
-            )
-        if (
-            cloud_borne_storage is not None
-            and spec.cloud_borne_storage != cloud_borne_storage
-        ):
-            raise ValueError(
-                f"cloud_borne_storage={cloud_borne_storage!r} conflicts "
-                "with the supplied core's population "
-                f"(spec.cloud_borne_storage={spec.cloud_borne_storage!r})."
             )
         return microphysics
     try:
@@ -132,18 +124,12 @@ def _resolve_microphysics(
             "ModalMicrophysicsTerm instance."
         ) from None
     core = factory(None)
-    overrides = {}
     if cloud_borne is not None and core.spec.cloud_borne != cloud_borne:
-        overrides["cloud_borne"] = cloud_borne
-    if (
-        cloud_borne_storage is not None
-        and core.spec.cloud_borne_storage != cloud_borne_storage
-    ):
-        overrides["cloud_borne_storage"] = cloud_borne_storage
-    if overrides:
-        # Rebuild on the same population with the flags applied; construction
+        # Rebuild on the same population with the flag flipped; construction
         # is compose-time only, so the double build costs nothing at run time.
-        core = factory(dataclasses.replace(core.spec, **overrides))
+        core = factory(
+            dataclasses.replace(core.spec, cloud_borne=cloud_borne)
+        )
     return core
 
 
@@ -151,7 +137,6 @@ def jam_aerosol_physics(
     *,
     microphysics: ModalMicrophysicsTerm | str = "placeholder",
     cloud_borne: bool | None = None,
-    cloud_borne_storage: str | None = None,
     arg_variant: str = "arg2000",
     optics: bool = True,
     optics_diagnostics: bool = False,
@@ -186,24 +171,13 @@ def jam_aerosol_physics(
             ``None`` (default) follows the core population's own
             ``spec.cloud_borne``; ``True``/``False`` override it for a
             string-named core (and merely validate an instance core). On:
-            the ``mc_*``/``nc_*`` mirrors are declared and cycled —
-            activation transfer + resuspension (``CloudBorneExchange``),
-            in-droplet wet removal, surface dry deposition, and the aqueous
-            sulfate goes to the cloud-borne modes. Off: the mirrors are not
-            declared at all (halving the aerosol transport bill) and the
-            harness scavenges interstitial aerosol by its activated
-            fraction, the implicit M7/TOMAS-style treatment. Both settings
-            are complete physics, so A/B cost/fidelity comparisons are one
-            flag apart.
-        cloud_borne_storage: where the explicit phase lives (#602 item
-            3) — ``"carry"`` (physics-carry fields: no spectral
-            transforms or advection, mixed vertically by
-            ``CloudBorneCarryStore``; the measured default, see the
-            resolver comment) or ``"tracers"`` (dycore-advected
-            ``mc_*``/``nc_*`` mirrors; rings pathologically on spectral
-            grids, retained for FV-dycore re-evaluation). ``None`` =
-            ``"carry"`` for string-named cores, the spec's own setting
-            for instance cores.
+            the ``mc_*``/``nc_*`` phase lives in the physics carry and is
+            cycled — activation transfer + resuspension
+            (``CloudBorneExchange``), in-droplet wet removal, surface dry
+            deposition, and the aqueous sulfate split. Off: no cloud-borne
+            store at all and the harness scavenges interstitial aerosol by
+            its activated fraction, the implicit M7/TOMAS-style treatment.
+            Both settings are complete physics, one flag apart.
         arg_variant: ``"arg2000"`` (default) or ``"ghosh2025"`` activation.
         seasalt/dms/dust: optional ``Parameters`` overrides for the natural
             emission schemes (Gong sea salt, Nightingale DMS, Tegen dust).
@@ -245,19 +219,7 @@ def jam_aerosol_physics(
         aqueous sulfur chemistry, and wet deposition.
 
     """
-    if isinstance(microphysics, str) and cloud_borne_storage is None:
-        # Measured default (#602 item 3 A/B, 2026-08-13): on the spectral
-        # grid the advected mirrors ring on the episodic cloud-borne
-        # fields until ~90% of cells are NEGATIVE at day 30 while costing
-        # 2.2x the carry run; carry storage is positive-definite, keeps
-        # the explicit cycle, and recovers ~85% of the implicit mode's
-        # saving. "tracers" remains reachable explicitly for FV-dycore
-        # re-evaluation (resolved advection of in-droplet aerosol is the
-        # one thing carry gives up).
-        cloud_borne_storage = "carry"
-    core = _resolve_microphysics(
-        microphysics, cloud_borne, cloud_borne_storage,
-    )
+    core = _resolve_microphysics(microphysics, cloud_borne)
     spec = core.spec
     emissions = [
         SeaSaltEmissions(params=seasalt, spec=spec),
@@ -315,11 +277,12 @@ def jam_aerosol_physics(
                 interstitial_names, params=conv_transport,
             )
         )
-    # Carry-stored cloud-borne phase (#602 item 3, EXPERIMENTAL — see
-    # cloud_borne_store): the store term runs first so every consumer this
-    # step sees a well-formed store, and applies the carry's turbulent
-    # vertical mixing (its mirrors are not in state.tracers, so
-    # TracerVerticalDiffusion above never sees them).
+    # Carry-stored cloud-borne phase (#602 item 3, the measured decision
+    # — see cloud_borne_store, which also records why the advected-tracer
+    # alternative was removed): the store term runs first so every
+    # consumer this step sees a well-formed store, and applies the
+    # carry's turbulent vertical mixing (its fields are not in
+    # state.tracers, so TracerVerticalDiffusion never sees them).
     store_terms = (
         [CloudBorneCarryStore(spec=spec, vertical_mixing=vertical_mixing)]
         if carry_mode(spec) else []

--- a/jcm/physics/aerosol/jam/jam_terms_test.py
+++ b/jcm/physics/aerosol/jam/jam_terms_test.py
@@ -75,17 +75,14 @@ class JamFactoryTest(unittest.TestCase):
     def test_harness_declares_aerosol_tracers(self):
         from jcm.physics.aerosol.jam import MAM4_SPEC, jam_aerosol_physics, tracer_specs
 
-        # Explicit tracers storage declares the full mirror set...
+        # The interstitial set is declared; cloud-borne names never are
+        # (the phase lives in the physics carry, #602).
         names = set()
-        for t in jam_aerosol_physics(cloud_borne_storage="tracers"):
+        for t in jam_aerosol_physics():
             names |= {s.name for s in t.required_tracers()}
         self.assertTrue(
             {s.name for s in tracer_specs(MAM4_SPEC)}.issubset(names)
         )
-        # ...while the carry default declares interstitial only.
-        names = set()
-        for t in jam_aerosol_physics():
-            names |= {s.name for s in t.required_tracers()}
         self.assertFalse(any(n.startswith(("mc_", "nc_")) for n in names))
 
 

--- a/jcm/physics/aerosol/jam/population.py
+++ b/jcm/physics/aerosol/jam/population.py
@@ -133,29 +133,18 @@ class ModalAerosolSpec:
     modes: tuple[AerosolMode, ...]
     species: tuple[AerosolSpecies, ...]
     family: str = "modal"
-    #: Whether the population prognoses an explicit cloud-borne mirror per
-    #: class (MAM-style ``mc_*``/``nc_*`` tracers alongside the interstitial
-    #: set). This is a property of the population *representation*, not of the
-    #: process harness: MAM keeps in-droplet aerosol as separate constituents,
-    #: while M7 (ECHAM-HAM) and sectional schemes like TOMAS represent it
-    #: implicitly, scavenging the interstitial tracers by their activated
-    #: fraction. ``False`` halves the aerosol tracer count (and the dycore
-    #: transport bill with it); the harness terms fall back to the implicit
-    #: treatment, so both settings are complete, comparable physics (#602).
+    #: Whether the population prognoses an explicit cloud-borne phase per
+    #: class (MAM-style ``mc_*``/``nc_*`` fields alongside the interstitial
+    #: tracers). This is a property of the population *representation*, not
+    #: of the process harness: MAM keeps in-droplet aerosol as separate
+    #: constituents, while M7 (ECHAM-HAM) and sectional schemes like TOMAS
+    #: represent it implicitly, scavenging the interstitial tracers by
+    #: their activated fraction. The explicit phase lives in the cross-step
+    #: physics carry (CAM's ``qqcw``-in-pbuf pattern), never in dycore
+    #: tracers — the measured #602 decision, see ``cloud_borne_store``.
+    #: ``False`` falls back to the implicit treatment; both settings are
+    #: complete, comparable physics.
     cloud_borne: bool = True
-    #: Where the explicit cloud-borne phase LIVES (#602 item 3, CAM's
-    #: ``pbuf`` pattern): ``"tracers"`` (dycore-advected ``mc_*``/``nc_*``
-    #: tracers, the default) or ``"carry"`` (cross-step physics-carry
-    #: fields — no spectral transforms or advection, mixed vertically by
-    #: ``CloudBorneCarryStore``; gives up resolved-scale advection of
-    #: in-droplet aerosol, exactly CAM's ``qqcw`` trade). The SPEC default
-    #: stays "tracers" as the plain data contract, but the
-    #: ``jam_aerosol_physics`` factory resolves its own default to
-    #: "carry": the 30-day T21 A/B measured the advected mirrors ringing
-    #: ~90% of cells negative at 2.2x the cost (see the factory resolver
-    #: comment). "tracers" is retained for FV-dycore re-evaluation.
-    #: Ignored when ``cloud_borne`` is False.
-    cloud_borne_storage: str = "tracers"
     #: Population policy for where freshly-emitted **primary** mass of a species
     #: goes: ``{species: ((mode_short, mass_fraction), ...)}`` with fractions
     #: summing to 1. This centralises the modal (or sectional) assumption with
@@ -169,14 +158,9 @@ class ModalAerosolSpec:
     )
 
     def __post_init__(self) -> None:
-        """Validate the family tag, storage mode, and species references."""
+        """Validate the family tag and species references."""
         if self.family not in ("modal", "sectional", "bulk"):
             raise ValueError(f"Unknown aerosol family {self.family!r}.")
-        if self.cloud_borne_storage not in ("tracers", "carry"):
-            raise ValueError(
-                "cloud_borne_storage must be 'tracers' or 'carry', got "
-                f"{self.cloud_borne_storage!r}."
-            )
         known = {s.name for s in self.species}
         for mode in self.modes:
             missing = set(mode.species) - known

--- a/jcm/physics/aerosol/jam/tracer_layout.py
+++ b/jcm/physics/aerosol/jam/tracer_layout.py
@@ -4,10 +4,10 @@ Aerosol mass and number live as ordinary entries in ``state.tracers`` so the
 dynamical core transports them and the existing diagnostics infrastructure
 works unchanged. The ``<class>`` token below is a per-class short name — a
 mode short for a modal scheme, a bin label for a sectional one — so the same
-conventions serve any population family. The *cloud-borne* mirror keys are
-emitted for cores that prognose an interstitial + cloud-borne population
-(e.g. MAM4); a core without that distinction simply declares only the
-interstitial keys.
+conventions serve any population family. The *cloud-borne* names
+(``mc_*``/``nc_*``) key the physics-carry store rather than dycore
+tracers (see ``cloud_borne_store``); ``tracer_specs`` declares only the
+interstitial set.
 
 Flat key conventions (the ``state.tracers`` API is flat-keyed):
 
@@ -53,34 +53,24 @@ def number_name(mode_short: str, *, cloud_borne: bool = False) -> str:
 
 
 def tracer_specs(spec: ModalAerosolSpec) -> tuple[TracerSpec, ...]:
-    """All ``TracerSpec``s for a population (interstitial + cloud-borne).
+    """All dycore ``TracerSpec``s for a population: the INTERSTITIAL set.
 
-    Returns one mass spec per (mode, species) and one number spec per mode,
-    each doubled for the cloud-borne mirror when the population prognoses
-    one (``spec.cloud_borne``) AND keeps it in the dycore tracers
-    (``cloud_borne_storage == "tracers"``); an implicit-in-droplet
-    population, or one storing the phase in the physics carry (#602 item
-    3), declares only the interstitial keys.
+    One mass spec per (mode, species) and one number spec per mode. The
+    cloud-borne phase (when ``spec.cloud_borne``) is never a dycore
+    tracer: it lives in the physics carry (see ``cloud_borne_store``, the
+    measured #602 decision), keyed by the same ``mc_*``/``nc_*`` naming.
     """
-    explicit_tracers = (
-        spec.cloud_borne and spec.cloud_borne_storage == "tracers"
-    )
-    phases = (False, True) if explicit_tracers else (False,)
     out: list[TracerSpec] = []
     for mode in spec.modes:
-        for cb in phases:
-            out.append(
-                TracerSpec(
-                    number_name(mode.short, cloud_borne=cb),
-                    units="kg^-1",
-                    nondimensionalize=False,
-                )
+        out.append(
+            TracerSpec(
+                number_name(mode.short),
+                units="kg^-1",
+                nondimensionalize=False,
             )
-            for sp in mode.species:
-                out.append(
-                    TracerSpec(
-                        mass_name(sp, mode.short, cloud_borne=cb),
-                        units="kg/kg",
-                    )
-                )
+        )
+        for sp in mode.species:
+            out.append(
+                TracerSpec(mass_name(sp, mode.short), units="kg/kg")
+            )
     return tuple(out)

--- a/jcm/physics/aerosol/jam/wetdep/wetdep_test.py
+++ b/jcm/physics/aerosol/jam/wetdep/wetdep_test.py
@@ -119,16 +119,22 @@ class WetDepTermTest(unittest.TestCase):
             mass=jnp.full(shape, 1e-9),
             number=jnp.full(shape, 1.0e8),
         )
+        from jcm.physics.aerosol.jam.cloud_borne_store import CARRY_KEY
+
         tracers = {}
+        carry = {}
         for mode in MAM4_SPEC.modes:
-            for cb in (False, True):
-                tracers[number_name(mode.short, cloud_borne=cb)] = jnp.full(
-                    (nlev, ncols), 1.0e8
+            tracers[number_name(mode.short)] = jnp.full((nlev, ncols), 1.0e8)
+            carry[number_name(mode.short, cloud_borne=True)] = jnp.full(
+                (nlev, ncols), 1.0e8
+            )
+            for sp in mode.species:
+                tracers[mass_name(sp, mode.short)] = jnp.full(
+                    (nlev, ncols), 1e-9
                 )
-                for sp in mode.species:
-                    tracers[mass_name(sp, mode.short, cloud_borne=cb)] = (
-                        jnp.full((nlev, ncols), 1e-9)
-                    )
+                carry[mass_name(sp, mode.short, cloud_borne=True)] = (
+                    jnp.full((nlev, ncols), 1e-9)
+                )
         state = PhysicsState.zeros((nlev, ncols)).copy(
             temperature=jnp.full((nlev, ncols), 275.0),
             tracers=tracers,
@@ -148,6 +154,7 @@ class WetDepTermTest(unittest.TestCase):
             rain_flux=rain_flux,
         )
         diagnostics = {
+            CARRY_KEY: carry,
             "_jam_state": aer,
             "activated_fraction": jnp.full((nlev, ncols), 0.7),
             "air_density": jnp.full((nlev, ncols), 1.0),
@@ -155,6 +162,15 @@ class WetDepTermTest(unittest.TestCase):
             "clouds": clouds,
         }
         return state, diagnostics, MAM4_SPEC, mass_name
+
+    @staticmethod
+    def _cb_rate(diag_in, diag_out, nm, dt=1800.0):
+        """Effective cloud-borne removal rate from the carry update."""
+        from jcm.physics.aerosol.jam.cloud_borne_store import CARRY_KEY
+        return (
+            np.asarray(diag_out[CARRY_KEY][nm])
+            - np.asarray(diag_in[CARRY_KEY][nm])
+        ) / dt
 
     def test_scavenging_is_a_sink(self):
         state, diagnostics, spec, mass_name = self._setup()
@@ -379,12 +395,12 @@ class WetDepTermTest(unittest.TestCase):
             conv_scav_ratio=jnp.asarray(0.99),
         )
         term = WetScavenging(params=params)
-        tend, _ = term(state, diagnostics, None, None)
+        tend, out = term(state, diagnostics, None, None)
 
         mode = spec.modes[0]
-        cb = np.asarray(
-            tend.tracers[mass_name(mode.species[0], mode.short,
-                                   cloud_borne=True)]
+        cb = self._cb_rate(
+            diagnostics, out,
+            mass_name(mode.species[0], mode.short, cloud_borne=True),
         )
         it = np.asarray(tend.tracers[mass_name(mode.species[0], mode.short)])
         # Removal only where condensate converts (levels 0-1), from the
@@ -403,13 +419,17 @@ class WetDepTermTest(unittest.TestCase):
             (number_name(mode.short, cloud_borne=True),
              number_name(mode.short)),
         ):
-            net = sum(np.asarray(tend.tracers[nm]) * dm_np for nm in pair)
+            cb_nm, int_nm = pair
+            net = (
+                self._cb_rate(diagnostics, out, cb_nm) * dm_np
+                + np.asarray(tend.tracers[int_nm]) * dm_np
+            )
             # Tolerance relative to the gross removal: the evap fraction
             # carries f32 round-off from the cumsum/divide, so "everything
             # re-released" holds to ~1e-6 of what was scavenged, not to
             # absolute zero on 1e8-scale number tracers.
             gross = float(
-                np.sum(np.abs(np.asarray(tend.tracers[pair[0]])) * dm_np)
+                np.sum(np.abs(self._cb_rate(diagnostics, out, cb_nm)) * dm_np)
             )
             np.testing.assert_allclose(
                 np.sum(net, axis=0), 0.0, atol=max(1e-5 * gross, 1e-20),
@@ -424,22 +444,25 @@ class WetDepTermTest(unittest.TestCase):
         from jcm.physics.aerosol.jam import number_name
 
         term = WetScavenging()
-        tend, _ = term(state, diagnostics, None, None)
+        _, out = term(state, diagnostics, None, None)
         cb_key = mass_name(spec.modes[0].species[0], spec.modes[0].short,
                            cloud_borne=True)
-        self.assertIn(cb_key, tend.tracers)
-        self.assertIn(number_name(spec.modes[0].short, cloud_borne=True),
-                      tend.tracers)
-        self.assertTrue(bool(jnp.all(tend.tracers[cb_key] < 0.0)))
+        nc_key = number_name(spec.modes[0].short, cloud_borne=True)
+        self.assertTrue(
+            bool((self._cb_rate(diagnostics, out, cb_key) < 0.0).all())
+        )
+        self.assertTrue(
+            bool((self._cb_rate(diagnostics, out, nc_key) < 0.0).all())
+        )
         # Independent of the interstitial activated fraction.
         diagnostics_af0 = dict(diagnostics)
         diagnostics_af0["activated_fraction"] = jnp.zeros_like(
             diagnostics["activated_fraction"]
         )
-        tend_af0, _ = term(state, diagnostics_af0, None, None)
+        _, out_af0 = term(state, diagnostics_af0, None, None)
         np.testing.assert_array_equal(
-            np.asarray(tend_af0.tracers[cb_key]),
-            np.asarray(tend.tracers[cb_key]),
+            self._cb_rate(diagnostics_af0, out_af0, cb_key),
+            self._cb_rate(diagnostics, out, cb_key),
         )
 
     def test_incloud_pathway_moves_with_the_representation(self):
@@ -535,14 +558,18 @@ class WetDepTermTest(unittest.TestCase):
                                     cloud_borne=True),
                           q_tot, fm))
 
-        # Explicit: each pair partitioned at its own exchange equilibrium.
+        # Explicit: each pair partitioned at its own exchange equilibrium
+        # (interstitial in the tracers, cloud-borne in the carry).
+        from jcm.physics.aerosol.jam.cloud_borne_store import CARRY_KEY
         tracers = dict(state.tracers)
+        carry = dict(diagnostics[CARRY_KEY])
         for key_int, key_cb, tot, frac in cases:
             q_cb = cf * frac * tot
             tracers[key_int] = jnp.full_like(tracers[key_int], tot - q_cb)
-            tracers[key_cb] = jnp.full_like(tracers[key_cb], q_cb)
-        tend_exp, _ = WetScavenging(params=params)(
-            state.copy(tracers=tracers), diagnostics, None, None,
+            carry[key_cb] = jnp.full_like(carry[key_cb], q_cb)
+        diag_exp = {**diagnostics, CARRY_KEY: carry}
+        tend_exp, out_exp = WetScavenging(params=params)(
+            state.copy(tracers=tracers), diag_exp, None, None,
         )
 
         # Implicit: everything interstitial, per-mode-fraction scavenged.
@@ -560,7 +587,7 @@ class WetDepTermTest(unittest.TestCase):
         for key_int, key_cb, tot, frac in cases:
             removed_explicit = -(
                 np.asarray(tend_exp.tracers[key_int])
-                + np.asarray(tend_exp.tracers[key_cb])
+                + self._cb_rate(diag_exp, out_exp, key_cb)
             )
             removed_implicit = -np.asarray(tend_imp.tracers[key_int])
             self.assertGreater(float(removed_explicit.max()), 0.0, key_int)

--- a/jcm/physics/convection/tracer_transport.py
+++ b/jcm/physics/convection/tracer_transport.py
@@ -31,14 +31,14 @@ subsidence:
   budget closes by construction).
 
 Downdraft tracer transport is not included yet (``mass_flux_down`` is
-published for it; the downdraft entrainment ledger is not) — the
-documented follow-up, typically a ~30% correction on the updraft
-circulation. Likewise not included: in-plume scavenging of soluble
-aerosol (ECHAM ``cuscav`` removes a large fraction of what the updraft
-carries before it detrains; here the plume is conservative and the
-convective wet removal lives separately in the JAM wetdep term), so
-expect a high bias in upper-tropospheric soluble aerosol in deep
-convective regions until that lands. Explicit stability: the per-column ledger is scaled so the
+published for it; the downdraft entrainment ledger is not) — tracked in
+jax-gcm#622, typically a ~30% correction on the updraft circulation.
+Likewise not included: in-plume scavenging of soluble aerosol (ECHAM
+``cuscav`` removes a large fraction of what the updraft carries before
+it detrains; here the plume is conservative and the convective wet
+removal lives separately in the JAM wetdep term), tracked in
+jax-gcm#621 — expect a high bias in upper-tropospheric soluble aerosol
+in deep convective regions until it lands. Explicit stability: the per-column ledger is scaled so the
 subsidence Courant number stays ≤ 1 (the scheme's own cloud-base CFL cap
 makes this a no-op in practice).
 

--- a/jcm/physics/echam/echam_terms.py
+++ b/jcm/physics/echam/echam_terms.py
@@ -74,7 +74,6 @@ def echam_physics(
     aerosol_module: str = "macv2sp",
     jam_microphysics: str = "placeholder",
     jam_cloud_borne: bool = True,
-    jam_cloud_borne_storage: str | None = None,
     jam_optics: bool = True,
     jam_arg_variant: str = "arg2000",
     jam_aqueous_scheme: str = "full",
@@ -147,18 +146,11 @@ def echam_physics(
         jam_microphysics: JAM core when ``aerosol_module="jam"`` —
             ``"placeholder"`` (κ-Köhler equilibrium) today; MAM4-JAX is #490.
         jam_cloud_borne: prognose the explicit cloud-borne aerosol phase
-            (#602). ``True`` (default) declares and cycles the ``mc_*`` /
-            ``nc_*`` mirror tracers (activation transfer, resuspension,
-            in-droplet wet removal, dry deposition); ``False`` drops them
-            entirely — about half the aerosol tracer count and most of the
-            dycore tracer-transport bill — and scavenges interstitial
-            aerosol by its activated fraction instead. The A/B
-            cost/fidelity switch.
-        jam_cloud_borne_storage: EXPERIMENTAL (#602 item 3, not exposed in
-            any yaml preset): where the explicit cloud-borne phase lives —
-            ``None``/"tracers" (dycore-advected) or ``"carry"``
-            (physics-carry fields, no advection). Exists for the
-            tracers-vs-carry A/B; do not use in production configs.
+            (#602). ``True`` (default) cycles the ``mc_*``/``nc_*`` phase
+            in the physics carry (activation transfer, resuspension,
+            in-droplet wet removal, dry deposition); ``False`` drops the
+            store and scavenges interstitial aerosol by its activated
+            fraction instead (the implicit M7/TOMAS-style treatment).
         jam_optics: include the online JAM aerosol direct-effect optics
             (#495), which overwrite the MACv2-SP optics that radiation
             reads. ``False`` keeps MACv2-SP optics (cheaper; also makes
@@ -326,7 +318,6 @@ def echam_physics(
         from jcm.physics.aerosol.jam.jam_terms import jam_aerosol_physics
         jam_terms = jam_aerosol_physics(
             microphysics=jam_microphysics, cloud_borne=jam_cloud_borne,
-            cloud_borne_storage=jam_cloud_borne_storage,
             optics=jam_optics,
             arg_variant=jam_arg_variant,
             aqueous_scheme=jam_aqueous_scheme,

--- a/jcm/prescribed_state_model.py
+++ b/jcm/prescribed_state_model.py
@@ -1,11 +1,11 @@
 """Diagnose physics tendencies from a prescribed atmospheric state series.
 
-.. note:: Carry-resident physics state is NOT threaded here: each evaluated
-   time sees a fresh (zero) cross-step carry, so prognostic carry slots —
-   TTE-TKE turbulence, and the carry-stored cloud-borne aerosol phase
-   (#602 item 3, the default JAM storage) — re-diagnose as their cold-start
-   values. For cloud-borne analysis of a saved run, read the run's own
-   ``jam_cloud_borne.*`` output rather than re-diagnosing.
+.. note:: Carry-resident physics state is NOT threaded here (jax-gcm#623):
+   each evaluated time sees a fresh (zero) cross-step carry, so prognostic
+   carry slots — TTE-TKE turbulence, and the carry-stored cloud-borne
+   aerosol phase (#602 item 3, the JAM storage) — re-diagnose as their
+   cold-start values. For cloud-borne analysis of a saved run, read the
+   run's own ``jam_cloud_borne.*`` output rather than re-diagnosing.
 
 
 ``PrescribedStateModel`` computes physics tendencies for each timestep

--- a/jcm/runners.py
+++ b/jcm/runners.py
@@ -306,12 +306,18 @@ def _physics_factories():
     return {"echam_physics": echam_physics}
 
 
+#: Yaml keys consumed by the runner itself, not the physics factory.
+_CONFIG_ONLY_PHYSICS_KEYS = frozenset({
+    "builder", "radiation_chunk_size", "defaults",
+})
+
 def _build_physics_from_factory(physics_cfg):
     """Build physics by delegating to a factory named by ``physics.builder``.
 
-    Only the factory keyword args present in the YAML are forwarded (filtered
-    against the factory signature), so config-only keys consumed elsewhere
-    (``builder``, ``radiation_chunk_size``) are ignored here.
+    The factory keyword args present in the YAML are forwarded; keys the
+    runner itself consumes (``_CONFIG_ONLY_PHYSICS_KEYS``) are skipped.
+    Anything else is an ERROR — a typo'd or removed key silently falling
+    back to defaults invalidates the experiment that set it.
     """
     import inspect
 
@@ -327,6 +333,14 @@ def _build_physics_from_factory(physics_cfg):
         )
     cfg_dict = OmegaConf.to_container(physics_cfg, resolve=True) or {}
     accepted = set(inspect.signature(factory).parameters)
+    unknown = set(cfg_dict) - accepted - _CONFIG_ONLY_PHYSICS_KEYS
+    if unknown:
+        raise ValueError(
+            f"physics config keys not accepted by {builder}: "
+            f"{sorted(unknown)}. Fix or delete them — a typo'd or "
+            "removed key silently falling back to the default would "
+            "invalidate the experiment that set it."
+        )
     kwargs = {k: v for k, v in cfg_dict.items()
               if k in accepted and v is not None}
     return factory(**kwargs)

--- a/jcm/runners_test.py
+++ b/jcm/runners_test.py
@@ -323,6 +323,17 @@ class TestEmissionsConfig(unittest.TestCase):
         self.assertIn("jam_anthropogenic_emissions", names)
         self.assertIn("jam_prescribed_aerosol_emissions", names)
 
+    def test_unknown_physics_key_raises(self):
+        # A typo'd factory kwarg must fail loudly, not silently fall back
+        # to the default it was trying to override (Codex on #624).
+        from omegaconf import open_dict
+        from jcm.runners import build_physics
+        cfg = _compose(["physics=echam-jam", "grid=echam_t42_l8_sigma"])
+        with open_dict(cfg):
+            cfg.physics.cloud_sheme = "2m"      # sic
+        with self.assertRaisesRegex(ValueError, "cloud_sheme"):
+            build_physics(cfg)
+
     def test_unknown_builder_raises(self):
         from jcm.runners import build_physics
         cfg = _compose(["physics=echam-jam", "grid=echam_t42_l8_sigma"])


### PR DESCRIPTION
Follow-up to #616, closing out the #602 storage question for good: the advected-tracer path for the cloud-borne phase is **removed**, and the repo gains a standing rule so follow-ups like #621/#622/#623 stop getting lost.

## Why remove rather than keep the escape hatch

#616 retained `cloud_borne_storage="tracers"` pending an FV-dycore (pySES) re-check. That check is parked by decision: pySES *is* the CAM-SE dycore, CAM itself keeps `qqcw` in pbuf rather than advecting it, and pySES is the configuration most sensitive to tracer count (#595) — there is no configuration left where advected mirrors could win. The decision and its evidence (the 30-day A/B, Eulerian and semi-Lagrangian legs, figures on #602) are recorded in the `cloud_borne_store` module docstring per the new CLAUDE.md rule.

Net effect: `ModalAerosolSpec.cloud_borne_storage` and `echam_physics(jam_cloud_borne_storage=...)` are gone; `tracer_specs` declares the interstitial set only, always; every dual-mode branch in the store/exchange/wetdep/drydep/aqueous/MAM4 terms collapses to the carry path (the `carry_mode` helper now just reads `spec.cloud_borne`); the implicit (`cloud_borne=False`) treatment is untouched. The diff is net-negative in the code and the tests convert their cloud-borne fixtures/assertions from tracer-tendency style to carry style — including the #612 representation-equivalence test, which now seeds the explicit leg's equilibrium partition in the carry.

## The process rule

New CLAUDE.md section: **file an issue for everything you find but don't fix** — bugs, fidelity gaps, deliberately-excluded pathways, and review findings triaged as "documented follow-up" must become issues before the PR that found them merges; docstring notes don't survive. Applied retroactively to this workstream's known gaps, now cross-linked from the code:

- #621 — convective in-plume scavenging of soluble aerosol (the `cuscav` analogue; the biggest remaining fidelity gap).
- #622 — downdraft tracer transport (the `mfd` leg of `ConvectiveTracerTransport`; distinct from sedimentation, which exists).
- #623 — `PrescribedStateModel` severs carry-resident physics state (TKE, cloud-borne).

Local gates per `jcm-local-ci`: ruff clean, fast + slow suites at CI dependency parity (numbers in checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aqshaa5nDrxcDWgg1FYw8Z
