### PR TITLE
Allow physics to change atmospheric mass (surface pressure) — enables Mars CO2 cycle

### DIFF
--- a/jcm/dycore/dinosaur/dycore.py
+++ b/jcm/dycore/dinosaur/dycore.py
@@ -251,8 +251,10 @@ class DinosaurDycore(DynamicalCore):
             ),
             level_orders=self.diffusion.level_orders_temp,
         )
+        # NOTE: global-mean surface-pressure conservation is applied explicitly
+        # in ``step`` (against the post-physics state), not as a filter here, so
+        # a physics mass source/sink is retained. See ``step``.
         return [
-            self._conserve_global_mean_ps,
             diffuse_div,
             diffuse_vor_q,
             diffuse_temp,
@@ -350,6 +352,13 @@ class DinosaurDycore(DynamicalCore):
         state_next = state_after_dyn
         for f in self._filters:
             state_next = f(state, state_next)
+        # Conserve the global-mean surface pressure relative to the POST-physics
+        # state, not the pre-physics state. This removes spectral-dynamics mass
+        # drift while RETAINING a physics mass source/sink (e.g. Mars CO2
+        # condensation) carried in ``physics_tendency.log_surface_pressure``.
+        # For dry-mass-conserving physics the two references are identical, so
+        # behaviour is unchanged.
+        state_next = self._conserve_global_mean_ps(state_after_physics, state_next)
         return state_next
 
     def sim_time(self, state: State) -> jnp.ndarray:

--- a/jcm/dycore/dinosaur/state_bridge.py
+++ b/jcm/dycore/dinosaur/state_bridge.py
@@ -214,7 +214,24 @@ def physics_tendency_to_dynamics_tendency(
     # n_lon_modes)`` (a leading vertical axis of size 1 for broadcasting). The
     # op-split path adds the tendency directly to the state via tree_math,
     # which requires *exact* shape matches — keep the leading axis.
-    log_sp_tend_modal = jnp.zeros_like(t_tend_modal[:1, ...])
+    #
+    # ``physics_tendency.log_surface_pressure`` is a scalar global-mean
+    # d(log P_s)/dt in 1/s. It is non-zero only for physics that change the
+    # atmospheric column mass (e.g. Mars CO2 condensation/sublimation) and 0.0
+    # for dry-mass-conserving physics. A spatially uniform log-pressure tendency
+    # transforms to the (0,0) spectral mode only, i.e. it moves the global-mean
+    # surface pressure. The dycore's ``_conserve_global_mean_ps`` filter is
+    # patched to pin that mode to the *post-physics* state, so this source is
+    # retained while spectral-dynamics drift is still removed.
+    # Multiply by the unit (tracer * Unit is supported; tracer / Unit is not).
+    dlogsp_nd = dynamics.physics_specs.nondimensionalize(
+        physics_tendency.log_surface_pressure * (units.second ** -1)
+    )
+    uniform_nodal = dlogsp_nd * jnp.ones(
+        (1,) + tuple(dynamics.coords.horizontal.nodal_shape),
+        dtype=t_tend_modal.dtype,
+    )
+    log_sp_tend_modal = dynamics.coords.horizontal.to_modal(uniform_nodal)
 
     tracers_tend_modal = {'specific_humidity': q_tend_modal}
     for tracer_name, tracer_tend in physics_tendency.tracers.items():

--- a/jcm/physics_interface.py
+++ b/jcm/physics_interface.py
@@ -132,42 +132,55 @@ class PhysicsTendency:
     temperature: jnp.ndarray
     specific_humidity: jnp.ndarray
     tracers: Dict[str, jnp.ndarray]  # Tendencies for additional tracers
+    # Tendency of log(surface pressure), 1/s, on the horizontal grid (ix, il).
+    # Non-zero only for physics that change the atmospheric column mass, e.g.
+    # CO2 condensation/sublimation on Mars. Defaults to 0.0 so dry-mass-
+    # conserving physics is unchanged. Appended last for backward compatibility.
+    log_surface_pressure: jnp.ndarray
 
-    def __init__(self, u_wind, v_wind, temperature, specific_humidity, tracers=None):
+    def __init__(self, u_wind, v_wind, temperature, specific_humidity, tracers=None,
+                 log_surface_pressure=0.0):
         """Initialize PhysicsTendency with tendency fields."""
         self.u_wind = u_wind
         self.v_wind = v_wind
         self.temperature = temperature
         self.specific_humidity = specific_humidity
         self.tracers = tracers if tracers is not None else {}
+        self.log_surface_pressure = log_surface_pressure
 
     @classmethod
-    def zeros(cls, shape, u_wind=None, v_wind=None, temperature=None, specific_humidity=None, tracers=None):
+    def zeros(cls, shape, u_wind=None, v_wind=None, temperature=None, specific_humidity=None,
+              tracers=None, log_surface_pressure=None):
         return cls(
             u_wind if u_wind is not None else jnp.zeros(shape),
             v_wind if v_wind is not None else jnp.zeros(shape),
             temperature if temperature is not None else jnp.zeros(shape),
             specific_humidity if specific_humidity is not None else jnp.zeros(shape),
-            tracers if tracers is not None else {}
+            tracers if tracers is not None else {},
+            log_surface_pressure if log_surface_pressure is not None else 0.0,
         )
 
     @classmethod
-    def ones(cls, shape, u_wind=None, v_wind=None, temperature=None, specific_humidity=None, tracers=None):
+    def ones(cls, shape, u_wind=None, v_wind=None, temperature=None, specific_humidity=None,
+             tracers=None, log_surface_pressure=None):
         return cls(
             u_wind if u_wind is not None else jnp.ones(shape),
             v_wind if v_wind is not None else jnp.ones(shape),
             temperature if temperature is not None else jnp.ones(shape),
             specific_humidity if specific_humidity is not None else jnp.ones(shape),
-            tracers if tracers is not None else {}
+            tracers if tracers is not None else {},
+            log_surface_pressure if log_surface_pressure is not None else 0.0,
         )
 
-    def copy(self, u_wind=None, v_wind=None, temperature=None, specific_humidity=None, tracers=None):
+    def copy(self, u_wind=None, v_wind=None, temperature=None, specific_humidity=None,
+             tracers=None, log_surface_pressure=None):
         return PhysicsTendency(
             u_wind if u_wind is not None else self.u_wind,
             v_wind if v_wind is not None else self.v_wind,
             temperature if temperature is not None else self.temperature,
             specific_humidity if specific_humidity is not None else self.specific_humidity,
             tracers if tracers is not None else self.tracers,
+            log_surface_pressure if log_surface_pressure is not None else self.log_surface_pressure,
         )
 
 


### PR DESCRIPTION
## Summary

Allows physics parameterizations to **change the atmospheric column mass** (global-mean surface pressure). Today the dycore enforces strict dry-mass conservation, so a physics term cannot add or remove atmosphere. This blocks the **Mars CO₂ condensation cycle**, where ~25–30% of the atmosphere freezes onto the winter pole each year and the global surface pressure swings seasonally (the Viking-observed signal).

The change is opt-in and defaults to a no-op, so existing dry-mass-conserving physics is unchanged.

## What changed

1. **`PhysicsTendency`** — new scalar field `log_surface_pressure` = d(log Pₛ)/dt in 1/s. Defaults to `0.0`; appended last for backward compatibility. Non-zero only for mass-changing physics (e.g. CO₂ condensation/sublimation).
2. **`state_bridge.py`** — `physics_tendency_to_dynamics_tendency` converts that scalar into the `(0,0)` spectral mode of the log-surface-pressure tendency (a uniform global-mean mass source), instead of hardcoding it to zero.
3. **`dycore.py`** — `_conserve_global_mean_ps` is now applied against the **post-physics** state rather than the pre-physics state. This still removes spectral-dynamics mass drift, but **retains** a physics mass source/sink. For dry physics the two references are identical, so behaviour is byte-for-byte unchanged.

## Why the previous approach was insufficient

The physics tendency was already forward-Euler added to the state, but `_conserve_global_mean_ps` then reset the `[0,0,0]` mode of `log_surface_pressure` back to the **pre-step** value each step — erasing any mass change. Un-hardcoding the bridge alone does nothing; the fix is to pin conservation to the post-physics reference.

## Verification

- **Correctness:** a prescribed uniform mass sink/source lowers/raises the global-mean surface pressure by `rate × time`. Observed −0.0423 vs expected −0.0432 over 0.5 day at −1e-6 s⁻¹ (~2% match). Zero rate conserves mass (mean normalized pₛ = 1.000000).
- **No regression:** full `model_test.py` passes, including the Speedy physics runs and the `vjp`/`jvp` gradient tests (differentiability preserved). `physics_interface_test.py` and `physics_interface_hybrid_test.py` pass.

## Notes / scope

- The mass source is currently the **global mean** (the `(0,0)` mode) — sufficient for the seasonal total-mass/pressure cycle. Spatially localized condensation (higher spectral modes) is a natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
