### PR TITLE
2M clouds: the faithful column_processes consolidation (#662-f5, #667, #685, #686, #687, #688, #689, #681)

### DIFF
--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -15,6 +15,7 @@ JAX-GCM is designed to be a fully differentiable climate model that balances eas
    design/dinosaur_sl_jam_configuration
    design/speedy_variable_levels
    design/frontal_gravity_wave_drag
+   design/lohmann_2m_column_processes
    design/aerosol_optics_diagnostics
    design/aerocom_erfari_sampling
    design/data_mirror

--- a/docs/source/design/lohmann_2m_column_processes.md
+++ b/docs/source/design/lohmann_2m_column_processes.md
@@ -1,0 +1,118 @@
+# The Lohmann 2M scheme is ECHAM's `column_processes` loop
+
+*(2026-08; issues #662, #667, #685, #686, #687, #688, #689; parent audit #614)*
+
+## The decision
+
+`cloud_microphysics_2m` runs the **entire** two-moment process chain inside one
+top-down `lax.scan`, one scan step per level, in the section order of ECHAM's
+`mo_cloud_micro_2m.f90` `column_processes` loop. Section 8 (the tendency
+ledger, `update_tendencies_and_important_vars`) has no cross-level coupling and
+runs vectorized on the stacked per-level outputs afterwards.
+
+The previous layout split the chain: "level-independent" processes
+(condensation partition, freezing, WBF, warm/cold precipitation formation) ran
+vectorized outside the sweep, and only sedimentation/melting/sublimation ran
+inside it. That looked like a harmless performance-friendly factorization. It
+was not, because in the reference **every process at level `jk` consumes the
+precipitation state the levels above produced *this step*** — the rain/snow
+fluxes (`prfl`/`pssfl`), the precipitation cover (`zclcpre`), and the falling
+ice flux (`zxiflux`) are loop-carried. Splitting the chain silently severed
+those couplings:
+
+- accretion by rain/snow from above read `qr`/`qs` tracers that no term
+  declared any more — both identically zero, so the pathway was dead code and
+  precipitation formation was understated ~3× (#662 finding 5, and through
+  `rate_cb = p_form/(qc+qi)` the leading suspect for the cloud-borne aerosol
+  drainage failure in #658);
+- the cloud∩precipitation overlap `zclcstar = min(paclc, zclcpre)` could not
+  be formed, so accretion geometry fell back to `paclc` (#685);
+- ice created mid-step (deposition, freezing, WBF) never met its
+  aggregation/riming sink that step (#686);
+- warm rain ran *first*, before condensation and activation, matching neither
+  ECHAM nor CAM (#667 finding 4).
+
+The restructure is therefore not an optimization choice reversed — it is the
+minimal faithful shape. Wall-clock cost is unchanged at leading order: the
+same arithmetic moves from a `(nlev,)`-vectorized context into the scan body,
+and the scan already existed.
+
+## What the sweep does per level
+
+In ECHAM section numbering: 4 sedimentation → 3.1 melting → 3.2/3.3
+sublimation/rain-evaporation → in-cloud prep with clear-sky evaporation
+(`zxlevap`/`zxievap`) → 5 the `zqcdif` condensation closure → 5.4
+supersaturation corrections → 5.5 in-cloud update + activation/nucleation →
+6.1 homogeneous freezing → 6.2 heterogeneous freezing + WBF → 7 precipitation
+geometry (`zclcstar`, `zauloc`, the Marshall–Palmer inversions
+`zxrp1`/`zxsp1`) → 7.1 warm rain → 7.2 cold precipitation → 7.3 flux update.
+
+One deliberate deviation, reviewed and kept: sedimentation runs **before**
+melting (MG/PUMAS order, `micro_pumas_v1.F90`), with the running ice tendency
+threaded through the melt routine so the two sinks cannot claim the same mass
+(#662 finding 2). ECHAM melts first; both orderings are internally consistent
+ledgers.
+
+## The state-splitting convention
+
+ECHAM is leapfrog: the scheme receives the t−1 state (`ptm1`, `pqm1`,
+`pxlm1`, `pxim1`) plus accumulated tendencies (`ptte`, `pqte`, …) and *adds*
+its own contributions to the tendencies. jcm is additive operator-split: each
+term returns its own tendency against a provisional post-upstream state.
+
+The mapping used (and documented on `cloud_microphysics_2m`):
+
+- primary inputs = the **post-upstream provisional** state (`thermo_run` T/q,
+  `clouds.qc/qi` with convective detrainment folded in) — what the returned
+  tendencies are relative to;
+- optional `*_m1` inputs = the **step-start** state — ECHAM's t−1 anchors.
+  Saturation and all section-1 fields evaluate there, and the differences
+  `(x − x_m1)` play the role of `ztmst·pqte` in the condensation closure and
+  of `ztmst·pxlte` in the clear-sky-evaporation split.
+
+The ledger reconstruction is identical either way:
+`pxlm1 + Δt·(upstream+own) ≡ qc_provisional + Δt·own`, so the negative-mass
+guard bounds the true end-of-step state and the host's tendency sum
+telescopes exactly as ECHAM's INOUT accumulation.
+
+## What this made live (previously inert or miscalibrated)
+
+| pathway | before | after |
+|---|---|---|
+| internal saturation adjustment | `zqcon ≈ 1/50…1/650` (zdqsdt ×1000; #667.1) | Newton damper 0.36–0.93; 10 % supersat → 1 % in one step |
+| grid-scale condensation | external Sundqvist bolt-on (double-adjustment risk) | ECHAM section-5 `zqcdif` closure in-scheme; bolt-on removed |
+| clear-sky condensate sink | none (`pxlevap = pxievap = 0`) | `zxlevap`/`zxievap` verbatim; cf=0 cells evaporate in one step |
+| rain/snow-from-above accretion | dead (`qr`/`qs` ≡ 0) | Marshall–Palmer inversion of carry fluxes |
+| WBF threshold updraft | fed a 0–1 clip as `peta` | ECHAM's diffusional-growth ζ (line 856); recomputed post-freezing |
+| diagnostic ICNC (`nic_cirrus=1`) | `prid` in µm (r³ off by 10¹⁸) → pinned at floor | Schumann volume-mean radius in metres |
+| cold-chain gate | step-start `qi > ccwmin` | `ll_cc` + in-scan `zxib > cqtmin` (#686) |
+
+## Deliberate omissions (tracked)
+
+- **Large-scale vertical velocity is not plumbed** (`zvervx` is TKE-only; the
+  `knvb`/`lonacc` inversion gate on `zauloc` is omitted; `het_mxphase_freezing`
+  likewise lacks `pvervel`). Tracked in #705.
+- **`nic_cirrus = 2`** still expects the Kärcher–Lohmann `pnicex`/`zqinucl`
+  source jcm does not compute (#552); its section-5 deposition branch returns
+  zero, as in the reference with a missing external source.
+- **Moist heat capacity**: ECHAM's `zlvdcp = Lv/(cpd + cpd·vtmpc2·q)`; jcm
+  uses `Lv/cpd`. ~1 % on latent heating; kept so the column enthalpy gate has
+  a single cp. Tracked in #706.
+
+## The gates
+
+`TestColumnWaterConservation2M` and `TestColumnEnthalpyConservation2M`
+(modelled on CAM's `check_energy_chng`) close the water and enthalpy budgets
+against the surface fluxes for warm-liquid, WBF, cold-fallout, and
+melt-in-place fixtures. `TestSaturationGate2M` pins that no supersaturation
+survives a step (the property whose absence let the double adjustment hide);
+`TestColdChainSameStepCoupling2M` pins that a deck glaciating via WBF exports
+a frozen flux the same step. Budget tests pin the ledger's self-consistency —
+a defect that mis-states the in-cloud state on both sides of a transfer needs
+a *state* assertion, which is why the het-INP test bounds the per-level
+fusion heat from below rather than trusting closure alone.
+
+`clouds.cloud_fraction` now means the post-microphysics cover under both the
+1M and 2M schemes (#687; documented on `CloudData`), and the 2M
+negative-mass repair is exported as `clouds.negative_mass_repair` [W/m²]
+(#689) so its sign-definite heating is measurable in any run.

--- a/jcm/config/physics/echam-rrtmgp-2m.yaml
+++ b/jcm/config/physics/echam-rrtmgp-2m.yaml
@@ -1,11 +1,12 @@
 # ECHAM with RRTMGP radiation and the Lohmann 2-moment microphysics
 # (Lohmann2MMicrophysics) in place of the 1-moment Echam1MMicrophysics.
 #
-# Same term list as ``echam-rrtmgp.yaml`` with one term swap. The 2M
-# scheme carries qc / qi / qnc / qni / qr / qs as prognostic tracers and
-# does its own saturation adjustment internally via
-# ``mixed_phase_deposition_and_corrections``, so it pairs with the pure-
-# cf ``SundqvistCloudFraction`` upstream just like the merged 1M does.
+# Same term list as ``physics=echam`` with one term swap. The 2M scheme
+# carries qc / qi / qnc / qni as prognostic tracers (rain/snow live in
+# the within-step fluxes, not tracers) and owns saturation adjustment
+# internally (the ECHAM section-5 condensation closure + supersaturation
+# corrections, #667), so it pairs with the pure-cf
+# ``SundqvistCloudFraction`` upstream just like the merged 1M does.
 #
 # Use it as::
 #

--- a/jcm/constants.py
+++ b/jcm/constants.py
@@ -65,9 +65,11 @@ class PhysicalConstants(NamedTuple):
     p0s1_bg: float = 101325.0
 
     # --- Latent heats (J/kg) ------------------------------------------------
+    # Only condensation and sublimation are independent; fusion is derived
+    # (see the ``alhf`` property), exactly as ECHAM's mo_physical_constants
+    # defines ``alf = als - alv``.
     alhc: float = 2.501e6              # Condensation
     alhs: float = 2.834e6              # Sublimation
-    alhf: float = 3.34e5               # Fusion
 
     # --- Radiation ----------------------------------------------------------
     sbc: float = 5.67e-8               # Stefan-Boltzmann constant (W/m²/K⁴)
@@ -95,6 +97,19 @@ class PhysicalConstants(NamedTuple):
     def rgrav(self) -> float:
         """Reciprocal of gravity (s²/m)."""
         return 1.0 / self.grav
+
+    @property
+    def alhf(self) -> float:
+        """Latent heat of fusion (J/kg) = alhs - alhc (ECHAM: alf = als - alv).
+
+        Derived, not a base field: the heat of fusion is fixed by energy
+        conservation once condensation and sublimation are chosen. The former
+        independent base value (3.34e5) disagreed with ``alhs - alhc``
+        (3.33e5) by 0.3 %, and both conventions were used interchangeably for
+        the same physical quantity — any column enthalpy budget then misses by
+        that 0.3 % depending on which branch a scheme took (#681).
+        """
+        return self.alhs - self.alhc
 
     @property
     def rd(self) -> float:

--- a/jcm/physics/clouds/cloud_data.py
+++ b/jcm/physics/clouds/cloud_data.py
@@ -72,6 +72,15 @@ class CloudData:
     rain_formation_warm: jnp.ndarray  # (ncols,)
     rain_from_melt: jnp.ndarray       # (ncols,)
 
+    # Column-integrated latent heating of the 2M negative-mass repair
+    # [W/m²] (#689): the ECHAM zdxlcor/zdxicor guard returns condensate
+    # below ccwmin (including dycore-ringing negatives) to vapour with
+    # the matching latent heat. Thermodynamically consistent but
+    # sign-definite — undershoots always become warming + drying — so it
+    # is exported for monitoring rather than folded silently into the
+    # tendencies. Zero under the 1M scheme.
+    negative_mass_repair: jnp.ndarray  # (ncols,)
+
     # Cloud properties
     droplet_number: jnp.ndarray  # Droplet number concentration [1/m³] (nlev, ncols)
 
@@ -117,6 +126,7 @@ class CloudData:
             precip_evaporation_rate=jnp.zeros((nlev,) + nodal_shape),
             rain_formation_warm=jnp.zeros(nodal_shape),
             rain_from_melt=jnp.zeros(nodal_shape),
+            negative_mass_repair=jnp.zeros(nodal_shape),
             droplet_number=jnp.zeros((nlev,) + nodal_shape),
             r_eff_liq=jnp.zeros((nlev,) + nodal_shape),
             r_eff_ice=jnp.zeros((nlev,) + nodal_shape),
@@ -141,6 +151,7 @@ class CloudData:
             'precip_evaporation_rate': self.precip_evaporation_rate,
             'rain_formation_warm': self.rain_formation_warm,
             'rain_from_melt': self.rain_from_melt,
+            'negative_mass_repair': self.negative_mass_repair,
             'droplet_number': self.droplet_number,
             'r_eff_liq': self.r_eff_liq,
             'r_eff_ice': self.r_eff_ice,

--- a/jcm/physics/clouds/cloud_data.py
+++ b/jcm/physics/clouds/cloud_data.py
@@ -18,7 +18,16 @@ import tree_math
 class CloudData:
     """Cloud-fraction, condensate, and surface-precip diagnostics."""
 
-    # Cloud fraction
+    # Cloud fraction. SEMANTICS (#687): after the microphysics term has
+    # run, this is the POST-microphysics cover — cells the scheme emptied
+    # of both condensates (end-of-step qc AND qi below ccwmin) have
+    # cloud_fraction = 0, under BOTH the 1M and 2M schemes (ECHAM's
+    # ``paclc`` write-back). Between SundqvistCloudFraction and the
+    # microphysics term it is the RH-diagnosed cover. The microphysics
+    # may only ever REMOVE cover relative to the diagnosed value, never
+    # add it. Consumers (radiation via the carry, COSP, AeroCom, the JAM
+    # cloud-borne/aqueous/wetdep terms) therefore always see the cloud
+    # the step actually left behind.
     cloud_fraction: jnp.ndarray      # Cloud fraction [1] (nlev, ncols)
 
     # Cloud condensate (updated by condensation within the cloud scheme)

--- a/jcm/physics/clouds/echam_1m.py
+++ b/jcm/physics/clouds/echam_1m.py
@@ -106,6 +106,10 @@ class MicrophysicsParameters:
                          # cloud-fraction floor below which a cell counts as
                          # cloud-free and its condensate force-evaporates
                          # (the ``nloidx`` partition, #668)
+    ccwmin: float        # ECHAM ``ccwmin`` (mo_echam_cloud_params): grid-mean
+                         # condensate below which a cell no longer counts as
+                         # cloudy — drives the post-microphysics ``paclc``
+                         # write-back (mo_cloud.f90:1280, #687)
 
     # Autoconversion scheme selector (int flag — JAX won't trace strings).
     # 0 = Beheng (1994) implicit form (default; robust at large dt).
@@ -131,7 +135,7 @@ class MicrophysicsParameters:
                  vt_rain_a=386.0, vt_rain_b=0.67, base_cdnc=100.0e6,
                  t_mix_min=238.15, t_mix_max=273.15,
                  epsilon=1.0e-12, d_epsilon=1.0e-30, dt_sedi=10.0,
-                 cqtmin=1.0e-12,
+                 cqtmin=1.0e-12, ccwmin=1.0e-7,
                  autoconversion_scheme=0) -> 'MicrophysicsParameters':
         """Return default microphysics parameters.
 
@@ -179,6 +183,7 @@ class MicrophysicsParameters:
             epsilon=jnp.array(epsilon),
             d_epsilon=jnp.array(d_epsilon),
             cqtmin=jnp.array(cqtmin),
+            ccwmin=jnp.array(ccwmin),
             dt_sedi=jnp.array(dt_sedi),
             autoconversion_scheme=int(autoconversion_scheme),
         )
@@ -1368,7 +1373,24 @@ class Echam1MMicrophysics(PhysicsTerm):
         diagnostics = {**diagnostics, "autoconv": autoconv_col,
                        "accretn": accretn_col, "wbf": zero_col}
 
+        # Post-microphysics cloud-cover write-back (ECHAM mo_cloud.f90:1280
+        # — ``paclc = FSEL(-(zxlp1_d*zxip1_d), paclc, 0)``): a cell whose
+        # end-of-step condensate falls below ``ccwmin`` in BOTH phases is
+        # no longer cloudy. This makes ``clouds.cloud_fraction`` mean the
+        # same thing under cloud_scheme='1m' and '2m' (#687): the cover
+        # the step actually leaves behind, which radiation, COSP, AeroCom
+        # and the JAM cloud-borne/aqueous/wetdep terms all read. The
+        # end-of-step condensate is interim + the scheme's own tendency
+        # (upstream increments are already inside the interim values).
+        qc_end = qc_interim + dt * micro_tend.dqcdt.T
+        qi_end = qi_interim + dt * micro_tend.dqidt.T
+        cloud_fraction_out = jnp.where(
+            (qc_end < params.ccwmin) & (qi_end < params.ccwmin),
+            0.0, cloud_fraction,
+        )
+
         clouds = clouds.copy(
+            cloud_fraction=cloud_fraction_out,
             precip_rain=micro_state.precip_rain,
             precip_snow=micro_state.precip_snow,
             # Per-level precipitation flux profiles for satellite-simulator

--- a/jcm/physics/clouds/echam_1m_test.py
+++ b/jcm/physics/clouds/echam_1m_test.py
@@ -904,3 +904,72 @@ class TestColumnSweepParameterGradients:
         assert jnp.isclose(d_cvtfall, fd, rtol=0.05), (
             f"AD {float(d_cvtfall)} vs FD {fd}"
         )
+
+
+class TestCloudFractionWriteBack1M:
+    """The 1M term clears the cover of cells it empties (#687).
+
+    ECHAM's 1M ``cloud`` routine writes the post-microphysics cover back
+    to ``paclc`` (mo_cloud.f90:1280): a cell whose end-of-step condensate
+    is below ``ccwmin`` in BOTH phases stops being cloudy. Without it,
+    ``clouds.cloud_fraction`` meant the RH-diagnosed pre-microphysics
+    cover under cloud_scheme='1m' but the post-microphysics cover under
+    '2m', so every shared consumer (radiation, COSP, AeroCom, the JAM
+    cloud-borne/aqueous/wetdep terms) switched semantics with the scheme.
+    """
+
+    @staticmethod
+    def _drive_term(qc0, qi0, cf0, q_scale=0.95):
+        from types import SimpleNamespace
+        from jcm.physics.clouds.echam_1m import Echam1MMicrophysics
+        from jcm.physics.clouds.cloud_data import CloudData
+        from jcm.physics_interface import PhysicsState
+
+        nlev, ncols = 8, 2
+        T = jnp.full((nlev, ncols), 285.0)
+        p = jnp.linspace(3e4, 1e5, nlev)[:, None] * jnp.ones((1, ncols))
+        from jcm.physics.clouds.sundqvist import saturation_specific_humidity
+        qsw = saturation_specific_humidity(p, T)
+        q = q_scale * qsw            # subsaturated: condensate evaporates
+        rho = p / (287.0 * T)
+        zeros = jnp.zeros((nlev, ncols))
+
+        state = PhysicsState(
+            u_wind=zeros, v_wind=zeros, temperature=T,
+            specific_humidity=q, geopotential=zeros,
+            normalized_surface_pressure=jnp.ones(ncols),
+            tracers={"qc": qc0, "qi": qi0},
+        )
+        clouds = CloudData.zeros((ncols,), nlev).copy(
+            cloud_fraction=cf0, qc=qc0, qi=qi0)
+        diagnostics = {
+            "_dt_seconds": 1800.0,
+            "pressure_full": p,
+            "air_density": rho,
+            "layer_thickness": jnp.full((nlev, ncols), 500.0),
+            "clouds": clouds,
+            "aerosol": SimpleNamespace(cdnc_factor=jnp.ones(ncols)),
+        }
+        term = Echam1MMicrophysics()
+        _, diags_out = term(state, diagnostics, None, None)
+        return diags_out["clouds"].cloud_fraction
+
+    def test_emptied_cell_loses_cover_kept_cell_keeps_it(self):
+        import numpy as np
+        nlev, ncols = 8, 2
+        qc0 = jnp.zeros((nlev, ncols))
+        qi0 = jnp.zeros((nlev, ncols))
+        cf0 = jnp.zeros((nlev, ncols))
+        # Level 3: a wisp of liquid (5e-7) — the 5 % saturation deficit
+        # evaporates it below ccwmin within the step. Level 5: a solid
+        # deck (1e-3) the same deficit can only nibble at.
+        qc0 = qc0.at[3].set(5e-7).at[5].set(1e-3)
+        cf0 = cf0.at[3].set(0.4).at[5].set(0.7)
+
+        cf_out = np.asarray(self._drive_term(qc0, qi0, cf0))
+        assert np.all(cf_out[3] == 0.0), (
+            f"emptied cell keeps cover {cf_out[3]} — no paclc write-back"
+        )
+        assert np.all(cf_out[5] > 0.0), (
+            "a cell still holding condensate lost its cover"
+        )

--- a/jcm/physics/clouds/lohmann_2m/assembly.py
+++ b/jcm/physics/clouds/lohmann_2m/assembly.py
@@ -188,6 +188,17 @@ def update_tendencies_and_important_vars(
     tracer_tendency_icnc = ztmst_rcp * (icnc * inv_air_density - tracer_tm1_icnc)
 
     # --- 5) Corrections to avoid negative in-cloud mass (merge logic)
+    # ECHAM's zdxlcor/zdxicor (mo_cloud_micro_2m.f90:3640-3660): where the
+    # reconstructed end-of-step GRID-MEAN condensate falls below ccwmin
+    # (1e-7 kg/kg — including small positives and dycore-ringing
+    # negatives), the residual is returned to vapour with the matching
+    # latent heat and the number tracers are zeroed. The grid-mean-vs-
+    # ccwmin pairing is verified against the reference (#688: ECHAM tests
+    # zxlp1/zxip1, both grid-mean, against the same 1e-7). The repair is
+    # thermodynamically consistent but SIGN-DEFINITE — an undershoot
+    # always becomes warming+drying — so it is returned to the caller and
+    # published as a diagnostic rather than folded silently into the
+    # tendencies (#689).
     # liquid
     ll_liq_neg = liq_mmr_next < params.ccwmin
     zdxlcor = jnp.where(ll_liq_neg, -ztmst_rcp * liq_mmr_next, 0.0)
@@ -284,6 +295,8 @@ def update_tendencies_and_important_vars(
         incloud_ice_before_snow,
         out_preffl,
         out_preffi,
+        zdxlcor,
+        zdxicor,
     )
 
 

--- a/jcm/physics/clouds/lohmann_2m/deposition_freezing.py
+++ b/jcm/physics/clouds/lohmann_2m/deposition_freezing.py
@@ -12,6 +12,8 @@ from math import pi
 
 import jcm.constants as c
 
+from jcm.physics import thermodynamics
+
 from ..lohmann_2m_params import CloudParams2M
 from ..cloud_utils import (
     eff_ice_crystal_radius,
@@ -217,68 +219,49 @@ def mixed_phase_deposition_and_corrections(
     )
 
     # -------------------------------------------------------------------------
-    # 6. Saturation vapour pressures and specific humidities at temperature_tmp
-    #    using Teten's formula (replaces Fortran lookup tables).
+    # 6. Saturation specific humidities and dqs/dT at temperature_tmp.
     #
-    #    Over ice  (lo2=True):  e_s = e_s_ice(T_tmp)
-    #    Over water(lo2=False): e_s = e_s_water(T_tmp)
+    #    ECHAM reads the mo_convect_tables lookups here: ``tlucua(it)`` is
+    #    eps·e_s from the Tetens pairs (ice c3ies=21.875/c4ies=7.66, water
+    #    c3les=17.269/c4les=35.86, prefactor c1es=610.78), indexed by
+    #    it = NINT(1000·T), and ``zdqsdt = 1000·(qs(it+1) − qs(it))`` — a
+    #    finite difference over 0.001 K, i.e. dqs/dT. We use the shared
+    #    ``jcm.physics.thermodynamics`` implementation of exactly those
+    #    Tetens pairs, with the analytic derivative (the 0.001 K difference
+    #    quotient to machine precision, without the subtraction noise).
     #
-    #    sat_spec_hum: q_s = eps * e_s / (p - (1-eps)*e_s)
-    #                      ≈ e_s / (p/(eps) - e_s)    [standard approximation]
-    #    where eps = Rd/Rv, vtmpc1 = Rv/Rd - 1
+    #    Two earlier ports of this block were badly wrong and are the
+    #    history behind #667: first c.ak (the BOLTZMANN constant) as the
+    #    exponent coefficient with c.p0s1_bg (101325 Pa!) as the prefactor
+    #    suppressed zqcon by ~1e6 (review finding 1.2); the repaired
+    #    version then evaluated the difference quotient at T + 1.0 K but
+    #    kept the ×1000 lookup-step factor, leaving zdqsdt ~1000× too
+    #    large and zqcon = 1/(1 + L/cp·zdqsdt) at ~1/650 — the scheme's
+    #    own saturation adjustment was still effectively inert (#667.1).
+    #    It also mixed a Clausius–Clapeyron integral form for qs(T) with
+    #    Tetens for qs(T+1), which the analytic pair here makes moot.
     # -------------------------------------------------------------------------
+    qs_ice_tmp, dqs_ice_dt = thermodynamics.saturation_specific_humidity_and_derivative(
+        temperature_tmp, pressure, phase="ice")
+    qs_wat_tmp, dqs_wat_dt = thermodynamics.saturation_specific_humidity_and_derivative(
+        temperature_tmp, pressure, phase="water")
 
-    # Re-evaluate at temperature_tmp (this replaces fortran lookup tables)
-    ztmp_ice = (c.alhs/c.rv)*(1.0/c.tmelt - 1.0/temperature_tmp)
-    ztmp_water = (c.alhc/c.rv)*(1.0/c.tmelt - 1.0/temperature_tmp)
-    zes_ice_new = 611 * jnp.exp(ztmp_ice)
-    zes_water_new = 611 * jnp.exp(ztmp_water)
+    qsat_tmp = jnp.where(lo2, qs_ice_tmp, qs_wat_tmp)   # pqsp1tmp
+    qsat_tmp_water = qs_wat_tmp                          # zqsp1tmpw
 
-    # Select phase-appropriate saturation vapour pressure
-    zes = jnp.where(lo2, zes_ice_new, zes_water_new)
-    zesw = zes_water_new
-
-    # Saturation specific humidity (standard formula)
-    # q_s = zes / (p - (1 - Rd/Rv)*zes)  — same form as ECHAM sat_spec_hum
-    def _qsat(e, p):
-        # q_s = eps·e_s / (p − (1−eps)·e_s). The leading eps was missing
-        # (qsat 1.61× high — review finding 2.20); note 1/(1+vtmpc1) ≡ eps.
-        e_clipped = jnp.minimum(e, 0.4 * p)   # safety clip (Fortran: zes < 0.4)
-        return c.eps * e_clipped / (p - (1.0 - c.eps) * e_clipped)
-
-    qsat_tmp = _qsat(zes, pressure)          # pqsp1tmp: phase-appropriate
-    qsat_tmp_water = _qsat(zesw, pressure)   # zqsp1tmpw: always over water
-
-    # zcor: correction factor d(q_s)/d(e_s) * p / (p - e_s)^2  (used in zlcdqsdt)
-    # In ECHAM: zcor = 1 / (1 - vtmpc1 * q_s)
+    # zcor = 1/(1 − vtmpc1·qs): d(qs)/d(es) factor, used in the ll1=False
+    # branch of zlcdqsdt below (kept for the exact Fortran mapping).
     zcor = 1.0 / jnp.maximum(1.0 - c.vtmpc1 * qsat_tmp, params.eps)
-    zcorw = 1.0 / jnp.maximum(1.0 - c.vtmpc1 * qsat_tmp_water, params.eps)  # noqa: F841 — used in Phase 5b
 
-    # -------------------------------------------------------------------------
-    # 7. Saturation specific humidity at (t+1) for zdqsdt
-    #    In Fortran: zqst1 uses tlucuap1 (lookup at it+1), approximated here
-    #    by evaluating at (T_tmp + 1 K) and taking finite difference.
-    # -------------------------------------------------------------------------
-    # ECHAM mo_convect_tables Tetens pairs: ice c3ies=21.875/c4ies=7.66,
-    # water c3les=17.269/c4les=35.86, prefactor c2es = c1es·(Rd/Rv) =
-    # 610.78·eps — the lookup table tlucua stores eps·e_s, which is why the
-    # /pressure form below carries no explicit eps. The previous code used
-    # c.ak (the BOLTZMANN constant, 1.38e-23) as the exponent coefficient
-    # and c.p0s1_bg (101325 Pa!) as the prefactor: exp(~0)·101325/p pinned
-    # zqst1 at its 0.5 cap, made zdqsdt ~ +490 and the zqcon
-    # thermodynamic factor ~1e-6 — suppressing internal condensation/
-    # deposition by six orders of magnitude (review finding 1.2).
-    ztmp_ice_p1 = jnp.minimum(21.875 * (temperature_tmp + 1.0 - c.tmelt) / jnp.maximum(temperature_tmp + 1.0 - 7.66, params.eps), 700.0)
-    ztmp_water_p1 = jnp.minimum(17.269 * (temperature_tmp + 1.0 - c.tmelt) / jnp.maximum(temperature_tmp + 1.0 - 35.86, params.eps), 700.0)
+    # dqs/dT on the phase surface lo2 selected (ECHAM zdqsdt, units kg/kg/K).
+    zdqsdt = jnp.where(lo2, dqs_ice_dt, dqs_wat_dt)
 
-    c2es = 610.78 * c.eps
-    zes_p1 = jnp.where(lo2, c2es * jnp.exp(ztmp_ice_p1), c2es * jnp.exp(ztmp_water_p1))
-    zqst1 = zes_p1 / pressure
-    zqst1 = jnp.minimum(zqst1, 0.5)
-    zqst1 = zqst1 / (1.0 - c.vtmpc1 * zqst1)
-
-    # zdqsdt = 1000*(q_s(T+1) - q_s(T))  [units: per 1000 K — as in Fortran]
-    zdqsdt = 1000.0 * (zqst1 - qsat_tmp)
+    # Phase-appropriate e_s, needed only for the ll1 regime switch below.
+    zes = jnp.where(
+        lo2,
+        thermodynamics.saturation_vapor_pressure(temperature_tmp, phase="ice"),
+        thermodynamics.saturation_vapor_pressure(temperature_tmp, phase="water"),
+    )
 
     # -------------------------------------------------------------------------
     # 8. Thermodynamic correction factor zqcon
@@ -288,7 +271,10 @@ def mixed_phase_deposition_and_corrections(
     #    a numerical regime of the lookup table; for the analytic formula the
     #    two expressions converge).
     # -------------------------------------------------------------------------
-    ll1 = zes < 0.4 * pressure   # equivalent to Fortran ll1 (zes < 0.4 in sat_spec_hum units)
+    # Fortran ``ll1 = (zes < 0.4)`` where sat_spec_hum's zes is eps·e_s/p —
+    # the lookup-validity regime switch, essentially always True at
+    # atmospheric conditions.
+    ll1 = (c.eps * zes / jnp.maximum(pressure, params.eps)) < 0.4
 
     zlc = jnp.where(lo2, lsdcp, lvdcp)
 

--- a/jcm/physics/clouds/lohmann_2m/scheme.py
+++ b/jcm/physics/clouds/lohmann_2m/scheme.py
@@ -4,6 +4,8 @@
 column as one flux-coupled top-down ``lax.scan`` — a faithful
 transcription of ECHAM's ``column_processes`` loop — and
 ``Lohmann2MMicrophysics`` wraps it as a composable ``PhysicsTerm``.
+Design rationale and the state-splitting convention:
+``docs/source/design/lohmann_2m_column_processes.md``.
 """
 
 from typing import ClassVar
@@ -152,7 +154,7 @@ def cloud_microphysics_2m(
     The large-scale vertical velocity is not plumbed to this scheme yet:
     ECHAM's ``zvervx`` (updraft for the WBF gate) uses only the TKE term
     here, and the ``knvb``/``lonacc`` inversion-level exception on
-    ``zauloc`` is omitted (it needs ``pvervel``).
+    ``zauloc`` is omitted (it needs ``pvervel``) — tracked in #705.
 
     qnc / qni are stored per kg of air; the scheme interior uses per-m^3,
     so we convert at the boundary.

--- a/jcm/physics/clouds/lohmann_2m/scheme.py
+++ b/jcm/physics/clouds/lohmann_2m/scheme.py
@@ -1,12 +1,13 @@
 """Lohmann 2M column-sweep orchestrator and composable physics term.
 
 ``cloud_microphysics_2m`` runs the full two-moment process chain over a
-column (lax.scan sweep), and ``Lohmann2MMicrophysics`` wraps it as a
-composable ``PhysicsTerm``. Split out of the monolithic ``lohmann_2m.py``
-module (pure move, no numerical change).
+column as one flux-coupled top-down ``lax.scan`` — a faithful
+transcription of ECHAM's ``column_processes`` loop — and
+``Lohmann2MMicrophysics`` wraps it as a composable ``PhysicsTerm``.
 """
 
 from typing import ClassVar
+from math import pi
 
 import jax
 import jax.numpy as jnp
@@ -26,6 +27,7 @@ from ..lohmann_2m_params import CloudParams2M
 from ..cloud_utils import (
     eff_ice_crystal_radius,
     minimum_CDNC,
+    threshold_vert_vel,
 )
 from .types import MicrophysicsTendencies_2M
 from .sedimentation_melt import melting_snow_and_ice, sedimentation_ice
@@ -53,15 +55,13 @@ from .assembly import (
 
 
 def cloud_microphysics_2m(
-    temperature: jnp.ndarray,       # (nlev,)  K
-    specific_humidity: jnp.ndarray, # (nlev,)  kg/kg
+    temperature: jnp.ndarray,       # (nlev,)  K      post-upstream provisional T
+    specific_humidity: jnp.ndarray, # (nlev,)  kg/kg  post-upstream provisional q
     pressure: jnp.ndarray,          # (nlev,)  Pa
-    qc: jnp.ndarray,                # (nlev,)  kg/kg cloud liquid mass mixing ratio
-    qi: jnp.ndarray,                # (nlev,)  kg/kg cloud ice mass mixing ratio
+    qc: jnp.ndarray,                # (nlev,)  kg/kg post-upstream cloud liquid
+    qi: jnp.ndarray,                # (nlev,)  kg/kg post-upstream cloud ice
     qnc: jnp.ndarray,               # (nlev,)  kg^-1 cloud droplet number per kg of air
     qni: jnp.ndarray,               # (nlev,)  kg^-1 ice crystal number per kg of air
-    qr: jnp.ndarray,                # (nlev,)  kg/kg rain mixing ratio (from prev step)
-    qs: jnp.ndarray,                # (nlev,)  kg/kg snow mixing ratio (from prev step)
     cloud_fraction: jnp.ndarray,    # (nlev,)  [0,1]
     air_density: jnp.ndarray,       # (nlev,)  kg/m^3
     layer_thickness: jnp.ndarray,   # (nlev,)  m   (dz, full-level layer depths)
@@ -71,40 +71,117 @@ def cloud_microphysics_2m(
     ice_nuclei_deposition: jnp.ndarray,  # (nlev,) 1/m³  deposition INP → cirrus nucleation
     dt: jnp.ndarray,                # scalar   seconds
     params: CloudParams2M,          # tunable parameters
+    temperature_m1: jnp.ndarray | None = None,        # (nlev,) K   step-start T (ECHAM ptm1)
+    specific_humidity_m1: jnp.ndarray | None = None,  # (nlev,)     step-start q (ECHAM pqm1)
+    qc_m1: jnp.ndarray | None = None,                 # (nlev,)     step-start qc (ECHAM pxlm1)
+    qi_m1: jnp.ndarray | None = None,                 # (nlev,)     step-start qi (ECHAM pxim1)
 ) -> tuple[
     MicrophysicsTendencies_2M,      # per-level tendencies
     jnp.ndarray, jnp.ndarray,       # surface rain / snow flux [kg/m^2/s]
     jnp.ndarray, jnp.ndarray,       # liq / ice effective radius [um] (nlev,)
     jnp.ndarray, jnp.ndarray,       # rain / snow(+ice) flux leaving each layer [kg/m^2/s] (nlev,)
 ]:
-    """Column-sweep orchestrator for the two-moment microphysics scheme.
+    """Column orchestrator for the two-moment microphysics scheme.
 
-    Processes (in ECHAM6 order):
+    A faithful transcription of the ECHAM6-HAM ``mo_cloud_micro_2m.f90``
+    ``column_processes`` loop: the WHOLE process chain runs inside one
+    top-down ``lax.scan``, because in the reference every process at level
+    ``jk`` sees the precipitation state (``prfl``/``pssfl``/``zclcpre``/
+    ``zxiflux``) that the levels above produced *this step*. Splitting the
+    "level-independent" processes out of the sweep — the previous layout —
+    silently severed exactly those couplings: rain/snow-from-above
+    accretion ran on tracers that no longer existed (#662 finding 5), the
+    precipitation-cover geometry ``zclcstar`` was unavailable (#685), and
+    ice created mid-step never met its aggregation sink (#686).
 
-      1. **Warm precipitation** (level-independent): qc → qr via KK2000
-         autoconversion + accretion (:func:`precip_formation_warm`).
-      2. **Mixed-phase deposition** (level-independent): vapor ↔ ice/liquid
-         deposition/condensation (:func:`mixed_phase_deposition_and_corrections`).
-      3. **Homogeneous freezing** (level-independent): all liquid → ice
-         where T < 238 K (:func:`freezing_below_238K`).
-      4. **Heterogeneous mixed-phase freezing** (level-independent):
-         DeMott (2010) INP parameterization (:func:`demott2010_inp`).
-         Uses prescribed coarse-mode aerosol + temperature.
-      5. **WBF** (level-independent): remaining liquid → ice in
-         mixed-phase clouds (:func:`WBF_process`).
-      6. **Cold precipitation** (level-independent): qi → qs aggregation +
-         qc → qs riming (:func:`precip_formation_cold`).
-      7. **Flux-coupled column sweep** (top-down ``lax.scan``):
-         - Ice sedimentation (:func:`sedimentation_ice`)
-         - Melting of snow / ice (:func:`melting_snow_and_ice`)
-         Precipitation fluxes (rain, snow, ice mass/number) propagate
-         downward through the scan carry.
+    Per level, in ECHAM section order (numbers = Fortran comments):
+
+      4.    Ice sedimentation (:func:`sedimentation_ice`), then
+      3.1   melting of snow / falling ice / in-cloud ice
+            (:func:`melting_snow_and_ice`). NOTE this sediment→melt order
+            is deliberately MG/PUMAS's (micro_pumas_v1: sediment 3093 →
+            melt 3293), not ECHAM's melt→sediment; the melt acts on the
+            post-sedimentation ice via the threaded tendency so the two
+            sinks cannot claim the same mass (#662 finding 2).
+      3.2/3 Snow/ice sublimation + rain evaporation on the incoming
+            fluxes (:func:`sublimation_snow_and_ice_evaporation_rain`).
+      (4b)  In-cloud condensate prep with clear-sky evaporation
+            ``zxlevap``/``zxievap`` (ECHAM 1310-1385): condensate in
+            cells with no cloud, and the clear-sky share of positive
+            upstream increments, evaporates back to vapour (#667).
+      5.    Grid-scale condensation source ``zqcdif`` → ``zcnd``/``zdep``
+            (the Sundqvist moisture-convergence closure, ECHAM 1389-1470)
+            followed by the supersaturation corrections
+            (:func:`mixed_phase_deposition_and_corrections`). The scheme
+            OWNS saturation adjustment — there is no external
+            condensation bolt-on (#667).
+      5.5   In-cloud water update + droplet activation / ICNC nucleation
+            (:func:`update_in_cloud_water`).
+      6.1   Homogeneous freezing below ``cthomi``
+            (:func:`freezing_below_238K`).
+      6.2   Heterogeneous mixed-phase freezing (JAM immersion INP with
+            the DeMott (2010) fallback) and the WBF process with the
+            Korolev/Mazin threshold updraft recomputed from the
+            post-freezing ice (:func:`WBF_process`).
+      7.    Precipitation geometry: ``zclcstar = min(paclc, zclcpre)``,
+            the layer-depth ``zauloc`` ramp, and the Marshall-Palmer
+            inversion of the carry fluxes into ``zxrp1``/``zxsp1`` (rain/
+            snow water content seen by accretion; ECHAM 1614-1655 /
+            Roeckner et al. 2003 eqs. 10.70, 10.74).
+      7.1   Warm-rain formation (:func:`precip_formation_warm`) — AFTER
+            condensation and activation, as in both references.
+      7.2   Cold precipitation formation (:func:`precip_formation_cold`).
+      7.3   Precipitation-flux update (:func:`update_precip_fluxes`).
+
+    Section 8 (:func:`update_tendencies_and_important_vars`) is per-level
+    algebra with no cross-level coupling, so it runs vectorized after the
+    sweep on the stacked per-level outputs.
+
+    State-splitting convention (operator-split host vs ECHAM leapfrog):
+    the primary ``temperature``/``specific_humidity``/``qc``/``qi`` are
+    the POST-UPSTREAM provisional state (ECHAM ``ptm1 + ztmst·ptte``
+    etc.), which is what the returned tendencies are relative to. The
+    optional ``*_m1`` arguments are the step-start state (ECHAM ``ptm1``/
+    ``pqm1``/``pxlm1``/``pxim1``): saturation anchors evaluate there, and
+    the differences ``(x - x_m1)`` play the role of ECHAM's accumulated
+    tendencies ``ztmst·pqte``/``ztmst·pxlte`` in the condensation closure
+    and the clear-sky-evaporation split. When omitted they default to the
+    provisional state (zero upstream increments), which reduces section 5
+    to a pure saturation adjustment.
+
+    The large-scale vertical velocity is not plumbed to this scheme yet:
+    ECHAM's ``zvervx`` (updraft for the WBF gate) uses only the TKE term
+    here, and the ``knvb``/``lonacc`` inversion-level exception on
+    ``zauloc`` is omitted (it needs ``pvervel``).
 
     qnc / qni are stored per kg of air; the scheme interior uses per-m^3,
     so we convert at the boundary.
     """
-    eps_dt = jnp.finfo(qc.dtype).eps
+    if temperature_m1 is None:
+        temperature_m1 = temperature
+    if specific_humidity_m1 is None:
+        specific_humidity_m1 = specific_humidity
+    if qc_m1 is None:
+        qc_m1 = qc
+    if qi_m1 is None:
+        qi_m1 = qi
 
+    eps_dt = jnp.finfo(qc.dtype).eps
+    zero = jnp.zeros_like(qc)
+    lsdcp = c.alhs / c.cpd
+    lvdcp = c.alhc / c.cpd
+
+    # ------------------------------------------------------------------
+    # Upstream increments (ECHAM's accumulated tendencies × ztmst)
+    # ------------------------------------------------------------------
+    dT_up = temperature - temperature_m1          # ztmst·ptte
+    dq_up = specific_humidity - specific_humidity_m1  # ztmst·pqte
+    dqc_up = qc - qc_m1                           # ztmst·(pxlte + detrainment)
+    dqi_up = qi - qi_m1                           # ztmst·(pxite + detrainment)
+
+    # ------------------------------------------------------------------
+    # Entry clamps on the number tracers (jcm addition, see below)
+    # ------------------------------------------------------------------
     # ECHAM's per-level loop clamps icnc to ``[icemin, icemax]`` and
     # forces cdnc to ``[cqtmin, cdnc_min_upper]``-or-above (lines 1252-3
     # of mo_cloud_micro_2m.f90 and the activation block in
@@ -117,13 +194,13 @@ def cloud_microphysics_2m(
     # output) and ``icemax`` (1e7 / m^3) so realistic clouds are
     # unaffected.
     _cdnc_max_phys_per_m3 = 1.0e11
-    inv_rho_safe = 1.0 / jnp.maximum(air_density, eps_dt)
-    qnc = jnp.clip(qnc, 0.0, _cdnc_max_phys_per_m3 * inv_rho_safe)
-    qni = jnp.clip(qni, 0.0, params.icemax * inv_rho_safe)
+    inv_rho = 1.0 / jnp.maximum(air_density, eps_dt)
+    qnc = jnp.clip(qnc, 0.0, _cdnc_max_phys_per_m3 * inv_rho)
+    qni = jnp.clip(qni, 0.0, params.icemax * inv_rho)
 
     # Number-per-kg-of-air → per-m^3 at the scheme's API boundary.
-    cdnc = qnc * air_density
-    icnc = qni * air_density
+    cdnc0 = qnc * air_density
+    icnc0 = qni * air_density
 
     # Minimum cloud-droplet number — the SAME ECHAM ``minimum_CDNC`` the warm
     # microphysics uses below (the dynamic max-radius floor or the fixed
@@ -141,433 +218,154 @@ def cloud_microphysics_2m(
     qc_in_cloud_kgm3 = jnp.where(
         cloud_fraction > params.epsec, qc * inv_cf_min * air_density, 0.0,
     )
-    cdnc_min = minimum_CDNC(qc_in_cloud_kgm3, params)
-    cdnc = jnp.maximum(cdnc, cdnc_min)
-
-    # pauloc==1 and pclcstar==cloud_fraction are conservative first-pass
-    # approximations. The true pclcstar is min(cloud cover, precip cover),
-    # which only exists inside the flux-coupled scan — see #685.
-    autoconv_factor = jnp.ones_like(qc)
-    min_cloud_precip_fraction = cloud_fraction
+    cdnc0 = jnp.maximum(cdnc0, minimum_CDNC(qc_in_cloud_kgm3, params))
 
     # ------------------------------------------------------------------
-    # Warm precipitation formation (KK2000 autoconversion + accretion)
+    # Step-start (t-1) thermodynamic fields — ECHAM section 1
     # ------------------------------------------------------------------
-    # ECHAM ll_prcp_warm (mo_cloud_micro_2m.f90:1662-1664): cloud cell
-    # with liquid present and CDNC at/above the activation floor —
-    # NO temperature condition. Warm-rain coalescence operates on
-    # supercooled liquid too; a (T > tmelt) gate left every supercooled
-    # stratus deck (polar boundary layers, storm tracks, 238-273 K)
-    # without its only liquid sink once the corrected mixed-phase
-    # partitioning (#554, finding 2.27) started producing supercooled
-    # liquid there — cloud water built up ~50x over a month of coupled
-    # T63L47 integration and NaN'd the run radiatively. The
-    # cdnc >= cdnc_min leg holds by construction after the entry floor.
-    warm_precip_mask = (cloud_fraction > params.epsec) & (qc > params.ccwmin)
+    # Saturation anchors are evaluated at the STEP-START state, exactly as
+    # ECHAM evaluates zqsi/zqsw/zeta/the subsaturations at (ptm1, pqm1);
+    # the provisional state enters only through the increments above.
+    # ``es_water`` uses the LIQUID-WATER coefficients at ALL temperatures —
+    # the Bergeron/WBF machinery depends on the water/ice saturation
+    # *difference* below freezing, which degenerates to zero if es_water
+    # switches to the ice coefficients below 0 °C.
+    es_water = thermodynamics.saturation_vapor_pressure(
+        temperature_m1, phase="water")
+    es_ice = thermodynamics.saturation_vapor_pressure(
+        temperature_m1, phase="ice")
+    qsat_water, dqsw_dt = (
+        thermodynamics.saturation_specific_humidity_and_derivative(
+            temperature_m1, pressure, phase="water"))
+    qsat_ice, dqsi_dt = (
+        thermodynamics.saturation_specific_humidity_and_derivative(
+            temperature_m1, pressure, phase="ice"))
 
-    # ECHAM runs the KK2000 warm-rain chain on the IN-CLOUD liquid (zxlb)
-    # and area-weights the products; feeding grid-mean qc underestimated
-    # the qc^2.47 autoconversion by ~cf^1.47 (review finding 2.22). Convert
-    # at the boundary: in-cloud in, grid-mean bookkeeping out.
-    qc_ic_warm = jnp.where(
-        cloud_fraction > params.epsec,
-        qc / jnp.maximum(cloud_fraction, params.epsec),
-        0.0,
-    )
-    (cdnc_warm, qc_ic_after_warm, _autoconv_in_cloud, _autoconv_rate,
-     _dcdnc_removal, autoconv_only, accretion_only) = (
-        precip_formation_warm(
-            warm_precip_mask,
-            autoconv_factor,
-            cloud_fraction,
-            min_cloud_precip_fraction,
-            air_density,
-            qr,
-            cdnc_min,
-            cdnc,
-            qc_ic_warm,
-            dt,
-            params,
-        )
-    )
-    qc_after_warm = jnp.where(
-        cloud_fraction > params.epsec,
-        qc_ic_after_warm * cloud_fraction,
-        qc,
-    )
-    qr_gain_warm = qc - qc_after_warm  # grid-mean mass moved qc → rain (kg/kg)
-
-    # ------------------------------------------------------------------
-    # Derived quantities used across multiple process steps
-    # ------------------------------------------------------------------
-    inv_cf = jnp.where(
-        cloud_fraction > params.epsec,
-        1.0 / jnp.maximum(cloud_fraction, params.epsec),
-        0.0,
-    )
-    in_cloud_liquid = qc_after_warm * inv_cf
-    in_cloud_ice = qi * inv_cf
-    inv_rho = 1.0 / jnp.maximum(air_density, eps_dt)
-    lsdcp = c.alhs / c.cpd
-    lvdcp = c.alhc / c.cpd
-    zero = jnp.zeros_like(qc)
-
-    # ------------------------------------------------------------------
-    # Mixed-phase deposition and corrections
-    # ------------------------------------------------------------------
-    # Saturation vapour pressures from the shared ECHAM coefficients
-    # (jcm.physics.thermodynamics). ``es_water`` uses the LIQUID-WATER
-    # coefficients at ALL temperatures — the Bergeron-Findeisen variable
-    # below and the threshold vertical velocity depend on the water/ice
-    # saturation *difference* below freezing, which degenerates to zero
-    # (killing the Bergeron process) if es_water switches to the ice
-    # coefficients below 0 °C.
-    es_water = thermodynamics.saturation_vapor_pressure(temperature, phase="water")
-    es_ice = thermodynamics.saturation_vapor_pressure(temperature, phase="ice")
-
-    qsat_water = c.eps * es_water / jnp.maximum(pressure - (1.0 - c.eps) * es_water, params.epsec)
-    qsat_ice = c.eps * es_ice / jnp.maximum(pressure - (1.0 - c.eps) * es_ice, params.epsec)
-    qsat_prev = jnp.where(temperature < params.tmelt, qsat_ice, qsat_water)
-
-    bergeron_variable = jnp.clip(
-        (specific_humidity - qsat_ice) / jnp.maximum(qsat_water - qsat_ice, params.epsec),
-        0.0, 1.0,
-    )
-
-    # Updraft velocity [cm/s] from TKE (vertical velocity not plumbed yet).
-    updraft_velocity = params.fact_tke * jnp.sqrt(jnp.maximum(2.0 * tke, 0.0)) * 100.0
-
-    (
-        condensation_rate, deposition_rate,
-        temp_tmp, q_tmp, qsat_tmp,
-        zvervmax_wbf,
-    ) = mixed_phase_deposition_and_corrections(
-        pressure,
-        icnc,
-        specific_humidity,
-        cloud_fraction,
-        es_ice, es_water,
-        bergeron_variable,
-        zero,               # tompkins_genti
-        lsdcp, lvdcp,
-        specific_humidity,
-        qsat_prev,
-        air_density,
-        temperature,
-        zero,               # ice_evaporation
-        qi,
-        zero,               # ice_detrainment_tendency
-        updraft_velocity,
-        zero,               # condensation_rate (INOUT, start at 0)
-        zero,               # deposition_rate (INOUT, start at 0)
-        dt,
-        params,
-    )
-
-    # ------------------------------------------------------------------
-    # Update in-cloud water/ice from deposition/condensation + activation
-    # ------------------------------------------------------------------
-    cloud_flag = cloud_fraction > 0.0
-
-    # Mean ice crystal radius for ICNC nucleation path.
-    ice_radius = eff_ice_crystal_radius(qi * air_density, icnc, params)
-
-    (
-        cloud_flag, icnc_uicw, _nucleation_rate, cdnc_uicw,
-        cloud_fraction_uicw, in_cloud_ice_uicw, in_cloud_liquid_uicw,
-        cdnc_min_uicw,
-    ) = update_in_cloud_water(
-        pressure,
-        activated_cdnc,       # aerosol-activated CDNC (from MACv2-SP)
-        condensation_rate,
-        deposition_rate,
-        zero,                 # tompkins_genti
-        zero,                 # tompkins_gentl
-        ice_nuclei_deposition,  # newly_formed_ice: cirrus deposition nucleation (#494)
-        q_tmp,                # specific_humidity_tmp
-        qsat_tmp,             # sat_spec_humidity_tmp
-        air_density,
-        ice_radius,
-        temperature,          # temp_prev
-        cloud_flag,
-        icnc,
-        zero,                 # nucleation_rate accumulator
-        cdnc_warm,
-        cloud_fraction,
-        in_cloud_ice,
-        in_cloud_liquid,
-        dt,
-        params,
-    )
-
-    # ``update_in_cloud_water`` rewrites ``paclc`` (a clear cell with positive
-    # condensation becomes cloudy), and the in-cloud condensate it returns is
-    # defined against that fraction. Every in-cloud → grid-mean conversion
-    # below therefore uses ``cloud_fraction_uicw``.
-
-    # ------------------------------------------------------------------
-    # Freezing below 238 K (homogeneous freezing, level-independent)
-    # ------------------------------------------------------------------
-    freezing_condition = temperature < params.cthomi
-    (
-        icnc_frz, _droplet_freezing_rate, cdnc_frz,
-        freezing_rate_hom, in_cloud_ice_frz, in_cloud_liquid_frz,
-    ) = freezing_below_238K(
-        freezing_condition,
-        cloud_fraction_uicw,
-        cdnc_min_uicw,
-        icnc_uicw,
-        zero,             # droplet_freezing_rate accumulator
-        cdnc_uicw,
-        zero,             # freezing_rate accumulator
-        in_cloud_ice_uicw,
-        in_cloud_liquid_uicw,
-        dt,
-        params.cqtmin,
-    )
-
-    # ------------------------------------------------------------------
-    # Heterogeneous mixed-phase freezing INP [1/m³]
-    #
-    # Prefer the online JAM heterogeneous ice nucleation (immersion+deposition
-    # on prognostic dust/BC, #494) where it is active; fall back to the DeMott
-    # (2010) parameterization on a prescribed coarse-aerosol number wherever the
-    # online source is empty (≈0) — e.g. clean air or before the JAM tracers
-    # spin up. Mirrors the ``activated_cdnc``/SPA-floor pattern for droplets.
-    # ------------------------------------------------------------------
-    het_condition = (temperature < params.tmelt) & (temperature >= params.cthomi)
-
-    demott_floor = demott2010_inp(temperature, params.n_aer_coarse)
-    n_inp = jnp.where(ice_nuclei > 0.0, ice_nuclei, demott_floor)
-
-    # Where het freezing is active and INP > current ICNC, set ICNC to
-    # INP and freeze a corresponding amount of liquid → ice.
-    icnc_het = jnp.where(het_condition & (n_inp > icnc_frz), n_inp, icnc_frz)
-
-    # Freeze liquid proportional to the new ice crystals formed, assuming
-    # each INP freezes one droplet with mass = mean droplet mass.
-    new_crystals = jnp.maximum(icnc_het - icnc_frz, 0.0)
-    mean_droplet_mass = jnp.where(
-        cdnc_frz > params.epsec,
-        in_cloud_liquid_frz * air_density / jnp.maximum(cdnc_frz, params.epsec),
-        0.0,
-    )
-    frozen_mass = new_crystals * mean_droplet_mass * inv_rho  # kg/kg
-    frozen_mass = jnp.minimum(frozen_mass, in_cloud_liquid_frz)
-
-    in_cloud_ice_het = in_cloud_ice_frz + frozen_mass
-    in_cloud_liquid_het = in_cloud_liquid_frz - frozen_mass
-    cdnc_het = jnp.where(
-        het_condition, jnp.maximum(cdnc_frz - new_crystals, params.cqtmin), cdnc_frz,
-    )
-
-    # Grid-mean freezing ledger (ECHAM pfrl): the single accumulator the
-    # assembly step debits from liquid, credits to ice, and converts to fusion
-    # heat. Carries both legs — homogeneous below cthomi, and the immersion
-    # freezing driven by ``ice_nuclei`` (#494).
-    #
-    # Only the heterogeneous leg is converted here. ``freezing_below_238K``
-    # already area-weights internally (``pfrl += pxlb·paclc``), whereas
-    # ``frozen_mass`` above is a bare in-cloud increment.
-    freezing_rate = freezing_rate_hom + frozen_mass * cloud_fraction_uicw
-
-    # ------------------------------------------------------------------
-    # WBF (Wegener-Bergeron-Findeisen): liquid → ice in mixed-phase
-    # ------------------------------------------------------------------
-    # ECHAM ll_WBF (mo_cloud_micro_2m.f90:1590-1594): the Bergeron
-    # conversion fires only in the mixed-phase window (cthomi < T < tmelt;
-    # below cthomi freezing_below_238K already emptied the liquid), with
-    # active deposition (zdep > 0), enough droplets (cdnc ≥ floor), AND —
-    # the criterion the port dropped — a weak updraft:
-    # 0.01·zvervx < zvervmax, the Korolev/Mazin threshold velocity below
-    # which ice grows at the liquid's expense. Without it every
-    # mixed-phase cloud glaciated in one step and no supercooled liquid
-    # survived (review finding 2.19). zvervmax comes from the deposition
-    # block (ECHAM recomputes it from post-freezing zxib — a second-order
-    # refinement over reusing the deposition-stage value).
-    wbf_mask = (
-        (temperature < params.tmelt)
-        & (temperature > params.cthomi)
-        & (in_cloud_liquid_het > params.epsec)
-        & (in_cloud_ice_het > params.epsec)
-        & (deposition_rate > 0.0)
-        & (0.01 * updraft_velocity < zvervmax_wbf)
-    )
-    # ``WBF_process`` computes the grid-mean transfer once (pxlb·paclc/dt) and
-    # reports it three ways — liquid debit, ice credit, fusion warming. All
-    # three are kept and seed the ledger together: they are one transfer, and
-    # the enthalpy budget only closes if the mass and the heat travel with it.
-    (
-        cdnc_wbf, in_cloud_liquid_wbf, in_cloud_ice_wbf,
-        liq_tend_wbf, ice_tend_wbf, dtedt_wbf,
-    ) = WBF_process(
-        wbf_mask,
-        cloud_fraction_uicw,
-        lsdcp, lvdcp,
-        cdnc_het,
-        in_cloud_liquid_het,
-        in_cloud_ice_het,
-        zero,             # cloud_liquid_tendency accumulator
-        zero,             # cloud_ice_tendency accumulator
-        zero,             # temp_tendency accumulator
-        dt,
-        params,
-    )
-
-    # ------------------------------------------------------------------
-    # Cold precipitation formation (ice aggregation → snow + riming)
-    # Uses post-freezing/WBF in-cloud values.
-    # ------------------------------------------------------------------
-    dynamic_viscosity = 4.1867e-3 * (5.69 + 0.017 * (temperature - params.tmelt))
-    cold_mask = (temperature <= params.tmelt) & (qi > params.ccwmin)
-
-    (
-        icnc_cold,
-        cdnc_cold,
-        _snow_rate_in_cloud,
-        in_cloud_ice_cold,
-        in_cloud_liquid_cold,
-        _psprn,
-        psacl,
-        _psacln,
-        _pmsnowacl,
-        snow_formation_gridmean,
-    ) = precip_formation_cold(
-        cold_mask,
-        autoconv_factor,
-        cloud_fraction_uicw,
-        cloud_fraction_uicw,   # pclcstar first-pass approximation (#685)
-        inv_rho,
-        inv_rho,
-        temperature,
-        dynamic_viscosity,
-        qs,
-        air_density,
-        cdnc_min,
-        icnc_het,         # WBF doesn't modify icnc; chain from het step
-        cdnc_wbf,
-        jnp.zeros_like(qc),
-        in_cloud_ice_wbf,
-        in_cloud_liquid_wbf,
-        dt,
-        params,
-    )
-
-    # Convert in-cloud → grid-mean for tendency computation.
-    qi_after_cold = in_cloud_ice_cold * cloud_fraction_uicw
-    # (qc_to_snow / qi_to_snow state differences removed with the qr/qs
-    # ledger — see the dqrdt/dqsdt note below.)
-
-    # ------------------------------------------------------------------
-    # Flux-coupled column sweep (top-down lax.scan)
-    #
-    # Sedimentation and melting couple across levels via precipitation
-    # fluxes: the flux leaving level k enters level k+1. We use
-    # jax.lax.scan from top of atmosphere to surface to propagate
-    # rain_flux, snow_flux, ice_flux, ice_flux_n, and
-    # falling_ice_fraction correctly.
-    # ------------------------------------------------------------------
-    # Precompute per-level inputs for the scan.
-    pressure_thickness = air_density * params.grav * layer_thickness
-    air_density_correction = (1.3 * inv_rho) ** 0.4
-    melt_mask = temperature > params.tmelt
-
-    # Pre-compute sublimation/evaporation quantities for the scan.
-    # ECHAM conventions (mo_cloud_micro_2m): the subsaturations are the
-    # NEGATIVE relative deficits ``min(q/qs − 1, 0)`` — the sublimation/
-    # evaporation chain needs the sign to produce a sink (zzeps =
-    # max(−…, coeff·subsat) with a final clip at 0). The previous
-    # positive-definite ``max(qs − q, 0)`` inverted the chain so the clip
-    # floored rain evaporation and snow sublimation at exactly zero —
-    # both processes were dead code (survey finding; §2.12-2M analog).
-    dp_over_g = pressure_thickness * c.rgrav
+    # Subsaturations for rain evaporation / snow sublimation: the NEGATIVE
+    # relative deficits ``min(q/qs − 1, 0)`` (ECHAM zsusatw_evap/zicesub) —
+    # the sublimation/evaporation chain needs the sign to produce a sink.
     subsat_wrt_ice = jnp.minimum(
-        specific_humidity / jnp.maximum(qsat_ice, params.epsec) - 1.0, 0.0,
+        specific_humidity_m1 / jnp.maximum(qsat_ice, params.epsec) - 1.0, 0.0,
     )
     subsat_wrt_water = jnp.minimum(
-        specific_humidity / jnp.maximum(qsat_water, params.epsec) - 1.0, 0.0,
+        specific_humidity_m1 / jnp.maximum(qsat_water, params.epsec) - 1.0, 0.0,
     )
+
     # Rotstayn thermodynamic + vapour-diffusion factor (ECHAM zastbstw =
     # zast + zbst), the same chain the 1M rain evaporation uses:
-    #   zast = Lv·(Lv/(Rv·T) − 1)/(T·0.024),  zbst = Rv·T/(Dv·esw),
-    # with Dv = 2.21/p. The previous value was the psychrometric factor
-    # 1 + L²qs/(Rv·cp·T²) (~2-5) — ~6 orders of magnitude smaller than
-    # zast+zbst, which would have made the (revived) evaporation ~1e6×
-    # too strong.
-    esw_orch = qsat_water * pressure / jnp.maximum(
-        c.eps + (1.0 - c.eps) * qsat_water, params.epsec,
-    )
-    zdv_orch = 2.21 / jnp.maximum(pressure, params.epsec)
-    zast_orch = (
-        c.alhc * (c.alhc / (c.rv * jnp.maximum(temperature, 1.0)) - 1.0)
-        / jnp.maximum(temperature, 1.0) / 0.024
-    )
-    zbst_orch = c.rv * temperature / jnp.maximum(zdv_orch * esw_orch, params.epsec)
-    thermo_term_water = zast_orch + zbst_orch
+    #   zast = Lv·(Lv/(Rv·T) − 1)/(T·ka),  zbst = Rv·T/(Dv·esw),
+    # with Dv = 2.21/p and ka = 0.024 W/m/K.
+    t_safe = jnp.maximum(temperature_m1, 1.0)
+    zdv = 2.21 / jnp.maximum(pressure, params.epsec)
+    zast = c.alhc * (c.alhc / (c.rv * t_safe) - 1.0) / (t_safe * 0.024)
+    zbst = c.rv * temperature_m1 / jnp.maximum(zdv * es_water, params.epsec)
+    thermo_term_water = zast + zbst
 
-    def _flux_coupled_step(carry, level_in):
-        """Process one level: sedi → melt → sublim/evap → update_precip."""
+    # Bergeron/WBF diffusional-growth factor (ECHAM zeta, line 856 of
+    # mo_cloud_micro_2m.f90). This is the ``peta`` that
+    # ``threshold_vert_vel`` multiplies by (esw−esi)/esi·ICNC·r to get the
+    # Korolev/Mazin threshold updraft [m/s]. The previous port fed a
+    # dimensionless 0..1 saturation-ratio clip here, which is not the
+    # reference quantity at all — the WBF gate and the lo2 phase decision
+    # were miscalibrated by orders of magnitude (#667).
+    zkair = 4.1867e-3 * (5.69 + 0.017 * (temperature_m1 - c.tmelt))
+    zeta_a = (1.0 / jnp.maximum(specific_humidity_m1, params.eps)
+              + lsdcp * c.alhc / (c.rv * t_safe ** 2))
+    zeta_b = c.grav * (lvdcp * c.rd / c.rv / t_safe - 1.0) / (c.rd * t_safe)
+    zeta_c = 1.0 / jnp.maximum(
+        params.crhoi * c.alhs ** 2 / (jnp.maximum(zkair, params.epsec)
+                                      * c.rv * t_safe ** 2)
+        + params.crhoi * c.rv * t_safe
+        / jnp.maximum(es_ice * zdv, params.epsec),
+        params.epsec,
+    )
+    bergeron_eta = (zeta_a / zeta_b * zeta_c
+                    * 4.0 * pi * params.crhoi * params.cap * inv_rho)
+
+    # Updraft velocity [cm/s] from TKE (ECHAM zvervx; the large-scale
+    # vertical-velocity contribution is not plumbed yet).
+    updraft_velocity = params.fact_tke * jnp.sqrt(
+        jnp.maximum(2.0 * tke, 0.0)) * 100.0
+
+    # Dynamic viscosity of air (ECHAM zviscos, Pruppacher & Klett 13-18a).
+    dynamic_viscosity = 4.1867e-3 * (
+        5.69 + 0.017 * (temperature_m1 - c.tmelt))
+
+    # Geometry / density helpers.
+    pressure_thickness = air_density * params.grav * layer_thickness
+    dp_over_g = pressure_thickness * c.rgrav
+    zqrho = 1.3 * inv_rho                      # ECHAM zqrho = 1.3/ρ
+    air_density_correction = zqrho ** 0.4      # ECHAM zaaa
+    melt_mask = temperature_m1 > params.tmelt  # ECHAM ll_mlt (ptm1)
+
+    # Heterogeneous mixed-phase INP [1/m³]: prefer the online JAM source
+    # (immersion on prognostic dust/BC, #494); fall back to the DeMott
+    # (2010) diagnostic on prescribed coarse aerosol where it is empty.
+    demott_floor = demott2010_inp(temperature_m1, params.n_aer_coarse)
+    n_inp = jnp.where(ice_nuclei > 0.0, ice_nuclei, demott_floor)
+
+    # ------------------------------------------------------------------
+    # The flux-coupled column sweep: ECHAM's column_processes loop
+    # ------------------------------------------------------------------
+    nlev_scan = temperature.shape[0]
+    is_bottom_level = jnp.arange(nlev_scan) == (nlev_scan - 1)
+
+    def _column_level_step(carry, level_in):
+        """One level of the ECHAM column_processes loop (sections 3-8)."""
         (rain_flux, snow_flux, ice_flux, ice_flux_n,
          falling_ice_frac, precip_cover) = carry
-        (cf_k, adc_k, dp_k, rho_k, inv_rho_k, qi_k, icnc_k, cdnc_k,
-         t_k, melt_k,
-         q_k, dpg_k, subice_k, subwat_k, qsi_k, qsw_k, thermo_k,
-         rain_form_k, snow_accr_k, snow_form_k,
-         is_bottom_k,
-         ) = level_in
+        (cf_k, t_m1_k, q_m1_k, dT_up_k, dq_up_k, dqc_up_k, dqi_up_k,
+         qc_m1_k, qi_m1_k, qc_run_k, qi_run_k,
+         p_k, rho_k, inv_rho_k, dp_k, dpg_k, dz_k, adc_k, zqrho_k,
+         cdnc0_k, icnc0_k,
+         esw_k, esi_k, qsw_k, qsi_k, dqsw_k, dqsi_k,
+         subice_k, subwat_k, thermo_k, eta_k, verv_k, visc_k, melt_k,
+         act_cdnc_k, n_inp_k, inp_dep_k, is_bottom_k) = level_in
 
-        # --- Sedimentation ---
-        (
-            qi_post_sedi, icnc_post_sedi,
-            ice_flux, ice_flux_n, falling_ice_frac,
-            _sedi_rate,
-        ) = sedimentation_ice(
+        zero_s = jnp.zeros_like(cf_k)
+
+        # --- 4. Sedimentation of cloud ice (grid-mean) -----------------
+        # Acts on the provisional grid-mean ice (ECHAM zxip1 = pxim1 +
+        # ztmst·pxite, with the upstream increments folded into qi here).
+        (zxip1, icnc_sedi, ice_flux, ice_flux_n, falling_ice_frac,
+         _sedi_rate) = sedimentation_ice(
             cf_k, adc_k, dp_k, rho_k, inv_rho_k,
-            qi_k, icnc_k,
+            jnp.maximum(qi_run_k, 0.0), icnc0_k,
             ice_flux, ice_flux_n, falling_ice_frac,
-            dt,
-            params,
+            dt, params,
         )
+        sedi_tend = (zxip1 - qi_run_k) / dt
 
-        # --- Melting --- per-level pimlt/psmlt/pximlt all reach the ledger:
-        # in-cloud melt and falling-ice melt go to cloud liquid, snow melt to
-        # rain, each with its own fusion cooling in update_tendencies.
-        #
-        # The running ice tendency is threaded THROUGH the routine, which is
-        # how ECHAM stops the two ice sinks claiming the same mass:
-        # ``pimlt = max(pxim1 + ztmst·pxite, 0)`` reconstructs the ice left
-        # AFTER sedimentation, then debits that. So the sedimentation delta
-        # must be in ``pxite`` on the way in, and what comes back out is the
-        # combined sediment-plus-melt tendency the ledger wants.
-        sedi_ice_tendency = (qi_post_sedi - qi_k) / dt
-        (
-            icnc_post_melt, _qmel, cdnc_post_melt,
-            rain_flux, snow_flux, ice_flux, ice_flux_n,
-            ice_tend_k, pimlt_k, psmlt_k, pximlt_k,
-        ) = melting_snow_and_ice(
-            melt_k, t_k, qi_k, dp_k,
-            icnc_post_sedi, lsdcp, lvdcp,
-            icnc_post_sedi,
+        # --- 3.1 Melting (fluxes + in-cloud ice) -----------------------
+        # Runs after sedimentation (MG/PUMAS order, see docstring); the
+        # running ice tendency is threaded THROUGH the routine so
+        # ``pimlt = max(qi + ztmst·pxite, 0)`` reconstructs the ice left
+        # AFTER sedimentation and the two sinks cannot claim the same
+        # mass (#662 finding 2).
+        (icnc_melt, _qmel, cdnc_melt,
+         rain_flux, snow_flux, ice_flux, ice_flux_n,
+         ice_tend_k, pimlt_k, psmlt_a, pximlt_k) = melting_snow_and_ice(
+            melt_k, t_m1_k, qi_run_k, dp_k,
+            icnc_sedi, lsdcp, lvdcp,
+            icnc_sedi,
             jnp.array(0.0),  # qmel accumulator
-            cdnc_k,
+            cdnc0_k,
             rain_flux, snow_flux, ice_flux, ice_flux_n,
-            sedi_ice_tendency,
+            sedi_tend,
             dt,
             params,
         )
 
-        # --- Sublimation / evaporation ---
-        precip_mask = (rain_flux > params.cqtmin) | (snow_flux > params.cqtmin)
-        falling_ice_mask_k = ice_flux > params.cqtmin
-
-        (
-            ice_flux, ice_flux_n,
-            ice_sublim_k, snow_sublim_k, rain_evap_k,
-        ) = sublimation_snow_and_ice_evaporation_rain(
+        # --- 3.2/3.3 Sublimation of snow/falling ice + rain evap -------
+        precip_mask = precip_cover > 0.0        # ECHAM ll_precip
+        falling_ice_mask_k = falling_ice_frac > 0.0  # ECHAM ll_falling_ice
+        (ice_flux, ice_flux_n,
+         xisub_k, sub_k, evp_k) = sublimation_snow_and_ice_evaporation_rain(
             precip_mask, falling_ice_mask_k,
-            q_k, t_k,
+            q_m1_k, t_m1_k,
             precip_cover, dp_k, dpg_k,
-            subice_k, lsdcp, inv_rho_k,
+            subice_k, lsdcp,
+            zqrho_k,          # ECHAM pqrho = zqrho = 1.3/ρ (was 1/ρ)
             qsi_k, inv_rho_k,
             snow_flux, rho_k,
             qsw_k, rain_flux,
@@ -578,60 +376,386 @@ def cloud_microphysics_2m(
             params,
         )
 
-        # --- Update precipitation fluxes ---
-        (
-            precip_cover, rain_flux, snow_flux, snow_melt,
-            _pfevapr, _pfrain, _pfsnow, _pfsubls,
-        ) = update_precip_fluxes(
-            cf_k, dp_k,
-            rain_evap_k, lsdcp, lvdcp,
-            rain_form_k, snow_accr_k, snow_form_k,
-            snow_sublim_k, t_k,
-            # ECHAM folds the sedimenting ice flux into the snow flux ONLY
-            # at the bottom level (Fortran ``kk == klev`` gate). Passing
-            # the undepleted carry at every level counted a constant
-            # cirrus flux into snow once per level below it — ~nlev× snow
-            # (review finding 2.17).
+        # --- In-cloud condensate prep + clear-sky evaporation ----------
+        # ECHAM 1310-1385. The step's total non-microphysical increments
+        # (upstream + sedimentation + melting) are split ECHAM-style: in
+        # cloudy cells positive increments enter the in-cloud state at
+        # their grid-mean magnitude while their clear-sky share
+        # ``(1−paclc)·max(增, 0)`` evaporates (the two add back to the full
+        # grid-mean increment); negative increments deplete in-cloud
+        # values clamped at zero; in cloud-FREE cells the entire
+        # condensate — carried plus incremented — evaporates. This is the
+        # clear-sky condensate sink the scheme previously lacked (#667):
+        # a cf=0 cell holding qc/qi now returns it to vapour with the
+        # matching latent cooling instead of carrying it untouchable.
+        ll_cc = cf_k > params.clc_min
+        cf_safe = jnp.maximum(cf_k, params.clc_min)
+
+        zxidt = dqi_up_k + dt * ice_tend_k
+        zxldt = dqc_up_k + pximlt_k + pimlt_k
+        ll_ipos = zxidt > 0.0
+        ll_lpos = zxldt > 0.0
+        zxidtstar = jnp.maximum(zxidt, 0.0)
+        zxldtstar = jnp.maximum(zxldt, 0.0)
+
+        zxib = jnp.where(ll_cc, qi_m1_k / cf_safe, 0.0)
+        incr_i = jnp.where(ll_ipos, zxidt,
+                           jnp.maximum(zxidt / cf_safe, -zxib))
+        zxib = zxib + jnp.where(ll_cc, incr_i, 0.0)
+        zxim1evp = (jnp.where(ll_cc, 0.0, qi_m1_k)
+                    + jnp.where(jnp.logical_and(~ll_cc, ~ll_ipos),
+                                zxidt, 0.0))
+
+        zxlb = jnp.where(ll_cc, qc_m1_k / cf_safe, 0.0)
+        incr_l = jnp.where(ll_lpos, zxldt,
+                           jnp.maximum(zxldt / cf_safe, -zxlb))
+        zxlb = zxlb + jnp.where(ll_cc, incr_l, 0.0)
+        zxlm1evp = (jnp.where(ll_cc, 0.0, qc_m1_k)
+                    + jnp.where(jnp.logical_and(~ll_cc, ~ll_lpos),
+                                zxldt, 0.0))
+
+        zxievap = (1.0 - cf_k) * zxidtstar + zxim1evp
+        zxlevap = (1.0 - cf_k) * zxldtstar + zxlm1evp
+
+        zxib = jnp.maximum(zxib, 0.0)
+        zxlb = jnp.maximum(zxlb, 0.0)
+        zxilb = zxib + zxlb
+
+        # --- Phase decision lo2 (ECHAM section 4 end) ------------------
+        # Ice-vs-liquid regime from the Korolev/Mazin threshold updraft,
+        # computed on the post-sedimentation ice.
+        ice_gm3 = 1000.0 * zxip1 * rho_k / cf_safe
+        zrieff = jnp.clip(
+            eff_ice_crystal_radius(ice_gm3, icnc_melt, params),
+            params.ceffmin, params.ceffmax)
+        zrih = -2261.0 + jnp.sqrt(5113188.0 + 2809.0 * zrieff ** 3)
+        zrice = 1.0e-6 * jnp.maximum(zrih, params.eps) ** (1.0 / 3.0)
+        zvervmax = threshold_vert_vel(
+            sat_vap_pres_water=esw_k, sat_vap_pres_ice=esi_k,
+            icnc=icnc_melt, ice_radius=zrice, eta=eta_k, params=params)
+        lo2 = jnp.logical_or(
+            t_m1_k < params.cthomi,
+            jnp.logical_and(t_m1_k < params.tmelt,
+                            0.01 * verv_k < zvervmax),
+        )
+
+        # --- 5. Condensation source zqcdif → zcnd / zdep ---------------
+        # The Sundqvist moisture-convergence closure (ECHAM 1389-1470):
+        # the humidity increment this step, minus the saturation-humidity
+        # change implied by the temperature increment (damped by the
+        # warming feedback), condenses into the cloudy fraction.
+        zlc = jnp.where(lo2, lsdcp, lvdcp)
+        zqsm1 = jnp.where(lo2, qsi_k, qsw_k)
+        zdqsdt = jnp.where(lo2, dqsi_k, dqsw_k)
+
+        zdtdt = (dT_up_k
+                 - lvdcp * (evp_k + zxlevap)
+                 - (lsdcp - lvdcp) * (psmlt_a + pximlt_k + pimlt_k)
+                 - lsdcp * (sub_k + zxievap + xisub_k))
+        zqp1 = jnp.maximum(q_m1_k + dq_up_k, 0.0)
+        ztp1 = t_m1_k + zdtdt
+
+        zdqsat = (zdtdt
+                  + cf_k * (zlc * dq_up_k
+                            + lvdcp * (evp_k + zxlevap)
+                            + lsdcp * (sub_k + zxievap + xisub_k)))
+        zdqsat = (zdqsat * zdqsdt
+                  / (1.0 + cf_k * zlc * zdqsdt))
+        zqcdif = (dq_up_k - zdqsat) * cf_k
+        # Bounds: dissipation limited to the available condensate,
+        # condensation to (almost) the available vapour (ECHAM qsec·zqp1,
+        # qsec = 1 − cqtmin ≈ xsec).
+        zqcdif = jnp.clip(zqcdif, -zxilb * cf_k, params.xsec * zqp1)
+
+        ll_dissip = zqcdif < 0.0
+        zifrac = jnp.clip(zxib / jnp.maximum(zxilb, params.epsec), 0.0, 1.0)
+        frac = jnp.where(ll_dissip, zifrac, 1.0)
+        zcnd0 = jnp.where(ll_dissip, zqcdif * (1.0 - zifrac), 0.0)
+        if params.nic_cirrus == 2:
+            # ECHAM: zdep = zqinucl·zifrac — the Kärcher-Lohmann
+            # nucleated vapour, which jcm does not compute (#552).
+            zdep0 = zero_s
+        else:
+            zdep0 = zqcdif * frac
+        ll_growth_liq = jnp.logical_and(~ll_dissip, ~lo2)
+        zdep0 = jnp.where(ll_growth_liq, 0.0, zdep0)
+        # Saturation adjustment for water condensation (ECHAM #485): in
+        # the liquid-growth regime the full zqcdif condenses.
+        zcnd0 = jnp.where(ll_growth_liq, zqcdif, zcnd0)
+
+        # --- 5.4 Supersaturation corrections ---------------------------
+        (zcnd, zdep, ztp1tmp, zqp1tmp, zqsp1tmp,
+         _zvervmax_dep) = mixed_phase_deposition_and_corrections(
+            p_k, icnc_melt, q_m1_k, cf_k,
+            esi_k, esw_k,
+            eta_k,
+            zero_s,             # tompkins_genti
+            lsdcp, lvdcp,
+            zqp1, zqsm1,
+            rho_k, ztp1,
+            zxievap,
+            zxip1,
+            zero_s,             # detrainment tendency (folded into qi)
+            verv_k,
+            zcnd0, zdep0,       # INOUT, seeded from section 5
+            dt,
+            params,
+        )
+
+        # --- 5.5 In-cloud water update + activation / nucleation -------
+        (cloud_flag, icnc_u, _nucl, cdnc_u, paclc, zxib, zxlb,
+         cdnc_min_k) = update_in_cloud_water(
+            p_k,
+            act_cdnc_k,
+            zcnd, zdep,
+            zero_s, zero_s,     # Tompkins sources
+            inp_dep_k,          # newly_formed_ice: cirrus dep-INP (#494)
+            zqp1tmp, zqsp1tmp,
+            rho_k,
+            zrice,              # prid: volume-mean ice radius [m]
+            t_m1_k,             # ptm1 (activation gates on step-start T)
+            ll_cc,
+            icnc_melt,
+            zero_s,             # nucleation_rate accumulator
+            cdnc_melt,
+            cf_k,
+            zxib, zxlb,
+            dt,
+            params,
+        )
+
+        # --- 6.1 Homogeneous freezing below cthomi ---------------------
+        frz_below = ztp1tmp <= params.cthomi
+        (icnc_f, _qfre, cdnc_f, zfrl, zxib, zxlb) = freezing_below_238K(
+            frz_below, paclc, cdnc_min_k,
+            icnc_u,
+            zero_s,             # droplet_freezing_rate accumulator
+            cdnc_u,
+            zero_s,             # freezing_rate accumulator (pfrl)
+            zxib, zxlb,
+            dt,
+            params.cqtmin,
+        )
+
+        # --- 6.2 Heterogeneous mixed-phase freezing + WBF --------------
+        # ECHAM ll_mxphase_frz: liquid present, mixed-phase window on the
+        # corrected temperature, droplets at/above the floor, cloud
+        # present. The jcm INP substitution (JAM immersion / DeMott
+        # fallback) freezes droplets up to the INP number, moving number,
+        # mass AND fusion heat together (#662 finding 3).
+        ll_mxfrz = (
+            (zxlb > params.cqtmin)
+            & (ztp1tmp < params.tmelt)
+            & (ztp1tmp > params.cthomi)
+            & (cdnc_f >= cdnc_min_k)
+            & cloud_flag
+        )
+        icnc_het = jnp.where(
+            jnp.logical_and(ll_mxfrz, n_inp_k > icnc_f), n_inp_k, icnc_f)
+        new_crystals = jnp.maximum(icnc_het - icnc_f, 0.0)
+        mean_droplet_mass = jnp.where(
+            cdnc_f > params.epsec,
+            zxlb * rho_k / jnp.maximum(cdnc_f, params.epsec),
+            0.0,
+        )
+        frozen_mass = jnp.minimum(
+            new_crystals * mean_droplet_mass * inv_rho_k, zxlb)
+        zxib = zxib + frozen_mass
+        zxlb = zxlb - frozen_mass
+        cdnc_h = jnp.where(
+            ll_mxfrz,
+            jnp.maximum(cdnc_f - new_crystals, params.cqtmin),
+            cdnc_f,
+        )
+        # Grid-mean freezing ledger (ECHAM pfrl): only the het leg is
+        # converted here — freezing_below_238K already area-weights
+        # internally (pfrl += pxlb·paclc).
+        zfrl = zfrl + frozen_mass * paclc
+
+        # WBF with the threshold updraft recomputed from the
+        # post-freezing in-cloud ice (ECHAM 1580-1594).
+        ice_gm3_wbf = 1000.0 * zxib * rho_k
+        zrieff_wbf = jnp.clip(
+            eff_ice_crystal_radius(ice_gm3_wbf, icnc_het, params),
+            params.ceffmin, params.ceffmax)
+        zrih_wbf = -2261.0 + jnp.sqrt(5113188.0 + 2809.0 * zrieff_wbf ** 3)
+        zrice_wbf = 1.0e-6 * jnp.maximum(zrih_wbf, params.eps) ** (1.0 / 3.0)
+        zvervmax_wbf = threshold_vert_vel(
+            sat_vap_pres_water=esw_k, sat_vap_pres_ice=esi_k,
+            icnc=icnc_het, ice_radius=zrice_wbf, eta=eta_k, params=params)
+        ll_wbf = (
+            ll_mxfrz
+            & cloud_flag
+            & (zdep > 0.0)
+            & (zxlb > 0.0)
+            & (0.01 * verv_k < zvervmax_wbf)
+        )
+        # ``WBF_process`` computes the grid-mean transfer once
+        # (pxlb·paclc/dt) and reports it three ways — liquid debit, ice
+        # credit, fusion warming. All three seed the ledger together:
+        # they are one transfer, and the enthalpy budget only closes if
+        # the mass and the heat travel with it (#662 finding 1).
+        (cdnc_w, zxlb, zxib,
+         wbf_liq_tend, wbf_ice_tend, wbf_dtedt) = WBF_process(
+            ll_wbf, paclc, lsdcp, lvdcp,
+            cdnc_h, zxlb, zxib,
+            zero_s, zero_s, zero_s,
+            dt,
+            params,
+        )
+        wbf_transfer_k = -dt * wbf_liq_tend   # grid-mean kg/kg moved liq→ice
+
+        # --- 7. Precipitation geometry + Marshall-Palmer inversion -----
+        # zclcstar: the cloud ∩ precipitation overlap that weights
+        # accretion by rain/snow from above (#685 — was paclc, i.e. the
+        # assumption that precip always covers at least the cloud).
+        zclcstar = jnp.minimum(paclc, precip_cover)
+        # zauloc: layer-depth-dependent fraction of the box in which
+        # newly formed rain participates in accretion (#685 — was 1).
+        zauloc = jnp.clip(params.cauloc / 5000.0 * dz_k,
+                          params.clmin, params.clmax)
+
+        zxlb = jnp.maximum(zxlb, 1.0e-20)
+        zxib = jnp.maximum(zxib, 1.0e-20)
+        zmlwc_k = zxlb          # in-cloud liquid before rain formation
+        zmiwc_k = zxib          # in-cloud ice before snow formation
+
+        # Rain/snow water content diagnosed from the carry fluxes by the
+        # Marshall-Palmer inversions (Roeckner et al. 2003 eqs. 10.70 /
+        # 10.74; ECHAM 1638-1654). This replaces the dead ``qr``/``qs``
+        # tracer reads (#662 finding 5): ECHAM carries no rain/snow
+        # tracers — the accretion "rain from above" is the flux the
+        # levels above just produced, inverted to a mixing ratio.
+        # Double-where guards on the fractional powers (infinite
+        # derivative at 0 base under the masked branch).
+        ll_pre = precip_cover > params.epsec
+        rain_present = jnp.logical_and(ll_pre, rain_flux > params.cqtmin)
+        snow_present = jnp.logical_and(ll_pre, snow_flux > params.cqtmin)
+        zclcpre_safe = jnp.maximum(precip_cover, params.epsec)
+        zqrho_sqrt = jnp.sqrt(zqrho_k)
+        zxrp1_base = jnp.where(
+            rain_present,
+            jnp.maximum(rain_flux, params.cqtmin)
+            / (12.45 * zclcpre_safe * zqrho_sqrt),
+            1.0,
+        )
+        zxrp1 = jnp.where(rain_present, zxrp1_base ** (8.0 / 9.0), 0.0)
+        zxsp1_base = jnp.where(
+            snow_present,
+            jnp.maximum(snow_flux, params.cqtmin)
+            / (params.cvtfall * zclcpre_safe),
+            1.0,
+        )
+        zxsp1 = jnp.where(snow_present, zxsp1_base ** (1.0 / 1.16), 0.0)
+
+        # --- 7.1 Warm-rain formation (KK2000) --------------------------
+        # ECHAM ll_prcp_warm: cloud present, liquid present, droplets
+        # at/above the activation floor — NO temperature condition
+        # (coalescence operates on supercooled liquid too).
+        ll_warm = (
+            cloud_flag
+            & (zxlb > params.cqtmin)
+            & (cdnc_w >= cdnc_min_k)
+        )
+        (cdnc_p, zxlb, _mratepr, zrpr, _rprn,
+         auto_only_k, accr_only_k) = precip_formation_warm(
+            ll_warm,
+            zauloc,
+            paclc,
+            zclcstar,
+            rho_k,
+            zxrp1,
+            cdnc_min_k,
+            cdnc_w,
+            zxlb,
+            dt,
+            params,
+        )
+
+        # --- 7.2 Cold precipitation formation --------------------------
+        # Gate is ECHAM's: the cloud flag only — the internal
+        # ``zxib > cqtmin`` check runs on the CURRENT in-cloud ice, so
+        # ice deposited/frozen/WBF-transferred THIS step meets its
+        # aggregation and riming sinks in the same step (#686).
+        (icnc_c, cdnc_c, _mrateps, zxib, zxlb,
+         _sprn, zsacl, _sacln, _msnowacl, zspr) = precip_formation_cold(
+            cloud_flag,
+            zauloc,
+            paclc,
+            zclcstar,
+            zqrho_k,            # ECHAM pqrho = 1.3/ρ (was 1/ρ)
+            inv_rho_k,
+            ztp1tmp,
+            visc_k,
+            zxsp1,
+            rho_k,
+            cdnc_min_k,
+            icnc_het,
+            cdnc_p,
+            zero_s,
+            zxib, zxlb,
+            dt,
+            params,
+        )
+
+        # --- 7.3 Update precipitation fluxes ---------------------------
+        (precip_cover, rain_flux, snow_flux, snow_melt_b,
+         _pfevapr, _pfrain, _pfsnow, _pfsubls) = update_precip_fluxes(
+            paclc, dp_k,
+            evp_k, lsdcp, lvdcp,
+            zrpr, zsacl, zspr,
+            sub_k, ztp1tmp,
+            # ECHAM folds the sedimenting ice flux into the snow flux
+            # ONLY at the bottom level (Fortran ``kk == klev`` gate).
             jnp.where(is_bottom_k, ice_flux, 0.0),
-            # Per-level melt bookkeeping (ECHAM zeroes zsmlt each jk):
-            # feed 0 in and take the routine's output as this level's
-            # increment, added to the melting-subroutine psmlt below.
             precip_cover, rain_flux, snow_flux, jnp.array(0.0),
             dt,
             params,
         )
-        psmlt_level = psmlt_k + snow_melt
+        psmlt_k = psmlt_a + snow_melt_b
+
+        # --- 8-prep: phase-presence flags for the effective radii ------
+        # ECHAM ll_liqcl/ll_icecl (1755-1760): actual condensate + number
+        # above its floor — NOT a temperature split.
+        ll_liqcl_k = jnp.logical_and(zxlb > params.epsec,
+                                     cdnc_c >= cdnc_min_k)
+        ll_icecl_k = jnp.logical_and(zxib > params.epsec,
+                                     icnc_c >= params.icemin)
+
+        # Per-level flux profiles for downstream (COSP/CloudSat)
+        # diagnostics: the grid-mean rain / frozen fluxes LEAVING this
+        # layer. The frozen profile adds the sedimenting cloud-ice flux
+        # at interior levels; at the bottom ``update_precip_fluxes`` has
+        # already folded it into snow (adding again would double-count).
+        frozen_flux_k = snow_flux + jnp.where(is_bottom_k, 0.0, ice_flux)
 
         carry_out = (rain_flux, snow_flux, ice_flux, ice_flux_n,
                      falling_ice_frac, precip_cover)
-        # Per-level flux profiles for downstream (COSP/CloudSat)
-        # diagnostics: the grid-mean rain / frozen fluxes LEAVING this
-        # layer (the carry values after update_precip_fluxes). The frozen
-        # profile adds the sedimenting cloud-ice flux at interior levels
-        # so it is the total falling frozen water; at the bottom level
-        # ``update_precip_fluxes`` has already folded ``ice_flux`` into
-        # ``snow_flux`` (ECHAM ``kk == klev`` gate), so adding it again
-        # there would double-count — hence the ``is_bottom_k`` guard,
-        # which also makes the bottom row equal ``surface_snow_flux``
-        # exactly.
-        frozen_flux_k = snow_flux + jnp.where(is_bottom_k, 0.0, ice_flux)
-        level_out = (ice_tend_k, icnc_post_melt, cdnc_post_melt,
-                     ice_sublim_k, snow_sublim_k, rain_evap_k,
-                     psmlt_level, pimlt_k, pximlt_k,
-                     rain_flux, frozen_flux_k)
+        level_out = (
+            zcnd, zdep, zfrl, zrpr, zsacl, zspr,
+            pimlt_k, pximlt_k, psmlt_k,
+            xisub_k, sub_k, evp_k,
+            zxlevap, zxievap,
+            ice_tend_k, wbf_liq_tend, wbf_ice_tend, wbf_dtedt,
+            zxib, zxlb, paclc, icnc_c, cdnc_c, cdnc_min_k, ztp1tmp,
+            zmlwc_k, zmiwc_k,
+            auto_only_k, accr_only_k,
+            rain_flux, frozen_flux_k,
+            wbf_transfer_k, ll_liqcl_k, ll_icecl_k,
+        )
         return carry_out, level_out
 
-    # Stack per-level inputs: shape (nlev,) each → scanned along axis 0.
-    nlev_scan = temperature.shape[0]
-    is_bottom_level = jnp.arange(nlev_scan) == (nlev_scan - 1)
     scan_inputs = (
-        cloud_fraction_uicw, air_density_correction, pressure_thickness,
-        air_density, inv_rho, qi_after_cold, icnc_cold, cdnc_cold,
-        temperature, melt_mask,
-        specific_humidity, dp_over_g, subsat_wrt_ice, subsat_wrt_water,
-        qsat_ice, qsat_water, thermo_term_water,
-        qr_gain_warm, psacl, snow_formation_gridmean,
-        is_bottom_level,
+        cloud_fraction, temperature_m1, specific_humidity_m1,
+        dT_up, dq_up, dqc_up, dqi_up,
+        qc_m1, qi_m1, qc, qi,
+        pressure, air_density, inv_rho, pressure_thickness, dp_over_g,
+        layer_thickness, air_density_correction, zqrho,
+        cdnc0, icnc0,
+        es_water, es_ice, qsat_water, qsat_ice, dqsw_dt, dqsi_dt,
+        subsat_wrt_ice, subsat_wrt_water, thermo_term_water,
+        bergeron_eta, updraft_velocity, dynamic_viscosity, melt_mask,
+        activated_cdnc, n_inp, ice_nuclei_deposition, is_bottom_level,
     )
 
     zero_scalar = jnp.array(0.0, dtype=qc.dtype)
@@ -639,54 +763,50 @@ def cloud_microphysics_2m(
                   zero_scalar, zero_scalar, zero_scalar)
 
     _final_carry, scan_outs = jax.lax.scan(
-        _flux_coupled_step, init_carry, scan_inputs,
+        _column_level_step, init_carry, scan_inputs,
     )
-    (ice_tendency_scan, icnc_after_scan, cdnc_after_scan,
+    (condensation_rate, deposition_rate, freezing_rate,
+     rain_formation, snow_accretion, snow_formation,
+     pimlt_per_level, pximlt_per_level, psmlt_per_level,
      ice_sublim, snow_sublim, rain_evap,
-     psmlt_per_level, pimlt_per_level, pximlt_per_level,
-     rain_flux_profile, snow_flux_profile) = scan_outs
+     xlevap, xievap,
+     ice_tendency_scan, liq_tend_wbf, ice_tend_wbf, dtedt_wbf,
+     in_cloud_ice_final, in_cloud_liquid_final, paclc_final,
+     icnc_final, cdnc_final, cdnc_min_final, ztp1tmp_all,
+     zmlwc, zmiwc,
+     autoconv_only, accretion_only,
+     rain_flux_profile, snow_flux_profile,
+     wbf_transfer, ll_liqcl, ll_icecl) = scan_outs
 
-    # Extract carry state at the bottom of the column. The first two
-    # elements are the surface rain and snow flux (kg/m^2/s) — these are
-    # the large-scale precipitation diagnostics that callers need.
-    (
-        surface_rain_flux, surface_snow_flux,
-        _, _, _, _,
-    ) = _final_carry
+    # Surface precipitation fluxes: the carry at the bottom of the column.
+    (surface_rain_flux, surface_snow_flux, _, _, _, _) = _final_carry
 
     # ------------------------------------------------------------------
-    # update_tendencies_and_important_vars: full ECHAM6 accounting step
+    # 8. update_tendencies_and_important_vars: the ECHAM6 accounting step
     # ------------------------------------------------------------------
-    liquid_cloud_flag = temperature > params.tmelt
-    ice_cloud_flag = temperature <= params.tmelt
     cloud_fraction_in = cloud_fraction
 
     (
         cloud_fraction_final,
         dqdt, dtedt, dqidt, dqcdt,
-        dqncdt_m3, dqnidt_m3,
+        dqncdt_perkg, dqnidt_perkg,
         _incloud_liq, _incloud_ice,
         liq_eff_radius, ice_eff_radius,
     ) = update_tendencies_and_important_vars(
-        icnc=icnc_after_scan,
-        cdnc=cdnc_after_scan,
-        # ECHAM's pxim1/pxlm1 are the GRID-MEAN condensate the step started
-        # from, matching the increments the ledger adds to them (condensation,
-        # rain formation, riming, melting, freezing are all grid-mean). They
-        # reach the outputs only through the negative-mass guard, which tests
-        # the reconstructed ``*_mmr_next`` against the grid-mean threshold
-        # ``ccwmin`` — so an in-cloud magnitude here (larger by 1/cf) would be
-        # compared against the wrong scale in both directions.
+        icnc=icnc_final,
+        cdnc=cdnc_final,
+        # ECHAM's pxim1/pxlm1 are the grid-mean condensate the increments
+        # accumulate on. Here the upstream increments are already inside
+        # ``qi``/``qc`` and the seeds below carry only the scheme's own
+        # tendencies, so the reconstruction pxim1 + ztmst·(upstream+own)
+        # + increments equals ``qi + ztmst·own + increments`` — the same
+        # number, with the negative-mass guard testing the actual
+        # end-of-step grid-mean state against ``ccwmin`` (#662 finding 6).
         ice_mmr_prev=qi,
         liq_mmr_prev=qc,
         # ECHAM convention: pxtm1_cdnc / pxtm1_icnc are the previous-step
-        # tracer values in per-kg-of-air. ``cdnc`` and ``icnc`` here are
-        # the working per-m^3 values (qnc * rho, qni * rho), so we pass
-        # the per-kg ``qnc``/``qni`` instead. With the original (per-m^3)
-        # values the formula mixes per-kg with per-m^3 in the same
-        # subtraction and the resulting per-step amplification (~1/rho^2
-        # at upper levels) compounds qnc/qni 10+ orders of magnitude
-        # over a few days, producing the day-6 NaN.
+        # tracer values in per-kg-of-air (the working cdnc/icnc are
+        # per-m³, so the tendency subtracts per-kg from per-m³·1/ρ).
         tracer_tm1_cdnc=qnc,
         tracer_tm1_icnc=qni,
         condensation_rate=condensation_rate,
@@ -700,62 +820,48 @@ def cloud_microphysics_2m(
         lvdcp=lvdcp,
         air_density=air_density,
         inv_air_density=inv_rho,
-        rain_formation=qr_gain_warm,
-        snow_accretion=psacl,
-        snow_formation=snow_formation_gridmean,
-        cloud_ice_evap=zero,         # not extracted from scan
+        rain_formation=rain_formation,
+        snow_accretion=snow_accretion,
+        snow_formation=snow_formation,
+        # Clear-sky evaporation of cloud ice / liquid (ECHAM zxievap /
+        # zxlevap): the in-scheme sink for condensate in cloud-free cells
+        # and for the clear-sky share of upstream increments (#667).
+        cloud_ice_evap=xievap,
         ice_flux_melt=pximlt_per_level,
         pxitec=zero,
-        # pxlevap is the clear-cell CLOUD-liquid evaporation (ECHAM
-        # zxlevap), not rain evaporation — passing rain_evap here as well
-        # as via pevp double-counted its moistening/cooling and removed
-        # the water from both qc and the rain flux (review finding 2.21).
-        pxlevap=zero,
+        pxlevap=xlevap,
         pxltec=zero,
-        # Falling-ice sublimation (ECHAM zxisub): the sublimation routine
-        # deducts this mass from the falling ice flux, so it must re-enter
-        # the column as vapor here — feeding zero destroyed water at the
-        # sublimation rate (only visible in cold columns where sedimenting
-        # ice crosses subsaturated layers).
+        # Falling-ice sublimation (ECHAM zxisub): deducted from the
+        # falling ice flux, so it must re-enter the column as vapour.
         pxisub=ice_sublim,
         snow_sublimation_mmr=snow_sublim,
         snow_melt=psmlt_per_level,
-        cloud_ice_in_cloud=in_cloud_ice_cold,
-        cloud_liquid_in_cloud=in_cloud_liquid_cold,
-        temp_tmp=temperature,
-        liquid_cloud_flag=liquid_cloud_flag,
-        ice_cloud_flag=ice_cloud_flag,
-        cloud_fraction=cloud_fraction_uicw,
+        cloud_ice_in_cloud=in_cloud_ice_final,
+        cloud_liquid_in_cloud=in_cloud_liquid_final,
+        temp_tmp=ztp1tmp_all,
+        liquid_cloud_flag=ll_liqcl,
+        ice_cloud_flag=ll_icecl,
+        cloud_fraction=paclc_final,
         specific_humidity_tendency=zero,
-        # WBF is the one process that reports its transfer as a tendency
-        # rather than a per-step increment, so its three legs seed the three
-        # INOUT accumulators here (heat, ice credit, liquid debit).
+        # WBF reports its transfer as a tendency, so its three legs seed
+        # the three INOUT accumulators (heat, ice credit, liquid debit).
         temp_tendency=dtedt_wbf,
-        # ECHAM folds ice sedimentation AND melting into pxite before this
-        # ledger (mo_cloud_micro_2m.f90 section 4), so the scan's combined
-        # per-level tendency arrives here as a seed rather than as one of the
-        # increments below; WBF's ice credit joins it. Without the
-        # sedimentation leg the bottom-reaching ice flux would leave as
-        # surface snow with no matching qi debit (#554).
+        # ECHAM folds ice sedimentation AND melting into pxite before
+        # this ledger (section 4), so the sweep's combined per-level
+        # tendency arrives as a seed; WBF's ice credit joins it.
         ice_tendency=ice_tendency_scan + ice_tend_wbf,
         liq_tendency=liq_tend_wbf,
         tracer_tendency_cdnc=zero,
         tracer_tendency_icnc=zero,
-        incloud_liq_before_rain=in_cloud_liquid,  # before warm step
-        incloud_ice_before_snow=in_cloud_ice_uicw, # before cold step
+        incloud_liq_before_rain=zmlwc,
+        incloud_ice_before_snow=zmiwc,
         dt=dt,
         params=params,
     )
 
-    # Mass tendencies: warm qc→qr, cold qi→qs + qc→qs, sedi+melt loss
     # ECHAM carries NO rain/snow mixing-ratio tracers: precipitation
-    # leaves each level exclusively through the prfl/psfl fluxes assembled
-    # in update_precip_fluxes, and the surface fluxes are the outputs. The
-    # previous state-difference dqrdt/dqsdt double-booked the same mass
-    # (once in prognostic qr/qs, once in the scan fluxes), went negative
-    # whenever qi_after_cold gained from WBF/het/deposition, and was then
-    # silently clipped by the non-negative-tracer guard — hidden mass
-    # destruction (review finding 2.18).
+    # leaves each level exclusively through the prfl/psfl fluxes and the
+    # surface fluxes are the outputs (review finding 2.18).
     dqrdt = jnp.zeros_like(qc)
     dqsdt = jnp.zeros_like(qc)
 
@@ -774,11 +880,10 @@ def cloud_microphysics_2m(
     cloud_fraction_final = jnp.minimum(cloud_fraction_final, cloud_fraction_in)
 
     # update_tendencies' tracer_tendency_{cdnc,icnc} is already in per-kg-
-    # of-air per second once we pass qnc/qni (per-kg) as the tm1 tracers
-    # — see the fix above. The legacy ``* inv_rho`` here was a second
-    # units error compounded with the per-kg-vs-per-m^3 swap above.
-    dqncdt = dqncdt_m3
-    dqnidt = dqnidt_m3
+    # of-air per second once qnc/qni (per-kg) are passed as the tm1
+    # tracers.
+    dqncdt = dqncdt_perkg
+    dqnidt = dqnidt_perkg
 
     tendencies = MicrophysicsTendencies_2M(
         dtedt=dtedt,
@@ -790,46 +895,34 @@ def cloud_microphysics_2m(
         dqrdt=dqrdt,
         dqsdt=dqsdt,
     )
+
     # Column-integrated rain sources [kg/m^2/s], split by pathway: the
-    # warm chain (KK2000 autoconversion + accretion, ``qr_gain_warm``) and
-    # snow melt (``psmlt_per_level``). Their ratio is the model's
-    # warm-rain fraction, the CloudSat-style observable that constrains
-    # the warm-rain parameters (ccraut, and the SPA activation fit through
-    # CDNC). Both are per-step grid-mean mixing-ratio increments, so the
-    # column flux is sum(dq * rho * dz) / dt.
+    # warm chain (KK2000 autoconversion + accretion, ``rain_formation``)
+    # and snow melt. Their ratio is the model's warm-rain fraction, the
+    # CloudSat-style observable that constrains the warm-rain parameters
+    # (ccraut, and the SPA activation fit through CDNC). Both are
+    # per-step grid-mean mixing-ratio increments, so the column flux is
+    # sum(dq * rho * dz) / dt.
     air_mass = air_density * layer_thickness  # [kg/m^2] per level
-    rain_formation_warm = jnp.sum(qr_gain_warm * air_mass) / dt
+    rain_formation_warm = jnp.sum(rain_formation * air_mass) / dt
     rain_from_melt = jnp.sum(psmlt_per_level * air_mass) / dt
 
     # AeroCom process rates [kg/m^2/s], same column-integral convention.
-    # autoconv and accretn split the warm chain above into its two
-    # pathways (their sum is qr_gain_warm up to the droplet-number
-    # limiter); wbf is the liquid mass converted to ice by the
-    # Wegener-Bergeron-Findeisen process. All are grid-mean, so the
-    # in-cloud WBF increment is weighted by cloud fraction.
+    # autoconv and accretn split the warm chain into its two pathways;
+    # wbf is the grid-mean liquid mass converted to ice by the
+    # Wegener-Bergeron-Findeisen process.
     autoconv_rate_col = jnp.sum(autoconv_only * air_mass) / dt
     accretion_rate_col = jnp.sum(accretion_only * air_mass) / dt
-    wbf_rate_col = jnp.sum(
-        (in_cloud_liquid_het - in_cloud_liquid_wbf) * cloud_fraction_uicw
-        * air_mass) / dt
+    wbf_rate_col = jnp.sum(wbf_transfer * air_mass) / dt
 
-    # Microphysical effective radii (ECHAM preffl/preffi, um) — consumed
-    # by the radiation term via the clouds carry (finding 2.36: the
-    # radiation-side fabricated r_eff(T)*clip(IWC) saturated at the LUT
-    # edge for thin cirrus, mis-forcing the TTL).
-    # The (nlev,) rain / frozen flux profiles (flux leaving each layer,
-    # stacked from the scan ys) go last so existing ``tend, rain, snow,
-    # *_`` call sites keep working; their bottom row equals the surface
-    # fluxes by construction (same carry values).
     # Per-level precip process rates for JAM wet scavenging (#499), grid
     # mean [kg/kg/s]. Formation is the full condensate→precip ledger the
-    # flux update integrates: the warm chain (KK2000 autoconversion +
-    # accretion, ``qr_gain_warm``), riming (``psacl``) and the cold snow
-    # formation. Evaporation is rain evap + snow sublimation; the falling
-    # cloud-ice sublimation (``ice_sublim``) is deliberately excluded — the
+    # flux update integrates: the warm chain, riming (``zsacl``) and the
+    # cold snow formation. Evaporation is rain evap + snow sublimation;
+    # the falling cloud-ice sublimation is deliberately excluded — the
     # sedimenting ice flux is not a scavenging carrier.
     precip_formation_rate = (
-        qr_gain_warm + psacl + snow_formation_gridmean
+        rain_formation + snow_accretion + snow_formation
     ) / dt
     precip_evaporation_rate = (rain_evap + snow_sublim) / dt
 
@@ -853,11 +946,10 @@ class Lohmann2MMicrophysics(PhysicsTerm):
     """ECHAM 2-moment cloud microphysics (Lohmann/Seifert-Beheng-style) term.
 
     Drop-in 2M alternative to :class:`Echam1MMicrophysics`. Declares the
-    full prognostic-tracer set (``qc``, ``qi``, ``qnc``, ``qni``, ``qr``,
-    ``qs``) — the ``qnc`` / ``qni`` number concentrations are stored per
-    kg of air with ``nondimensionalize=False`` so the modal/nodal
-    converters don't apply the gram/kg scaling that mass mixing ratios
-    get.
+    prognostic-tracer set (``qc``, ``qi``, ``qnc``, ``qni``) — the
+    ``qnc`` / ``qni`` number concentrations are stored per kg of air with
+    ``nondimensionalize=False`` so the modal/nodal converters don't apply
+    the gram/kg scaling that mass mixing ratios get.
 
     Reads the post-condensation ``cloud_fraction`` / ``qc`` / ``qi`` from
     the public ``"clouds"`` key (set by :class:`SundqvistCloudFraction`
@@ -939,14 +1031,15 @@ class Lohmann2MMicrophysics(PhysicsTerm):
         # vdiff->convection->cloud coupling, ECHAM physc order): the upstream
         # vdiff and convection terms have already advanced ``thermo_run`` with
         # their tendencies and convection forwarded its detrained condensate
-        # into ``clouds.qc/qi``. Doing the saturation balance + clear-sky
-        # evaporation on this post-upstream (T, q) — instead of the step-start state — is
-        # what makes the in-step moist-energy balance consistent and the
-        # clear-sky evaporation stable (see
-        # ``.claude/coupled_cloud_operator_design.md``). Tendencies are returned
-        # relative to this state; the host's additive sum with convection's
-        # tendency telescopes back to the correct final state. Falls back to the
-        # step-start state if no upstream term seeded ``thermo_run``.
+        # into ``clouds.qc/qi``. The provisional state is what the returned
+        # tendencies are relative to (the host's additive sum with the
+        # upstream tendencies telescopes back to the correct final state),
+        # while the STEP-START state supplies ECHAM's (ptm1, pqm1, pxlm1,
+        # pxim1) anchors: saturation evaluates there, and the differences
+        # play the role of the accumulated tendencies in the condensation
+        # closure and the clear-sky-evaporation split (see
+        # ``cloud_microphysics_2m``). Falls back to the step-start state if
+        # no upstream term seeded ``thermo_run``.
         thermo_run = diagnostics.get("thermo_run")
         if thermo_run is None:
             temperature_in = state.temperature
@@ -963,8 +1056,10 @@ class Lohmann2MMicrophysics(PhysicsTerm):
         zeros = jnp.zeros_like(state.temperature)
         qnc = state.tracers.get("qnc", zeros)
         qni = state.tracers.get("qni", zeros)
-        qr = state.tracers.get("qr", zeros)
-        qs = state.tracers.get("qs", zeros)
+        # Step-start tracers — the baseline the upstream increments in
+        # ``clouds.qc``/``clouds.qi`` accumulated on (ECHAM pxlm1/pxim1).
+        qc_m1 = state.tracers.get("qc", zeros)
+        qi_m1 = state.tracers.get("qi", zeros)
 
         if "vertical_diffusion" in diagnostics:
             tke = diagnostics["vertical_diffusion"].tke
@@ -1001,51 +1096,38 @@ class Lohmann2MMicrophysics(PhysicsTerm):
             "ice_nuclei_deposition", zeros_2d
         )
 
+        # The core owns grid-scale condensation now (the ECHAM section-5
+        # zqcdif closure + supersaturation corrections run inside the
+        # sweep), so there is NO external Sundqvist condensation bolt-on
+        # any more. The bolt-on dated from when the internal adjustment
+        # was suppressed ~1e6x by the c.ak/zdqsdt transcription bugs
+        # (#667): with those fixed, summing both would remove
+        # supersaturation twice per step with double the latent heating.
         (tend_all, surface_rain_flux, surface_snow_flux,
          r_eff_liq_all, r_eff_ice_all, rain_formation_warm, rain_from_melt,
          autoconv_all, accretion_all, wbf_all,
          precip_form_all, precip_evap_all, cloud_fraction_all,
          rain_flux_all, snow_flux_all) = jax.vmap(
             cloud_microphysics_2m,
-            in_axes=(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, None, None),
+            in_axes=(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                     None, None, 1, 1, 1, 1),
             out_axes=(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
         )(
             temperature_in, specific_humidity_in, pressure_full,
-            qc_interim, qi_interim, qnc, qni, qr, qs,
+            qc_interim, qi_interim, qnc, qni,
             cloud_fraction, air_density, layer_thickness, tke,
             activated_cdnc, ice_nuclei, ice_nuclei_deposition, dt, params_2m,
-        )
-
-        # Grid-mean Sundqvist condensation / evaporation — the implicit
-        # saturation adjustment the 1M column-sweep performs but the 2M
-        # microphysics lacked. Without it the 2M scheme forms almost no
-        # stratiform cloud in saturated cells (an A/B spin-up gave a
-        # radiatively-active LWP ~50x smaller than 1M) and the condensate it
-        # does carry — convective detrainment advected into sub-saturated
-        # cells — accumulates unbounded. This step condenses vapour -> qc/qi
-        # where the post-convection grid box is supersaturated (forming
-        # radiatively-active cloud) and evaporates qc/qi where it is
-        # sub-saturated, capped at the available cloud water, via the
-        # warming-feedback-damped Newton step (so it is stable, unlike the
-        # clear-cell-evaporation bolt-on). ``condensation_evaporation`` is
-        # broadcasting-native, so it runs directly on the (nlev, ncols) state.
-        from ..sundqvist import (
-            condensation_evaporation as _sundqvist_cond_evap,
-            CloudParameters as _SundqvistCloudParams,
-        )
-        dtedt_strat, dqdt_strat, dqcdt_strat, dqidt_strat = _sundqvist_cond_evap(
-            temperature_in, specific_humidity_in, qc_interim, qi_interim,
-            cloud_fraction, pressure_full, dt, _SundqvistCloudParams.default(),
+            state.temperature, state.specific_humidity, qc_m1, qi_m1,
         )
 
         tendency = PhysicsTendency(
             u_wind=jnp.zeros_like(state.u_wind),
             v_wind=jnp.zeros_like(state.v_wind),
-            temperature=tend_all.dtedt.T + dtedt_strat,
-            specific_humidity=tend_all.dqdt.T + dqdt_strat,
+            temperature=tend_all.dtedt.T,
+            specific_humidity=tend_all.dqdt.T,
             tracers={
-                "qc": tend_all.dqcdt.T + dqcdt_strat,
-                "qi": tend_all.dqidt.T + dqidt_strat,
+                "qc": tend_all.dqcdt.T,
+                "qi": tend_all.dqidt.T,
                 "qnc": tend_all.dqncdt.T,
                 "qni": tend_all.dqnidt.T,
             },

--- a/jcm/physics/clouds/lohmann_2m/scheme.py
+++ b/jcm/physics/clouds/lohmann_2m/scheme.py
@@ -792,6 +792,7 @@ def cloud_microphysics_2m(
         dqncdt_perkg, dqnidt_perkg,
         _incloud_liq, _incloud_ice,
         liq_eff_radius, ice_eff_radius,
+        zdxlcor, zdxicor,
     ) = update_tendencies_and_important_vars(
         icnc=icnc_final,
         cdnc=cdnc_final,
@@ -926,6 +927,17 @@ def cloud_microphysics_2m(
     ) / dt
     precip_evaporation_rate = (rain_evap + snow_sublim) / dt
 
+    # Negative-mass-repair diagnostic (#689): the column-integrated
+    # latent heating of the zdxlcor/zdxicor guard [W/m²]. The repair is
+    # ECHAM-faithful and thermodynamically consistent, but sign-definite
+    # — every condensate undershoot the dycore leaves becomes warming +
+    # drying, never the reverse — so its magnitude and geographic pattern
+    # must be observable in a run rather than silently folded into
+    # dtedt/dqdt. Positive values = spurious heating from repairing
+    # negative/sub-ccwmin condensate.
+    negative_mass_repair = jnp.sum(
+        (c.alhc * zdxlcor + c.alhs * zdxicor) * air_mass)
+
     # NOTE the (nlev,) rain / frozen flux profiles stay LAST: call sites and
     # tests unpack them positionally from the end (``*_, rain_b, snow_b``),
     # so new outputs are inserted before them, not appended.
@@ -933,6 +945,7 @@ def cloud_microphysics_2m(
         liq_eff_radius, ice_eff_radius, rain_formation_warm, rain_from_melt, \
         autoconv_rate_col, accretion_rate_col, wbf_rate_col, \
         precip_formation_rate, precip_evaporation_rate, cloud_fraction_final, \
+        negative_mass_repair, \
         rain_flux_profile, snow_flux_profile
 
 
@@ -1107,11 +1120,12 @@ class Lohmann2MMicrophysics(PhysicsTerm):
          r_eff_liq_all, r_eff_ice_all, rain_formation_warm, rain_from_melt,
          autoconv_all, accretion_all, wbf_all,
          precip_form_all, precip_evap_all, cloud_fraction_all,
+         negative_mass_repair_all,
          rain_flux_all, snow_flux_all) = jax.vmap(
             cloud_microphysics_2m,
             in_axes=(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                      None, None, 1, 1, 1, 1),
-            out_axes=(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+            out_axes=(0,) * 16,
         )(
             temperature_in, specific_humidity_in, pressure_full,
             qc_interim, qi_interim, qnc, qni,
@@ -1166,6 +1180,10 @@ class Lohmann2MMicrophysics(PhysicsTerm):
             # style observable for the warm-rain calibration.
             rain_formation_warm=rain_formation_warm,
             rain_from_melt=rain_from_melt,
+            # Column-integrated latent heating of the negative-mass
+            # repair [W/m²] (#689): sign-definite spurious warming from
+            # returning sub-ccwmin/negative condensate to vapour.
+            negative_mass_repair=negative_mass_repair_all,
         )
         # Advance the running condensate view so terms downstream (the
         # satellite simulators and the AeroCom diagnostics) describe the

--- a/jcm/physics/clouds/lohmann_2m_params.py
+++ b/jcm/physics/clouds/lohmann_2m_params.py
@@ -109,6 +109,19 @@ class CloudParams2M:
     fact_coll_eff: jnp.ndarray  # temp-dependent collection efficiency factor
     fact_tke: jnp.ndarray       # turbulence enhancement factor
 
+    # Local accretion geometry (ECHAM zauloc = cauloc·dz/5000, clipped to
+    # [clmin, clmax]): the fraction of the box in which NEWLY formed
+    # rain/snow participates in accretion, a resolution-(layer-depth-)
+    # dependent ramp (mo_cloud_micro_2m.f90:1618-1619). ECHAM zeroes it
+    # additionally at the two levels around a diagnosed low-level
+    # inversion when the large-scale vertical velocity is downward
+    # (knvb/lonacc gate) — that needs pvervel, which is not plumbed to
+    # this scheme yet; see the vertical-velocity issue referenced in the
+    # scheme docstring.
+    cauloc: jnp.ndarray      # [-] zauloc ramp factor (ECHAM 2M hardwires 3)
+    clmin: jnp.ndarray       # [-] lower zauloc clip (ECHAM 0.0)
+    clmax: jnp.ndarray       # [-] upper zauloc clip (ECHAM 0.5)
+
     # Pruppacher & Klett (1997) ice mass-size relation
     fact_PK: jnp.ndarray     # [-] (g, cm) parameter; see cloud_utils notes
     pow_PK: jnp.ndarray      # [-]
@@ -175,6 +188,9 @@ class CloudParams2M:
         exp_1: float = -1.0 / (2.47 - 1.0),
         fact_coll_eff: float = 0.09,
         fact_tke: float = 0.7,
+        cauloc: float = 3.0,
+        clmin: float = 0.0,
+        clmax: float = 0.5,
         fact_PK: float = 8.253e-3,
         pow_PK: float = 2.475,
         cdnc_min_fixed: float = 40.0,  # [cm^-3] ECHAM warm-microphysics floor; KK2000 autoconv (rate ∝ Nc^-1.79) runs away below this in clean air
@@ -247,6 +263,9 @@ class CloudParams2M:
             exp_1=jnp.array(exp_1),
             fact_coll_eff=jnp.array(fact_coll_eff),
             fact_tke=jnp.array(fact_tke),
+            cauloc=jnp.array(cauloc),
+            clmin=jnp.array(clmin),
+            clmax=jnp.array(clmax),
             fact_PK=jnp.array(fact_PK),
             pow_PK=jnp.array(pow_PK),
             pirho_rcp=jnp.array(pirho_rcp_val),

--- a/jcm/physics/clouds/lohmann_2m_params.py
+++ b/jcm/physics/clouds/lohmann_2m_params.py
@@ -116,8 +116,7 @@ class CloudParams2M:
     # additionally at the two levels around a diagnosed low-level
     # inversion when the large-scale vertical velocity is downward
     # (knvb/lonacc gate) — that needs pvervel, which is not plumbed to
-    # this scheme yet; see the vertical-velocity issue referenced in the
-    # scheme docstring.
+    # this scheme yet (#705).
     cauloc: jnp.ndarray      # [-] zauloc ramp factor (ECHAM 2M hardwires 3)
     clmin: jnp.ndarray       # [-] lower zauloc clip (ECHAM 0.0)
     clmax: jnp.ndarray       # [-] upper zauloc clip (ECHAM 0.5)

--- a/jcm/physics/clouds/lohmann_2m_test.py
+++ b/jcm/physics/clouds/lohmann_2m_test.py
@@ -2109,8 +2109,8 @@ class TestColumnEnthalpyConservation2M:
 
         # Per level inside the deck (levels 4-7 hold the condensate), the
         # extra warming is exactly the extra frozen mass times the scheme's
-        # own fusion heat, ``lsdcp - lvdcp``. Note that is (alhs - alhc), NOT
-        # the independent ``alhf`` constant — they differ by 0.3 %.
+        # own fusion heat, ``lsdcp - lvdcp`` = (alhs - alhc)/cpd — which is
+        # also ``c.alhf/cpd`` now that the fusion heat is derived (#681).
         #
         # Column totals cannot carry this check: more crystals means smaller
         # crystals, so the extra ice also sediments more slowly and the

--- a/jcm/physics/clouds/lohmann_2m_test.py
+++ b/jcm/physics/clouds/lohmann_2m_test.py
@@ -1436,7 +1436,7 @@ class TestColumnWaterConservation2M:
 
         tend, rain_sfc, snow_sfc, *_ = cloud_microphysics_2m(
             T, q, p, qc, qi, qnc, qni,
-            jnp.zeros(nlev), jnp.zeros(nlev), cf, rho, dz,
+            cf, rho, dz,
             jnp.full(nlev, 0.1), jnp.full(nlev, 5e7),
             jnp.zeros(nlev), jnp.zeros(nlev),
             1800.0, params,
@@ -1485,7 +1485,7 @@ class TestColumnWaterConservation2M:
         (tend, rain_sfc, snow_sfc, _rl, _ri, _rfw, _rfm, _au, _ac, _wbf,
          form, evap, _cf, rain_prof, snow_prof) = cloud_microphysics_2m(
             T, q, p, qc, jnp.zeros(nlev), qnc, jnp.zeros(nlev),
-            jnp.zeros(nlev), jnp.zeros(nlev), cf, rho, dz,
+            cf, rho, dz,
             jnp.full(nlev, 0.1), jnp.full(nlev, 5e7),
             jnp.zeros(nlev), jnp.zeros(nlev),
             1800.0, params,
@@ -1535,7 +1535,7 @@ class TestColumnWaterConservation2M:
         (tend, rain_sfc, snow_sfc, _rl, _ri, _rfw, _rfm, _au, _ac, _wbf,
          form, evap, _cf, _rp, _sp) = cloud_microphysics_2m(
             T, q, p, jnp.zeros(nlev), qi, jnp.zeros(nlev), qni,
-            jnp.zeros(nlev), jnp.zeros(nlev), cf, rho, dz,
+            cf, rho, dz,
             jnp.full(nlev, 0.1), jnp.full(nlev, 5e7),
             jnp.zeros(nlev), jnp.zeros(nlev),
             1800.0, params,
@@ -1589,7 +1589,7 @@ class TestColumnWaterConservation2M:
             params = CloudParams2M.default(nic_cirrus=nic)
             tend, _, _, *_ = cloud_microphysics_2m(
                 T, q, p, jnp.zeros(nlev), qi, jnp.zeros(nlev), qni,
-                jnp.zeros(nlev), jnp.zeros(nlev), cf, rho, dz,
+                cf, rho, dz,
                 jnp.full(nlev, 0.1), jnp.full(nlev, 5e7),
                 jnp.zeros(nlev), jnp.zeros(nlev),
                 1800.0, params,
@@ -1628,7 +1628,7 @@ class TestColumnWaterConservation2M:
         qi = jnp.full(nlev, 1.5e-4)
         tend, _, _, *_ = cloud_microphysics_2m(
             T, q, p, jnp.zeros(nlev), qi, jnp.zeros(nlev), jnp.zeros(nlev),
-            jnp.zeros(nlev), jnp.zeros(nlev), jnp.full(nlev, 0.287), rho,
+            jnp.full(nlev, 0.287), rho,
             jnp.full(nlev, 800.0), jnp.full(nlev, 0.1), jnp.full(nlev, 5e7),
             jnp.zeros(nlev), jnp.zeros(nlev), 720.0, CloudParams2M.default(),
         )
@@ -1671,7 +1671,7 @@ class TestColumnWaterConservation2M:
 
         tend, rain_sfc, snow_sfc, *_ = cloud_microphysics_2m(
             T, q, p, qc, qi, qnc, jnp.zeros(nlev),
-            jnp.zeros(nlev), jnp.zeros(nlev), cf, rho, dz,
+            cf, rho, dz,
             jnp.full(nlev, 0.1), jnp.full(nlev, 5e7),
             jnp.zeros(nlev), jnp.zeros(nlev),
             1800.0, params,
@@ -1719,7 +1719,7 @@ class TestColumnWaterConservation2M:
 
         tend, rain_sfc, snow_sfc, *_ = cloud_microphysics_2m(
             T, q, p, qc, qi, jnp.zeros(nlev), qni,
-            jnp.zeros(nlev), jnp.zeros(nlev), cf, rho, dz,
+            cf, rho, dz,
             jnp.full(nlev, 0.1), jnp.full(nlev, 5e7),
             jnp.zeros(nlev), jnp.zeros(nlev),
             1800.0, params,
@@ -1735,12 +1735,22 @@ class TestColumnWaterConservation2M:
             f"(snow_sfc {float(snow_sfc):.3e}, gross {gross:.3e})"
         )
         # The ice source cloud occupies levels 6..11; level 12 is clear
-        # (cf = 0, no in-cloud deposition), so any qi gain there can only
-        # be sedimenting ice re-depositing out of the falling flux — the
-        # part of the pxite seed that total-water closure cannot see.
-        assert float(tend.dqidt[12]) > 0.0, (
-            "no below-cloud-base qi gain from the sedimenting flux — the "
-            "scan's net ice change is not entering the pxite ledger"
+        # (cf = 0, no in-cloud deposition), so any water gain there can
+        # only come out of the falling flux: the sedimentation
+        # equilibrium re-deposits part of it into the layer, and — since
+        # the layer is cloud-free — the clear-sky evaporation (ECHAM
+        # zxievap on the positive ice increment) returns it to VAPOUR
+        # with the matching Ls cooling, alongside the pxisub sublimation
+        # credit. Before the column_processes restructure the absorbed
+        # mass stayed as qi (no clear-sky sink existed, #667); the pinned
+        # invariant is that the flux deposits mass into the layer at all
+        # (the pxite seed), not which phase carries it.
+        assert float(tend.dqdt[12] + tend.dqidt[12]) > 0.0, (
+            "no below-cloud-base water gain from the sedimenting flux — "
+            "the scan's net ice change is not entering the ledger"
+        )
+        assert float(tend.dtedt[12]) < 0.0, (
+            "below-cloud sublimation of the re-deposited ice must cool"
         )
 
 
@@ -1781,7 +1791,7 @@ class TestColumnEnthalpyConservation2M:
         nlev = T.shape[0]
         z = jnp.zeros(nlev)
         tend, rain_sfc, snow_sfc, *_ = cloud_microphysics_2m(
-            T, q, p, qc, qi, qnc, qni, z, z, cf, rho, dz, tke,
+            T, q, p, qc, qi, qnc, qni, cf, rho, dz, tke,
             jnp.full(nlev, 5e7), inp, z,
             TestColumnEnthalpyConservation2M.DT, CloudParams2M.default(),
         )
@@ -1923,19 +1933,37 @@ class TestColumnEnthalpyConservation2M:
         _, _, _, _, qi, _, _, _, rho, dz, _, _ = cols
         mass = np.asarray(rho * dz)
 
-        assert rain_sfc == 0.0 and snow_sfc == 0.0, (
-            "fixture is meant to melt in place, not precipitate"
+        # Melting in place: since the whole chain runs per level, the
+        # melt-produced liquid legitimately meets the warm-rain path in
+        # the same step now — allow only a vanishing drizzle relative to
+        # the melting itself, not exactly zero.
+        available = float(np.sum(np.asarray(qi) * mass)) / self.DT
+        assert rain_sfc + snow_sfc < 1e-8 * available, (
+            f"fixture is meant to melt in place, not precipitate "
+            f"(precip {rain_sfc + snow_sfc:.3e} vs melt {available:.3e})"
         )
         dqc_col = float(np.sum(np.asarray(tend.dqcdt) * mass))
         dqi_col = float(np.sum(np.asarray(tend.dqidt) * mass))
+        dq_col = float(np.sum(np.asarray(tend.dqdt) * mass))
         assert dqc_col > 0.0, "no melting happened — fixture is vacuous"
-        # Melting is a pure qi → qc transfer: what liquid gains, ice loses.
-        np.testing.assert_allclose(dqc_col, -dqi_col, rtol=1e-5)
-        # ...and no more ice than the column actually holds may melt.
+        # Melting is not a PURE qi → qc transfer any more: with the whole
+        # chain running per level, the clear-sky share of the melt credit
+        # evaporates (ECHAM zxlevap on zxldt ∋ zimlt) and the section-5
+        # dissipation evaporates in-cloud liquid in this subsaturated
+        # fixture. What must hold instead: every kg of ice that vanished
+        # reappears exactly once, as liquid or vapour.
+        np.testing.assert_allclose(dqc_col + dq_col, -dqi_col, rtol=1e-4)
+        # ...and no more ice than the column actually holds may melt: the
+        # double-melt defect (#662 finding 2) produced 2 × qi/dt of new
+        # water out of qi of ice.
         available = float(np.sum(np.asarray(qi) * mass)) / self.DT
-        assert dqc_col < available * (1.0 + 1e-5), (
-            f"melted {dqc_col:.4e} kg/m²/s from a column holding only "
+        assert -dqi_col < available * (1.0 + 1e-5), (
+            f"ice debit {-dqi_col:.4e} kg/m²/s from a column holding only "
             f"{available:.4e} — the ice is being melted twice"
+        )
+        assert dqc_col + dq_col < available * (1.0 + 1e-5), (
+            f"created {dqc_col + dq_col:.4e} kg/m²/s of liquid+vapour from "
+            f"only {available:.4e} of melting ice"
         )
 
     def test_water_budget_closes_for_cloud_ice_above_freezing(self):
@@ -2024,7 +2052,7 @@ class TestColumnEnthalpyConservation2M:
         nlev = T.shape[0]
         z = jnp.zeros(nlev)
         return cloud_microphysics_2m(
-            T, q, p, qc, qi, qnc, qni, z, z, cf, rho, dz, tke,
+            T, q, p, qc, qi, qnc, qni, cf, rho, dz, tke,
             jnp.full(nlev, 5e7), inp, z,
             TestColumnEnthalpyConservation2M.DT, CloudParams2M.default(),
         )
@@ -2108,21 +2136,30 @@ class TestColumnEnthalpyConservation2M:
         assert float(np.sum(d_qi)) > 0.0, "the frozen mass never became ice"
 
         # Per level inside the deck (levels 4-7 hold the condensate), the
-        # extra warming is exactly the extra frozen mass times the scheme's
-        # own fusion heat, ``lsdcp - lvdcp`` = (alhs - alhc)/cpd — which is
-        # also ``c.alhf/cpd`` now that the fusion heat is derived (#681).
-        #
-        # Column totals cannot carry this check: more crystals means smaller
-        # crystals, so the extra ice also sediments more slowly and the
-        # column ice gain is ~3x the frozen mass. dqc and dtedt are clean
-        # because nothing downstream feeds back on them here.
+        # extra warming must carry AT LEAST the fusion heat of the frozen
+        # liquid, ``lsdcp - lvdcp`` = (alhs - alhc)/cpd = ``c.alhf/cpd``
+        # (#681). It is no longer EXACTLY that: with the whole process
+        # chain running per level (the column_processes restructure), the
+        # extra ice legitimately feeds back within the same step — more
+        # crystal surface shifts the deposition/condensation partition
+        # and the new ice meets riming/aggregation (#686) — so downstream
+        # heat rides on top. The mass-vs-number defect this test pins
+        # (#662 finding 3) fails the LOWER bound: number-only freezing
+        # leaves d_te ~ 0 while d_qc < 0 is enforced above. Fabricated
+        # heat is excluded by the enthalpy-closure gate below, not by a
+        # per-level attribution.
         fusion = (c.alhs - c.alhc) / c.cpd
         for k in range(4, 8):
             assert d_qc[k] < 0.0, f"level {k} lost no liquid to INP"
-            np.testing.assert_allclose(
-                d_te[k], -d_qc[k] * fusion, rtol=1e-3,
-                err_msg=f"level {k}: fusion heat does not match frozen mass",
+            assert d_te[k] > -d_qc[k] * fusion * 0.99, (
+                f"level {k}: extra warming {d_te[k]:.3e} is below the "
+                f"fusion heat of the frozen mass {-d_qc[k] * fusion:.3e} — "
+                "the het transfer is moving mass without its heat"
             )
+        # And the perturbed run must still close the column enthalpy
+        # budget — the guard against the extra in-step coupling smuggling
+        # heat in from nowhere.
+        self._assert_enthalpy_closes("het INP mixed phase", tuple(cols))
 
 
 class TestPrecipFluxProfiles2M:
@@ -2160,7 +2197,7 @@ class TestPrecipFluxProfiles2M:
         nlev = T.shape[0]
         return cloud_microphysics_2m(
             T, q, p, qc, qi, qnc, qni,
-            jnp.zeros(nlev), jnp.zeros(nlev), cf, rho, dz,
+            cf, rho, dz,
             jnp.full(nlev, 0.1), jnp.full(nlev, 5e7),
             jnp.zeros(nlev), jnp.zeros(nlev),
             1800.0, CloudParams2M.default(),
@@ -2197,7 +2234,7 @@ class TestPrecipFluxProfiles2M:
         T, q, p, qc, qi, qnc, qni, cf, rho, dz = column
         nlev = T.shape[0]
         extras = (
-            jnp.zeros(nlev), jnp.zeros(nlev), cf, rho, dz,
+            cf, rho, dz,
             jnp.full(nlev, 0.1), jnp.full(nlev, 5e7),
             jnp.zeros(nlev), jnp.zeros(nlev),
         )
@@ -2205,7 +2242,7 @@ class TestPrecipFluxProfiles2M:
         batched = tuple(jnp.stack([a] * 3, axis=0) for a in args)
         (*_, rain_b, snow_b) = jax.vmap(
             cloud_microphysics_2m,
-            in_axes=(0,) * 16 + (None, None),
+            in_axes=(0,) * 14 + (None, None),
         )(*batched, 1800.0, CloudParams2M.default())
         assert rain_b.shape == (3, nlev)
         for i in range(3):

--- a/jcm/physics/clouds/lohmann_2m_test.py
+++ b/jcm/physics/clouds/lohmann_2m_test.py
@@ -1798,6 +1798,21 @@ class TestColumnEnthalpyConservation2M:
         return tend, float(rain_sfc), float(snow_sfc)
 
     @staticmethod
+    def _run_full(cols):
+        """Full return tuple, for tests that need more than the tendencies."""
+        from jcm.physics.clouds.lohmann_2m import cloud_microphysics_2m
+        from jcm.physics.clouds.lohmann_2m_params import CloudParams2M
+
+        T, q, p, qc, qi, qnc, qni, cf, rho, dz, tke, inp = cols
+        nlev = T.shape[0]
+        z = jnp.zeros(nlev)
+        return cloud_microphysics_2m(
+            T, q, p, qc, qi, qnc, qni, cf, rho, dz, tke,
+            jnp.full(nlev, 5e7), inp, z,
+            TestColumnEnthalpyConservation2M.DT, CloudParams2M.default(),
+        )
+
+    @staticmethod
     def _assert_enthalpy_closes(name, cols):
         """Assert the identity above and return (residual, gross) [W/m²]."""
         import numpy as np
@@ -2042,20 +2057,6 @@ class TestColumnEnthalpyConservation2M:
         cf_out = np.asarray(out_warm[12])
         assert np.all(cf_out <= cf_in + 1e-6), "published cover exceeds input"
 
-    @staticmethod
-    def _run_full(cols):
-        """Full return tuple, for tests that need more than the tendencies."""
-        from jcm.physics.clouds.lohmann_2m import cloud_microphysics_2m
-        from jcm.physics.clouds.lohmann_2m_params import CloudParams2M
-
-        T, q, p, qc, qi, qnc, qni, cf, rho, dz, tke, inp = cols
-        nlev = T.shape[0]
-        z = jnp.zeros(nlev)
-        return cloud_microphysics_2m(
-            T, q, p, qc, qi, qnc, qni, cf, rho, dz, tke,
-            jnp.full(nlev, 5e7), inp, z,
-            TestColumnEnthalpyConservation2M.DT, CloudParams2M.default(),
-        )
 
     def test_homogeneous_freezing_removes_all_the_liquid(self):
         """Below cthomi every drop freezes, in a partly-cloudy box too.
@@ -2160,6 +2161,104 @@ class TestColumnEnthalpyConservation2M:
         # budget — the guard against the extra in-step coupling smuggling
         # heat in from nowhere.
         self._assert_enthalpy_closes("het INP mixed phase", tuple(cols))
+
+
+class TestSaturationGate2M:
+    """The scheme owns saturation adjustment — no supersaturation survives.
+
+    The gate #667 asked for: with the zdqsdt fix the internal Newton step
+    is live, and with the external bolt-on removed it is the ONLY
+    condensation path — so a supersaturated cloudy cell must be pulled to
+    (about) saturation within a step. The absence of this assertion is
+    what let the double adjustment survive the c.ak fix.
+    """
+
+    def test_liquid_supersaturation_removed_in_one_step(self):
+        import numpy as np
+        from jcm.physics.clouds.lohmann_2m import cloud_microphysics_2m
+        from jcm.physics.clouds.lohmann_2m_params import CloudParams2M
+        from jcm.physics import thermodynamics
+
+        nlev = 12
+        dt = 1800.0
+        T = jnp.full(nlev, 285.0)
+        p = jnp.linspace(5e4, 1e5, nlev)
+        rho = p / (287.0 * T)
+        qs0, _ = thermodynamics.saturation_specific_humidity_and_derivative(
+            T, p, phase="water")
+        q = 1.10 * qs0                       # 10 % supersaturated
+        z = jnp.zeros(nlev)
+        tend, *_ = cloud_microphysics_2m(
+            T, q, p, z, z, z, z, jnp.full(nlev, 0.9), rho,
+            jnp.full(nlev, 500.0), z, jnp.full(nlev, 1e8), z, z,
+            dt, CloudParams2M.default(),
+        )
+        T_new = T + dt * tend.dtedt
+        q_new = q + dt * tend.dqdt
+        qs_new, _ = thermodynamics.saturation_specific_humidity_and_derivative(
+            T_new, p, phase="water")
+        s_after = np.asarray(q_new / qs_new)
+        # ECHAM's zoversat tolerance is 1 % of qs; allow a little slack
+        # for the Newton linearisation.
+        assert float(np.max(s_after)) <= 1.015, (
+            f"supersaturation survives the step (max q/qs = "
+            f"{np.max(s_after):.4f}) — the internal adjustment is inert "
+            "or a second adjustment is fighting it"
+        )
+        # ...and the condensate the adjustment formed actually exists.
+        assert float(jnp.sum(tend.dqcdt)) > 0.0, "no liquid was condensed"
+
+
+class TestColdChainSameStepCoupling2M:
+    """Ice created during the step meets its cold-chain sinks (#686).
+
+    A pure supercooled liquid deck (qi = 0 at entry) glaciates via WBF
+    within the step. Under the old ``qi > ccwmin`` entry gate the cold
+    chain was masked off for that step, so the fresh ice had no
+    aggregation/riming sink and could only sediment. ECHAM gates on the
+    CURRENT in-cloud ice, so snow forms in the same step.
+    """
+
+    def test_wbf_glaciated_deck_forms_snow_same_step(self):
+        import numpy as np
+        from jcm.physics.clouds.lohmann_2m import cloud_microphysics_2m
+        from jcm.physics.clouds.lohmann_2m_params import CloudParams2M
+        from jcm.physics.clouds.sundqvist import saturation_specific_humidity
+
+        nlev = 12
+        T = jnp.full(nlev, 258.0)            # mixed-phase window
+        p = jnp.linspace(3e4, 8e4, nlev)
+        rho = p / (287.0 * T)
+        q = 1.02 * jax.vmap(saturation_specific_humidity)(p, T)  # depositing
+        qc = jnp.zeros(nlev).at[4:8].set(3e-4)
+        qi = jnp.zeros(nlev)                 # NO ice at entry
+        cf = jnp.where(qc > 0, 0.9, 0.0)
+        z = jnp.zeros(nlev)
+        # TKE = 0: quiescent, the Korolev/Mazin gate stays open → WBF fires.
+        out = cloud_microphysics_2m(
+            T, q, p, qc, qi, jnp.where(qc > 0, 5e7, 0.0), z,
+            cf, rho, jnp.full(nlev, 500.0), z,
+            jnp.full(nlev, 5e7), z, z,
+            1800.0, CloudParams2M.default(),
+        )
+        tend = out[0]
+        frozen_flux_profile = out[14]
+        # The deck must have glaciated...
+        dqc_col = float(jnp.sum(tend.dqcdt * rho * 500.0))
+        assert dqc_col < -1e-6, "WBF did not glaciate the deck"
+        # ...and the fresh ice must reach a snow sink IN THIS STEP: the
+        # frozen flux leaving the deck bottom (level 7) must be nonzero.
+        # Sedimentation alone cannot explain it at this magnitude within
+        # one step from qi = 0 — but assert the mechanism directly too:
+        # a positive frozen flux with zero entry qi requires in-step
+        # aggregation/riming of ice that WBF/deposition created.
+        deck_bottom_flux = float(np.asarray(frozen_flux_profile)[7])
+        assert deck_bottom_flux > 1e-8, (
+            f"no frozen precipitation leaves the glaciated deck "
+            f"(flux {deck_bottom_flux:.3e} kg/m²/s) — ice made this step "
+            "has no cold-chain sink (#686)"
+        )
+
 
 
 class TestPrecipFluxProfiles2M:

--- a/jcm/physics/clouds/lohmann_2m_test.py
+++ b/jcm/physics/clouds/lohmann_2m_test.py
@@ -1273,7 +1273,7 @@ class TestUpdateTendencies_2M:
             params=_P,
         )
 
-        assert len(out) == 11
+        assert len(out) == 13
         for a in out:
             assert a.shape == (n,)
             assert jnp.all(jnp.isfinite(a))
@@ -1483,7 +1483,7 @@ class TestColumnWaterConservation2M:
         params = CloudParams2M.default()
 
         (tend, rain_sfc, snow_sfc, _rl, _ri, _rfw, _rfm, _au, _ac, _wbf,
-         form, evap, _cf, rain_prof, snow_prof) = cloud_microphysics_2m(
+         form, evap, _cf, _nmr, rain_prof, snow_prof) = cloud_microphysics_2m(
             T, q, p, qc, jnp.zeros(nlev), qnc, jnp.zeros(nlev),
             cf, rho, dz,
             jnp.full(nlev, 0.1), jnp.full(nlev, 5e7),
@@ -1533,7 +1533,7 @@ class TestColumnWaterConservation2M:
         params = CloudParams2M.default()
 
         (tend, rain_sfc, snow_sfc, _rl, _ri, _rfw, _rfm, _au, _ac, _wbf,
-         form, evap, _cf, _rp, _sp) = cloud_microphysics_2m(
+         form, evap, _cf, _nmr, _rp, _sp) = cloud_microphysics_2m(
             T, q, p, jnp.zeros(nlev), qi, jnp.zeros(nlev), qni,
             cf, rho, dz,
             jnp.full(nlev, 0.1), jnp.full(nlev, 5e7),
@@ -2242,7 +2242,7 @@ class TestColdChainSameStepCoupling2M:
             1800.0, CloudParams2M.default(),
         )
         tend = out[0]
-        frozen_flux_profile = out[14]
+        frozen_flux_profile = out[-1]
         # The deck must have glaciated...
         dqc_col = float(jnp.sum(tend.dqcdt * rho * 500.0))
         assert dqc_col < -1e-6, "WBF did not glaciate the deck"

--- a/jcm/physics/clouds/sundqvist.py
+++ b/jcm/physics/clouds/sundqvist.py
@@ -159,15 +159,20 @@ def saturation_vapor_pressure_ice(temperature: jnp.ndarray) -> jnp.ndarray:
 
 
 def saturation_specific_humidity(
-    pressure: jnp.ndarray, 
-    temperature: jnp.ndarray
+    pressure: jnp.ndarray,
+    temperature: jnp.ndarray,
+    t_mix_min: float = 238.15,
 ) -> jnp.ndarray:
     """Calculate saturation specific humidity
-    
+
     Args:
         pressure: Pressure (Pa)
         temperature: Temperature (K)
-        
+        t_mix_min: Lower endpoint of the mixed-phase blend (K). Callers
+            holding a :class:`CloudParameters` must pass
+            ``config.t_mix_min`` so the ``es`` ramp cannot desynchronise
+            from the latent-heat ramp built on the same field (#667).
+
     Returns:
         Saturation specific humidity (kg/kg)
 
@@ -175,16 +180,20 @@ def saturation_specific_humidity(
     # Use appropriate saturation vapor pressure based on temperature
     es_water = saturation_vapor_pressure_water(temperature)
     es_ice = saturation_vapor_pressure_ice(temperature)
-    
+
     # Blend between ice and water saturation in mixed phase region
-    # Linear interpolation between t_ice and tmelt.
+    # Linear interpolation between t_mix_min and tmelt. This is CAM's
+    # default mixed-phase qsat form (wv_sat_methods.F90:479-513), with the
+    # width an ECHAM-derived default (tmelt − cthomi = 35 K) rather than
+    # CAM's 20 K — see #667 for the reference comparison.
     # NOTE (review 2.27): ECHAM mo_cover uses a BINARY lo2 switch (ice qs
     # only below cthomi or when ice > csecfrl is already present) rather
     # than this blend; the cloud-fraction path applies that switch via
     # _qs_cover below. The blended form remains for callers without a qi
-    # field (and for the condensation Newton pair, which must switch qs
-    # and L together with the 1M sweep lo2 work - tracked follow-up).
-    weight = jnp.clip((temperature - 238.15) / (c.tmelt - 238.15), 0.0, 1.0)
+    # field (and for the condensation Newton pair, which switches qs
+    # and L together on the same weight).
+    weight = jnp.clip(
+        (temperature - t_mix_min) / (c.tmelt - t_mix_min), 0.0, 1.0)
     es = weight * es_water + (1.0 - weight) * es_ice
 
     # Convert to saturation specific humidity
@@ -198,17 +207,20 @@ def _qs_cover(
     pressure: jnp.ndarray,
     temperature: jnp.ndarray,
     cloud_ice: jnp.ndarray,
+    t_ice: float = 238.15,
 ) -> jnp.ndarray:
     # qs for the CLOUD-COVER decision: ECHAM binary lo2 phase switch,
     #   lo2 = (T < cthomi) OR (T < tmelt AND qi > csecfrl)
     # (ice memory: ice saturation only where ice already exists or
     # homogeneous freezing guarantees it; csecfrl = 5e-6 kg/kg at T63).
+    # ``t_ice`` is the homogeneous-freezing threshold (ECHAM cthomi),
+    # wired from ``CloudParameters.t_ice`` (#667 — the field was dead).
     # The previous unconditional blend inflated RH by up to ~35 % near
     # -35 C in ice-free air (over-diagnosing cloud) and under-diagnosed
     # cirrus where ice exists (review finding 2.27).
     es_water = saturation_vapor_pressure_water(temperature)
     es_ice = saturation_vapor_pressure_ice(temperature)
-    lo2 = (temperature < 238.15) | (
+    lo2 = (temperature < t_ice) | (
         (temperature < c.tmelt) & (cloud_ice > 5.0e-6)
     )
     es = jnp.where(lo2, es_ice, es_water)
@@ -370,7 +382,7 @@ def calculate_cloud_fraction(
     """
     if cloud_ice is None:
         cloud_ice = jnp.zeros_like(temperature)
-    qs = _qs_cover(pressure, temperature, cloud_ice)
+    qs = _qs_cover(pressure, temperature, cloud_ice, t_ice=config.t_ice)
 
     # Diagnostic relative humidity — NOT clipped at 1. ECHAM uses
     # ``zqr = q/(qsat·zsat)`` directly without clipping; super-saturated
@@ -428,17 +440,22 @@ def calculate_cloud_fraction(
 def _qs_and_dqs_dt(
     pressure: jnp.ndarray,
     temperature: jnp.ndarray,
+    t_mix_min: float = 238.15,
 ) -> Tuple[jnp.ndarray, jnp.ndarray]:
     """Saturation specific humidity and its temperature derivative.
 
     Closed-form derivative of :func:`saturation_specific_humidity` for
     the mixed-phase Tetens-style formulation, so the Newton step is
     bit-reproducible under JIT without finite-difference noise. Mirrors
-    what ECHAM's ``ua / dua`` lookup tables provide.
+    what ECHAM's ``ua / dua`` lookup tables provide. ``t_mix_min`` must
+    be the same value the caller's latent-heat ramp uses (#667: this was
+    hardcoded while the L ramp read the live ``config.t_mix_min``, so a
+    CLI override moved the two ramps apart).
     """
     es_water = saturation_vapor_pressure_water(temperature)
     es_ice = saturation_vapor_pressure_ice(temperature)
-    weight = jnp.clip((temperature - 238.15) / (c.tmelt - 238.15), 0.0, 1.0)
+    weight = jnp.clip(
+        (temperature - t_mix_min) / (c.tmelt - t_mix_min), 0.0, 1.0)
     es = weight * es_water + (1.0 - weight) * es_ice
 
     p_safe = jnp.maximum(pressure, 1.0)
@@ -528,7 +545,8 @@ def condensation_evaporation(
 
     # ---- Pass 1: linearised Newton step ---------------------------------
     # ECHAM's ``cuadjtq`` and ``mo_cloud`` lines 776-779 (``zqcon``).
-    qs, dqs_dt = _qs_and_dqs_dt(pressure, temperature)
+    qs, dqs_dt = _qs_and_dqs_dt(
+        pressure, temperature, t_mix_min=config.t_mix_min)
     q_excess = specific_humidity - qs
     cond1 = q_excess / (1.0 + L_cp * dqs_dt)
 
@@ -546,7 +564,7 @@ def condensation_evaporation(
     # (small per-step condensation due to the warming-feedback denominator).
     T_p1 = temperature + L_cp * cond1
     q_p1 = specific_humidity - cond1
-    qs_p1, _ = _qs_and_dqs_dt(pressure, T_p1)
+    qs_p1, _ = _qs_and_dqs_dt(pressure, T_p1, t_mix_min=config.t_mix_min)
     oversat_tol = 0.01 * qs_p1                   # ECHAM's ``zoversat``
     cond2 = jnp.maximum(
         (q_p1 - qs_p1 - oversat_tol) / (1.0 + L_cp * dqs_dt),


### PR DESCRIPTION
The July-2026 cloud audit filed its findings separately for provenance, but many touch the same code and **counteract each other** in full simulations (an inert internal saturation adjustment masked by an external bolt-on; dead rain-from-above accretion partly masked by an over-generous accretion geometry), so fixing them piecemeal would have shifted the climate at every step. This PR lands the remaining cluster in one branch, with each issue an atomic commit.

Closes #662 (finding 5 — the last one open), #667, #685, #686, #687, #689.
Refs #688 (threshold verified reference-correct, kept; evidence below), #681 (landed here as the first commit), #658 (unblocks the cloud-borne scavenging numerator), #552, #705, #706.

## The central change: the 2M chain is ECHAM's `column_processes` loop

The reference runs the **entire** process chain per level, top-down, because every process at level jk consumes the precipitation state (`prfl`/`pssfl`/`zclcpre`/`zxiflux`) the levels above produced *this step*. The port had factored the "level-independent" processes out of the flux-coupled scan — which silently severed exactly those couplings. Moving the whole chain into the `lax.scan` (design doc: `docs/source/design/lohmann_2m_column_processes.md`) closes four issues at once:

- **#662 finding 5** — `zxrp1`/`zxsp1` are now the Marshall–Palmer inversions of the carry fluxes (Roeckner et al. 2003 eqs. 10.70/10.74), replacing reads of `qr`/`qs` tracers that no term declares (both were identically zero: accretion by rain from above and snow-from-above riming were dead code). Probe: rain formation now compounds down a warm deck (2.3e-7 → 3.1e-7 kg/kg per level) instead of staying flat.
- **#685** — `zclcstar = min(paclc, zclcpre)` from the in-scan precipitation cover, and `zauloc = clip(cauloc·dz/5000, clmin, clmax)`. The `knvb`/`lonacc` exception needs `pvervel` (not plumbed) → #705.
- **#686** — cold precip is gated by ECHAM's `ll_cc` only; the internal `zxib > cqtmin` check runs on the *current* in-cloud ice, so ice deposited/frozen/WBF-transferred this step meets aggregation/riming in the same step. Gated by a new test: a qi=0 deck glaciating via WBF exports a frozen flux the same step.
- **#667.4** — warm rain runs *after* condensation and activation (both references); the docstring no longer claims "ECHAM6 order" for the old layout. The sediment→melt order deliberately stays MG/PUMAS's (reviewed in #662).

## #667: the scheme owns saturation adjustment

- **zdqsdt fixed** (commit 2): ECHAM's derivative is a finite difference over one lookup step (0.001 K); the port stepped 1.0 K but kept the ×1000 factor, so `zqcon = 1/(1+L/cp·zdqsdt)` sat at ~1/50…1/650 and the internal adjustment was inert. Both points now come from the shared `jcm.physics.thermodynamics` Tetens pairs with the analytic derivative. Measured: zqcon at 285 K goes 1/644 → 0.357.
- **Section-5 condensation ported**: the `zqcdif` moisture-convergence closure (zdqsat with the melt/evap heat corrections, the `zifrac` cnd/dep split, the dissipation branch) seeds `mixed_phase_deposition_and_corrections`.
- **The Sundqvist bolt-on is removed** from the Term — with zdqsdt fixed, keeping it would remove supersaturation twice per step with double the latent heating, exactly as the issue predicted. Gate: `TestSaturationGate2M` (10 % supersat → ECHAM's 1 % zoversat tolerance in one step).
- **`zxlevap`/`zxievap` ported verbatim** — condensate in cloud-free cells and the clear-sky share of positive increments evaporate with matching latent cooling. Probe: a cf=0 cell holding 5e-4 qc returns it to vapour in one step (previously untouchable, `max|dqcdt| = 0`).
- **One saturation convention**: the binary `lo2` switch governs the scheme; `sundqvist._qs_and_dqs_dt` takes `t_mix_min` from the config so the es-ramp and L-ramp cannot desynchronise under a Hydra override; the dead `t_ice` field now drives `_qs_cover`.

### Latent defects the restructure surfaced (all fixed verbatim from the Fortran)

- `peta`: `threshold_vert_vel` received a dimensionless 0–1 saturation-ratio clip where ECHAM's diffusional-growth factor ζ (mo_cloud_micro_2m.f90:856) belongs — the WBF weak-updraft gate and the lo2 phase decision were miscalibrated by orders of magnitude. ζ is now computed at the t−1 anchors, and the WBF threshold is recomputed from the post-freezing ice (ECHAM 1580-94).
- `prid`: `update_in_cloud_water`'s mean ice radius must be the Schumann (2011) **volume-mean radius in metres**; it received an effective radius in **microns** (r³ off by 1e18), pinning the `nic_cirrus=1` diagnostic ICNC at the `icemin` floor.
- `zqrho = 1.3/ρ` (not 1/ρ) in the sublimation ventilation factor and the cold-chain aggregation.
- `ll_liqcl`/`ll_icecl` are condensate+number flags (ECHAM 1755-60), not a temperature split — fixes which cells export effective radii.

### State-splitting convention

Primary inputs are the post-upstream provisional state (what the returned tendencies are relative to); optional `*_m1` inputs are the step-start state = ECHAM's (ptm1, pqm1, pxlm1, pxim1) anchors, with the differences playing `ztmst·pqte` in the closure. The ledger reconstruction is identical either way, so the host's additive tendency sum telescopes exactly as ECHAM's INOUT accumulation. Documented on the function and in the design doc.

## The rest

- **#687** — the 1M term now writes ECHAM's `paclc` write-back too (mo_cloud.f90:1280), so `clouds.cloud_fraction` means the post-microphysics cover under both schemes; semantics documented on `CloudData`. Note: `tools/release_validation/health.py`'s 0.4–0.8 cover band was calibrated on the pre-microphysics cover — should be re-checked, though the write-back only clears near-empty cells.
- **#689** — the negative-mass repair (`zdxlcor`/`zdxicor`) is exported as `clouds.negative_mass_repair` [W/m², column-integrated latent heating], so its sign-definite warming is measurable in any run. The repair itself is unchanged.
- **#688** — verified against the reference: ECHAM tests grid-mean `zxlp1`/`zxip1` against the same `ccwmin = 1e-7`, so the post-#662 pairing is reference-correct and kept. Whether thin-cirrus/#494 bootstrap needs a cf-aware floor is now measurable via the new diagnostic + IWP in real runs.
- **#681** — `alhf` is a derived `@property` (`alhs − alhc`), exactly ECHAM's `alf = als − alv`; the 0.3 %-inconsistent independent base value is gone. Tiedtke's melting heat shifts 0.3 % (within its test tolerance).

## Out of scope, deliberately

- **#552** (Kärcher–Lohmann / Liu–Penner cirrus nucleation) is a full new-scheme port, not a counteracting fix — left open; the `nic_cirrus=2` section-5 branch returns zero deposition as with a missing external source in ECHAM.
- **#692** (pySES xdist segfault) is test infra.
- **#705** (vertical-velocity plumbing) and **#706** (moist cp — must move together with the enthalpy gate) filed from findings here.

## Verification

- `ruff` clean; fast suite (1884) at 95 % coverage; slow suite at PR coverage — all green locally.
- Conservation gates: `TestColumnWaterConservation2M` + `TestColumnEnthalpyConservation2M` (4 fixtures each) pass through the restructure. Three test expectations were architecture-bound and updated to reference-invariant form (below-cloud sedimented ice arrives as vapour via `zxievap`; melting is "exactly once", not "purely to qc"; het-INP warming bounded below by the fusion heat with the enthalpy gate excluding fabrication) — each documented in the test.
- New gates: `TestSaturationGate2M`, `TestColdChainSameStepCoupling2M`, `TestCloudFractionWriteBack1M`.
- Gradients: AD-vs-FD on d(surface precip)/d(ccraut) through the full scan agree to 4 significant figures; d/dT finite everywhere.
- Representative runs: 60-day T63L47 1M-vs-2M A/B (identical dry-JW init, real orography/SSTs, RRTMGP), results in the thread below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xp7fvAnh4mfw7WRXFd1e3x
