### PR TITLE
fix(clouds): route every 2M process transfer into the tendency ledger (#662)

### DIFF
--- a/jcm/physics/clouds/lohmann_2m/scheme.py
+++ b/jcm/physics/clouds/lohmann_2m/scheme.py
@@ -363,10 +363,13 @@ def cloud_microphysics_2m(
 
     # Grid-mean freezing ledger (ECHAM pfrl): the single accumulator the
     # assembly step debits from liquid, credits to ice, and converts to fusion
-    # heat. Carries both legs — homogeneous below cthomi and the immersion
-    # freezing driven by ``ice_nuclei`` (#494) — since both routines above
-    # work on in-cloud condensate, hence the cloud-fraction weighting.
-    freezing_rate = (freezing_rate_hom + frozen_mass) * cloud_fraction_uicw
+    # heat. Carries both legs — homogeneous below cthomi, and the immersion
+    # freezing driven by ``ice_nuclei`` (#494).
+    #
+    # Only the heterogeneous leg is converted here. ``freezing_below_238K``
+    # already area-weights internally (``pfrl += pxlb·paclc``), whereas
+    # ``frozen_mass`` above is a bare in-cloud increment.
+    freezing_rate = freezing_rate_hom + frozen_mass * cloud_fraction_uicw
 
     # ------------------------------------------------------------------
     # WBF (Wegener-Bergeron-Findeisen): liquid → ice in mixed-phase
@@ -656,6 +659,7 @@ def cloud_microphysics_2m(
     # ------------------------------------------------------------------
     liquid_cloud_flag = temperature > params.tmelt
     ice_cloud_flag = temperature <= params.tmelt
+    cloud_fraction_in = cloud_fraction
 
     (
         cloud_fraction_final,
@@ -754,6 +758,20 @@ def cloud_microphysics_2m(
     # destruction (review finding 2.18).
     dqrdt = jnp.zeros_like(qc)
     dqsdt = jnp.zeros_like(qc)
+
+    # The microphysics may REMOVE cloud, never create it. ECHAM's write-back
+    # to ``paclc`` exists to clear cells the scheme has just emptied of both
+    # condensates; the upward branch of ``update_in_cloud_water`` — which
+    # sets cf = clip(RH, 0.01, 1) wherever a clear cell has any condensation
+    # or deposition — is a second, RH-based cloud-cover closure, and
+    # ``SundqvistCloudFraction`` is the one this stack uses. Publishing the
+    # raw value substitutes it: an ice-supersaturated stratospheric column
+    # above ``cloud_top_pressure_pa``, which Sundqvist deliberately reports
+    # as cloud-free, comes back overcast (cf = 1) on ~1e-6 kg/kg of ice, and
+    # COSP, AeroCom and the JAM cloud-borne / aqueous / wetdep terms all read
+    # it. Clipping to the incoming cover keeps the emptying behaviour and
+    # drops the closure substitution.
+    cloud_fraction_final = jnp.minimum(cloud_fraction_final, cloud_fraction_in)
 
     # update_tendencies' tracer_tendency_{cdnc,icnc} is already in per-kg-
     # of-air per second once we pass qnc/qni (per-kg) as the tm1 tracers

--- a/jcm/physics/clouds/lohmann_2m/scheme.py
+++ b/jcm/physics/clouds/lohmann_2m/scheme.py
@@ -145,7 +145,8 @@ def cloud_microphysics_2m(
     cdnc = jnp.maximum(cdnc, cdnc_min)
 
     # pauloc==1 and pclcstar==cloud_fraction are conservative first-pass
-    # approximations — refine in later 5b steps.
+    # approximations. The true pclcstar is min(cloud cover, precip cover),
+    # which only exists inside the flux-coupled scan — see #685.
     autoconv_factor = jnp.ones_like(qc)
     min_cloud_precip_fraction = cloud_fraction
 
@@ -299,13 +300,18 @@ def cloud_microphysics_2m(
         params,
     )
 
+    # ``update_in_cloud_water`` rewrites ``paclc`` (a clear cell with positive
+    # condensation becomes cloudy), and the in-cloud condensate it returns is
+    # defined against that fraction. Every in-cloud → grid-mean conversion
+    # below therefore uses ``cloud_fraction_uicw``.
+
     # ------------------------------------------------------------------
     # Freezing below 238 K (homogeneous freezing, level-independent)
     # ------------------------------------------------------------------
     freezing_condition = temperature < params.cthomi
     (
         icnc_frz, _droplet_freezing_rate, cdnc_frz,
-        _freezing_rate, in_cloud_ice_frz, in_cloud_liquid_frz,
+        freezing_rate_hom, in_cloud_ice_frz, in_cloud_liquid_frz,
     ) = freezing_below_238K(
         freezing_condition,
         cloud_fraction_uicw,
@@ -355,6 +361,13 @@ def cloud_microphysics_2m(
         het_condition, jnp.maximum(cdnc_frz - new_crystals, params.cqtmin), cdnc_frz,
     )
 
+    # Grid-mean freezing ledger (ECHAM pfrl): the single accumulator the
+    # assembly step debits from liquid, credits to ice, and converts to fusion
+    # heat. Carries both legs — homogeneous below cthomi and the immersion
+    # freezing driven by ``ice_nuclei`` (#494) — since both routines above
+    # work on in-cloud condensate, hence the cloud-fraction weighting.
+    freezing_rate = (freezing_rate_hom + frozen_mass) * cloud_fraction_uicw
+
     # ------------------------------------------------------------------
     # WBF (Wegener-Bergeron-Findeisen): liquid → ice in mixed-phase
     # ------------------------------------------------------------------
@@ -377,12 +390,16 @@ def cloud_microphysics_2m(
         & (deposition_rate > 0.0)
         & (0.01 * updraft_velocity < zvervmax_wbf)
     )
+    # ``WBF_process`` computes the grid-mean transfer once (pxlb·paclc/dt) and
+    # reports it three ways — liquid debit, ice credit, fusion warming. All
+    # three are kept and seed the ledger together: they are one transfer, and
+    # the enthalpy budget only closes if the mass and the heat travel with it.
     (
         cdnc_wbf, in_cloud_liquid_wbf, in_cloud_ice_wbf,
-        _liq_tend_wbf, _ice_tend_wbf, dtedt_wbf,
+        liq_tend_wbf, ice_tend_wbf, dtedt_wbf,
     ) = WBF_process(
         wbf_mask,
-        cloud_fraction,
+        cloud_fraction_uicw,
         lsdcp, lvdcp,
         cdnc_het,
         in_cloud_liquid_het,
@@ -415,8 +432,8 @@ def cloud_microphysics_2m(
     ) = precip_formation_cold(
         cold_mask,
         autoconv_factor,
-        cloud_fraction,
-        min_cloud_precip_fraction,
+        cloud_fraction_uicw,
+        cloud_fraction_uicw,   # pclcstar first-pass approximation (#685)
         inv_rho,
         inv_rho,
         temperature,
@@ -434,7 +451,7 @@ def cloud_microphysics_2m(
     )
 
     # Convert in-cloud → grid-mean for tendency computation.
-    qi_after_cold = in_cloud_ice_cold * cloud_fraction
+    qi_after_cold = in_cloud_ice_cold * cloud_fraction_uicw
     # (qc_to_snow / qi_to_snow state differences removed with the qr/qs
     # ledger — see the dqrdt/dqsdt note below.)
 
@@ -509,17 +526,21 @@ def cloud_microphysics_2m(
             params,
         )
 
-        # --- Melting --- (per-level pimlt/psmlt/pximlt are KEPT: the
-        # in-cloud melt mass goes to cloud liquid, the falling-ice melt to
-        # cloud liquid, the snow melt to rain — all with per-level fusion
-        # cooling in update_tendencies. The previous scan discarded all
-        # three (melted in-cloud ice VANISHED from the mass ledger, only
-        # the ICNC→CDNC number transfer survived) and broadcast a
-        # column-accumulated snow_melt to every level (finding 2.23).
+        # --- Melting --- per-level pimlt/psmlt/pximlt all reach the ledger:
+        # in-cloud melt and falling-ice melt go to cloud liquid, snow melt to
+        # rain, each with its own fusion cooling in update_tendencies.
+        #
+        # The running ice tendency is threaded THROUGH the routine, which is
+        # how ECHAM stops the two ice sinks claiming the same mass:
+        # ``pimlt = max(pxim1 + ztmst·pxite, 0)`` reconstructs the ice left
+        # AFTER sedimentation, then debits that. So the sedimentation delta
+        # must be in ``pxite`` on the way in, and what comes back out is the
+        # combined sediment-plus-melt tendency the ledger wants.
+        sedi_ice_tendency = (qi_post_sedi - qi_k) / dt
         (
             icnc_post_melt, _qmel, cdnc_post_melt,
             rain_flux, snow_flux, ice_flux, ice_flux_n,
-            _ice_tend, pimlt_k, psmlt_k, pximlt_k,
+            ice_tend_k, pimlt_k, psmlt_k, pximlt_k,
         ) = melting_snow_and_ice(
             melt_k, t_k, qi_k, dp_k,
             icnc_post_sedi, lsdcp, lvdcp,
@@ -527,7 +548,7 @@ def cloud_microphysics_2m(
             jnp.array(0.0),  # qmel accumulator
             cdnc_k,
             rain_flux, snow_flux, ice_flux, ice_flux_n,
-            jnp.array(0.0),  # ice_tendency
+            sedi_ice_tendency,
             dt,
             params,
         )
@@ -591,7 +612,7 @@ def cloud_microphysics_2m(
         # which also makes the bottom row equal ``surface_snow_flux``
         # exactly.
         frozen_flux_k = snow_flux + jnp.where(is_bottom_k, 0.0, ice_flux)
-        level_out = (qi_post_sedi, icnc_post_melt, cdnc_post_melt,
+        level_out = (ice_tend_k, icnc_post_melt, cdnc_post_melt,
                      ice_sublim_k, snow_sublim_k, rain_evap_k,
                      psmlt_level, pimlt_k, pximlt_k,
                      rain_flux, frozen_flux_k)
@@ -601,7 +622,7 @@ def cloud_microphysics_2m(
     nlev_scan = temperature.shape[0]
     is_bottom_level = jnp.arange(nlev_scan) == (nlev_scan - 1)
     scan_inputs = (
-        cloud_fraction, air_density_correction, pressure_thickness,
+        cloud_fraction_uicw, air_density_correction, pressure_thickness,
         air_density, inv_rho, qi_after_cold, icnc_cold, cdnc_cold,
         temperature, melt_mask,
         specific_humidity, dp_over_g, subsat_wrt_ice, subsat_wrt_water,
@@ -617,7 +638,7 @@ def cloud_microphysics_2m(
     _final_carry, scan_outs = jax.lax.scan(
         _flux_coupled_step, init_carry, scan_inputs,
     )
-    (qi_after_scan, icnc_after_scan, cdnc_after_scan,
+    (ice_tendency_scan, icnc_after_scan, cdnc_after_scan,
      ice_sublim, snow_sublim, rain_evap,
      psmlt_per_level, pimlt_per_level, pximlt_per_level,
      rain_flux_profile, snow_flux_profile) = scan_outs
@@ -645,8 +666,15 @@ def cloud_microphysics_2m(
     ) = update_tendencies_and_important_vars(
         icnc=icnc_after_scan,
         cdnc=cdnc_after_scan,
-        ice_mmr_prev=in_cloud_ice_cold,
-        liq_mmr_prev=in_cloud_liquid_cold,
+        # ECHAM's pxim1/pxlm1 are the GRID-MEAN condensate the step started
+        # from, matching the increments the ledger adds to them (condensation,
+        # rain formation, riming, melting, freezing are all grid-mean). They
+        # reach the outputs only through the negative-mass guard, which tests
+        # the reconstructed ``*_mmr_next`` against the grid-mean threshold
+        # ``ccwmin`` — so an in-cloud magnitude here (larger by 1/cf) would be
+        # compared against the wrong scale in both directions.
+        ice_mmr_prev=qi,
+        liq_mmr_prev=qc,
         # ECHAM convention: pxtm1_cdnc / pxtm1_icnc are the previous-step
         # tracer values in per-kg-of-air. ``cdnc`` and ``icnc`` here are
         # the working per-m^3 values (qnc * rho, qni * rho), so we pass
@@ -660,7 +688,7 @@ def cloud_microphysics_2m(
         condensation_rate=condensation_rate,
         deposition_rate=deposition_rate,
         rain_evap_mmr=rain_evap,
-        freezing_rate=_freezing_rate,
+        freezing_rate=freezing_rate,
         tompkins_ice=zero,
         tompkins_liq=zero,
         incloud_ice_melt=pimlt_per_level,
@@ -695,15 +723,18 @@ def cloud_microphysics_2m(
         ice_cloud_flag=ice_cloud_flag,
         cloud_fraction=cloud_fraction_uicw,
         specific_humidity_tendency=zero,
-        temp_tendency=dtedt_wbf,     # seed with WBF contribution
-        # ECHAM folds ice sedimentation into pxite BEFORE this ledger
-        # (mo_cloud_micro_2m.f90 section 4: pxite = ztmst_rcp·(zxip1 −
-        # pxim1) after sedimentation_ice) — seeding zero here emitted the
-        # bottom-reaching ice flux as surface snow with no qi debit,
-        # opening the flux-form budget by exactly that flux (Codex review
-        # on #554).
-        ice_tendency=(qi_after_scan - qi_after_cold) / dt,
-        liq_tendency=zero,
+        # WBF is the one process that reports its transfer as a tendency
+        # rather than a per-step increment, so its three legs seed the three
+        # INOUT accumulators here (heat, ice credit, liquid debit).
+        temp_tendency=dtedt_wbf,
+        # ECHAM folds ice sedimentation AND melting into pxite before this
+        # ledger (mo_cloud_micro_2m.f90 section 4), so the scan's combined
+        # per-level tendency arrives here as a seed rather than as one of the
+        # increments below; WBF's ice credit joins it. Without the
+        # sedimentation leg the bottom-reaching ice flux would leave as
+        # surface snow with no matching qi debit (#554).
+        ice_tendency=ice_tendency_scan + ice_tend_wbf,
+        liq_tendency=liq_tend_wbf,
         tracer_tendency_cdnc=zero,
         tracer_tendency_icnc=zero,
         incloud_liq_before_rain=in_cloud_liquid,  # before warm step
@@ -761,7 +792,7 @@ def cloud_microphysics_2m(
     autoconv_rate_col = jnp.sum(autoconv_only * air_mass) / dt
     accretion_rate_col = jnp.sum(accretion_only * air_mass) / dt
     wbf_rate_col = jnp.sum(
-        (in_cloud_liquid_het - in_cloud_liquid_wbf) * cloud_fraction
+        (in_cloud_liquid_het - in_cloud_liquid_wbf) * cloud_fraction_uicw
         * air_mass) / dt
 
     # Microphysical effective radii (ECHAM preffl/preffi, um) — consumed
@@ -1009,9 +1040,8 @@ class Lohmann2MMicrophysics(PhysicsTerm):
             # ECHAM writes the post-microphysics cloud fraction back to
             # ``paclc``: cells the scheme has just emptied of both condensates,
             # or driven below ``clc_min``, are no longer cloudy. Radiation and
-            # the aerosol cloud-borne partition both read this, so leaving the
-            # pre-microphysics value here left them seeing cloud that the step
-            # had already removed.
+            # the aerosol cloud-borne partition read this, and must see the
+            # cloud the step actually leaves behind.
             cloud_fraction=cloud_fraction_all.T,
             qnc_prev=qnc, qni_prev=qni,
             precip_rain=surface_rain_flux,

--- a/jcm/physics/clouds/lohmann_2m/scheme.py
+++ b/jcm/physics/clouds/lohmann_2m/scheme.py
@@ -790,7 +790,7 @@ def cloud_microphysics_2m(
     return tendencies, surface_rain_flux, surface_snow_flux, \
         liq_eff_radius, ice_eff_radius, rain_formation_warm, rain_from_melt, \
         autoconv_rate_col, accretion_rate_col, wbf_rate_col, \
-        precip_formation_rate, precip_evaporation_rate, \
+        precip_formation_rate, precip_evaporation_rate, cloud_fraction_final, \
         rain_flux_profile, snow_flux_profile
 
 
@@ -955,11 +955,11 @@ class Lohmann2MMicrophysics(PhysicsTerm):
         (tend_all, surface_rain_flux, surface_snow_flux,
          r_eff_liq_all, r_eff_ice_all, rain_formation_warm, rain_from_melt,
          autoconv_all, accretion_all, wbf_all,
-         precip_form_all, precip_evap_all,
+         precip_form_all, precip_evap_all, cloud_fraction_all,
          rain_flux_all, snow_flux_all) = jax.vmap(
             cloud_microphysics_2m,
             in_axes=(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, None, None),
-            out_axes=(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+            out_axes=(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
         )(
             temperature_in, specific_humidity_in, pressure_full,
             qc_interim, qi_interim, qnc, qni, qr, qs,
@@ -1006,6 +1006,13 @@ class Lohmann2MMicrophysics(PhysicsTerm):
         # update_tendencies_and_important_vars; expose surface precip
         # diagnostics from the lax.scan.
         clouds_next = clouds.copy(
+            # ECHAM writes the post-microphysics cloud fraction back to
+            # ``paclc``: cells the scheme has just emptied of both condensates,
+            # or driven below ``clc_min``, are no longer cloudy. Radiation and
+            # the aerosol cloud-borne partition both read this, so leaving the
+            # pre-microphysics value here left them seeing cloud that the step
+            # had already removed.
+            cloud_fraction=cloud_fraction_all.T,
             qnc_prev=qnc, qni_prev=qni,
             precip_rain=surface_rain_flux,
             precip_snow=surface_snow_flux,

--- a/jcm/physics/clouds/lohmann_2m_test.py
+++ b/jcm/physics/clouds/lohmann_2m_test.py
@@ -1744,6 +1744,289 @@ class TestColumnWaterConservation2M:
         )
 
 
+class TestColumnEnthalpyConservation2M:
+    """Column enthalpy closes against the surface precipitation flux.
+
+    Every internal phase change leaves
+
+        E = Σ ρ·dz·(cpd·T − Lv·qc − Ls·qi)
+
+    invariant: condensation trades Lv of vapour enthalpy for Lv of warming,
+    freezing trades Lf for Lf, and so on. Vapour cancels out of E entirely,
+    which is what makes this test independent of
+    ``TestColumnWaterConservation2M`` above. The only way the column can
+    change E is by exporting condensate across the surface — rain leaves as
+    liquid (Lv per kg), snow as ice (Ls per kg) — so
+
+        Σ ρ·dz·(cpd·dT/dt − Lv·dqc/dt − Ls·dqi/dt) == Lv·rain + Ls·snow.
+
+    Modelled on CAM's ``check_energy_chng`` (column-integrated total energy
+    against ``previous + dt·boundary_flux``) rather than on a negativity
+    limiter, which cannot see a budget that is open in both directions.
+
+    This is the gate for a whole class of defect (#662): a process routine
+    that mutates its local in-cloud state and reports only the latent heat —
+    or only the mass — to the assembly ledger breaks this identity while
+    leaving total water perfectly conserved, so no water budget can catch it.
+    """
+
+    DT = 1800.0
+
+    @staticmethod
+    def _run(cols):
+        from jcm.physics.clouds.lohmann_2m import cloud_microphysics_2m
+        from jcm.physics.clouds.lohmann_2m_params import CloudParams2M
+
+        T, q, p, qc, qi, qnc, qni, cf, rho, dz, tke, inp = cols
+        nlev = T.shape[0]
+        z = jnp.zeros(nlev)
+        tend, rain_sfc, snow_sfc, *_ = cloud_microphysics_2m(
+            T, q, p, qc, qi, qnc, qni, z, z, cf, rho, dz, tke,
+            jnp.full(nlev, 5e7), inp, z,
+            TestColumnEnthalpyConservation2M.DT, CloudParams2M.default(),
+        )
+        return tend, float(rain_sfc), float(snow_sfc)
+
+    @staticmethod
+    def _assert_enthalpy_closes(name, cols):
+        """Assert the identity above and return (residual, gross) [W/m²]."""
+        import numpy as np
+        import jcm.constants as c
+
+        tend, rain_sfc, snow_sfc = TestColumnEnthalpyConservation2M._run(cols)
+        _, _, _, _, _, _, _, _, rho, dz, _, _ = cols
+        mass = np.asarray(rho * dz)                       # [kg/m²] per level
+
+        heating = mass * c.cpd * np.asarray(tend.dtedt)   # [W/m²] per level
+        dE = float(np.sum(
+            heating
+            - mass * c.alhc * np.asarray(tend.dqcdt)
+            - mass * c.alhs * np.asarray(tend.dqidt)
+        ))
+        boundary = c.alhc * rain_sfc + c.alhs * snow_sfc
+        gross = float(np.sum(np.abs(heating))) + abs(boundary)
+        residual = dE - boundary
+
+        assert gross > 1.0, f"{name}: column did nothing — fixture is vacuous"
+        assert abs(residual) < 1e-5 * gross, (
+            f"{name}: column enthalpy open by {residual:+.4e} W/m² "
+            f"({100 * residual / gross:+.2f} % of gross {gross:.3e}); "
+            f"rain {rain_sfc:.3e}, snow {snow_sfc:.3e} kg/m²/s"
+        )
+        return residual, gross
+
+    # -- fixtures ---------------------------------------------------------
+    # Each returns (T, q, p, qc, qi, qnc, qni, cf, rho, dz, tke, ice_nuclei).
+
+    @staticmethod
+    def _warm_liquid(nlev=20):
+        from jcm.physics.clouds.sundqvist import saturation_specific_humidity
+
+        T = jnp.linspace(280.0, 300.0, nlev)
+        p = jnp.linspace(2e4, 1e5, nlev)
+        rho = p / (287.0 * T)
+        qsw = jax.vmap(saturation_specific_humidity)(p, T)
+        idx = jnp.arange(nlev)
+        q = jnp.where((idx >= 10) & (idx < 16), 0.95 * qsw, 0.7 * qsw)
+        qc = jnp.zeros(nlev).at[10:16].set(1e-3)
+        cf = jnp.where(qc > 0, 0.7, 0.0)
+        return (T, q, p, qc, jnp.zeros(nlev), jnp.where(qc > 0, 5e7, 0.0),
+                jnp.zeros(nlev), cf, rho, jnp.full(nlev, 500.0),
+                jnp.full(nlev, 0.1), jnp.zeros(nlev))
+
+    @staticmethod
+    def _wbf_mixed_phase(nlev=12, tke=0.0):
+        from jcm.physics.clouds.sundqvist import saturation_specific_humidity
+
+        T = jnp.full(nlev, 258.0)          # mixed-phase window
+        p = jnp.linspace(3e4, 8e4, nlev)
+        rho = p / (287.0 * T)
+        q = 1.02 * jax.vmap(saturation_specific_humidity)(p, T)  # depositing
+        qc = jnp.zeros(nlev).at[4:8].set(3e-4)
+        qi = jnp.zeros(nlev).at[4:8].set(5e-5)
+        cf = jnp.where((qc + qi) > 0, 0.9, 0.0)
+        # Quiescent: the Korolev/Mazin threshold-velocity gate stays open, so
+        # the Bergeron conversion actually fires.
+        return (T, q, p, qc, qi, jnp.where(qc > 0, 5e7, 0.0),
+                jnp.where(qi > 0, 1e5, 0.0), cf, rho, jnp.full(nlev, 500.0),
+                jnp.full(nlev, tke), jnp.zeros(nlev))
+
+    @staticmethod
+    def _cold_ice_to_surface(nlev=20):
+        from jcm.physics.clouds.sundqvist import saturation_specific_humidity
+
+        T = jnp.linspace(210.0, 262.0, nlev)   # never above freezing
+        p = jnp.linspace(2e4, 1e5, nlev)
+        rho = p / (287.0 * T)
+        q = 0.9 * jax.vmap(saturation_specific_humidity)(p, T)
+        qi = jnp.zeros(nlev).at[6:12].set(5e-4)
+        cf = jnp.where(qi > 0, 0.7, 0.0)
+        # Few, large crystals → fast fallout that reaches the ground.
+        return (T, q, p, jnp.zeros(nlev), qi, jnp.zeros(nlev),
+                jnp.where(qi > 0, 2e3, 0.0), cf, rho, jnp.full(nlev, 500.0),
+                jnp.full(nlev, 0.1), jnp.zeros(nlev))
+
+    @staticmethod
+    def _cloud_ice_above_freezing(nlev=12):
+        from jcm.physics.clouds.sundqvist import saturation_specific_humidity
+
+        T = jnp.full(nlev, 280.0)              # entire column above tmelt
+        p = jnp.linspace(5e4, 1e5, nlev)
+        rho = p / (287.0 * T)
+        q = 0.8 * jax.vmap(saturation_specific_humidity)(p, T)
+        qi = jnp.zeros(nlev).at[4:8].set(2e-4)
+        cf = jnp.where(qi > 0, 0.7, 0.0)
+        return (T, q, p, jnp.zeros(nlev), qi, jnp.zeros(nlev),
+                jnp.where(qi > 0, 1e4, 0.0), cf, rho, jnp.full(nlev, 500.0),
+                jnp.zeros(nlev), jnp.zeros(nlev))
+
+    # -- the four fixtures ------------------------------------------------
+
+    def test_enthalpy_closes_warm_liquid(self):
+        self._assert_enthalpy_closes("warm liquid", self._warm_liquid())
+
+    def test_enthalpy_closes_wbf_mixed_phase(self):
+        """A Bergeron cell must move mass, not just latent heat.
+
+        ``WBF_process`` returns a liquid debit, an ice credit and the fusion
+        warming for one and the same transfer. Take the warming alone and the
+        column gains ``Lf × wbf_col`` of enthalpy from nothing.
+        """
+        cols = self._wbf_mixed_phase()
+        tend, _, _ = self._run(cols)
+        _, _, _, _, _, _, _, _, rho, dz, _, _ = cols
+        dqc_col = float(jnp.sum(tend.dqcdt * rho * dz))
+        assert dqc_col < -1e-6, (
+            f"WBF fixture lost no liquid (column dqcdt {dqc_col:.3e}) — the "
+            "Bergeron transfer is not reaching the qc tendency"
+        )
+        self._assert_enthalpy_closes("WBF mixed phase", cols)
+
+    def test_enthalpy_closes_cold_ice_reaching_surface(self):
+        cols = self._cold_ice_to_surface()
+        _, _, snow_sfc = self._run(cols)
+        assert snow_sfc > 0.0, "fallout never reached the ground"
+        self._assert_enthalpy_closes("cold ice to surface", cols)
+
+    def test_enthalpy_closes_cloud_ice_above_freezing(self):
+        """Cloud ice above 0 °C must melt exactly once.
+
+        Sedimentation runs before melting, so the melt must act on what
+        sedimentation left. If ``pimlt`` is computed from the
+        pre-sedimentation ice, it and the sedimented flux claim the same
+        mass and the column makes ``2 × qi/dt`` of liquid out of ``qi``.
+        """
+        import numpy as np
+
+        cols = self._cloud_ice_above_freezing()
+        tend, rain_sfc, snow_sfc = self._run(cols)
+        _, _, _, _, qi, _, _, _, rho, dz, _, _ = cols
+        mass = np.asarray(rho * dz)
+
+        assert rain_sfc == 0.0 and snow_sfc == 0.0, (
+            "fixture is meant to melt in place, not precipitate"
+        )
+        dqc_col = float(np.sum(np.asarray(tend.dqcdt) * mass))
+        dqi_col = float(np.sum(np.asarray(tend.dqidt) * mass))
+        assert dqc_col > 0.0, "no melting happened — fixture is vacuous"
+        # Melting is a pure qi → qc transfer: what liquid gains, ice loses.
+        np.testing.assert_allclose(dqc_col, -dqi_col, rtol=1e-5)
+        # ...and no more ice than the column actually holds may melt.
+        available = float(np.sum(np.asarray(qi) * mass)) / self.DT
+        assert dqc_col < available * (1.0 + 1e-5), (
+            f"melted {dqc_col:.4e} kg/m²/s from a column holding only "
+            f"{available:.4e} — the ice is being melted twice"
+        )
+
+    def test_water_budget_closes_for_cloud_ice_above_freezing(self):
+        """The same fixture, against total water.
+
+        Melting ice twice makes liquid out of nothing, which opens the water
+        budget too — at ≈18 mm/day with no surface precipitation at all. The
+        fixtures in ``TestColumnWaterConservation2M`` never reach this state
+        (none of them carry cloud ice in air above freezing), which is why
+        this column belongs in both budgets.
+        """
+        import numpy as np
+
+        cols = self._cloud_ice_above_freezing()
+        tend, rain_sfc, snow_sfc = self._run(cols)
+        _, _, _, _, _, _, _, _, rho, dz, _, _ = cols
+        mass = np.asarray(rho * dz)
+        dw = np.asarray(tend.dqdt + tend.dqcdt + tend.dqidt)
+        P = rain_sfc + snow_sfc
+        # Scale the bound on the GROSS movement of each phase, not on the net
+        # per-level sum: melting is an internal qi → qc transfer, so the net
+        # is ~0 by construction here and would make any relative bound
+        # vacuous. The double melt showed up as a residual ≈ 26 mm/day.
+        gross = float(np.sum(
+            (np.abs(np.asarray(tend.dqdt)) + np.abs(np.asarray(tend.dqcdt))
+             + np.abs(np.asarray(tend.dqidt))) * mass
+        )) + abs(P)
+        residual = float(np.sum(dw * mass) + P)
+        assert gross > 0.0
+        assert abs(residual) < max(1e-5 * gross, 1e-12), (
+            f"water budget open by {residual:.3e} kg/m²/s with no "
+            f"precipitation (gross {gross:.3e})"
+        )
+
+    def test_het_freezing_moves_mass_and_fusion_heat(self):
+        """Immersion INP must freeze droplet MASS, not just crystal number.
+
+        The aerosol → ice coupling of #494 sets ICNC from the online INP and
+        freezes one mean-mass droplet per new crystal. That transfer was
+        applied to the local in-cloud arrays but never added to the freezing
+        accumulator the assembly ledger reads, so raising INP created
+        crystals with zero mass and destroyed droplets with zero mass — the
+        one finding that conserves water and so hides from every budget
+        check. Water conservation cannot see it; the Lf signature can.
+
+        WBF is suppressed here (strong turbulence shuts the threshold-
+        velocity gate): with it active the whole liquid reservoir glaciates
+        either way and the heterogeneous pathway is invisible in the totals.
+        """
+        import numpy as np
+        import jcm.constants as c
+
+        cols = list(self._wbf_mixed_phase(tke=5.0))
+        nlev = cols[0].shape[0]
+        qc = cols[3]
+
+        cols[11] = jnp.zeros(nlev)                       # no online INP
+        base, _, _ = self._run(tuple(cols))
+        cols[11] = jnp.where(qc > 0, 1e6, 0.0)           # 1e6 /m³ immersion INP
+        high, _, _ = self._run(tuple(cols))
+
+        d_qc = np.asarray(high.dqcdt - base.dqcdt)
+        d_qi = np.asarray(high.dqidt - base.dqidt)
+        d_te = np.asarray(high.dtedt - base.dtedt)
+        d_ni = np.asarray(high.dqnidt - base.dqnidt)
+
+        assert np.sum(d_ni) > 0.0, "INP did not raise the crystal number"
+        assert float(np.sum(d_qc)) < 0.0, (
+            "raising INP froze no droplet mass — heterogeneous freezing is "
+            "moving crystal number only"
+        )
+        assert float(np.sum(d_qi)) > 0.0, "the frozen mass never became ice"
+
+        # Per level inside the deck (levels 4-7 hold the condensate), the
+        # extra warming is exactly the extra frozen mass times the scheme's
+        # own fusion heat, ``lsdcp - lvdcp``. Note that is (alhs - alhc), NOT
+        # the independent ``alhf`` constant — they differ by 0.3 %.
+        #
+        # Column totals cannot carry this check: more crystals means smaller
+        # crystals, so the extra ice also sediments more slowly and the
+        # column ice gain is ~3x the frozen mass. dqc and dtedt are clean
+        # because nothing downstream feeds back on them here.
+        fusion = (c.alhs - c.alhc) / c.cpd
+        for k in range(4, 8):
+            assert d_qc[k] < 0.0, f"level {k} lost no liquid to INP"
+            np.testing.assert_allclose(
+                d_te[k], -d_qc[k] * fusion, rtol=1e-3,
+                err_msg=f"level {k}: fusion heat does not match frozen mass",
+            )
+
+
 class TestPrecipFluxProfiles2M:
     """COSP-hook invariants for the per-level rain / snow flux profiles.
 

--- a/jcm/physics/clouds/lohmann_2m_test.py
+++ b/jcm/physics/clouds/lohmann_2m_test.py
@@ -1483,7 +1483,7 @@ class TestColumnWaterConservation2M:
         params = CloudParams2M.default()
 
         (tend, rain_sfc, snow_sfc, _rl, _ri, _rfw, _rfm, _au, _ac, _wbf,
-         form, evap, rain_prof, snow_prof) = cloud_microphysics_2m(
+         form, evap, _cf, rain_prof, snow_prof) = cloud_microphysics_2m(
             T, q, p, qc, jnp.zeros(nlev), qnc, jnp.zeros(nlev),
             jnp.zeros(nlev), jnp.zeros(nlev), cf, rho, dz,
             jnp.full(nlev, 0.1), jnp.full(nlev, 5e7),
@@ -1533,7 +1533,7 @@ class TestColumnWaterConservation2M:
         params = CloudParams2M.default()
 
         (tend, rain_sfc, snow_sfc, _rl, _ri, _rfw, _rfm, _au, _ac, _wbf,
-         form, evap, _rp, _sp) = cloud_microphysics_2m(
+         form, evap, _cf, _rp, _sp) = cloud_microphysics_2m(
             T, q, p, jnp.zeros(nlev), qi, jnp.zeros(nlev), qni,
             jnp.zeros(nlev), jnp.zeros(nlev), cf, rho, dz,
             jnp.full(nlev, 0.1), jnp.full(nlev, 5e7),

--- a/jcm/physics/clouds/lohmann_2m_test.py
+++ b/jcm/physics/clouds/lohmann_2m_test.py
@@ -1970,6 +1970,104 @@ class TestColumnEnthalpyConservation2M:
             f"precipitation (gross {gross:.3e})"
         )
 
+    def test_published_cloud_fraction_never_exceeds_the_input(self):
+        """The microphysics may clear cloud, not conjure it.
+
+        The published cover exists so that cells emptied of both condensates
+        stop being cloudy for radiation, COSP and the JAM aerosol terms.
+        ``update_in_cloud_water`` also has an upward branch — clear cell with
+        any condensation gets cf = clip(RH, 0.01, 1) — which is a second,
+        RH-based cover closure competing with ``SundqvistCloudFraction``.
+
+        The fixture is the state that makes the difference stark: an
+        ice-supersaturated column at 5 hPa, above ``cloud_top_pressure_pa``,
+        where Sundqvist deliberately reports no cloud because "the RH-closure
+        otherwise fills the cold, near-zero-qsat stratosphere with spurious
+        cloud". Unclipped it comes back overcast.
+        """
+        import numpy as np
+        from jcm.physics import thermodynamics
+
+        nlev = 6
+        T = jnp.full(nlev, 210.0)
+        p = jnp.full(nlev, 5e2)                     # 5 hPa — stratosphere
+        rho = p / (287.0 * T)
+        esi = thermodynamics.saturation_vapor_pressure(T, phase="ice")
+        qsi = 0.622 * esi / jnp.maximum(p - 0.378 * esi, 1e-12)
+        q = 1.6 * qsi                               # strongly supersaturated
+        zeros = jnp.zeros(nlev)
+        # cloud_fraction = 0 everywhere: Sundqvist reports no stratospheric cloud.
+        cols = (T, q, p, zeros, zeros, zeros, zeros, zeros,
+                rho, jnp.full(nlev, 500.0), zeros, zeros)
+
+        cf_published = np.asarray(self._run_full(cols)[12])
+        assert float(np.max(cf_published)) == 0.0, (
+            f"cloud-free stratosphere published as cf={np.max(cf_published):.3f} "
+            "— the microphysics is substituting its own RH cover closure"
+        )
+
+        # And the clearing direction still works: a cell the scheme empties
+        # must lose its cover.
+        warm = self._cloud_ice_above_freezing()
+        out_warm = self._run_full(warm)
+        cf_in = np.asarray(warm[7])
+        cf_out = np.asarray(out_warm[12])
+        assert np.all(cf_out <= cf_in + 1e-6), "published cover exceeds input"
+
+    @staticmethod
+    def _run_full(cols):
+        """Full return tuple, for tests that need more than the tendencies."""
+        from jcm.physics.clouds.lohmann_2m import cloud_microphysics_2m
+        from jcm.physics.clouds.lohmann_2m_params import CloudParams2M
+
+        T, q, p, qc, qi, qnc, qni, cf, rho, dz, tke, inp = cols
+        nlev = T.shape[0]
+        z = jnp.zeros(nlev)
+        return cloud_microphysics_2m(
+            T, q, p, qc, qi, qnc, qni, z, z, cf, rho, dz, tke,
+            jnp.full(nlev, 5e7), inp, z,
+            TestColumnEnthalpyConservation2M.DT, CloudParams2M.default(),
+        )
+
+    def test_homogeneous_freezing_removes_all_the_liquid(self):
+        """Below cthomi every drop freezes, in a partly-cloudy box too.
+
+        ``freezing_below_238K`` zeroes the in-cloud liquid outright and
+        reports the transfer already area-weighted (``pfrl += pxlb·paclc``),
+        so the ledger must receive it as-is. Area-weight it a second time and
+        only ``cf`` of the liquid is debited from ``qc`` while the in-cloud
+        state says the cloud is fully glaciated — the grid box then carries
+        liquid water below the homogeneous freezing point indefinitely,
+        halving the remainder each step.
+
+        No budget test can catch this: the liquid debit, the ice credit and
+        the fusion heat all come from that one number, so water and enthalpy
+        both close on the wrong value. Only the state can tell.
+        """
+        import numpy as np
+
+        nlev = 8
+        cf_val = 0.4                               # well away from 1.0
+        T = jnp.full(nlev, 230.0)                  # below cthomi = 238 K
+        p = jnp.linspace(2e4, 4e4, nlev)
+        rho = p / (287.0 * T)
+        q = jnp.full(nlev, 1e-6)
+        qc = jnp.zeros(nlev).at[3:6].set(1e-4)     # grid-mean liquid
+        cf = jnp.where(qc > 0, cf_val, 0.0)
+        dz = jnp.full(nlev, 500.0)
+        cols = (T, q, p, qc, jnp.zeros(nlev), jnp.where(qc > 0, 5e7, 0.0),
+                jnp.zeros(nlev), cf, rho, dz,
+                jnp.zeros(nlev), jnp.zeros(nlev))
+
+        tend, _, _ = self._run(cols)
+        mass = np.asarray(rho * dz)
+        held = float(np.sum(np.asarray(qc) * mass))
+        frozen = -float(np.sum(np.asarray(tend.dqcdt) * mass)) * self.DT
+
+        assert frozen > 0.0, "no liquid froze below cthomi"
+        # All of it, not cf of it. The double-weighted form gives cf_val*held.
+        np.testing.assert_allclose(frozen, held, rtol=1e-3)
+
     def test_het_freezing_moves_mass_and_fusion_heat(self):
         """Immersion INP must freeze droplet MASS, not just crystal number.
 


### PR DESCRIPTION
Findings 1, 2, 3, 4 and 6 of #662, plus the column enthalpy-conservation test
that gates them. **Finding 5 is deliberately not here** — see the last section.

## Root cause

Five independent symptoms, one shape: a process routine computes a transfer,
applies it to its *local in-cloud* arrays, and the grid-mean tendency ledger in
`assembly.py` never hears about it — or hears only half of it. Water stays
conserved in three of the five, which is why nothing caught them.

The ledger (`update_tendencies_and_important_vars`) is ECHAM's: it starts from
the grid-mean condensate the step began with and adds grid-mean per-step
increments. Every fix below is "convert the transfer to grid-mean and put it in
the accumulator the ledger reads".

### 1. WBF applied its latent heat and discarded the mass

`WBF_process` computes the Bergeron transfer once and returns it three ways: a
liquid debit, an ice credit, and the matching fusion warming. The sweep kept
only the warming (`_liq_tend_wbf`, `_ice_tend_wbf` were dropped on the floor).
Supercooled liquid was heated as though it had glaciated but never left `qc`.
All three now seed the three INOUT accumulators.

### 2. Cloud ice above 0 °C melted twice

`melting_snow_and_ice` reconstructs the ice available to melt as
`max(pxim1 + dt·pxite, 0)`. It was handed the **pre**-sedimentation ice with
`pxite = 0`, so ice that sedimentation had already moved into the falling flux
melted a second time — and the routine's own ice debit was discarded on top.
The sedimentation tendency is now threaded *through* the routine (which is how
ECHAM keeps the two sinks from claiming the same mass) and its output tendency
seeds the ledger.

The sediment → melt *ordering* is unchanged; it matches MG/PUMAS. The bug was
the discard, not the order.

### 3. Heterogeneous freezing moved crystal number but not mass

`frozen_mass` was applied to `in_cloud_ice_het` / `in_cloud_liquid_het` but
never added to the freezing accumulator, so raising `ice_nuclei` created
crystals with zero mass and destroyed droplets with zero mass. Water conserves
perfectly — which is why this one hides from every budget check — but it meant
the JAM aerosol → ice coupling of #494 moved number and nothing else, while the
effective radii were computed on liquid the tracers never lost.

A single grid-mean `freezing_rate` (ECHAM `pfrl`) now carries both the
homogeneous and the heterogeneous leg; the ledger converts it to fusion heat
automatically.

### 4. `cloud_fraction_final` was discarded — cherry-picked, then clipped

Cherry-picked from @duncanwp's `fix/662-cloud-fraction-final` (`c29a820`) —
thanks. Cells the microphysics has just emptied no longer keep a non-zero cloud
fraction for radiation and the aerosol partition to read.

**One change on top of it.** The published cover is now clipped to the incoming
cover: the microphysics may *remove* cloud, never create it. `update_in_cloud_water`
has an upward branch — a clear cell with any condensation gets
`cf = clip(RH, 0.01, 1)` — which is a second, RH-based cover closure competing
with `SundqvistCloudFraction`. Publishing it raw substituted that closure. Measured:
an ice-supersaturated column at 5 hPa, **above `cloud_top_pressure_pa`, which
Sundqvist deliberately reports as cloud-free for exactly this reason**, came back
**overcast (cf = 1.0)** on ~1e-6 kg/kg of ice — and COSP, AeroCom and the JAM
cloud-borne / aqueous / wetdep terms all read that field.

### 6. The negative-mass guard was fed in-cloud values

`ice_mmr_prev` / `liq_mmr_prev` are ECHAM's `pxim1` / `pxlm1`: the **grid-mean**
condensate the step started from. They were being passed the post-process
in-cloud values, so `ll_liq_neg = liq_mmr_next < ccwmin` compared an in-cloud
magnitude (larger by 1/cf) against a grid-mean threshold — the guard
under-triggered, and where it did fire it injected an in-cloud-sized correction
into a grid-mean tendency and into `dqdt`/`dtedt`.

### Also: one cloud fraction for every in-cloud → grid-mean conversion

`update_in_cloud_water` is where ECHAM rewrites `paclc` — a clear cell with
positive condensation becomes cloudy, and its in-cloud condensate is defined
against that *new* fraction. Conversions downstream were still using the
pre-activation `cloud_fraction`, so in exactly those cells they converted at
cf = 0 and the whole transfer vanished from the ledger while the in-cloud state
moved. Everything after that call now uses `cloud_fraction_uicw`. Findings 1
and 3 do not close without it.

## The gate: `TestColumnEnthalpyConservation2M`

Internal phase changes leave

```
E = Σ ρ·dz·(cpd·T − Lv·qc − Ls·qi)
```

invariant — condensation trades Lv of vapour enthalpy for Lv of warming,
freezing trades Lf for Lf. Vapour cancels out of `E` entirely, which is what
makes this independent of the existing `TestColumnWaterConservation2M`. The
only way the column changes `E` is by exporting condensate, so

```
Σ ρ·dz·(cpd·dT/dt − Lv·dqc/dt − Ls·dqi/dt) == Lv·rain_sfc + Ls·snow_sfc
```

Modelled on CAM's `check_energy_chng` (column energy against
`previous + dt·boundary_flux`), not on PUMAS's `omsm` limiter — a negativity
guard cannot see a budget that is open in both directions.

Four fixtures, as the issue specifies: warm liquid, WBF-active mixed phase,
cold ice reaching the surface, and cloud ice above 0 °C. The first and third
are controls — they passed before and must keep passing. The water test is
extended with the fourth fixture too.

**Verified to fail without the fix**: with `scheme.py` reverted, the four
finding-targeted tests fail and the two controls still pass.

## Evidence

Column enthalpy residual (`dE/dt − boundary`), single-column probes:

| fixture | before | after |
|---|---|---|
| warm liquid → rain *(control)* | −3.2e−4 W/m² (−0.00 %) | −3.2e−4 W/m² |
| cold ice → surface snow *(control)* | −6.5e−5 W/m² (−0.00 %) | −3.4e−5 W/m² |
| WBF-active mixed phase | **+39.9 W/m² (+3.81 %)** | −5.3e−5 W/m² |
| cloud ice above 0 °C | **−587.8 W/m² (−425.7 %)** | −2.8e−5 W/m² |

The WBF residual was `Lf × wbf_col` to 0.2 % (3.337e5 × 1.198e−4 = 39.96),
exactly as #662 predicted.

Cloud ice above 0 °C, water budget — with **zero** surface precipitation:
residual +2.07e−4 kg/m²/s (≈18 mm/day) → +6.6e−12. `Σ dqcdt·m` was exactly
2× the ice debit (4.147e−4 vs 2.074e−4); it is now equal and opposite.

Heterogeneous freezing, `ice_nuclei` 0 → 1e6 m⁻³, WBF suppressed, level 5
(Σ Δ`dqnidt` = +2355 kg⁻¹s⁻¹ in both, so the crystals were always being made):

| | before | after |
|---|---|---|
| Δ `dqcdt` | +2.45e−11 — *wrong sign*, 60× too small | −1.486e−9 |
| Δ `dtedt` | −8.13e−9 — *wrong sign* | +4.925e−7 |
| Δ`dtedt` / −Δ`dqcdt` | — | **331.46** = `(alhs−alhc)/cpd` exactly |

## Caught by review, fixed here

A `/code-review high` pass over the diff found a defect I had introduced, which
three independent finder angles located at the same line:

**`freezing_below_238K` already area-weights its own transfer**
(`pfrl += pxlb·paclc`, `deposition_freezing.py:508`) and zeroes the in-cloud
liquid outright. Folding it into the same `* cloud_fraction` conversion as the
heterogeneous leg weighted it twice, so below 238 K only `cf` of the liquid was
debited from `qc` while the in-cloud state said the cloud was fully glaciated —
grid-mean liquid water persisting below the homogeneous freezing point, halving
each step. Only `frozen_mass` (the het leg) is a bare in-cloud increment.

**The enthalpy test structurally could not catch it**: the liquid debit, the ice
credit and the fusion heat all come from that one number, so water and enthalpy
both close on the wrong value. It needs a *state* assertion, which is what
`test_homogeneous_freezing_removes_all_the_liquid` is — below `cthomi` every drop
freezes, in a partly-cloudy box too. Verified to fail on the double-weighted form
(froze 0.0417 of 0.0714 kg/m², i.e. exactly `cf`).

That is a general limitation worth stating: a budget test pins the *ledger's*
self-consistency, not the agreement between the ledger and the in-cloud state.
Both new state-level tests (this one and the cloud-fraction clip) exist because
of it.

## Expected impact on a running model

These are physics changes, not bookkeeping:

- supercooled liquid now actually leaves `qc` where WBF fires — LWP should drop
  in mixed-phase decks;
- warm columns carrying cloud ice stop manufacturing liquid and stop cooling
  twice;
- JAM's `ice_nuclei` (#494) now removes droplet mass and releases fusion heat,
  so the aerosol → ice coupling has a thermodynamic effect for the first time;
- the post-microphysics cloud fraction reaches radiation and the aerosol
  partition (finding 4);
- newly-formed cloud cells no longer convert their transfers at cf = 0.

**No coupled integration has been run** — validation here is the unit suite plus
single-column probes, by agreement on scope. Worth watching LWP/IWP in the next
release-validation pass.

## Not in this PR — #662 stays open

**Finding 5** (`qr`/`qs` are permanently zero, so accretion by rain from above
is dead) needs `precip_formation_warm`/`_cold` moved *inside* the flux-coupled
scan, because the rain flux they need only exists in the scan carry. Warm
precip is the first step of the chain and everything downstream depends on it,
so that means moving the whole level-independent chain into the scan body and
turning ~12 arrays into scan `ys` — a restructure of the orchestrator, not a
patch. It also changes precipitation formation by ~3×, which deserves its own
evidence rather than being buried here. The Marshall–Palmer inversion to port
is `echam_1m.py:892-903` (per @duncanwp's comment on #662).

Issues filed for everything found but not fixed (repo rule):

| | |
|---|---|
| #681 | `c.alhf` (3.34e5) and `alhs − alhc` (3.33e5) disagree by 0.3 % and are used interchangeably. Surfaced because the enthalpy identity only closes against the latter — which is what the scheme's `lsdcp − lvdcp` is. |
| #685 | `pclcstar`/`pauloc` are placeholders, so accretion in partly precipitation-covered boxes is overestimated. Needs the same scan refactor as finding 5. Cross-linked from both call sites. |
| #686 | `cold_mask` gates on the step-start `qi`, so ice created *this* step (WBF, deposition, #494 het freezing) gets no aggregation or riming sink. Latent before, load-bearing now that the WBF ice credit reaches `dqidt`. |
| #687 | `clouds.cloud_fraction` now means the post-microphysics cover under `2m` and the diagnosed cover under `1m` — a 1M/2M A/B differs by a definition as well as by physics. |
| #688 | The grid-mean `ccwmin` guard clears thin stratiform cloud (cf = 0.05, in-cloud IWC 1e-6). Reference-correct, but the threshold has never been tuned against grid-mean values here. |
| #689 | A negative `qc`/`qi` undershoot is repaired by condensing vapour — consistent, but sign-definite (~+0.12 K/day per 1e-6 undershoot). Worth a diagnostic. |

## Testing

- `ruff check .` clean.
- Full CI gates (lint, fast `-m "not slow"` cov≥90, slow cov≥80) on a Derecho
  `develop`-queue node — **not** the login node, which produces ~50 phantom
  failures across unrelated subsystems (the `jcm-local-ci` skill documents this;
  I reproduced it before noticing `nproc` = 1).
- `/code-review high` (8 finder angles + verification) — findings above.
- `jcm/physics/clouds/lohmann_2m_test.py`: 62 pre-existing + 8 new, all passing.

**The slow gate is red on an unrelated flake — #692.**
`pyses_dycore_test.py::TestCoupledEchamSmoke::test_model_drives_float32_physics`
segfaults its xdist worker intermittently. Five full slow-gate runs:

| worktree | without `--cov` | with `--cov` |
|---|---|---|
| `origin/dev` @ f6d1bcd | 93 passed | 93 passed |
| this branch | 93 passed | **segfault**, **segfault** |

The branch correlation is spurious, and the mechanism settles it rather than the
statistics: that test builds `echam_physics(radiation_scheme="grey")`, which
resolves `cloud_scheme` to its `"1m"` default, so its stack holds
`echam_1m_microphysics` and **no Lohmann 2M term** — this diff is confined to
`jcm/physics/clouds/lohmann_2m/` and is never constructed, traced or executed by
it. Run alone it passes on both worktrees in near-identical time (59.80s vs
59.56s). The segfault also destroys the coverage data, which is why the run
reports ~29 % and trips `--cov-fail-under=80`.

I would not merge on a red gate without that being understood — flagging it
rather than asking anyone to take "it's flaky" on faith.
