### PR TITLE
feat(convection): downdraft tracer transport + in-plume scavenging (#621, #622)

### DIFF
--- a/jcm/config/physics/echam-jam.yaml
+++ b/jcm/config/physics/echam-jam.yaml
@@ -52,3 +52,8 @@ jam_cloud_borne: true
 # Prescribed-emission terms (driven by forcing.emissions_file):
 jam_anthropogenic: true        # bulk SO2/BC/OC → in-model speciation + injection
 jam_prescribed_speciated: true # already-speciated per-tracer fields (CAM-faithful)
+
+# Convective tracer transport + in-plume scavenging (#621/#622). false is
+# the reconciliation A/B: WetScavenging then reverts to its environment-
+# profile convective in-cloud pathway (the pre-#621 sink).
+jam_convective_transport: true

--- a/jcm/physics/aerosol/jam/jam_terms.py
+++ b/jcm/physics/aerosol/jam/jam_terms.py
@@ -205,12 +205,17 @@ def jam_aerosol_physics(
             diffuses all tracers in vdiff; without this the dycore is the
             sole aerosol transporter). On by default.
         convective_transport: bulk mass-flux transport of the interstitial
-            aerosol and gas tracers through Tiedtke updrafts with
-            compensating subsidence (ECHAM ``cuxtte`` analogue; #602 item
-            2). Cloud-borne mirrors are deliberately excluded — their
-            updraft processing is entangled with convective scavenging
-            and neither reference model transports a stratiform
-            cloud-borne phase convectively. On by default.
+            aerosol and gas tracers through Tiedtke updrafts and
+            downdrafts with compensating subsidence (ECHAM ``cuxtte``
+            analogue; #602 item 2, #622), including CAM
+            ``aero_convproc``-style in-plume scavenging of the soluble
+            (activatable-mode) tracers (#621) — which moves the
+            convective in-cloud wet-removal pathway out of
+            ``WetScavenging`` (``in_plume_convective``). Cloud-borne
+            mirrors are deliberately excluded — their updraft processing
+            is entangled with convective scavenging and neither reference
+            model transports a stratiform cloud-borne phase convectively.
+            On by default.
 
     Returns:
         The ordered term list: natural emissions, prescribed oxidants and

--- a/jcm/physics/aerosol/jam/jam_terms.py
+++ b/jcm/physics/aerosol/jam/jam_terms.py
@@ -70,6 +70,7 @@ from jcm.physics.aerosol.jam.wetdep.wetdep_term import (
     WetScavenging,
     WetDepParameters,
 )
+from jcm.physics.aerosol.jam.tracer_layout import mass_name, number_name
 from jcm.physics.convection.tracer_transport import (
     ConvectiveTracerTransport,
     ConvTransportParameters,
@@ -272,9 +273,24 @@ def jam_aerosol_physics(
         interstitial_names = tuple(
             n for n in transport_names if not n.startswith(("mc_", "nc_"))
         )
+        # In-plume scavenging weights (jax-gcm#621): soluble = the
+        # activatable modes' interstitial tracers; insoluble aerosol and
+        # the gas precursors ride the plume unscavenged. WetScavenging
+        # retires its own environment-profile convective pathway in turn
+        # (``in_plume_convective`` below).
+        soluble = set()
+        for mode in spec.modes:
+            if mode.can_activate:
+                soluble.add(number_name(mode.short))
+                soluble.update(
+                    mass_name(sp, mode.short) for sp in mode.species
+                )
         transport_terms.append(
             ConvectiveTracerTransport(
                 interstitial_names, params=conv_transport,
+                scav_weights=tuple(
+                    1.0 if n in soluble else 0.0 for n in interstitial_names
+                ),
             )
         )
     # Carry-stored cloud-borne phase (#602 item 3, the measured decision
@@ -320,7 +336,8 @@ def jam_aerosol_physics(
         # In-cloud aqueous SO2 oxidation → cloud-borne sulfate; runs in the
         # post-cloud block (needs current clouds), just before wet scavenging.
         AqueousSulfur(params=aqueous, spec=spec, scheme=aqueous_scheme),
-        WetScavenging(params=wetdep, spec=spec),
+        WetScavenging(params=wetdep, spec=spec,
+                      in_plume_convective=convective_transport),
     ]
     terms = [*pre_core, core, *optics_terms, *post_core]
     return terms

--- a/jcm/physics/aerosol/jam/wetdep/wetdep_term.py
+++ b/jcm/physics/aerosol/jam/wetdep/wetdep_term.py
@@ -27,7 +27,11 @@ treatment):
   stratiform pathway: scavenging ratio × (per-layer updraft precip
   formation / in-updraft condensate), from ``ConvectionData``'s
   ``precip_formation`` (ECHAM ``pdmfup``) and ``qc_conv``/``qi_conv``;
-  activatable modes only.
+  activatable modes only. With ``in_plume_convective=True`` this
+  environment-profile pathway is retired: the composed
+  ``ConvectiveTracerTransport`` scavenges inside the updraft instead
+  (jax-gcm#621, CAM ``aero_convproc``-style) and this term only folds
+  the transport term's surface fluxes into the ``wet_*`` ledger.
 * **Re-evaporation re-injection** — aerosol scavenged by the stratiform
   pathways is carried in the falling precip; where that precip evaporates
   or sublimates, the same fraction of the carried aerosol returns to the
@@ -223,9 +227,20 @@ class WetScavenging(PhysicsTerm):
         params: WetDepParameters | None = None,
         *,
         spec: ModalAerosolSpec | None = None,
+        in_plume_convective: bool = False,
     ):
-        """Hold params and the population."""
+        """Hold params and the population.
+
+        ``in_plume_convective``: the composed ``ConvectiveTracerTransport``
+        scavenges soluble aerosol inside the updraft (jax-gcm#621), so
+        this term drops its own environment-profile convective in-cloud
+        pathway (``conv_in_cloud_rate``) to avoid double counting —
+        keeping convective below-cloud washout, which is a distinct
+        (impaction) pathway — and folds the transport term's published
+        surface fluxes into the AeroCom ``wet_*`` ledger.
+        """
         self.params = nnx.Param(params or WetDepParameters.default())
+        self._in_plume_convective = in_plume_convective
         self._spec = spec or MAM4_SPEC
         if carry_mode(self._spec):
             # In carry mode the store term must run upstream each step
@@ -292,10 +307,15 @@ class WetScavenging(PhysicsTerm):
         else:
             conv_precip = conv.precip_conv
             conv_condensate = conv.qc_conv + conv.qi_conv
-            rate_conv_incloud = conv_in_cloud_rate(
-                conv.precip_formation, conv_condensate,
-                air_density, dz, params,
-            )
+            if self._in_plume_convective:
+                # Retired here: the transport term removes inside the
+                # ascent scan (see __init__ docstring).
+                rate_conv_incloud = jnp.zeros_like(state.temperature)
+            else:
+                rate_conv_incloud = conv_in_cloud_rate(
+                    conv.precip_formation, conv_condensate,
+                    air_density, dz, params,
+                )
             # Convective washout acts only at/below the convective cloud
             # top — rain cannot collect aerosol above where it forms. The
             # top is the lowest-pressure level with in-updraft condensate
@@ -501,9 +521,22 @@ class WetScavenging(PhysicsTerm):
         # (scavenging minus re-injection), column-integrated, accumulated
         # onto the per-step-reset keys.
         from jcm.physics.aerosol.jam.emissions.flux_diagnostic import (
-            accumulate_deposition_fluxes)
+            DEPOSITED_SPECIES, _species_of, accumulate_deposition_fluxes)
         diagnostics = accumulate_deposition_fluxes(
             diagnostics, flux_tends,
             diagnostics["air_density"], diagnostics["layer_thickness"],
             kind="wet")
+        # In-plume convective scavenging (jax-gcm#621) removes mass in the
+        # transport term, whose tendencies never pass through this
+        # accumulator — fold its published surface fluxes in here so the
+        # ``wet_*`` ledger stays the complete wet sink. The keys all exist
+        # after the accumulate call above.
+        conv_scav = diagnostics.get("_conv_scav_flux")
+        if self._in_plume_convective and conv_scav:
+            diagnostics = dict(diagnostics)
+            for nm, flx in conv_scav.items():
+                species = _species_of(nm)
+                if species in DEPOSITED_SPECIES:
+                    key = f"wet_{species}"
+                    diagnostics[key] = diagnostics[key] + flx
         return tendency, diagnostics

--- a/jcm/physics/aerosol/jam/wetdep/wetdep_test.py
+++ b/jcm/physics/aerosol/jam/wetdep/wetdep_test.py
@@ -308,6 +308,49 @@ class WetDepTermTest(unittest.TestCase):
         key = mass_name(spec.modes[0].species[0], spec.modes[0].short)
         self.assertTrue(np.all(np.isfinite(np.asarray(tend.tracers[key]))))
 
+    def test_in_plume_flag_retires_env_conv_incloud(self):
+        # With in-plume scavenging in the transport term (jax-gcm#621),
+        # this term must drop its environment-profile convective in-cloud
+        # removal (weaker sink than the default under convective precip)
+        # while keeping the below-cloud convective washout (stronger sink
+        # than with no convection at all).
+        state, diagnostics, spec, mass_name = self._setup(precip=0.0)
+        diag_conv = self._attach_convection(diagnostics, 4, 2)
+        key = mass_name(spec.modes[0].species[0], spec.modes[0].short)
+        both = WetScavenging()(state, diag_conv, None, None)[0]
+        plume = WetScavenging(in_plume_convective=True)(
+            state, diag_conv, None, None,
+        )[0]
+        none = WetScavenging(in_plume_convective=True)(
+            state, diagnostics, None, None,
+        )[0]
+        self.assertGreater(                       # sums are ≤ 0: less removal
+            float(plume.tracers[key].sum()), float(both.tracers[key].sum()),
+        )
+        self.assertLess(                          # washout pathway retained
+            float(plume.tracers[key].sum()), float(none.tracers[key].sum()),
+        )
+
+    def test_conv_scav_flux_folds_into_wet_ledger(self):
+        # The transport term's published surface fluxes must appear in the
+        # AeroCom ``wet_*`` keys — but only when the in-plume pathway owns
+        # convective scavenging.
+        from jcm.physics.aerosol.jam.emissions.flux_diagnostic import (
+            _species_of)
+        state, diagnostics, spec, mass_name = self._setup()
+        key = mass_name(spec.modes[0].species[0], spec.modes[0].short)
+        diagnostics = dict(diagnostics)
+        diagnostics["_conv_scav_flux"] = {key: jnp.full((2,), 3.0e-12)}
+        _, d_on = WetScavenging(in_plume_convective=True)(
+            state, diagnostics, None, None,
+        )
+        _, d_off = WetScavenging()(state, diagnostics, None, None)
+        wet_key = f"wet_{_species_of(key)}"
+        np.testing.assert_allclose(
+            np.asarray(d_on[wet_key]) - np.asarray(d_off[wet_key]),
+            3.0e-12, rtol=1e-4,     # float32 accumulation roundoff
+        )
+
     def test_incloud_driven_by_formation_not_surface_precip(self):
         # The in-cloud pathway must key off the cloud scheme's per-level
         # formation rate, not a reconstruction from the surface precip: a

--- a/jcm/physics/convection/tiedtke_nordeng/downdraft.py
+++ b/jcm/physics/convection/tiedtke_nordeng/downdraft.py
@@ -172,6 +172,38 @@ def find_lfs(
     return lfs_level, lfs_found
 
 
+def downdraft_entrainment_ledger(
+    mfd: jnp.ndarray,
+    layer_thickness: jnp.ndarray,
+    entrdd: float,
+) -> jnp.ndarray:
+    """Absolute per-layer downdraft entrainment flux [kg/m²/s] (#622).
+
+    ECHAM ``cuddraf`` entrains ``zentr = entrdd·|mfd(k-1)|·dz`` into each
+    descent layer (matched by an equal detrainment in the bulk, so
+    |mfd| is conserved going down); entrainment is shut off in the two
+    surface-taper layers. ``mfd[k]`` is the flux leaving layer k through
+    its BOTTOM interface, so the flux entering from above is
+    ``mfd[k-1]`` — zero at and above the LFS, which zeroes the ledger
+    there without an explicit LFS index. Where the downdraft died
+    mid-descent (``mfd[k] == 0`` with inflow above), the ledger is also
+    zero so plume continuity dumps the arriving flux as pure
+    detrainment, matching the Fortran's buoyancy shut-off.
+
+    Vertical on axis 0; trailing axes broadcast (a ``(nlev,)`` column and
+    a ``(nlev, ncols)`` block agree per column).
+    """
+    nlev = mfd.shape[0]
+    mfd_in = jnp.concatenate(
+        [jnp.zeros_like(mfd[:1]), mfd[:-1]], axis=0
+    )
+    levels = jnp.arange(nlev).reshape((nlev,) + (1,) * (mfd.ndim - 1))
+    in_bulk = (mfd < 0.0) & (levels < nlev - 2)
+    return jnp.where(
+        in_bulk, entrdd * jnp.abs(mfd_in) * layer_thickness, 0.0
+    )
+
+
 def downdraft_step(
     carry_and_rain: Tuple,
     level_inputs: Tuple

--- a/jcm/physics/convection/tiedtke_nordeng/downdraft_test.py
+++ b/jcm/physics/convection/tiedtke_nordeng/downdraft_test.py
@@ -40,6 +40,7 @@ from jcm.physics.convection.tiedtke_nordeng.flux_tendencies import (
 from jcm.physics.convection.tiedtke_nordeng.updraft import calculate_updraft
 from jcm.physics.convection.tiedtke_nordeng.downdraft import (
     calculate_downdraft,
+    downdraft_entrainment_ledger,
 )
 
 
@@ -230,6 +231,51 @@ class TestDowndraftTemperature(unittest.TestCase):
             f"td(surface)={td[last]:.2f} should exceed td(LFS)={td[first]:.2f} "
             "via adiabatic compression."
         )
+
+
+class TestDowndraftEntrainmentLedger(unittest.TestCase):
+    """The #622 export: cuddraf's zentr = entrdd·|mfd_in|·dz per layer."""
+
+    def test_bulk_taper_and_lfs_masking(self):
+        nlev, entrdd, dz_val = 10, 2.0e-4, 400.0
+        lev = jnp.arange(nlev)[:, None]
+        # LFS at 4, bulk to nlev-3, cuddraf taper below.
+        mfd = jnp.where((lev >= 4) & (lev < nlev - 2), -0.02, 0.0)
+        mfd = mfd.at[nlev - 2].set(-0.01)
+        dz = jnp.full((nlev, 1), dz_val)
+        ledger = np.asarray(downdraft_entrainment_ledger(mfd, dz, entrdd))
+        # Zero at and above the LFS (no inflow from above yet).
+        np.testing.assert_array_equal(ledger[:5, 0], 0.0)
+        # Bulk: entrdd·|mfd_in|·dz.
+        np.testing.assert_allclose(
+            ledger[5:nlev - 2, 0], entrdd * 0.02 * dz_val, rtol=1e-6,
+        )
+        # Surface taper: entrainment shut off (Fortran itopde).
+        np.testing.assert_array_equal(ledger[nlev - 2:, 0], 0.0)
+
+    def test_dead_downdraft_has_zero_ledger(self):
+        # Buoyancy shut-off (mfd == 0 with inflow above): no entrainment,
+        # so plume continuity dumps the arriving flux as detrainment.
+        lev = jnp.arange(10)[:, None]
+        mfd = jnp.where((lev >= 3) & (lev <= 5), -0.02, 0.0)
+        ledger = np.asarray(downdraft_entrainment_ledger(
+            mfd, jnp.full((10, 1), 400.0), 2.0e-4,
+        ))
+        self.assertEqual(float(ledger[6, 0]), 0.0)
+
+    def test_column_and_block_shapes_agree(self):
+        # Broadcasting-native: a (nlev,) column and a (nlev, ncols) block
+        # must agree per column.
+        lev = jnp.arange(10)
+        mfd_col = jnp.where((lev >= 4) & (lev < 8), -0.02, 0.0)
+        dz_col = jnp.full(10, 400.0)
+        col = np.asarray(downdraft_entrainment_ledger(mfd_col, dz_col, 2e-4))
+        block = np.asarray(downdraft_entrainment_ledger(
+            mfd_col[:, None] * jnp.ones((1, 3)),
+            dz_col[:, None] * jnp.ones((1, 3)), 2e-4,
+        ))
+        for c in range(3):
+            np.testing.assert_allclose(block[:, c], col)
 
 
 if __name__ == "__main__":

--- a/jcm/physics/convection/tiedtke_nordeng/tiedtke_nordeng.py
+++ b/jcm/physics/convection/tiedtke_nordeng/tiedtke_nordeng.py
@@ -1178,14 +1178,23 @@ class TiedtkeConvection(PhysicsTerm):
             _entrain = (
                 _state_all.entr.T * _mfu_below * layer_thickness
             )
+            # Downdraft ledger (#622): linear in mfd, so the cap scaling
+            # already applied to ``_mfd`` carries through exactly.
+            # Function-level import: downdraft.py imports from this module.
+            from .downdraft import downdraft_entrainment_ledger
+            _entrain_dn = downdraft_entrainment_ledger(
+                _mfd, layer_thickness, params.entrdd,
+            )
         else:
             _mfu = jnp.zeros_like(pressure_full)
             _mfd = jnp.zeros_like(pressure_full)
             _entrain = jnp.zeros_like(pressure_full)
+            _entrain_dn = jnp.zeros_like(pressure_full)
         convection = ConvectionData(
             mass_flux_up=_mfu,
             mass_flux_down=_mfd,
             entrain_up=_entrain,
+            entrain_down=_entrain_dn,
             cloud_base=jnp.zeros(ncols, dtype=int),
             cloud_top=jnp.zeros(ncols, dtype=int),
             cape=jnp.zeros(ncols),

--- a/jcm/physics/convection/tiedtke_nordeng/types.py
+++ b/jcm/physics/convection/tiedtke_nordeng/types.py
@@ -180,16 +180,20 @@ class ConvectionData:
     ``convection.<field>``). The ``cloud_base`` / ``cloud_top`` / ``cape``
     fields are reserved for the future port of the equivalent ECHAM
     diagnostics; they are zero-filled today. ``mass_flux_up``/``down`` and
-    ``entrain_up`` are populated (post-rescale, post-cap — the same ledger
-    scaling as the tendencies) for the convective tracer transport
-    (#602): the updraft flux at each layer's TOP interface, and the
-    absolute per-layer entrainment flux; per-layer detrainment follows
-    from plume continuity, so it is not stored separately.
+    ``entrain_up``/``entrain_down`` are populated (post-rescale, post-cap —
+    the same ledger scaling as the tendencies) for the convective tracer
+    transport (#602, #622): the updraft flux at each layer's TOP
+    interface, the downdraft flux at each layer's BOTTOM interface (the
+    downdraft scan's convention), and the absolute per-layer entrainment
+    fluxes; per-layer detrainment follows from plume continuity, so it is
+    not stored separately.
     """
 
     mass_flux_up: jnp.ndarray        # Updraft mass flux [kg/m²/s] (nlev, ncols)
     mass_flux_down: jnp.ndarray      # Downdraft mass flux [kg/m²/s] (nlev, ncols)
     entrain_up: jnp.ndarray          # Updraft entrainment flux per layer
+                                     # [kg/m²/s] (nlev, ncols)
+    entrain_down: jnp.ndarray        # Downdraft entrainment flux per layer
                                      # [kg/m²/s] (nlev, ncols)
     cloud_base: jnp.ndarray          # Cloud base level index (ncols,)
     cloud_top: jnp.ndarray           # Cloud top level index (ncols,)
@@ -221,6 +225,7 @@ class ConvectionData:
             mass_flux_up=jnp.zeros((nlev,) + nodal_shape),
             mass_flux_down=jnp.zeros((nlev,) + nodal_shape),
             entrain_up=jnp.zeros((nlev,) + nodal_shape),
+            entrain_down=jnp.zeros((nlev,) + nodal_shape),
             cloud_base=jnp.zeros(nodal_shape, dtype=int),
             cloud_top=jnp.zeros(nodal_shape, dtype=int),
             cape=jnp.zeros(nodal_shape),

--- a/jcm/physics/convection/tracer_transport.py
+++ b/jcm/physics/convection/tracer_transport.py
@@ -243,9 +243,11 @@ def convective_tracer_tendency(
         # concentration would INJECT plume mass and drive the wet_*
         # ledger negative (same floor WetScavenging applies to its
         # removal reads). Transport of the signed value is untouched.
+        # ``w`` reshapes against q_mix's rank so a bare (K, nlev) column
+        # works the same as a (K, nlev, ncols) block.
         removed = (
-            w[:, jnp.newaxis] * frac_k[jnp.newaxis]
-            * jnp.maximum(q_mix, 0.0)
+            w.reshape((-1,) + (1,) * (q_mix.ndim - 1))
+            * frac_k[jnp.newaxis] * jnp.maximum(q_mix, 0.0)
         )
         q_up_k = q_mix - removed
         r_k = m_up_k[jnp.newaxis] * removed           # (K, ncols) flux

--- a/jcm/physics/convection/tracer_transport.py
+++ b/jcm/physics/convection/tracer_transport.py
@@ -238,7 +238,15 @@ def convective_tracer_tendency(
             / jnp.maximum(denom, _MF_FLOOR)[jnp.newaxis],
             q_k,
         )
-        removed = w[:, jnp.newaxis] * frac_k[jnp.newaxis] * q_mix
+        # Scavenge only the nonnegative part: spectral ringing leaves
+        # negative lobes on near-zero tracers, and removing a negative
+        # concentration would INJECT plume mass and drive the wet_*
+        # ledger negative (same floor WetScavenging applies to its
+        # removal reads). Transport of the signed value is untouched.
+        removed = (
+            w[:, jnp.newaxis] * frac_k[jnp.newaxis]
+            * jnp.maximum(q_mix, 0.0)
+        )
         q_up_k = q_mix - removed
         r_k = m_up_k[jnp.newaxis] * removed           # (K, ncols) flux
         return q_up_k, (q_up_k, r_k)

--- a/jcm/physics/convection/tracer_transport.py
+++ b/jcm/physics/convection/tracer_transport.py
@@ -4,15 +4,16 @@ ECHAM transports every tracer through Tiedtke convection (the
 ``cuxtte``/``mo_cuascn`` xt budgeting) and CAM's ``convtran`` does the
 same for constituents; jcm applied the convective mass fluxes only to
 heat, moisture and momentum (#602 item 2). This term closes that gap for
-an explicit tracer list using the profiles the Tiedtke term now publishes
+an explicit tracer list using the profiles the Tiedtke term publishes
 in ``ConvectionData``: the updraft mass flux at each layer's top
-interface (``mass_flux_up``) and the absolute per-layer entrainment flux
-(``entrain_up``), both carrying the scheme's rescale + cap ledger
-scaling, so tracer transport is proportional to the heat and moisture
-transport actually applied.
+interface (``mass_flux_up``), the downdraft mass flux at each layer's
+bottom interface (``mass_flux_down``), and the absolute per-layer
+entrainment fluxes (``entrain_up``/``entrain_down``), all carrying the
+scheme's rescale + cap ledger scaling, so tracer transport is
+proportional to the heat and moisture transport actually applied.
 
 The scheme is a bulk entraining/detraining plume with compensating
-subsidence:
+subsidence, plus the mirrored downdraft leg (jax-gcm#622):
 
 * Per-layer detrainment is derived from plume continuity,
   ``D_k = max(E_raw_k − (M_k − M_{k+1}), 0)`` with the effective
@@ -24,21 +25,44 @@ subsidence:
   ``q_up_k = (M_{k+1}·q_up_{k+1} + E_k·q_k) / (M_{k+1} + E_k)`` — a
   convex mix, so the plume concentration is bounded by the environment
   profile it entrained.
+* The downdraft (ECHAM ``cudlfs``/``cuddraf``, CAM ``convtran``'s
+  ``cond`` loop) is the mirror image: the same continuity derivation on
+  the downdraft profile turns the level-of-free-sinking seed into
+  entrainment of that layer's air and the surface taper into sub-cloud
+  detrainment, and a downward scan carries the in-downdraft
+  concentration. Deviation from the Fortran: ``cudlfs`` seeds the
+  downdraft with a 50/50 updraft/wet-bulb-environment mix, which moves
+  plume-processed air across without a matching debit in the updraft
+  budget; entraining environment air instead keeps the column budget
+  telescoping exactly (CAM's downdraft does the same — environment
+  entrainment only, "no transformation or removal is applied in the
+  downdraft").
 * Environment tendency in flux form: detrainment source, entrainment
-  sink, and compensating subsidence between (downward advection of
-  environment air at the interface updraft flux). Column tracer mass is
-  conserved exactly (the subsidence fluxes telescope; the plume's own
-  budget closes by construction).
+  sink, and the compensating advection between (downward at the updraft
+  interface flux, upward at the downdraft interface flux). Column tracer
+  mass is conserved exactly up to the scavenging sink (all flux sums
+  telescope; each plume's own budget closes by construction).
 
-Downdraft tracer transport is not included yet (``mass_flux_down`` is
-published for it; the downdraft entrainment ledger is not) — tracked in
-jax-gcm#622, typically a ~30% correction on the updraft circulation.
-Likewise not included: in-plume scavenging of soluble aerosol (ECHAM
-``cuscav`` removes a large fraction of what the updraft carries before
-it detrains; here the plume is conservative and the convective wet
-removal lives separately in the JAM wetdep term), tracked in
-jax-gcm#621 — expect a high bias in upper-tropospheric soluble aerosol
-in deep convective regions until it lands. Explicit stability: the per-column ledger is scaled so the
+In-plume scavenging (jax-gcm#621) follows CAM's ``aero_convproc``
+(mirage2 form): the fraction of the plume's condensate converted to
+precipitation in a layer sets a first-order removal,
+``cdt = pdmfup / (M_u·q_cond)`` and removed fraction
+``w·(1 − exp(−cdt))``, applied to the in-plume concentration inside the
+ascent scan after entrainment mixing — so aerosol scavenged low in the
+plume never detrains aloft. The updraft-area fraction cancels in
+``cdt`` (CAM's Note1: the cam5 variant needs the unknown updraft
+fraction; the mirage2 form does not). ``w`` is a per-tracer weight
+(soluble/activatable modes only) times the differentiable
+``scav_ratio``; the removed flux deposits at the surface (like CAM's
+``dconudt_wetdep``; per-tracer surface fluxes are published under
+``_conv_scav_flux`` for the JAM wetdep ledger, which retires its own
+environment-profile convective in-cloud pathway when this one is
+active — jax-gcm#621's double-counting reconciliation). Aerosol
+resuspension by evaporating convective precip is not modelled (CAM's
+``dcondt_prevap``) — the removed flux goes straight to the surface,
+matching the existing wetdep treatment of convective scavenging.
+
+Explicit stability: the per-column ledger is scaled so the combined
 subsidence Courant number stays ≤ 1 (the scheme's own cloud-base CFL cap
 makes this a no-op in practice).
 
@@ -65,27 +89,54 @@ from jcm.physics_interface import PhysicsTendency
 #: squared-underflow window.
 _MF_FLOOR = 1.0e-10
 
+#: In-plume condensate threshold for scavenging [kg/kg] — CAM
+#: ``aero_convproc`` ``clw_cut``: below this the updraft is effectively
+#: precipitation-free and the removal-rate division is unreliable.
+_CLW_CUT = 1.0e-6
+
 
 @tree_math.struct
 class ConvTransportParameters:
-    """Tunable knob for convective tracer transport (differentiable)."""
+    """Tunable knobs for convective tracer transport (differentiable)."""
 
     transport_scale: jnp.ndarray   # multiplies the mass-flux ledger
+    scav_ratio: jnp.ndarray        # in-plume scavenging ratio for soluble
+                                   # tracers [-] (CAM ``aqfrac`` analogue)
 
     @classmethod
     def default(cls) -> "ConvTransportParameters":
-        return cls(transport_scale=jnp.asarray(1.0))
+        # scav_ratio mirrors the JAM wetdep ``conv_scav_ratio`` default it
+        # supersedes for transported species.
+        return cls(
+            transport_scale=jnp.asarray(1.0),
+            scav_ratio=jnp.asarray(0.99),
+        )
 
 
 def convective_tracer_tendency(
     q: jnp.ndarray,        # (K, nlev, ncols) tracer stack
     mfu: jnp.ndarray,      # (nlev, ncols) updraft flux at layer TOP [kg/m²/s]
-    entrain: jnp.ndarray,  # (nlev, ncols) per-layer entrainment flux [kg/m²/s]
+    entrain: jnp.ndarray,  # (nlev, ncols) per-layer updraft entrainment [kg/m²/s]
     air_density: jnp.ndarray,
     layer_thickness: jnp.ndarray,
     dt: jnp.ndarray,
-) -> jnp.ndarray:
-    """Bulk-plume + compensating-subsidence tracer tendency [.../s]."""
+    mfd: jnp.ndarray | None = None,          # (nlev, ncols) downdraft flux at
+                                             # layer BOTTOM [kg/m²/s], ≤ 0
+    entrain_down: jnp.ndarray | None = None,  # (nlev, ncols) per-layer
+                                              # downdraft entrainment [kg/m²/s]
+    scav_weights: jnp.ndarray | None = None,  # (K,) per-tracer removal weight
+    precip_formation: jnp.ndarray | None = None,  # (nlev, ncols) updraft
+                                                  # precip generation [kg/m²/s]
+    plume_condensate: jnp.ndarray | None = None,  # (nlev, ncols) in-updraft
+                                                  # qc+qi [kg/kg]
+) -> tuple[jnp.ndarray, jnp.ndarray]:
+    """Bulk-plume + subsidence tracer tendency and scavenged surface flux.
+
+    Returns ``(dq, scav_flux)``: the environment tendency [.../s] shaped
+    like ``q``, and the per-tracer scavenged surface flux
+    ``(K, ncols)`` [tracer·kg/m²/s] satisfying
+    ``sum_k(dq·dm) = −scav_flux`` exactly (zero without scavenging).
+    """
     dm = air_density * layer_thickness
     mfu = jnp.maximum(mfu, 0.0)
     # No flux through the model top: a residual plume reaching the top
@@ -104,9 +155,9 @@ def convective_tracer_tendency(
     # (mfu + E) per layer never forms. With thin layers aloft (generic in
     # hybrid coordinates) the wrong guard let the sink exceed 1 and drove
     # detrainment-layer tracers negative (adversarial review, confirmed
-    # repro). All four ledger arrays are positively homogeneous in
-    # (mfu, entrain), so scaling AFTER the derivation is exactly linear
-    # and preserves continuity and column conservation.
+    # repro). All ledger arrays are positively homogeneous in the mass
+    # fluxes, so scaling AFTER the derivation is exactly linear and
+    # preserves continuity and column conservation.
     mfu_below = jnp.concatenate(
         [mfu[1:], jnp.zeros_like(mfu[:1])], axis=0
     )
@@ -114,18 +165,72 @@ def convective_tracer_tendency(
     detrain = jnp.maximum(entrain - delta, 0.0)
     entrain_eff = detrain + delta                     # >= 0 by construction
 
+    # Downdraft ledger (jax-gcm#622), mirrored: ``mfd[k]`` is the flux
+    # leaving layer k through its BOTTOM interface (the downdraft scan's
+    # convention — the taper halves then land in the two lowest layers
+    # exactly as cuddraf's ``itopde`` split), so the flux entering from
+    # above is ``mfd[k-1]``. Magnitudes throughout; the bottom layer's
+    # outflow is forced to zero (no flux through the surface — a residual
+    # detrains there via continuity, mirroring the model-top handling).
+    if mfd is not None:
+        md_out = jnp.maximum(-mfd, 0.0)
+        md_out = md_out.at[-1].set(0.0)
+        md_in = jnp.concatenate(
+            [jnp.zeros_like(md_out[:1]), md_out[:-1]], axis=0
+        )
+        e_dn_raw = (
+            jnp.maximum(entrain_down, 0.0)
+            if entrain_down is not None else jnp.zeros_like(md_out)
+        )
+        delta_dn = md_out - md_in                     # E − D per layer
+        detrain_dn = jnp.maximum(e_dn_raw - delta_dn, 0.0)
+        entrain_dn = detrain_dn + delta_dn            # >= 0 by construction
+    else:
+        md_out = md_in = detrain_dn = entrain_dn = jnp.zeros_like(mfu)
+
+    # Combined Courant guard: both legs remove environment air from layer
+    # k at (E_up_eff + mfu_below) + (E_dn_eff + md_in); one shared scale
+    # keeps the two circulations proportional.
     courant = jnp.max(
-        (entrain_eff + mfu_below) * dt / dm, axis=0, keepdims=True,
+        (entrain_eff + mfu_below + entrain_dn + md_in) * dt / dm,
+        axis=0, keepdims=True,
     )
     scale = jnp.minimum(1.0, 1.0 / jnp.maximum(courant, 1.0))
     mfu = mfu * scale
     mfu_below = mfu_below * scale
     detrain = detrain * scale
     entrain_eff = entrain_eff * scale
+    md_out = md_out * scale
+    md_in = md_in * scale
+    detrain_dn = detrain_dn * scale
+    entrain_dn = entrain_dn * scale
 
-    # Upward plume scan for the in-plume concentration (surface -> top).
+    # In-plume scavenging profile (jax-gcm#621, CAM aero_convproc
+    # mirage2 form): cdt = precip formed / plume condensate flux is the
+    # first-order removal exponent over the layer transit — the updraft
+    # area fraction cancels. Gated exactly like CAM: only where the
+    # plume holds condensate and precip actually forms.
+    m_up = mfu_below + entrain_eff                    # post-mix plume flux
+    if scav_weights is not None:
+        pf = jnp.maximum(precip_formation, 0.0)
+        cond_flux = m_up * jnp.maximum(plume_condensate, 0.0)
+        cdt = jnp.where(
+            (pf > 0.0) & (plume_condensate > _CLW_CUT) & (m_up > _MF_FLOOR),
+            pf / jnp.maximum(cond_flux, _MF_FLOOR * _CLW_CUT),
+            0.0,
+        )
+        base_frac = -jnp.expm1(-cdt)                  # ∈ [0, 1)
+        w = jnp.clip(scav_weights, 0.0, 1.0)
+    else:
+        base_frac = jnp.zeros_like(m_up)
+        w = jnp.zeros(q.shape[0], dtype=q.dtype)
+
+    # Upward plume scan for the in-plume concentration (surface -> top),
+    # removing the scavenged share right after entrainment mixing (CAM
+    # applies dconudt_wetdep to conu inside the same ascent loop) so what
+    # detrains aloft is the already-scavenged concentration.
     def ascend(q_up_below, xs):
-        m_below_k, e_k, q_k = xs                      # (ncols,), (ncols,), (K, ncols)
+        m_below_k, e_k, q_k, m_up_k, frac_k = xs
         denom = m_below_k + e_k
         q_mix = jnp.where(
             (denom > _MF_FLOOR)[jnp.newaxis],
@@ -133,34 +238,67 @@ def convective_tracer_tendency(
             / jnp.maximum(denom, _MF_FLOOR)[jnp.newaxis],
             q_k,
         )
-        return q_mix, q_mix
+        removed = w[:, jnp.newaxis] * frac_k[jnp.newaxis] * q_mix
+        q_up_k = q_mix - removed
+        r_k = m_up_k[jnp.newaxis] * removed           # (K, ncols) flux
+        return q_up_k, (q_up_k, r_k)
 
     q_lev = jnp.moveaxis(q, 1, 0)                     # (nlev, K, ncols)
-    _, q_up_rev = jax.lax.scan(
+    _, (q_up_rev, r_rev) = jax.lax.scan(
         ascend,
         q_lev[-1],                                    # seeded, overwritten at base
-        (mfu_below, entrain_eff, q_lev),
+        (mfu_below, entrain_eff, q_lev, m_up, base_frac),
         reverse=True,
     )
     q_up = jnp.moveaxis(q_up_rev, 0, 1)               # (K, nlev, ncols)
+    scav_flux = jnp.sum(r_rev, axis=0)                # (K, ncols)
 
-    # Compensating subsidence: environment air enters each layer from
+    # Downward plume scan for the in-downdraft concentration (top ->
+    # surface) — cuddraf's tracer budget: mix the arriving flux with the
+    # layer's entrained environment air; detrainment leaves at the mixed
+    # concentration, so the plume budget closes exactly like the updraft.
+    def descend(q_dn_above, xs):
+        m_in_k, e_k, q_k = xs
+        denom = m_in_k + e_k
+        q_mix = jnp.where(
+            (denom > _MF_FLOOR)[jnp.newaxis],
+            (m_in_k[jnp.newaxis] * q_dn_above + e_k[jnp.newaxis] * q_k)
+            / jnp.maximum(denom, _MF_FLOOR)[jnp.newaxis],
+            q_k,
+        )
+        return q_mix, q_mix
+
+    _, q_dn_lev = jax.lax.scan(
+        descend,
+        q_lev[0],                                     # seeded, overwritten at LFS
+        (md_in, entrain_dn, q_lev),
+    )
+    q_dn = jnp.moveaxis(q_dn_lev, 0, 1)               # (K, nlev, ncols)
+
+    # Compensating advection: environment air enters each layer from
     # above at the layer-top updraft flux and leaves to the layer below
-    # at the layer-bottom flux. The top layer's "from above" is itself
-    # (no flux through the model top), which keeps the telescoping sum —
-    # and hence column conservation — exact.
+    # at the layer-bottom flux; the downdraft drives the mirror-image
+    # upward environment flow through its own interface fluxes. The top
+    # layer's "from above" is itself (no flux through the model top) and
+    # the bottom pads are dead (md_out[-1] = 0), which keeps the
+    # telescoping sums — and hence column conservation — exact.
     q_above = jnp.concatenate([q[:, :1], q[:, :-1]], axis=1)
+    q_below = jnp.concatenate([q[:, 1:], q[:, -1:]], axis=1)
     dq = (
         detrain[jnp.newaxis] * q_up
         - entrain_eff[jnp.newaxis] * q
         + mfu[jnp.newaxis] * q_above
         - mfu_below[jnp.newaxis] * q
+        + detrain_dn[jnp.newaxis] * q_dn
+        - entrain_dn[jnp.newaxis] * q
+        + md_out[jnp.newaxis] * q_below
+        - md_in[jnp.newaxis] * q
     ) / dm[jnp.newaxis]
-    return dq
+    return dq, scav_flux
 
 
 class ConvectiveTracerTransport(PhysicsTerm):
-    """Updraft + compensating-subsidence transport of an explicit tracer list."""
+    """Updraft + downdraft + subsidence transport of an explicit tracer list."""
 
     name: ClassVar[str] = "convective_tracer_transport"
     category: ClassVar[str] = "tracer_transport"
@@ -173,13 +311,30 @@ class ConvectiveTracerTransport(PhysicsTerm):
         self,
         tracer_names: tuple[str, ...],
         params: ConvTransportParameters | None = None,
+        scav_weights: tuple[float, ...] | None = None,
     ):
-        """Hold the tracer list and params."""
+        """Hold the tracer list, params and per-tracer scavenging weights.
+
+        ``scav_weights`` (aligned with ``tracer_names``) selects which
+        tracers the in-plume scavenging acts on — 1 for soluble aerosol,
+        0 for insoluble aerosol and gases; ``None`` disables scavenging
+        entirely. The static mask multiplies the differentiable
+        ``params.scav_ratio``.
+        """
         if not tracer_names:
             raise ValueError(
                 "ConvectiveTracerTransport needs a non-empty tracer list."
             )
+        if scav_weights is not None and len(scav_weights) != len(tracer_names):
+            raise ValueError(
+                "scav_weights must align with tracer_names: got "
+                f"{len(scav_weights)} weights for {len(tracer_names)} tracers."
+            )
         self._tracer_names = tuple(tracer_names)
+        self._scav_weights = (
+            tuple(float(x) for x in scav_weights)
+            if scav_weights is not None else None
+        )
         self.params = nnx.Param(params or ConvTransportParameters.default())
 
     def __call__(self, state, diagnostics, forcing, terrain):
@@ -193,17 +348,43 @@ class ConvectiveTracerTransport(PhysicsTerm):
             q = jnp.stack([
                 state.tracers.get(nm, zeros) for nm in self._tracer_names
             ])
-            dq = convective_tracer_tendency(
+            if self._scav_weights is not None:
+                scav_kwargs = dict(
+                    scav_weights=(
+                        jnp.asarray(self._scav_weights, dtype=q.dtype)
+                        * params.scav_ratio
+                    ),
+                    precip_formation=conv.precip_formation,
+                    plume_condensate=conv.qc_conv + conv.qi_conv,
+                )
+            else:
+                scav_kwargs = {}
+            dq, scav_flux = convective_tracer_tendency(
                 q,
                 params.transport_scale * conv.mass_flux_up,
                 params.transport_scale * conv.entrain_up,
                 diagnostics["air_density"],
                 diagnostics["layer_thickness"],
                 dt,
+                mfd=params.transport_scale * conv.mass_flux_down,
+                entrain_down=params.transport_scale * conv.entrain_down,
+                **scav_kwargs,
             )
             tracer_tends = {
                 nm: dq[k] for k, nm in enumerate(self._tracer_names)
             }
+            if self._scav_weights is not None:
+                # Per-tracer surface deposition of in-plume scavenged mass
+                # [kg/m²/s], for downstream wet-deposition bookkeeping
+                # (the JAM wetdep term folds these into the AeroCom
+                # ``wet_*`` fluxes). Underscore key: internal handoff,
+                # not a user-facing output field.
+                diagnostics = dict(diagnostics)
+                diagnostics["_conv_scav_flux"] = {
+                    nm: scav_flux[k]
+                    for k, nm in enumerate(self._tracer_names)
+                    if self._scav_weights[k] > 0.0
+                }
 
         tendency = PhysicsTendency(
             u_wind=jnp.zeros_like(state.u_wind),

--- a/jcm/physics/convection/tracer_transport.py
+++ b/jcm/physics/convection/tracer_transport.py
@@ -343,6 +343,10 @@ class ConvectiveTracerTransport(PhysicsTerm):
         zeros = jnp.zeros_like(state.temperature)
         if conv is None:
             tracer_tends = {nm: zeros for nm in self._tracer_names}
+            scav_flux = jnp.zeros(
+                (len(self._tracer_names),) + state.temperature.shape[1:],
+                dtype=state.temperature.dtype,
+            )
         else:
             dt = diagnostics.get("_dt_seconds", 1800.0)
             q = jnp.stack([
@@ -373,18 +377,22 @@ class ConvectiveTracerTransport(PhysicsTerm):
             tracer_tends = {
                 nm: dq[k] for k, nm in enumerate(self._tracer_names)
             }
-            if self._scav_weights is not None:
-                # Per-tracer surface deposition of in-plume scavenged mass
-                # [kg/m²/s], for downstream wet-deposition bookkeeping
-                # (the JAM wetdep term folds these into the AeroCom
-                # ``wet_*`` fluxes). Underscore key: internal handoff,
-                # not a user-facing output field.
-                diagnostics = dict(diagnostics)
-                diagnostics["_conv_scav_flux"] = {
-                    nm: scav_flux[k]
-                    for k, nm in enumerate(self._tracer_names)
-                    if self._scav_weights[k] > 0.0
-                }
+        if self._scav_weights is not None:
+            # Per-tracer surface deposition of in-plume scavenged mass
+            # [kg/m²/s], for downstream wet-deposition bookkeeping (the
+            # JAM wetdep term folds these into the AeroCom ``wet_*``
+            # fluxes). Underscore key: internal handoff, not a
+            # user-facing output field. Published UNCONDITIONALLY (zeros
+            # without a convection diagnostic): the diagnostics dict is a
+            # ``lax.scan`` carry, so its key set must not depend on
+            # whether the step had convection composed — the structural
+            # probe runs without it and the carry structures must match.
+            diagnostics = dict(diagnostics)
+            diagnostics["_conv_scav_flux"] = {
+                nm: scav_flux[k]
+                for k, nm in enumerate(self._tracer_names)
+                if self._scav_weights[k] > 0.0
+            }
 
         tendency = PhysicsTendency(
             u_wind=jnp.zeros_like(state.u_wind),

--- a/jcm/physics/convection/tracer_transport_test.py
+++ b/jcm/physics/convection/tracer_transport_test.py
@@ -343,6 +343,23 @@ class ScavengingTest(unittest.TestCase):
                 1e-6 * max(float(jnp.sum(jnp.abs(dq[k]) * dm)), 1e-30),
             )
 
+    def test_bare_column_matches_ncols_one(self):
+        # Broadcasting-native: (K, nlev) column inputs must agree with the
+        # same column as a (K, nlev, 1) block (the SCM driver shape).
+        q, mfu, entrain, rho, dz, cond, pf = self._setup()
+        args3 = dict(scav_weights=jnp.asarray([1.0, 0.5]),
+                     precip_formation=pf, plume_condensate=cond)
+        dq3, scav3 = convective_tracer_tendency(
+            q, mfu, entrain, rho, dz, 1800.0, **args3)
+        dq1, scav1 = convective_tracer_tendency(
+            q[..., 0], mfu[:, 0], entrain[:, 0], rho[:, 0], dz[:, 0],
+            1800.0, scav_weights=jnp.asarray([1.0, 0.5]),
+            precip_formation=pf[:, 0], plume_condensate=cond[:, 0])
+        np.testing.assert_allclose(np.asarray(dq1), np.asarray(dq3[..., 0]),
+                                   rtol=1e-6, atol=1e-30)
+        np.testing.assert_allclose(np.asarray(scav1),
+                                   np.asarray(scav3[:, 0]), rtol=1e-6)
+
     def test_dry_plume_scavenges_nothing(self):
         # No condensate (below CAM's clw_cut) -> gate closed everywhere.
         q, mfu, entrain, rho, dz, _, pf = self._setup()

--- a/jcm/physics/convection/tracer_transport_test.py
+++ b/jcm/physics/convection/tracer_transport_test.py
@@ -1,4 +1,4 @@
-"""Tests for the convective bulk-plume tracer transport (#602 item 2)."""
+"""Tests for the convective bulk-plume tracer transport (#602, #621, #622)."""
 
 import unittest
 
@@ -30,6 +30,32 @@ def _plume(nlev=10, ncols=1, base=8, top=3, mf=0.05):
     return mfu, entrain
 
 
+def _downdraft(nlev=10, ncols=1, lfs=4, mf=0.02, entrdd=2.0e-4, dz=400.0):
+    """Synthetic downdraft mirroring the Tiedtke scan's conventions.
+
+    ``mfd[k]`` (≤ 0) is the flux leaving layer k through its BOTTOM
+    interface: the LFS seed at ``lfs``, constant through the bulk, halved
+    in the second-to-last layer and zero in the last (the cuddraf
+    ``itopde`` taper). ``entrain_down`` is the cuddraf turbulent ledger
+    ``entrdd·|mfd_in|·dz`` in the bulk, zero in the taper.
+    """
+    lev = jnp.arange(nlev)[:, None]
+    mfd = jnp.where((lev >= lfs) & (lev < nlev - 2), -mf, 0.0)
+    mfd = mfd.at[nlev - 2].set(-0.5 * mf)
+    mfd = jnp.broadcast_to(mfd, (nlev, ncols))
+    mfd_in = jnp.concatenate([jnp.zeros((1, ncols)), mfd[:-1]], axis=0)
+    e_dn = jnp.where(
+        (mfd < 0) & (lev < nlev - 2), entrdd * jnp.abs(mfd_in) * dz, 0.0
+    )
+    return mfd, e_dn
+
+
+def _column_budgets(dq, dm):
+    net = float(jnp.sum(dq * dm[jnp.newaxis]))
+    gross = float(jnp.sum(jnp.abs(dq) * dm[jnp.newaxis]))
+    return net, gross
+
+
 class ConvectiveTendencyTest(unittest.TestCase):
     def _grid(self, nlev=10, ncols=1):
         rho = jnp.linspace(0.4, 1.2, nlev)[:, None] * jnp.ones((1, ncols))
@@ -43,10 +69,8 @@ class ConvectiveTendencyTest(unittest.TestCase):
             jnp.linspace(2.0, 0.1, 10)[:, None] ** 2 * 1e-9
             * jnp.ones((1, 1)),
         ])
-        dq = convective_tracer_tendency(q, mfu, entrain, rho, dz, 1800.0)
-        dm = rho * dz
-        net = float(jnp.sum(dq * dm[jnp.newaxis]))
-        gross = float(jnp.sum(jnp.abs(dq) * dm[jnp.newaxis]))
+        dq, _ = convective_tracer_tendency(q, mfu, entrain, rho, dz, 1800.0)
+        net, gross = _column_budgets(dq, rho * dz)
         self.assertGreater(gross, 0.0, "plume did nothing — fixture off")
         self.assertLessEqual(abs(net), 1e-6 * gross)
 
@@ -56,7 +80,7 @@ class ConvectiveTendencyTest(unittest.TestCase):
         rho, dz = self._grid()
         mfu, entrain = _plume(base=8, top=3)
         q = jnp.zeros((1, 10, 1)).at[0, 8:].set(1.0e-9)
-        dq = convective_tracer_tendency(q, mfu, entrain, rho, dz, 1800.0)
+        dq, _ = convective_tracer_tendency(q, mfu, entrain, rho, dz, 1800.0)
         # Detrainment lands in the layer ABOVE the last carrying interface
         # (mfu is the layer-TOP flux, so the plume dies inside level top-1).
         self.assertGreater(float(dq[0, 2, 0]), 0.0)
@@ -69,7 +93,7 @@ class ConvectiveTendencyTest(unittest.TestCase):
         rho, dz = self._grid()
         mfu, entrain = _plume()
         q0 = jnp.linspace(0.0, 1.0e-9, 10)[:, None][jnp.newaxis]
-        dq = convective_tracer_tendency(q0, mfu, entrain, rho, dz, 1800.0)
+        dq, _ = convective_tracer_tendency(q0, mfu, entrain, rho, dz, 1800.0)
         q1 = q0 + 1800.0 * dq
         self.assertGreaterEqual(float(q1.min()), -1e-25)
         self.assertLessEqual(float(q1.max()), 1.0e-9 * (1.0 + 1e-6))
@@ -81,10 +105,8 @@ class ConvectiveTendencyTest(unittest.TestCase):
         mfu = jnp.full((10, 1), 0.05)
         entrain = jnp.zeros((10, 1)).at[9].set(0.05)
         q = jnp.stack([jnp.linspace(1.0, 0.1, 10)[:, None] * 1e-9])
-        dq = convective_tracer_tendency(q, mfu, entrain, rho, dz, 1800.0)
-        dm = rho * dz
-        net = float(jnp.sum(dq * dm[jnp.newaxis]))
-        gross = float(jnp.sum(jnp.abs(dq) * dm[jnp.newaxis]))
+        dq, _ = convective_tracer_tendency(q, mfu, entrain, rho, dz, 1800.0)
+        net, gross = _column_budgets(dq, rho * dz)
         self.assertLessEqual(abs(net), 1e-6 * max(gross, 1e-30))
 
     def test_thin_detrainment_layer_stays_bounded(self):
@@ -107,31 +129,36 @@ class ConvectiveTendencyTest(unittest.TestCase):
         # Tracer concentrated in the detrainment layer (level 0): the
         # over-drained case.
         q = jnp.zeros((1, nlev, 1)).at[0, 0].set(1.0)
-        dq = convective_tracer_tendency(q, mfu, entrain, rho, dz, dt)
+        dq, _ = convective_tracer_tendency(q, mfu, entrain, rho, dz, dt)
         q1 = q + dt * dq
         self.assertGreaterEqual(float(q1.min()), -1e-9)
         # Bounded-in-[0,1] tracer cannot exceed 1 either.
         q = jnp.ones((1, nlev, 1))
-        dq = convective_tracer_tendency(q, mfu, entrain, rho, dz, dt)
+        dq, _ = convective_tracer_tendency(q, mfu, entrain, rho, dz, dt)
         q1 = q + dt * dq
         self.assertLessEqual(float(q1.max()), 1.0 + 1e-9)
         self.assertGreaterEqual(float(q1.min()), -1e-9)
 
     def test_conserves_with_distinct_tracers_and_columns(self):
-        # K=2 tracers x 2 distinct columns: a transposed (K, ncols) carry
-        # in the plume scan mixes them and breaks the per-tracer,
-        # per-column budgets.
+        # K=2 tracers x 2 distinct columns, both legs active: a transposed
+        # (K, ncols) carry in either plume scan mixes them and breaks the
+        # per-tracer, per-column budgets.
         nlev = 10
         rho = jnp.linspace(0.4, 1.2, nlev)[:, None] * jnp.ones((1, 2))
         dz = jnp.full((nlev, 2), 400.0)
         mfu, entrain = _plume(ncols=2)
         mfu = mfu * jnp.asarray([1.0, 0.5])[None, :]
         entrain = entrain * jnp.asarray([1.0, 0.5])[None, :]
+        mfd, e_dn = _downdraft(ncols=2)
+        mfd = mfd * jnp.asarray([1.0, 0.5])[None, :]
+        e_dn = e_dn * jnp.asarray([1.0, 0.5])[None, :]
         q = jnp.stack([
             jnp.zeros((nlev, 2)).at[8:].set(1.0e-9),
             jnp.linspace(1.0, 0.2, nlev)[:, None] * jnp.ones((1, 2)) * 1e-8,
         ])
-        dq = convective_tracer_tendency(q, mfu, entrain, rho, dz, 1800.0)
+        dq, _ = convective_tracer_tendency(
+            q, mfu, entrain, rho, dz, 1800.0, mfd=mfd, entrain_down=e_dn,
+        )
         dm = rho * dz
         for k in range(2):
             for col in range(2):
@@ -144,11 +171,14 @@ class ConvectiveTendencyTest(unittest.TestCase):
     def test_huge_mass_flux_stays_positive(self):
         # The per-column CFL rescale bounds the explicit update: even a
         # mass flux that would empty a layer many times over cannot drive
-        # a tracer negative.
+        # a tracer negative — with the downdraft leg adding to the sink.
         rho, dz = self._grid()
         mfu, entrain = _plume(mf=50.0)
+        mfd, e_dn = _downdraft(mf=20.0)
         q = jnp.zeros((1, 10, 1)).at[0, 8:].set(1.0e-9)
-        dq = convective_tracer_tendency(q, mfu, entrain, rho, dz, 1800.0)
+        dq, _ = convective_tracer_tendency(
+            q, mfu, entrain, rho, dz, 1800.0, mfd=mfd, entrain_down=e_dn,
+        )
         q1 = q + 1800.0 * dq
         self.assertGreaterEqual(float(q1.min()), -1e-25)
         self.assertTrue(bool(jnp.all(jnp.isfinite(dq))))
@@ -156,20 +186,168 @@ class ConvectiveTendencyTest(unittest.TestCase):
     def test_no_mass_flux_no_tendency(self):
         rho, dz = self._grid()
         q = jnp.ones((1, 10, 1)) * 1e-9
-        dq = convective_tracer_tendency(
+        dq, scav = convective_tracer_tendency(
             q, jnp.zeros((10, 1)), jnp.zeros((10, 1)), rho, dz, 1800.0,
+            mfd=jnp.zeros((10, 1)), entrain_down=jnp.zeros((10, 1)),
         )
         np.testing.assert_array_equal(np.asarray(dq), 0.0)
+        np.testing.assert_array_equal(np.asarray(scav), 0.0)
+
+
+class DowndraftLegTest(unittest.TestCase):
+    """The mfd side of the transport (jax-gcm#622)."""
+
+    def _grid(self, nlev=10, ncols=1):
+        rho = jnp.linspace(0.4, 1.2, nlev)[:, None] * jnp.ones((1, ncols))
+        dz = jnp.full((nlev, ncols), 400.0)
+        return rho, dz
+
+    def test_downdraft_conserves_column_mass_exactly(self):
+        rho, dz = self._grid()
+        mfd, e_dn = _downdraft()
+        q = jnp.stack([
+            (jnp.linspace(0.3, 2.0, 10)[:, None]) ** 2 * 1e-9
+            * jnp.ones((1, 1)),
+        ])
+        dq, _ = convective_tracer_tendency(
+            q, jnp.zeros((10, 1)), jnp.zeros((10, 1)), rho, dz, 1800.0,
+            mfd=mfd, entrain_down=e_dn,
+        )
+        net, gross = _column_budgets(dq, rho * dz)
+        self.assertGreater(gross, 0.0, "downdraft did nothing — fixture off")
+        self.assertLessEqual(abs(net), 1e-6 * gross)
+
+    def test_downdraft_carries_lfs_air_into_subcloud(self):
+        # A tracer confined to the LFS layer must appear in the two
+        # sub-cloud taper layers (where the descent detrains) and be
+        # reduced at the LFS (where the seed mass is entrained).
+        rho, dz = self._grid()
+        mfd, e_dn = _downdraft(lfs=4)
+        q = jnp.zeros((1, 10, 1)).at[0, 4].set(1.0e-9)
+        dq, _ = convective_tracer_tendency(
+            q, jnp.zeros((10, 1)), jnp.zeros((10, 1)), rho, dz, 1800.0,
+            mfd=mfd, entrain_down=e_dn,
+        )
+        self.assertLess(float(dq[0, 4, 0]), 0.0)
+        self.assertGreater(float(dq[0, 8, 0]), 0.0)
+        self.assertGreater(float(dq[0, 9, 0]), 0.0)
+
+    def test_downdraft_plume_bounded_by_environment(self):
+        # The descent is a convex mix all the way down: no new extrema.
+        rho, dz = self._grid()
+        mfd, e_dn = _downdraft()
+        q0 = jnp.linspace(1.0e-9, 0.0, 10)[:, None][jnp.newaxis]
+        dq, _ = convective_tracer_tendency(
+            q0, jnp.zeros((10, 1)), jnp.zeros((10, 1)), rho, dz, 1800.0,
+            mfd=mfd, entrain_down=e_dn,
+        )
+        q1 = q0 + 1800.0 * dq
+        self.assertGreaterEqual(float(q1.min()), -1e-25)
+        self.assertLessEqual(float(q1.max()), 1.0e-9 * (1.0 + 1e-6))
+
+    def test_downdraft_dying_middescent_still_conserves(self):
+        # Buoyancy shut-off mid-column (mfd -> 0 with inflow above):
+        # continuity must dump the arriving flux as detrainment there.
+        rho, dz = self._grid()
+        lev = jnp.arange(10)[:, None]
+        mfd = jnp.where((lev >= 3) & (lev <= 5), -0.02, 0.0)
+        e_dn = jnp.where((lev > 3) & (lev <= 5), 2.0e-4 * 0.02 * 400.0, 0.0)
+        q = jnp.stack([jnp.linspace(0.5, 1.5, 10)[:, None] * 1e-9])
+        dq, _ = convective_tracer_tendency(
+            q, jnp.zeros((10, 1)), jnp.zeros((10, 1)), rho, dz, 1800.0,
+            mfd=mfd, entrain_down=e_dn,
+        )
+        net, gross = _column_budgets(dq, rho * dz)
+        self.assertGreater(gross, 0.0)
+        self.assertLessEqual(abs(net), 1e-6 * gross)
+
+
+class ScavengingTest(unittest.TestCase):
+    """CAM aero_convproc-style in-plume removal (jax-gcm#621)."""
+
+    def _setup(self, nlev=10, ncols=1):
+        rho = jnp.linspace(0.4, 1.2, nlev)[:, None] * jnp.ones((1, ncols))
+        dz = jnp.full((nlev, ncols), 400.0)
+        mfu, entrain = _plume(nlev=nlev, ncols=ncols)
+        # Condensate and precip formation inside the cloudy layers only.
+        lev = jnp.arange(nlev)[:, None]
+        cloudy = (lev >= 4) & (lev <= 7)
+        cond = jnp.where(cloudy, 5.0e-4, 0.0) * jnp.ones((1, ncols))
+        pf = jnp.where(cloudy, 1.0e-5, 0.0) * jnp.ones((1, ncols))
+        q = jnp.stack([
+            jnp.zeros((nlev, ncols)).at[8:].set(1.0e-9),
+            jnp.zeros((nlev, ncols)).at[8:].set(1.0e-9),
+        ])
+        return q, mfu, entrain, rho, dz, cond, pf
+
+    def test_budget_closes_to_scavenged_flux(self):
+        # Column change must equal MINUS the scavenged surface flux,
+        # per tracer, exactly.
+        q, mfu, entrain, rho, dz, cond, pf = self._setup()
+        dq, scav = convective_tracer_tendency(
+            q, mfu, entrain, rho, dz, 1800.0,
+            scav_weights=jnp.asarray([1.0, 0.5]),
+            precip_formation=pf, plume_condensate=cond,
+        )
+        dm = rho * dz
+        for k in range(2):
+            net = float(jnp.sum(dq[k] * dm))
+            self.assertGreater(float(scav[k, 0]), 0.0)
+            self.assertLessEqual(
+                abs(net + float(scav[k, 0])),
+                1e-6 * float(jnp.sum(jnp.abs(dq[k]) * dm)),
+            )
+
+    def test_scavenging_thins_what_detrains_aloft(self):
+        # With removal inside the ascent, less tracer survives to the
+        # detrainment layers than in the conservative plume.
+        q, mfu, entrain, rho, dz, cond, pf = self._setup()
+        dq0, _ = convective_tracer_tendency(q, mfu, entrain, rho, dz, 1800.0)
+        dq1, _ = convective_tracer_tendency(
+            q, mfu, entrain, rho, dz, 1800.0,
+            scav_weights=jnp.asarray([1.0, 1.0]),
+            precip_formation=pf, plume_condensate=cond,
+        )
+        self.assertLess(float(dq1[0, 2, 0]), float(dq0[0, 2, 0]))
+
+    def test_zero_weights_recover_conservative_plume(self):
+        q, mfu, entrain, rho, dz, cond, pf = self._setup()
+        dq0, _ = convective_tracer_tendency(q, mfu, entrain, rho, dz, 1800.0)
+        dq1, scav = convective_tracer_tendency(
+            q, mfu, entrain, rho, dz, 1800.0,
+            scav_weights=jnp.zeros(2),
+            precip_formation=pf, plume_condensate=cond,
+        )
+        np.testing.assert_allclose(np.asarray(dq1), np.asarray(dq0))
+        np.testing.assert_array_equal(np.asarray(scav), 0.0)
+
+    def test_dry_plume_scavenges_nothing(self):
+        # No condensate (below CAM's clw_cut) -> gate closed everywhere.
+        q, mfu, entrain, rho, dz, _, pf = self._setup()
+        _, scav = convective_tracer_tendency(
+            q, mfu, entrain, rho, dz, 1800.0,
+            scav_weights=jnp.ones(2),
+            precip_formation=pf,
+            plume_condensate=jnp.full(mfu.shape, 1.0e-7),
+        )
+        np.testing.assert_array_equal(np.asarray(scav), 0.0)
 
 
 class _Conv:
-    def __init__(self, mfu, entrain):
+    def __init__(self, mfu, entrain, mfd=None, e_dn=None, pf=None, cond=None):
+        zeros = jnp.zeros_like(mfu)
         self.mass_flux_up = mfu
         self.entrain_up = entrain
+        self.mass_flux_down = mfd if mfd is not None else zeros
+        self.entrain_down = e_dn if e_dn is not None else zeros
+        self.precip_formation = pf if pf is not None else zeros
+        self.qc_conv = cond if cond is not None else zeros
+        self.qi_conv = zeros
 
 
 class ConvectiveTracerTransportTermTest(unittest.TestCase):
-    def _setup(self, with_conv=True, nlev=10, ncols=1):
+    def _setup(self, with_conv=True, with_downdraft=False, with_scav=False,
+               nlev=10, ncols=1):
         shape = (nlev, ncols)
         tracers = {"m_so4_acc": jnp.zeros(shape).at[8:].set(1.0e-9)}
         state = PhysicsState.zeros(shape).copy(
@@ -182,11 +360,23 @@ class ConvectiveTracerTransportTermTest(unittest.TestCase):
         }
         if with_conv:
             mfu, entrain = _plume(nlev=nlev, ncols=ncols)
-            diagnostics["convection"] = _Conv(mfu, entrain)
+            kwargs = {}
+            if with_downdraft:
+                kwargs["mfd"], kwargs["e_dn"] = _downdraft(
+                    nlev=nlev, ncols=ncols,
+                )
+            if with_scav:
+                lev = jnp.arange(nlev)[:, None]
+                cloudy = (lev >= 4) & (lev <= 7)
+                kwargs["cond"] = jnp.where(cloudy, 5.0e-4, 0.0) * jnp.ones(
+                    (1, ncols))
+                kwargs["pf"] = jnp.where(cloudy, 1.0e-5, 0.0) * jnp.ones(
+                    (1, ncols))
+            diagnostics["convection"] = _Conv(mfu, entrain, **kwargs)
         return state, diagnostics
 
     def test_transports_and_conserves(self):
-        state, diagnostics = self._setup()
+        state, diagnostics = self._setup(with_downdraft=True)
         term = ConvectiveTracerTransport(("m_so4_acc",))
         tend, _ = term(state, diagnostics, None, None)
         dq = np.asarray(tend.tracers["m_so4_acc"])
@@ -204,13 +394,41 @@ class ConvectiveTracerTransportTermTest(unittest.TestCase):
             np.asarray(tend.tracers["m_so4_acc"]), 0.0,
         )
 
+    def test_scavenging_publishes_surface_flux(self):
+        # With weights, the term must remove exactly its published
+        # ``_conv_scav_flux`` from the column, and only list weighted
+        # tracers there.
+        state, diagnostics = self._setup(with_scav=True)
+        term = ConvectiveTracerTransport(
+            ("m_so4_acc",), scav_weights=(1.0,),
+        )
+        tend, diag_out = term(state, diagnostics, None, None)
+        flux = diag_out["_conv_scav_flux"]["m_so4_acc"]
+        self.assertGreater(float(flux[0]), 0.0)
+        net = float(np.sum(np.asarray(tend.tracers["m_so4_acc"])) * 400.0)
+        self.assertLessEqual(abs(net + float(flux[0])), 1e-6 * float(flux[0]))
+
+    def test_unweighted_tracer_not_in_scav_flux(self):
+        state, diagnostics = self._setup(with_scav=True)
+        state = state.copy(tracers={
+            **state.tracers, "so2": jnp.full((10, 1), 1.0e-9),
+        })
+        term = ConvectiveTracerTransport(
+            ("m_so4_acc", "so2"), scav_weights=(1.0, 0.0),
+        )
+        _, diag_out = term(state, diagnostics, None, None)
+        self.assertIn("m_so4_acc", diag_out["_conv_scav_flux"])
+        self.assertNotIn("so2", diag_out["_conv_scav_flux"])
+
     def test_grad_through_transport_scale(self):
-        state, diagnostics = self._setup()
+        state, diagnostics = self._setup(with_downdraft=True)
 
         def loss(scale):
             term = ConvectiveTracerTransport(
                 ("m_so4_acc",),
-                params=ConvTransportParameters(transport_scale=scale),
+                params=ConvTransportParameters(
+                    transport_scale=scale, scav_ratio=jnp.asarray(0.99),
+                ),
             )
             tend, _ = term(state, diagnostics, None, None)
             return jnp.sum(tend.tracers["m_so4_acc"] ** 2)
@@ -219,9 +437,31 @@ class ConvectiveTracerTransportTermTest(unittest.TestCase):
         self.assertTrue(np.isfinite(float(g)))
         self.assertNotEqual(float(g), 0.0)
 
+    def test_grad_through_scav_ratio(self):
+        state, diagnostics = self._setup(with_scav=True)
+
+        def loss(ratio):
+            term = ConvectiveTracerTransport(
+                ("m_so4_acc",),
+                params=ConvTransportParameters(
+                    transport_scale=jnp.asarray(1.0), scav_ratio=ratio,
+                ),
+                scav_weights=(1.0,),
+            )
+            tend, _ = term(state, diagnostics, None, None)
+            return jnp.sum(tend.tracers["m_so4_acc"] ** 2)
+
+        g = jax.grad(loss)(jnp.asarray(0.99))
+        self.assertTrue(np.isfinite(float(g)))
+        self.assertNotEqual(float(g), 0.0)
+
     def test_empty_tracer_list_rejected(self):
         with self.assertRaises(ValueError):
             ConvectiveTracerTransport(())
+
+    def test_misaligned_scav_weights_rejected(self):
+        with self.assertRaises(ValueError):
+            ConvectiveTracerTransport(("a", "b"), scav_weights=(1.0,))
 
 
 if __name__ == "__main__":

--- a/jcm/physics/convection/tracer_transport_test.py
+++ b/jcm/physics/convection/tracer_transport_test.py
@@ -408,6 +408,18 @@ class ConvectiveTracerTransportTermTest(unittest.TestCase):
         net = float(np.sum(np.asarray(tend.tracers["m_so4_acc"])) * 400.0)
         self.assertLessEqual(abs(net + float(flux[0])), 1e-6 * float(flux[0]))
 
+    def test_scav_flux_published_without_convection_too(self):
+        # The diagnostics dict is a lax.scan carry: the key set must be
+        # identical whether or not convection ran this step, or the
+        # structural probe's carry mismatches the stepped one (the
+        # aerocom end-to-end repro: 73- vs 74-child carry TypeError).
+        state, diagnostics = self._setup(with_conv=False)
+        term = ConvectiveTracerTransport(("m_so4_acc",), scav_weights=(1.0,))
+        _, diag_out = term(state, diagnostics, None, None)
+        np.testing.assert_array_equal(
+            np.asarray(diag_out["_conv_scav_flux"]["m_so4_acc"]), 0.0,
+        )
+
     def test_unweighted_tracer_not_in_scav_flux(self):
         state, diagnostics = self._setup(with_scav=True)
         state = state.copy(tracers={

--- a/jcm/physics/convection/tracer_transport_test.py
+++ b/jcm/physics/convection/tracer_transport_test.py
@@ -321,6 +321,28 @@ class ScavengingTest(unittest.TestCase):
         np.testing.assert_allclose(np.asarray(dq1), np.asarray(dq0))
         np.testing.assert_array_equal(np.asarray(scav), 0.0)
 
+    def test_negative_lobe_never_scavenged(self):
+        # Spectral ringing leaves negative lobes on near-zero tracers;
+        # scavenging a negative in-plume concentration would inject mass
+        # and turn the deposition flux negative (Codex P1 on #636). The
+        # flux must stay >= 0 and the budget must still close to it.
+        q, mfu, entrain, rho, dz, cond, pf = self._setup()
+        q = q.at[0].set(-1.0e-10)                 # all-negative tracer 0
+        dq, scav = convective_tracer_tendency(
+            q, mfu, entrain, rho, dz, 1800.0,
+            scav_weights=jnp.ones(2),
+            precip_formation=pf, plume_condensate=cond,
+        )
+        self.assertGreaterEqual(float(scav.min()), 0.0)
+        np.testing.assert_array_equal(np.asarray(scav[0]), 0.0)
+        dm = rho * dz
+        for k in range(2):
+            net = float(jnp.sum(dq[k] * dm))
+            self.assertLessEqual(
+                abs(net + float(scav[k, 0])),
+                1e-6 * max(float(jnp.sum(jnp.abs(dq[k]) * dm)), 1e-30),
+            )
+
     def test_dry_plume_scavenges_nothing(self):
         # No condensate (below CAM's clw_cut) -> gate closed everywhere.
         q, mfu, entrain, rho, dz, _, pf = self._setup()

--- a/jcm/physics/diagnostics/aerocom_test.py
+++ b/jcm/physics/diagnostics/aerocom_test.py
@@ -5,6 +5,7 @@ import unittest
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 from jcm.physics.diagnostics.aerocom import (
     OVERLAP_MAXIMUM,
@@ -561,6 +562,41 @@ class AerosolGroupEndToEndTest(unittest.TestCase):
             key = f"aerocom_burden_{spec}"
             self.assertIn(key, ds.data_vars)
             self.assertTrue(np.isfinite(np.asarray(ds[key])).all(), key)
+
+
+class PerBandOpticsSerializationTest(unittest.TestCase):
+    """JAM's per-band optics fields must survive ``to_xarray``.
+
+    Regression: ``*_sw_per_band`` / ``*_lw_per_band`` are
+    ``(band, level, lon, lat)`` and the shape→dims lookup had no band
+    coordinate, so the FIRST full-output echam-jam+RRTMGP run after
+    jax-gcm#584 crashed at output conversion (grey-radiation
+    compositions never build the per-band fields, which is how CI
+    missed it).
+    """
+
+    @pytest.mark.slow
+    def test_jam_rrtmgp_per_band_output_serializes(self):
+        from jcm.model import Model
+        from jcm.physics.echam.echam_levels import get_echam_levels
+        from jcm.physics.echam.echam_terms import echam_physics
+        from jcm.terrain import TerrainData
+        from jcm.utils import get_coords
+
+        coords = get_coords(get_echam_levels(47), spectral_truncation=21)
+        model = Model(
+            coords=coords, terrain=TerrainData.aquaplanet(coords),
+            time_step=900.0,
+            physics=echam_physics(cloud_scheme="2m", aerosol_module="jam",
+                                  radiation_scheme="rrtmgp"),
+        )
+        ds = model.run(total_time=0.02, save_interval=0.02).to_xarray()
+        sw = "jam_band_optics.aod_sw_per_band"
+        lw = "jam_band_optics.aod_lw_per_band"
+        self.assertIn(sw, ds.data_vars)
+        self.assertEqual(ds[sw].dims[1], "sw_band")
+        self.assertIn(lw, ds.data_vars)
+        self.assertEqual(ds[lw].dims[1], "lw_band")
 
 
 class AerocomOpticsConfigTest(unittest.TestCase):

--- a/jcm/physics/echam/echam_terms.py
+++ b/jcm/physics/echam/echam_terms.py
@@ -80,6 +80,7 @@ def echam_physics(
     jam_ice_scheme: str = "niemand",
     jam_anthropogenic: bool = False,
     jam_prescribed_speciated: bool = False,
+    jam_convective_transport: bool = True,
     enable_cosp: bool = False,
     cosp_ncolumns: int = 40,
     cosp_calipso: bool = False,
@@ -324,6 +325,7 @@ def echam_physics(
             ice_scheme=jam_ice_scheme,
             anthropogenic=jam_anthropogenic,
             prescribed_speciated=jam_prescribed_speciated,
+            convective_transport=jam_convective_transport,
             optics_diagnostics=aerocom_optics,
         )
         # The per-band Mie optics are only consumed by the interval-gated

--- a/jcm/predictions.py
+++ b/jcm/predictions.py
@@ -191,6 +191,24 @@ class ModelPredictions:
                     )
                 additional_coords['mode'] = np.asarray(_mode_shorts)
                 break
+        # Spectral-band coordinates for the JAM per-band optics fields
+        # (#584): ``*_sw_per_band`` / ``*_lw_per_band`` are
+        # ``(time, band, level, lon, lat)`` and need a named band dim or
+        # the shape→dims lookup fails (first hit by the first full-output
+        # echam-jam run after #584). Lengths come from the arrays
+        # themselves (RRTMGP: 14 SW / 16 LW); the additional_coords
+        # collision check still guards a band count equal to the layer
+        # count.
+        # Band count 1 (grey radiation) is skipped: a length-1 coord here
+        # would shadow the existing ``(1, ...)`` surface-axis mappings for
+        # every other field; those fields already serialize via that axis.
+        for _key, _val in physics_preds_dict.items():
+            for _suffix, _dim in (('_sw_per_band', 'sw_band'),
+                                  ('_lw_per_band', 'lw_band')):
+                if (_key.endswith(_suffix) and _dim not in additional_coords
+                        and getattr(_val, 'ndim', 0) >= 2
+                        and _val.shape[1] > 1):
+                    additional_coords[_dim] = np.arange(_val.shape[1])
 
         pred_ds = data_to_xarray(
             dynamics_predictions.asdict() | physics_preds_dict,


### PR DESCRIPTION
Closes #622, closes #621.

## What

`ConvectiveTracerTransport` gains the two legs its docstring deferred:

**Downdraft transport (#622)** — the Tiedtke term now exports the
`entrdd`-based absolute downdraft entrainment ledger
(`ConvectionData.entrain_down`, post-rescale/post-cap like the rest of the
ledger), and the transport term runs a descent scan mirroring the ascent
one. Continuity derives per-layer detrainment from the published `mfd`
profile, so the LFS seed appears as entrainment of that layer's air and
the `itopde` surface taper lands as sub-cloud detrainment in the lowest
two layers — column conservation telescopes exactly, same as the updraft
budget. Both legs share one Courant guard so the circulations stay
proportional.

**In-plume scavenging (#621)** — per Duncan's call on the grounding
question ("Use the CAM one"): the removal follows CAM `aero_convproc`'s
mirage2 form, `cdt = pdmfup / (M_u·q_cond)` with removed fraction
`w·(1 − exp(−cdt))`, applied to the in-plume concentration inside the
ascent scan right after entrainment mixing (CAM's `dconudt_wetdep` loop
placement) and gated exactly like CAM (`clw_cut = 1e-6`, `rprd > 0`).
The updraft-area fraction cancels in this form — CAM's own Note1 flags
the cam5 variant's sensitivity to the unknowable `fupdr`, so mirage2 is
the right variant for us. `w` = static per-tracer weight (activatable
modes' interstitial tracers; gases and insoluble modes ride unscavenged)
× differentiable `ConvTransportParameters.scav_ratio` (default 0.99,
matching the wetdep knob it supersedes). Removed flux deposits at the
surface; per-tracer fluxes are published under `_conv_scav_flux`.

**Reconciliation (the #621 double-counting requirement)** —
`WetScavenging(in_plume_convective=True)` (wired by the JAM factory
whenever `convective_transport` is on) retires its environment-profile
`conv_in_cloud_rate` pathway for transported species, keeps convective
below-cloud washout (a distinct impaction pathway), and folds the
transport term's `_conv_scav_flux` into the AeroCom `wet_*` ledger so
the wet-deposition budget stays complete.

## Fortran grounding

- #622 is grounded in the harness's `mo_cudescent.f90` (`cudlfs` LFS
  seed + tracer init, `cuddraf` descent with `zentr = entrdd·|mfd|·dz`
  and the `itopde` taper) and `mo_cufluxdts.f90` (`cuflx`/`cudtdq`
  deviation-flux tendencies). One documented deviation: `cudlfs` seeds
  the downdraft with a 50/50 updraft/wet-bulb-environment mix, which
  moves plume-processed air across without a matching debit in the
  updraft budget; we entrain environment air instead, which keeps the
  column budget exact — and matches CAM's downdraft ("no transformation
  or removal is applied in the downdraft", entrainment mixing only).
- #621 is grounded in CAM's `aero_convproc.F90` (ESCOMP/CAM
  `cam_development`, `src/chemistry/aerosol/`) — ECHAM(-HAM) has no
  equivalent in the harness source and Duncan confirmed CAM is the
  reference here.

## Tests

- `tracer_transport_test.py`: downdraft leg — exact column conservation
  (incl. mid-descent buoyancy death), LFS→sub-cloud transport direction,
  convex-mix boundedness, combined-leg CFL positivity, per-tracer/
  per-column budget independence. Scavenging — budget closes to the
  scavenged flux exactly, scavenged plumes detrain less aloft, zero
  weights bit-recover the conservative plume, dry plume (below
  `clw_cut`) removes nothing, `_conv_scav_flux` publication, gradients
  through `transport_scale` and `scav_ratio`.
- `downdraft_test.py`: ledger unit tests (bulk value, LFS/taper/death
  masking, column-vs-block broadcasting).
- `wetdep_test.py`: `in_plume_convective` retires the env pathway while
  keeping washout; `_conv_scav_flux` folds into `wet_*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EYsAZJeaPcP2DAzzxtXRN
