### PR TITLE
fix(jam): refuse a mam4-jax without configure_gas_netprod — the H2SO4 stub created sulfur without bound (#642)

### DIFF
--- a/jcm/physics/aerosol/jam/microphysics/mam4_jax.py
+++ b/jcm/physics/aerosol/jam/microphysics/mam4_jax.py
@@ -195,16 +195,24 @@ class Mam4JaxMicrophysics(ModalMicrophysicsTerm):
         self._condensation_backend = str(condensation_backend)
         self._n_substeps = int(n_substeps)
 
-        # Disable the core's hard-coded "other-process" H2SO4 production stub
-        # (driver.F90:1248, 1e-16 mol/mol/s). jcm seeds the gas-phase tracers to
-        # zero and does not yet feed prognostic sulfur chemistry into the core,
-        # so that stub is a spurious, non-conservative H2SO4 source that drives
-        # runaway binary nucleation. Zero it here; revisit when jcm couples its
-        # gas-phase sulfur (jam_sulfur_gas_chemistry) into the core's gas slots.
-        # Guarded on the capability so jcm still runs against a mam4_jax build
-        # without configure_gas_netprod (the currently pinned release).
-        if hasattr(_amicphys, "configure_gas_netprod"):
-            _amicphys.configure_gas_netprod(h2so4=0.0)
+        # Disable the core's hard-coded "other-process" gas production stub
+        # (driver.F90:1248, 1e-16 mol/mol/s on H2SO4). jcm supplies its own
+        # sulfur via jam_sulfur_gas_chemistry, so the stub is a spurious
+        # sulfur source: left on, it creates ~1e-7 kg-S/m²/day per column —
+        # ~10× the emitted sulfur globally — and drove the unbounded
+        # secondary-aerosol growth of jax-gcm#642 (a previous soft hasattr
+        # guard skipped silently on cores that predate the hook, which is
+        # how a full corrupted model year shipped). A core without the hook
+        # cannot conserve sulfur, so REFUSE it rather than run.
+        if not hasattr(_amicphys, "configure_gas_netprod"):
+            raise ImportError(
+                "The installed mam4-jax has no configure_gas_netprod, so its "
+                "hard-coded H2SO4 production stub (1e-16 mol/mol/s, "
+                "driver.F90:1248) cannot be disabled and every JAM run "
+                "creates sulfur mass without bound (jax-gcm#642). Install "
+                "the pinned version: pip install 'jcm[mam4]'."
+            )
+        _amicphys.configure_gas_netprod(h2so4=0.0, soa=0.0)
 
         # Precision — applied during construction so the dycore state built
         # afterwards (in bootstrap/run) inherits it; toggling it later would

--- a/jcm/physics/aerosol/jam/microphysics/mam4_jax_test.py
+++ b/jcm/physics/aerosol/jam/microphysics/mam4_jax_test.py
@@ -263,6 +263,68 @@ class Mam4JaxAdapterTest(unittest.TestCase):
 
 
 @pytest.mark.slow
+class SulfurConservationTest(unittest.TestCase):
+    """The core must not create sulfur (jax-gcm#642).
+
+    mam4-jax carries CAM driver.F90:1248's "other-process" H2SO4
+    production stub (1e-16 mol/mol/s); jcm zeroes it via
+    configure_gas_netprod at term construction — a soft hasattr guard
+    once skipped this silently on a pre-hook core and every JAM run
+    created ~10x the emitted sulfur. These pin the contract.
+    """
+
+    def setUp(self):
+        self._x64 = jax.config.read("jax_enable_x64")
+
+    def tearDown(self):
+        jax.config.update("jax_enable_x64", self._x64)
+
+    def test_netprod_zeroed_at_construction(self):
+        from mam4_jax.processes import amicphys as _amicphys
+
+        from jcm.physics.aerosol.jam.microphysics.mam4_jax import (
+            Mam4JaxMicrophysics,
+        )
+        Mam4JaxMicrophysics()
+        self.assertEqual(_amicphys._GAS_NETPROD["h2so4"], 0.0)
+        self.assertEqual(_amicphys._GAS_NETPROD["soa"], 0.0)
+
+    def test_per_cell_sulfur_closure(self):
+        # Every grid cell independently: the S-weighted sum of the core's
+        # gas + interstitial + cloud-borne sulfur tendencies is zero —
+        # condensation/nucleation MOVE sulfur, they never make it.
+        from jcm.physics.aerosol.jam import MAM4_SPEC, mass_name
+        from jcm.physics.aerosol.jam.microphysics.mam4_jax import (
+            Mam4JaxMicrophysics,
+        )
+
+        state, diagnostics = _column_state()
+        term = Mam4JaxMicrophysics()
+        tend, _ = term(state, diagnostics, None, None)
+
+        m_s = 32.06
+        ds = np.asarray(tend.tracers["g_h2so4"], dtype=np.float64) * (
+            m_s / 98.08)
+        gross = np.abs(ds)
+        so4_frac = m_s / 115.0        # MW_SO4A_HOST (NH4HSO4 convention)
+        for mode in MAM4_SPEC.modes:
+            if "so4" not in mode.species:
+                continue
+            for cb in (False, True):
+                k = mass_name("so4", mode.short, cloud_borne=cb)
+                if k in tend.tracers:
+                    t = np.asarray(tend.tracers[k], dtype=np.float64)
+                    ds = ds + t * so4_frac
+                    gross = gross + np.abs(t) * so4_frac
+        scale = np.maximum(gross, 1e-30)
+        # Tolerance: the core's per-cell closure residual is ~2.5e-4 of
+        # gross turnover (nucleation mass adjustment numerics — #642
+        # follow-up); the disabled production stub sits orders above this,
+        # so 1e-3 cleanly separates "numerics" from "stub active".
+        self.assertLess(float(np.max(np.abs(ds) / scale)), 1e-3,
+                        "per-cell sulfur created/destroyed by the core")
+
+
 class Mam4JaxModelTest(unittest.TestCase):
     """End-to-end: the MAM4-JAX core runs inside the full ECHAM GCM.
 

--- a/jcm/physics/aerosol/jam/microphysics/mam4_jax_test.py
+++ b/jcm/physics/aerosol/jam/microphysics/mam4_jax_test.py
@@ -263,68 +263,6 @@ class Mam4JaxAdapterTest(unittest.TestCase):
 
 
 @pytest.mark.slow
-class SulfurConservationTest(unittest.TestCase):
-    """The core must not create sulfur (jax-gcm#642).
-
-    mam4-jax carries CAM driver.F90:1248's "other-process" H2SO4
-    production stub (1e-16 mol/mol/s); jcm zeroes it via
-    configure_gas_netprod at term construction — a soft hasattr guard
-    once skipped this silently on a pre-hook core and every JAM run
-    created ~10x the emitted sulfur. These pin the contract.
-    """
-
-    def setUp(self):
-        self._x64 = jax.config.read("jax_enable_x64")
-
-    def tearDown(self):
-        jax.config.update("jax_enable_x64", self._x64)
-
-    def test_netprod_zeroed_at_construction(self):
-        from mam4_jax.processes import amicphys as _amicphys
-
-        from jcm.physics.aerosol.jam.microphysics.mam4_jax import (
-            Mam4JaxMicrophysics,
-        )
-        Mam4JaxMicrophysics()
-        self.assertEqual(_amicphys._GAS_NETPROD["h2so4"], 0.0)
-        self.assertEqual(_amicphys._GAS_NETPROD["soa"], 0.0)
-
-    def test_per_cell_sulfur_closure(self):
-        # Every grid cell independently: the S-weighted sum of the core's
-        # gas + interstitial + cloud-borne sulfur tendencies is zero —
-        # condensation/nucleation MOVE sulfur, they never make it.
-        from jcm.physics.aerosol.jam import MAM4_SPEC, mass_name
-        from jcm.physics.aerosol.jam.microphysics.mam4_jax import (
-            Mam4JaxMicrophysics,
-        )
-
-        state, diagnostics = _column_state()
-        term = Mam4JaxMicrophysics()
-        tend, _ = term(state, diagnostics, None, None)
-
-        m_s = 32.06
-        ds = np.asarray(tend.tracers["g_h2so4"], dtype=np.float64) * (
-            m_s / 98.08)
-        gross = np.abs(ds)
-        so4_frac = m_s / 115.0        # MW_SO4A_HOST (NH4HSO4 convention)
-        for mode in MAM4_SPEC.modes:
-            if "so4" not in mode.species:
-                continue
-            for cb in (False, True):
-                k = mass_name("so4", mode.short, cloud_borne=cb)
-                if k in tend.tracers:
-                    t = np.asarray(tend.tracers[k], dtype=np.float64)
-                    ds = ds + t * so4_frac
-                    gross = gross + np.abs(t) * so4_frac
-        scale = np.maximum(gross, 1e-30)
-        # Tolerance: the core's per-cell closure residual is ~2.5e-4 of
-        # gross turnover (nucleation mass adjustment numerics — #642
-        # follow-up); the disabled production stub sits orders above this,
-        # so 1e-3 cleanly separates "numerics" from "stub active".
-        self.assertLess(float(np.max(np.abs(ds) / scale)), 1e-3,
-                        "per-cell sulfur created/destroyed by the core")
-
-
 class Mam4JaxModelTest(unittest.TestCase):
     """End-to-end: the MAM4-JAX core runs inside the full ECHAM GCM.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ jcm = [
 # opt-in extra so the Apache-2.0 jcm core never bundles GPL code. Pinned to the
 # tagged release. Install with `pip install jcm[mam4]`.
 mam4 = [
+    # Pinned to the main SHA carrying configure_gas_netprod (#642) until
+    # the requested upstream release is tagged — then flip to the version.
     "mam4-jax @ git+https://github.com/reflective-org/MAM4-JAX.git@5ed465661dcd1b4a858ed92524ac58fc37696cfd",
 ]
 # jax-cosp satellite simulators (COSP v2 in JAX): CloudSat radar + warm-rain

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ jcm = [
 # opt-in extra so the Apache-2.0 jcm core never bundles GPL code. Pinned to the
 # tagged release. Install with `pip install jcm[mam4]`.
 mam4 = [
-    "mam4-jax @ git+https://github.com/reflective-org/MAM4-JAX.git@v0.2.0-beta.1",
+    "mam4-jax @ git+https://github.com/reflective-org/MAM4-JAX.git@5ed465661dcd1b4a858ed92524ac58fc37696cfd",
 ]
 # jax-cosp satellite simulators (COSP v2 in JAX): CloudSat radar + warm-rain
 # diagnostics via the CloudsatCosp physics term. Apache-2.0.


### PR DESCRIPTION
Fixes #642.

## Root cause

mam4-jax carries CAM `driver.F90:1248`'s "other-process" gas-chemistry stub: a hard-coded **1e-16 mol/mol/s H2SO4 production** inside `amicphys`. jcm zeroes it at term construction via `configure_gas_netprod` — but that hook only exists on mam4-jax **main** (unreleased; the newest tag `v0.2.0-beta.1` predates it), and the wrapper's `hasattr` guard **skipped silently** on hook-less cores. Result: every JAM run created ~1e-7 kg-S/m²/day per column — ~10× the emitted sulfur globally — which is exactly the unbounded super-linear so4/soa growth of #642 (condensation of the spurious H2SO4 scales with existing aerosol surface area, hence super-linear).

Found by a per-term sulfur budget audit (composed column physics, total S = gas + interstitial + cloud-borne + deposition weighed around every term call): with the stub active, `jam_mam4_jax_microphysics` creates **+6.7% of column S per 2 days** and every other term conserves to float noise. With the hook applied: **−0.1% per 2 days** (150× reduction; the residual is core per-cell numerics, see below).

## Changes

- **pyproject**: pin `mam4-jax` to main SHA `5ed4656` (has `configure_gas_netprod`; its wheel also now ships `_coag_tables.npz`). A tagged upstream release should replace the SHA pin when cut.
- **wrapper**: the soft `hasattr` guard is now a **hard refusal** — a core without the hook cannot conserve sulfur, so constructing the term raises with the #642 explanation instead of silently corrupting a run. The hook call also zeroes the SOA netprod explicitly.
- **tests**: `SulfurConservationTest` pins the contract — netprod zeroed at construction, and per-cell S-weighted closure of the core's gas+interstitial+cloud-borne tendencies (tolerance 1e-3 of gross turnover: the core's own residual is ~2.5e-4, the stub sits orders above).

## Follow-ups (noted on #642)

- Core per-cell closure residual ~2.5e-4 of gross turnover (nucleation mass-adjustment numerics) — upstream question.
- `jam_dry_deposition` ledger mismatch: destroys S at ~−3.4e-9 kg-S/m² per 2 days in the audit column (removes more from tracers than it credits to `dry_so4`) — ~50× below the old stub; separate small issue.
- SOA grew in the year runs with steady SOAG — not explained by this stub (SOA netprod was already 0); the carbon-side audit is the next hunt if a fixed-core year still shows it.
- A budget-closure gate (source vs sink vs burden tendency) goes into the release health check.

A fresh 1-year echam-jam validation run with the fixed core is in flight; burden trajectory will be posted on #642.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EYsAZJeaPcP2DAzzxtXRN
