### PR TITLE
fix(forcing): yearly bundles now load at non-native resolutions (#634)

### DIFF
--- a/jcm/data/bc/interpolate.py
+++ b/jcm/data/bc/interpolate.py
@@ -62,6 +62,16 @@ def _upsample_ds(ds: xr.Dataset, grid: HorizontalGridTypes) -> xr.Dataset:
 
     """
 
+    # Variables without a full lat/lon grid — e.g. the yearly bundles'
+    # global-mean GHG series co2/ch4/n2o (time,) — must bypass the
+    # spatial pipeline: the pole padding's expand_dims would broadcast
+    # them onto the grid, which downstream consumers then read as a
+    # corrupt spatial field (#634).
+    non_spatial = [v for v in ds.data_vars
+                   if not {"lat", "lon"} <= set(ds[v].dims)]
+    passthrough = ds[non_spatial]
+    ds = ds.drop_vars(non_spatial)
+
     # Pad latitude with extra rows at poles so data can be interpolated to higher latitudes than exist in T30 grid
     south_pole = ds.isel(lat=0).mean(dim="lon", keep_attrs=True)
     north_pole = ds.isel(lat=-1).mean(dim="lon", keep_attrs=True)
@@ -86,7 +96,7 @@ def _upsample_ds(ds: xr.Dataset, grid: HorizontalGridTypes) -> xr.Dataset:
         method="linear"
     )
 
-    return ds_interp
+    return xr.merge([ds_interp, passthrough])
 
 def upsample_forcings_ds(ds: xr.Dataset, grid: HorizontalGridTypes) -> xr.Dataset:
     f"""Upsample forcing data to target resolution with physical constraints.

--- a/jcm/data/bc/interpolate_test.py
+++ b/jcm/data/bc/interpolate_test.py
@@ -99,6 +99,21 @@ class TestUpsampleForcings(unittest.TestCase):
         self.assertEqual(out.sizes["lon"], 64)
         self.assertEqual(out.sizes["lat"], 32)
 
+    def test_scalar_series_pass_through_untouched(self):
+        # The yearly bundles carry global-mean GHG series as (time,)
+        # variables; the pole padding must not broadcast them onto the
+        # grid (#634 — SPEEDY read the ballooned co2 as a spatial field
+        # and crashed in radiation at any non-native resolution).
+        ds = self._source()
+        times = pd.date_range("2023-01-01", periods=12, freq="MS")
+        ds["co2"] = (("time",), np.full(12, 419.5))
+        ds = ds.assign_coords(time=times)
+        out = upsample_forcings_ds(ds, _t21_grid())
+        self.assertEqual(out["co2"].dims, ("time",))
+        np.testing.assert_array_equal(out["co2"].values, ds["co2"].values)
+        # spatial fields still regrid
+        self.assertEqual(out.sizes["lon"], 64)
+
 
 class TestUpsampleTerrain(unittest.TestCase):
 


### PR DESCRIPTION
Closes #634.

\`_upsample_ds\`'s pole padding (\`expand_dims(lon=..., lat=...)\`) broadcast every non-spatial variable onto the grid. The yearly transient bundles are the first forcing files with such variables — the global-mean GHG series \`co2/ch4/n2o (time,)\` — so loading any of them at a resolution other than the file's own turned \`co2\` into a corrupt \`(lon, lat, time)\` field, which SPEEDY's radiation consumed as its CO2 absorptivity and crashed with the broadcast error in #634.

Fix: variables without both \`lat\` and \`lon\` dims bypass the spatial pipeline and merge back unchanged (values verified bit-identical).

Verified: the #634 repro (SPEEDY T31 + \`forcing_amip/1982.nc\`) and the same with \`forcing_era5/2023.nc\` both run clean end-to-end; new regression test in \`interpolate_test.py\`; full \`jcm/data\` + \`forcing_test\` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EYsAZJeaPcP2DAzzxtXRN