### PR TITLE
fix(deps): flax floor is >=0.12.1 — the release that ADDED nnx get_value()

### DIFF
--- a/jcm/physics/echam/parameters_test.py
+++ b/jcm/physics/echam/parameters_test.py
@@ -38,7 +38,7 @@ def test_echam_physics_default_kwargs():
     convection_term = next(
         t for t in physics.terms if t.category == "convection"
     )
-    assert abs(float(convection_term.params.value.entrpen) - 1.0e-4) < 1e-7
+    assert abs(float(convection_term.params.get_value().entrpen) - 1.0e-4) < 1e-7
 
 
 def test_echam_physics_per_scheme_kwargs():
@@ -50,13 +50,13 @@ def test_echam_physics_per_scheme_kwargs():
     convection_term = next(
         t for t in physics.terms if t.category == "convection"
     )
-    assert abs(float(convection_term.params.value.entrpen) - 5.0e-4) < 1e-7
+    assert abs(float(convection_term.params.get_value().entrpen) - 5.0e-4) < 1e-7
 
     # Untouched terms still see their defaults.
     cloud_fraction_term = next(
         t for t in physics.terms if t.category == "cloud_fraction"
     )
-    assert abs(float(cloud_fraction_term.params.value.crt) - 0.75) < 1e-7
+    assert abs(float(cloud_fraction_term.params.get_value().crt) - 0.75) < 1e-7
 
 
 def test_physics_terms_compute_tendencies():

--- a/jcm/runners_test.py
+++ b/jcm/runners_test.py
@@ -139,7 +139,7 @@ class TestBuilders(unittest.TestCase):
             t for t in physics.terms if t.category == "convection"
         )
         self.assertAlmostEqual(
-            float(convection_term.params.value.entrpen), 4e-4,
+            float(convection_term.params.get_value().entrpen), 4e-4,
         )
 
     def test_build_physics_curated_preset(self):
@@ -154,7 +154,7 @@ class TestBuilders(unittest.TestCase):
             t for t in physics.terms if t.category == "convection"
         )
         self.assertAlmostEqual(
-            float(convection_term.params.value.entrpen), 4e-4,
+            float(convection_term.params.get_value().entrpen), 4e-4,
         )
 
     def test_build_physics_swap_radiation_via_preset(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,16 @@
 # ``dinosaur>=X.Y`` — a VCS requirement cannot be published to PyPI and
 # makes the wheel uninstallable for downstream users (see #577).
 dinosaur @ git+https://github.com/shoyer/dinosaur@semi-lagrangian
-flax>=0.12.0
+# Floor is 0.12.1: that release ADDED `nnx.Variable.get_value()` and deprecated
+# the `.value` property in its favour. jcm reads every nnx.Param/nnx.Variable
+# through `.get_value()` (~94 sites under jcm/physics/**), so on exactly 0.12.0
+# the lookup misses the class and falls through `Variable.__getattr__` to the
+# *wrapped* object — `AttributeError: 'SpeedyCoords' object has no attribute
+# 'get_value'` as soon as a Model is built (#655). Do NOT "fix" that by moving
+# to `.value`: that is the deprecated direction, and no flax ever released has
+# both. (0.12.0 is unusable here anyway — it imports the long-gone private
+# `jax._src.core.mutable_array`.)
+flax>=0.12.1
 jax-datetime
 tree-math
 hydra-core


### PR DESCRIPTION
Closes #655.

## The report is right about the symptom, backwards about the cause

#655 says `nnx.Variable.get_value()` "no longer exists in flax>=0.12.0" and was removed "sometime between April 2026 and the 0.12.0 release". The opposite is true: **`get_value()` was ADDED in 0.12.1**. Verified by unpacking every wheel and grepping `flax/nnx/variablelib.py`:

| flax | `def get_value` |
|---|---|
| 0.10.0 – 0.12.0 | **absent** |
| 0.12.1 – 0.12.9 | present |

The claimed timeline is also impossible: 0.12.0 shipped **2025-09-25**, seven months *before* 567ecb3 (2026-04-27), the commit it credits with introducing the call sites "when `.get_value()` was still valid". At that commit flax was 0.12.7, which has it. The code has always been on the new API.

So the bug is not 94 stale call sites — it is that the `flax>=0.12.0` floor (incidentally raised by 3aba895) advertises a version jcm cannot run on. **It is off by one patch release.**

## Why neither suggested fix in the issue is right

- **"Replace `.get_value()` with `.value`"** would migrate onto the API flax is *removing*. In 0.12.1+ `.value` is a deprecation shim whose own warning reads: `"'.value' access is now deprecated. ... For other Variable types use: variable.get_value()"`.
- **"Pin flax back"** is impossible — no earlier release ever had `get_value()`.

## Why no dev box or CI ever hit it

Everything resolves to the newest flax (this dev box: 0.12.6; PyPI latest: 0.12.9). You only reproduce by installing the floor exactly, which is what the reporter did. Separately, 0.12.0 cannot even be imported against a current jax — it does `from jax._src.core import mutable_array`, long gone (`ImportError` on jax 0.10.2). So nothing of value is lost by raising the floor.

## What is in this PR

Two separable commits:

1. **`requirements.txt`: `flax>=0.12.0` → `>=0.12.1`**, with a comment recording why the floor is where it is and an explicit "do not "fix" this by moving to `.value`" note, so the next person reading #655 doesn't undo it. (`pyproject.toml` takes `dependencies` from this file via `dynamic`, so this is the installed floor.)

2. **Five test call sites off the deprecated `.value`** in `jcm/physics/echam/parameters_test.py` and `jcm/runners_test.py`. These were the *only* remaining `.value` readers in the tree — the ~94 production sites were already correct — so they were the sole source of flax deprecation noise and the only thing that breaks outright when `.value` is deleted.

For (2) I swept the category rather than the spellings I'd been shown: enumerated all 35 attributes bound to an `nnx.Param`/`Variable`/`List` and checked each for `.value` reads or writes. None remain; the only `.value` tokens left under `jcm/` are `ast.*` node attributes in `requires_audit_test.py`.

## Verification

- Full fast suite under a side-installed **flax 0.12.1** (the new floor): **1769 passed**.
- Both touched modules on flax **0.12.1 and 0.12.6** with `-W error::DeprecationWarning:flax.*`: **102 passed**, no warning raised.
- Reproduced the original `AttributeError` on 0.12.0 and confirmed it is gone on 0.12.1.
- `ruff check .` clean.

**Local suite caveat, so CI is read correctly:** this dev box has the released dinosaur, but `dev` now requires the `semi-lagrangian` fork, so 120 tests fail locally with `RuntimeError: the installed dinosaur has no semi-Lagrangian transport`. I ran the full suite on clean `origin/dev` and on this branch and diffed the failure sets — **identical, 120 on both, zero regressions and zero fixes.** CI installs from `requirements.txt` so it gets the fork and should be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xp7fvAnh4mfw7WRXFd1e3x