### PR TITLE
fix(jam): zero the interim SOAG production default (root cause of #654)

### DIFF
--- a/jcm/physics/aerosol/jam/chemistry/sulfur_gas.py
+++ b/jcm/physics/aerosol/jam/chemistry/sulfur_gas.py
@@ -106,11 +106,20 @@ def _k_dms_no3(t: jnp.ndarray) -> jnp.ndarray:
 class SulfurGasParameters:
     """Tunable knobs for the gas-phase sulfur chemistry (differentiable)."""
 
-    soag_production: jnp.ndarray   # interim SOAG source [kg/kg/s] at the surface
+    soag_production: jnp.ndarray   # prescribed SOAG source [kg/kg/s], BL-weighted
 
     @classmethod
     def default(cls) -> "SulfurGasParameters":
-        return cls(soag_production=jnp.asarray(2.0e-15))
+        # 0 by default: jcm has no biogenic VOC chemistry yet, so any
+        # nonzero value here is an unopposed global SOA source. The
+        # previous 2e-15 "interim" default (~0.9 mg SOA/m²/day column-
+        # integrated) was the sole SOA source in every JAM run and, being
+        # ~5× the total sulfur source with only weak accumulation-mode
+        # removal against it, drove multi-hundred-mg/m² SOA burdens that
+        # in turn distorted sulfate removal (jax-gcm#654). Until real
+        # biogenic emissions land, JAM carries zero SOA unless a run
+        # opts in explicitly.
+        return cls(soag_production=jnp.asarray(0.0))
 
 
 def sulfur_gas_tendencies(


### PR DESCRIPTION
Fixes #654.

## Root cause (the full elimination chain is on the issue)

`SulfurGasParameters.default()` shipped `soag_production = 2e-15 kg/kg/s` — an explicitly 'interim' prescribed SOAG source, on by default in every JAM run (~0.9 mg SOA/m²/day column-integrated, ~5× the total sulfur source). It is JAM's ONLY SOA source: the stub-off A/B year gives **soa = exactly 0.00** mg/m² vs 18.6 (day 365, stub-on) → 772 (day 730). With only weak accumulation-mode removal opposing it (~0.4 %/day), it marched burdens toward multi-thousand-mg equilibria, and past AOD ~1 the bloated aerosol distorted sulfate condensation/removal too (so4 stub-off day 430: 3.3 mg/m², normal regime, vs the stub-on march to 88).

Not non-conservation anywhere: the per-term column audits close at 1×/10×/50× burden seeds, transport is exonerated by species discrimination (primaries flat ×1.02–1.09 while condensables grew ×38–41), and the #643 netprod switch is verified active in the runaway runs.

## Change

One default: `soag_production → 0.0`, with the rationale in the comment. Runs can still opt in explicitly. Consequence (deliberate): JAM carries zero SOA until real biogenic VOC emissions land — honest absence over an unopposed global stub; tracked as the biogenic-source item on JEM-Cal#4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EYsAZJeaPcP2DAzzxtXRN