### PR TITLE
perf(tests): eval_shape structural probe + single-column NoA test (#627)

### DIFF
--- a/jcm/physics/composable_physics.py
+++ b/jcm/physics/composable_physics.py
@@ -360,12 +360,15 @@ class ComposablePhysics(nnx.Module, Physics):
         cross-step slots, so we union it with this structural template
         (zero values, used only for shape).
 
-        Implementation: runs ``compute_tendencies`` once at Model
-        construction time with a non-zero isothermal probe state
-        (288 K, q=0, etc.) so radiation terms don't hit 0/0=NaN.
-        The result is *only ever used as a zero-filled template* —
-        never as live cross-step physics state. (Mis-using its
-        output as live state was the architectural bug `#470
+        Implementation: traces ``compute_tendencies`` once with
+        ``jax.eval_shape`` at Model construction time — only the output
+        pytree structure and shapes/dtypes are consumed, so nothing is
+        compiled or executed (eagerly running the full physics stack
+        un-jitted here cost tens of seconds per Model for the big ECHAM
+        compositions, twice per construction). The result is *only ever
+        used as a zero-filled template* — never as live cross-step
+        physics state. (Mis-using its output as live state was the
+        architectural bug `#470
         <https://github.com/climate-analytics-lab/jax-gcm/issues/470>`_
         tracks; the operator-split refactor in `#471` moved live
         state to ``initial_carry_state``.)
@@ -373,12 +376,10 @@ class ComposablePhysics(nnx.Module, Physics):
         """
         from jax.tree_util import tree_map
 
-        # Probe at a well-conditioned isothermal state. Using
-        # ``PhysicsState.zeros`` here produces 0/0 = NaN in radiation
-        # terms; the non-zero T=288 K probe walks the same code paths
-        # without the division-by-zero. We zero the output anyway
-        # so the probe values themselves don't matter — only the
-        # pytree structure / shapes do.
+        # The probe defines the input pytree STRUCTURE (which tracers
+        # exist, which forcing fields are present); its values are never
+        # computed with — eval_shape traces abstractly, so even 0/0
+        # paths in radiation cannot produce NaNs here.
         nodal_shape = coords.horizontal.nodal_shape
         nlev = coords.nodal_shape[0]
         shape_3d = (nlev,) + nodal_shape
@@ -401,10 +402,12 @@ class ComposablePhysics(nnx.Module, Physics):
         probe_forcing = ForcingData.zeros(nodal_shape)
         probe_terrain = TerrainData.aquaplanet(coords)
 
-        _, diagnostics = self.compute_tendencies(
+        diagnostics = jax.eval_shape(
+            lambda s, f, t: self.compute_tendencies(s, f, t)[1],
             probe_state, probe_forcing, probe_terrain,
         )
-        return tree_map(jnp.zeros_like, diagnostics)
+        return tree_map(lambda leaf: jnp.zeros(leaf.shape, leaf.dtype),
+                        diagnostics)
 
     def initial_carry_state(self, coords) -> dict[str, jnp.ndarray]:
         """Aggregate per-term cross-step carry-state slots.

--- a/jcm/physics/diagnostics/aerocom_remaining_test.py
+++ b/jcm/physics/diagnostics/aerocom_remaining_test.py
@@ -453,32 +453,50 @@ import pytest  # noqa: E402
 
 @pytest.mark.slow
 class AerosolFreeRadiationSlowTest(unittest.TestCase):
-    """One real RRTMGP step: noa differs from all-sky iff aerosol is present."""
+    """One real RRTMGP step: noa differs from all-sky iff aerosol is present.
+
+    Runs the full ECHAM composition (RRTMGP + 2M clouds + MACv2-SP with
+    ``aerosol_free_radiation=True``) in the single-column host rather than
+    a T21 ``Model``: the claim under test — the second, aerosol-free
+    RRTMGP solve and its published ``*_noa`` fluxes — is per-column
+    physics, and running 2048 spectral columns through the most expensive
+    double-compile in the suite bought only wall clock (#627, ~7 min of
+    every PR gate). The column sits in the East-Asian MACv2-SP plume
+    (30°N, 117°E) and is sunlit at the default start time, so the
+    anthropogenic AOD is nonzero and the SW must respond.
+    """
 
     def test_noa_fluxes_differ_with_aerosol_and_match_without(self):
-        from jcm.model import Model
+        import jax.numpy as jnp
+
         from jcm.physics.echam.echam_levels import get_echam_levels
         from jcm.physics.echam.echam_terms import echam_physics
-        from jcm.runners import inject_jw_profile
-        from jcm.terrain import TerrainData
-        from jcm.utils import get_coords
+        from jcm.rce import rce_initial_state
+        from jcm.single_column_model import SingleColumnModel
 
-        coords = get_coords(get_echam_levels(47), spectral_truncation=21)
         physics = echam_physics(
             radiation_scheme="rrtmgp", cloud_scheme="2m",
             aerosol_module="macv2sp", aerosol_free_radiation=True,
             checkpoint_terms=False)
-        model = Model(coords=coords, terrain=TerrainData.aquaplanet(coords),
-                      physics=physics, time_step=12.0)
-        inject_jw_profile(model, rh=0.6)
-        dt_days = 12.0 / 1440.0
-        preds = model.resume(save_interval=dt_days, total_time=dt_days)
-        rad = preds.physics["radiation"]
+        vertical = get_echam_levels(47)
+        scm = SingleColumnModel(
+            physics=physics, vertical=vertical,
+            lat_deg=30.0, lon_deg=117.0, dt_seconds=720.0)
+        column = rce_initial_state(vertical, sst=300.0)
+        # Seed every tracer the composition declares (the 2M scheme carries
+        # number concentrations beyond rce_initial_state's qc/qi).
+        column = column.copy(tracers={
+            spec.name: jnp.zeros(47) for spec in physics.required_tracers()})
+        preds = scm.run([column])
+        rad = preds.physics_data["radiation"]
+        # Guard the geometry assumption explicitly: a dark column would make
+        # the SW assertion below fail for the wrong reason.
+        self.assertGreater(float(np.asarray(rad.cos_zenith).max()), 0.0)
         sw_noa = np.asarray(jax.device_get(rad.toa_sw_up_noa))
         sw_all = np.asarray(jax.device_get(rad.toa_sw_up))
         self.assertTrue(np.isfinite(sw_noa).all())
         # MACv2-SP puts nonzero anthropogenic AOD in 2005 defaults, so the
-        # aerosol-free SW must differ measurably somewhere sunlit...
+        # aerosol-free SW must differ measurably in this sunlit plume column...
         self.assertGreater(np.abs(sw_noa - sw_all).max(), 1e-3)
         # ...while the LW (MACv2-SP models SW effects only) stays equal.
         lw_noa = np.asarray(jax.device_get(rad.toa_lw_up_noa))

--- a/jcm/physics/layout_audit_test.py
+++ b/jcm/physics/layout_audit_test.py
@@ -132,7 +132,8 @@ INERT_IN_HARNESS = frozenset({
 #: below fails if a term is in neither set.
 NOT_AUDITED = frozenset({
     "AnthropogenicEmissions", "AqueousSulfur", "ArgActivation",
-    "CloudBorneExchange", "CloudsatCosp", "ConvectiveTracerTransport",
+    "CloudBorneCarryStore", "CloudBorneExchange", "CloudsatCosp",
+    "ConvectiveTracerTransport",
     "DmsEmissions", "DustEmissions", "Echam1MMicrophysics",
     "EchamBoundaryConditions", "EchamSurface", "GreyTwoStreamRadiation",
     "HeldSuarez", "HinesGwd", "JamOpticsTerm", "Lohmann2MMicrophysics",


### PR DESCRIPTION
Recovers the two dominant items from the #627 CI-runtime analysis without weakening what either test checks, and fixes a latent dev-red.

## 1. `get_empty_data` traces instead of executing

The structural probe eagerly ran the entire composed physics stack un-jitted — ~36 s for the default ECHAM composition, **twice per Model construction** — while its output is only ever consumed as a zero-filled shape/dtype template. It now uses `jax.eval_shape`: verified leaf-for-leaf identical (structure, shapes, dtypes) against the eager probe, ~3 s, no kernels dispatched, and the 0/0=NaN hazard the 288 K probe values guarded against cannot occur abstractly. This is most of the `TestInitialCarryState` 4.5× regression (40.3 s → 3.9 s measured) and shaves every model-constructing test plus real Model construction in production.

## 2. NoA double-radiation test on one column, not 2048

`test_noa_fluxes_differ_with_aerosol_and_match_without` (409 s on CI — the slowest test in the suite) ran a full T21L47 Model step to verify per-column physics: the second, aerosol-free RRTMGP solve publishes `*_noa` fluxes that differ in SW iff aerosol is present and never in LW. It now runs the **identical ECHAM composition** (RRTMGP + 2M + MACv2-SP, `aerosol_free_radiation=True`) in the `SingleColumnModel` host at a sunlit East-Asian plume column, with an explicit `cos_zenith > 0` guard so the SW assertion cannot pass or fail vacuously. The spectral grid is not reducible below T21, so the column host is the way to shrink columns. Measured 74.9 s on a develop node (T21 Model version: 146.5 s same node class); the residual is the irreducible double-RRTMGP compile.

## 3. dev is currently red: `CloudBorneCarryStore` unclassified

The term (from the cloud-borne carry work) and the layout-audit roster-rot check merged green on parallel branches; their combination fails `test_every_term_is_classified` on dev. Classified `NOT_AUDITED` beside its sibling `CloudBorneExchange` — it needs the `_jam_cloud_borne` carry and TTE-TKE exchange coefficients no synthetic harness supplies.

## Gates (develop node)

lint clean · fast **1749 passed**, ≥90% · slow **82 passed**, ≥80% · timed section: NoA 74.9 s, carry 3.9 s.

## Not done here (candidates noted in #627)

- Batch the all-sky and aerosol-free RRTMGP solves through one vmap axis so the double solve compiles once — production win for every noa run, but a delicate radiation refactor.
- Persist the XLA compilation cache across CI runs (actions/cache) — would cut every compile-bound slow test.

Closes nothing; #627 stays open for the follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EYsAZJeaPcP2DAzzxtXRN