### PR TITLE
Per-component step cost: where a timestep's GPU time actually goes

### DIFF
--- a/.claude/skills/jcm-benchmark/SKILL.md
+++ b/.claude/skills/jcm-benchmark/SKILL.md
@@ -37,6 +37,35 @@ stable override set** for its grid, not just `physics=`/`grid=` — see
 Runs take tens of minutes; launch with `run_in_background` and watch with a
 Monitor on `run.log`, or the tool call will time out.
 
+## "Which term is it?" — tools/profile_terms.py
+
+`benchmark.py` answers *how fast*; it cannot say *where the time went*, because
+a step is one fused XLA module. For that, same presets, different tool:
+
+```bash
+$PY tools/profile_terms.py --preset ma-t63-l47 --gpu 3
+```
+
+It prints ms/step and ms/call for the dynamical core, each bridge direction and
+every physics term, by joining a profiler trace to the `jax.named_scope` labels
+that `jcm.profiling` puts in the HLO. Three rules when quoting it:
+
+- It disables CUDA graph capture so that kernels stay individually
+  attributable, so its **total** step time is high by design (264 vs 236 ms at
+  T63L47). Never quote it as throughput — that is `benchmark.py`'s number.
+- Read the "mixed kernels" percentage first. That is device time in fusions
+  spanning two components, charged whole to one of them; when it is large the
+  per-term split is soft and only the coarse dynamics/physics/bridge division
+  is safe to quote.
+- **Do not lengthen the window to "get a better average".** The profiler's
+  event buffer holds ~1e6 events and a T63L47 JAM step emits ~19,000 kernels,
+  so ~20 steps is the ceiling there. A one-day window recorded 20 of its 120
+  steps and reported a 4× undercount. The tool now fails instead, but the
+  instinct is the trap. It is also unnecessary: kernel shapes are static and
+  there are no data-dependent branches, so a step costs the same regardless of
+  state — the window only needs to span whole radiation sub-cycles, which the
+  default does.
+
 ## Methodology — the part that matters
 
 **Never quote jcm's `N sim days/hr` log line.** It is *cumulative including

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -16,3 +16,4 @@ API
    jcm.physics_interface.PhysicsTendency
    jcm.physics_interface.Physics
    jcm.checkpoint
+   jcm.profiling

--- a/docs/source/design/pyses_performance_review.md
+++ b/docs/source/design/pyses_performance_review.md
@@ -143,15 +143,20 @@ Measured on the **spectral T63L47** arm of the same physics (`ma-t63-l47`,
 chain does not). Reproduced to within 0.2 % across two independent runs. Device
 time per step:
 
-| component | ms/step | % |
-|---|---:|---:|
-| `RRTMGPRadiation` | 116.4 | 44 |
-| `JamOpticsTerm` | 40.6 | 15 |
-| `Mam4JaxMicrophysics` | 36.7 | 14 |
-| dynamics (spectral) | 19.0 | 7 |
-| `TiedtkeConvection` | 14.9 | 6 |
-| all other physics terms | ~34 | 13 |
-| dynamics↔physics bridge | 1.8 | 1 |
+| component | ms/step | % | ms/call |
+|---|---:|---:|---:|
+| `RRTMGPRadiation` | 116.4 | 44 | 1164 |
+| `JamOpticsTerm` | 40.6 | 15 | 406 |
+| `Mam4JaxMicrophysics` | 36.7 | 14 | 36.7 |
+| dynamics (spectral) | 19.0 | 7 | 19.0 |
+| `TiedtkeConvection` | 14.9 | 6 | 14.9 |
+| all other physics terms | ~34 | 13 | ~34 |
+| dynamics↔physics bridge | 1.8 | 1 | 1.8 |
+
+`ms/step` is amortised over every step; `ms/call` is the cost on a step where
+the component runs. They differ for `RRTMGPRadiation` and `JamOpticsTerm`,
+which both ride the 1-in-10 radiation gate (the optics gate exists precisely
+because its per-band Mie output is consumed only by radiation).
 
 The inferred *ordering* holds: optics and MAM4 are the two largest JAM terms,
 and the 10 remaining JAM terms are collectively small. The correction is that
@@ -159,6 +164,11 @@ and the 10 remaining JAM terms are collectively small. The correction is that
 — it is ~1.16 s on each step it runs. That makes B3 (`compute_cre=False`,
 halving the RRTMGP work) the highest-value lever on this list, ahead of the
 B1/B2 optics and MAM4 work the section was written to gate.
+
+A radiation step is therefore ~1.7 s and an intermediate step ~0.1 s, a 16×
+swing. Anything that reasons about per-step cost — load balancing, a
+memory-pressure estimate, an ensemble scheduler — has two populations to
+account for, not one mean.
 
 The bridge, often assumed to be a real cost of the composable design, is 1 % of
 device time and not worth optimising.

--- a/docs/source/design/pyses_performance_review.md
+++ b/docs/source/design/pyses_performance_review.md
@@ -131,11 +131,37 @@ steps; CRE is a diagnostic — keep it for analysis runs only. One flag.
 **B4. Radiation interval 2 h → 3 h.** Science trade-off; standard in ECHAM
 lineage. Only if B1–B3 are insufficient.
 
-### C. First step before investing in B: one profiled run
+### C. First step before investing in B: one profiled run — DONE
 
-A single `jax.profiler` trace of ~4 steps (1-GPU 2m-jam) would confirm the
-MAM4 : optics : rest split this review infers structurally. Cheap insurance
-(~30 min GPU) before spending effort on B1/B2.
+This section asked for a profiled run to confirm the MAM4 : optics : rest split
+inferred above. `tools/profile_terms.py` now does it as a repeatable
+measurement rather than a one-off (see `jcm.profiling` for how the attribution
+works, and the `jcm-benchmark` skill for when to trust it).
+
+Measured on the **spectral T63L47** arm of the same physics (`ma-t63-l47`,
+1× A100-80GB, two radiation sub-cycles; the dycore differs from ne30, the JAM
+chain does not). Reproduced to within 0.2 % across two independent runs. Device
+time per step:
+
+| component | ms/step | % |
+|---|---:|---:|
+| `RRTMGPRadiation` | 116.4 | 44 |
+| `JamOpticsTerm` | 40.6 | 15 |
+| `Mam4JaxMicrophysics` | 36.7 | 14 |
+| dynamics (spectral) | 19.0 | 7 |
+| `TiedtkeConvection` | 14.9 | 6 |
+| all other physics terms | ~34 | 13 |
+| dynamics↔physics bridge | 1.8 | 1 |
+
+The inferred *ordering* holds: optics and MAM4 are the two largest JAM terms,
+and the 10 remaining JAM terms are collectively small. The correction is that
+**RRTMGP still dominates everything else combined even at a 1-in-10 sub-cycle**
+— it is ~1.16 s on each step it runs. That makes B3 (`compute_cre=False`,
+halving the RRTMGP work) the highest-value lever on this list, ahead of the
+B1/B2 optics and MAM4 work the section was written to gate.
+
+The bridge, often assumed to be a real cost of the composable design, is 1 % of
+device time and not worth optimising.
 
 ## 5. Verification round (measured, ne30 2m-jam, 1× A100 unless noted)
 

--- a/docs/source/developer.rst
+++ b/docs/source/developer.rst
@@ -139,7 +139,47 @@ See :doc:`jax_gotchas` for more details.
 Profiling
 ^^^^^^^^^
 
-To profile the model and identify performance bottlenecks:
+Where a timestep's time goes
+""""""""""""""""""""""""""""
+
+For the usual question — *which physics term is this configuration spending its
+time in?* — use the ready-made tool rather than a hand-rolled trace:
+
+.. code-block:: console
+
+   $ python tools/profile_terms.py --preset ma-t63-l47 --gpu 3
+
+It runs the preset twice to warm up (both discarded), traces a third run, and
+prints milliseconds per step for the dynamical core, each direction of the
+dynamics/physics bridge, and every physics term individually, alongside the
+fraction of device time it could not attribute cleanly.
+
+The default window is two radiation sub-cycles. Resist lengthening it: the
+profiler's event buffer holds about a million events and a T63L47 JAM step
+emits ~19,000 kernels, so a longer window overflows it and undercounts. The
+short window loses nothing, because kernel shapes are static and the model
+takes no data-dependent branches, so a step's cost does not vary with the
+state.
+
+The attribution works because :mod:`jcm.profiling` wraps the dycore call, the
+bridge and each :class:`~jcm.physics.physics_term.PhysicsTerm` in a
+:func:`jax.named_scope`. XLA records that scope in the ``op_name`` metadata of
+every instruction traced inside it, and the profiler reports the instruction
+behind each GPU kernel, so kernel time joins back to the component that emitted
+it. The scopes are always on and cost nothing at runtime. A new driver-level
+stage that deserves its own line in the report needs a scope adding there;
+individual physics terms need no changes, since the term loop already labels
+them by ``PhysicsTerm.name``.
+
+Note that ``profile_terms.py`` disables CUDA graph capture — otherwise every
+kernel reports the same synthetic instruction and nothing is attributable — so
+its *total* step time reads high. For throughput use ``tools/benchmark.py`` and
+the ``jcm-benchmark`` skill's methodology.
+
+Raw traces
+""""""""""
+
+To inspect the timeline directly:
 
 .. code-block:: python
 

--- a/jcm/model.py
+++ b/jcm/model.py
@@ -24,6 +24,7 @@ from dinosaur.scales import units
 from functools import partial
 import logging
 
+from jcm import profiling
 from jcm.date import DateData, parse_duration_days
 from jcm.forcing import ForcingData, default_forcing
 from jcm.predictions import ModelPredictions
@@ -709,20 +710,33 @@ class Model:
         def step(state, physics_state):
             date = self._date_from_sim_time(self.dycore.sim_time(state))
             forcing_now = forcing.select(date, calendar=self.calendar)
-            physics_state_grid = self.dycore.to_physics_state(state)
-            if self._dycore_field_names:
-                # Dycore-supplied diagnostic fields (frontogenesis, ...):
-                # re-injected every step under a plumbing key that
-                # ComposablePhysics strips from its output, so the scan
-                # carry's pytree structure is unaffected (the codex-P1
-                # lesson from the observers work: anything that rides the
-                # carry must exist in the construction-time template).
-                extra = self.dycore.physics_fields(state, physics_state_grid)
-                physics_state = {**physics_state, "_dycore_fields": extra}
+            # The scopes opened here and in ComposablePhysics's term loop label
+            # this step's HLO, so that a profiler trace can be split into
+            # dynamics / bridge / per-term cost. See jcm.profiling.
+            with profiling.scope(profiling.BRIDGE_TO_PHYSICS):
+                physics_state_grid = self.dycore.to_physics_state(state)
+                if self._dycore_field_names:
+                    # Dycore-supplied diagnostic fields (frontogenesis, ...):
+                    # re-injected every step under a plumbing key that
+                    # ComposablePhysics strips from its output, so the scan
+                    # carry's pytree structure is unaffected (the codex-P1
+                    # lesson from the observers work: anything that rides the
+                    # carry must exist in the construction-time template).
+                    extra = self.dycore.physics_fields(state,
+                                                       physics_state_grid)
+                    physics_state = {**physics_state,
+                                     "_dycore_fields": extra}
             call = partial(
                 compute_physics_step_gridpoint,
                 physics=self.physics, time_step=self.dt_si.m,
             )
+            # Scope the physics call as a whole. It ENCLOSES the per-term
+            # scopes, so under the innermost-wins attribution rule it retains
+            # only the driver's own overhead: verification, the column
+            # reshapes and the tendency accumulation between terms. Applied to
+            # the callable rather than at the call sites so that the sharding
+            # branch below stays as it was.
+            call = profiling.scoped(call, profiling.BRIDGE_TO_DYNAMICS)
             args = (physics_state_grid, forcing_now, self.terrain,
                     physics_state)
             axis = _ambient_explicit_axis()
@@ -751,7 +765,8 @@ class Model:
                 physics_tendency, new_physics_state = auto_axes(
                     call, axes=axis, out_sharding=specs,
                 )(*args)
-            state_next = self.dycore.step(state, physics_tendency)
+            with profiling.scope(profiling.DYNAMICS):
+                state_next = self.dycore.step(state, physics_tendency)
             return state_next, new_physics_state
 
         return step

--- a/jcm/physics/composable_physics.py
+++ b/jcm/physics/composable_physics.py
@@ -27,6 +27,7 @@ import jax.numpy as jnp
 from jax.sharding import NamedSharding, PartitionSpec
 from flax import nnx
 
+from jcm import profiling
 from jcm.physics_interface import Physics, PhysicsState, PhysicsTendency
 from jcm.forcing import ForcingData
 from jcm.terrain import TerrainData
@@ -253,6 +254,9 @@ class ComposablePhysics(nnx.Module, Physics):
 
         for term in self.terms:
             call_fn = jax.checkpoint(term) if self.checkpoint_terms else term
+            # Tag the term's instructions so a profiler trace can be attributed
+            # back to it; see jcm.profiling.
+            call_fn = profiling.scoped(call_fn, term.name)
             tend, diagnostics = call_fn(state, diagnostics, forcing, terrain)
             tendencies += tend
 
@@ -344,6 +348,9 @@ class ComposablePhysics(nnx.Module, Physics):
                 if self.checkpoint_terms
                 else term
             )
+            # Tag the term's instructions so a profiler trace can be attributed
+            # back to it; see jcm.profiling.
+            call_fn = profiling.scoped(call_fn, term.name)
             tend, diagnostics = call_fn(
                 vectorized_state, diagnostics, forcing, terrain,
             )

--- a/jcm/profiling.py
+++ b/jcm/profiling.py
@@ -1,0 +1,138 @@
+"""Trace-time scope labels that make a compiled step attributable per component.
+
+A jitted JCM step is one XLA module: dynamics, the spectral/gridpoint bridge and
+every physics term are fused into a single stream of kernels with no runtime
+boundary between them, so a wall-clock timer cannot say where the time went.
+What survives compilation is instruction *metadata*: a
+:func:`jax.named_scope` entered while tracing is recorded as an ``op_name``
+prefix on every HLO instruction produced inside it, and it stays there through
+optimization. A profiler trace reports the HLO instruction behind each kernel,
+so joining the two attributes measured device time back to the component that
+emitted it. ``tools/profile_terms.py`` is that join.
+
+The labels are unconditional rather than gated behind a debug flag: a named
+scope is trace-time-only metadata that XLA does not optimize on, so it costs
+nothing at runtime, and leaving it always on means the profiled build is the
+production build rather than a near-copy of it.
+
+Scopes are emitted at exactly two places, both of them drivers rather than
+physics:
+
+- :mod:`jcm.model`'s operator-split step, for the dynamical core and the two
+  bridge directions;
+- :class:`jcm.physics.composable_physics.ComposablePhysics`'s term loops, one
+  scope per :class:`~jcm.physics.physics_term.PhysicsTerm`.
+
+Labelling the loops rather than the terms is deliberate. ``PhysicsTerm.__call__``
+is overridden by every one of the ~60 concrete terms, so a base-class wrapper
+would not run; the loop is the one place that sees all of them, and it keeps the
+schemes themselves free of profiling code.
+"""
+
+from __future__ import annotations
+
+import jax
+
+#: Marks a scope as one of ours. Compiled ``op_name`` metadata interleaves JCM
+#: scopes with names JAX and flax introduce on their own (``jit(...)``,
+#: transpose/remat wrappers, module paths), so the parser needs to recognise a
+#: label rather than trust its position in the path. The colon cannot occur in
+#: a Python identifier, hence never in a term name.
+SCOPE_PREFIX = "jcm:"
+
+#: Label for the dynamical core's advance, ``DynamicalCore.step`` — which also
+#: carries the forward-Euler tendency add and the spectral filters.
+DYNAMICS = "dynamics"
+
+#: Label for the dynamics-to-physics projection, ``to_physics_state`` plus any
+#: dycore-supplied diagnostic fields: the spectral-to-gridpoint transforms and
+#: tracer cleaning that precede the physics.
+BRIDGE_TO_PHYSICS = "bridge_to_physics"
+
+#: Label for the physics call's own overhead: forcing time selection,
+#: state/tendency verification, the gridpoint-to-column reshapes and the
+#: tendency accumulation that wrap the term loop. This scope ENCLOSES the
+#: per-term scopes, and the innermost-wins rule in :func:`label_from_op_name`
+#: is what leaves it holding the coupling overhead alone.
+BRIDGE_TO_DYNAMICS = "bridge_to_dynamics"
+
+
+def scope(label: str):
+    """Return a :func:`jax.named_scope` context manager tagged for the profiler.
+
+    Parameters
+    ----------
+    label
+        Component name, e.g. :data:`DYNAMICS` or a
+        :class:`~jcm.physics.physics_term.PhysicsTerm`'s ``name``.
+
+    Returns
+    -------
+    context manager
+        Entering it prefixes ``jcm:<label>`` onto the ``op_name`` metadata of
+        every HLO instruction traced inside.
+
+    """
+    return jax.named_scope(f"{SCOPE_PREFIX}{label}")
+
+
+def scoped(fn, label: str):
+    """Wrap a callable so every trace of it runs inside :func:`scope`.
+
+    Parameters
+    ----------
+    fn
+        Any traceable callable, including a ``functools.partial`` or a
+        ``jax.checkpoint``-wrapped term (which have no ``__name__``, so this
+        deliberately does not use ``functools.wraps``).
+    label
+        Component name, as for :func:`scope`.
+
+    Returns
+    -------
+    callable
+        ``fn`` with the scope applied.
+
+    Notes
+    -----
+    Preferred over an inline ``with`` block at the call site when the callable
+    is invoked from more than one branch: labelling the function once keeps the
+    branches themselves unindented and unmodified.
+
+    """
+    def wrapper(*args, **kwargs):
+        with scope(label):
+            return fn(*args, **kwargs)
+    return wrapper
+
+
+def label_from_op_name(op_name: str) -> str | None:
+    """Extract the JCM component label from an HLO ``op_name``, if any.
+
+    Parameters
+    ----------
+    op_name
+        The ``metadata={op_name="..."}`` string of an HLO instruction, e.g.
+        ``jit(_run_from_state)/scan/jcm:tiedtke_convection/mul``.
+
+    Returns
+    -------
+    str or None
+        The label of the INNERMOST JCM scope on the path, or ``None`` if the
+        instruction was not traced inside one.
+
+    Notes
+    -----
+    Innermost wins because the scopes nest: :data:`BRIDGE_TO_DYNAMICS` encloses
+    the whole physics call, and each term scope sits inside it. Charging an
+    instruction to the deepest scope containing it therefore bills a term's work
+    to the term and leaves the enclosing scope holding only the glue between
+    terms, which is the split we want. Scopes that JAX and flax open on their
+    own lack the prefix and are skipped.
+
+    """
+    label = None
+    for part in op_name.split("/"):
+        if part.startswith(SCOPE_PREFIX):
+            label = part[len(SCOPE_PREFIX):]
+    return label

--- a/jcm/profiling_test.py
+++ b/jcm/profiling_test.py
@@ -1,0 +1,77 @@
+"""Tests for the profiler scope labels.
+
+The load-bearing property is not that ``scope()`` returns a context manager,
+but that the label it opens still exists in the *optimized* HLO — after
+inlining, fusion and DCE have run. If XLA ever stopped propagating ``op_name``
+metadata, ``tools/profile_terms.py`` would keep producing a report, with every
+kernel silently falling into the ``unattributed`` bucket. That is what
+``test_scope_survives_compilation`` is here to catch.
+"""
+
+import jax
+import jax.numpy as jnp
+
+from jcm import profiling
+
+
+def test_scope_prefixes_the_label():
+    with profiling.scope("my_term"):
+        pass  # the context manager is a no-op outside tracing
+    assert profiling.SCOPE_PREFIX == "jcm:"
+
+
+def test_label_from_op_name_finds_a_scope():
+    assert profiling.label_from_op_name(
+        "jit(step)/jcm:dynamics/add"
+    ) == "dynamics"
+
+
+def test_label_from_op_name_ignores_foreign_scopes():
+    """Scopes JAX and flax open themselves must not be mistaken for labels."""
+    assert profiling.label_from_op_name("jit(step)/while/body/mul") is None
+    assert profiling.label_from_op_name("") is None
+
+
+def test_label_from_op_name_takes_the_innermost():
+    """A term nested in the enclosing physics scope is charged to the term."""
+    assert profiling.label_from_op_name(
+        "jit(step)/jcm:bridge_to_dynamics/checkpoint/jcm:hines_gwd/mul"
+    ) == "hines_gwd"
+
+
+def test_component_labels_are_distinct():
+    labels = {profiling.DYNAMICS, profiling.BRIDGE_TO_PHYSICS,
+              profiling.BRIDGE_TO_DYNAMICS}
+    assert len(labels) == 3
+
+
+def test_scoped_labels_a_callable():
+    """``scoped`` must accept callables without ``__name__``, e.g. partials."""
+    import functools
+
+    fn = functools.partial(lambda x, k: jnp.sin(x) * k, k=2.0)
+    labelled = profiling.scoped(fn, "gamma")
+
+    text = jax.jit(labelled).lower(jnp.ones(4)).compile().as_text()
+    assert "jcm:gamma" in text
+    # And it is transparent: same values as the unwrapped callable.
+    assert jnp.allclose(labelled(jnp.ones(4)), fn(jnp.ones(4)))
+
+
+def test_scope_survives_compilation():
+    """A scope opened while tracing is still readable in the optimized HLO."""
+    def f(x):
+        with profiling.scope("alpha"):
+            y = jnp.sin(x) * 2.0
+        with profiling.scope("beta"):
+            return jnp.cos(y) + 1.0
+
+    text = jax.jit(f).lower(jnp.ones((8, 8))).compile().as_text()
+    labels = set()
+    for line in text.splitlines():
+        if 'op_name="' in line:
+            op_name = line.split('op_name="')[1].split('"')[0]
+            label = profiling.label_from_op_name(op_name)
+            if label is not None:
+                labels.add(label)
+    assert {"alpha", "beta"} <= labels

--- a/tools/profile_terms.py
+++ b/tools/profile_terms.py
@@ -1,0 +1,816 @@
+#!/usr/bin/env python
+"""Where a JCM timestep's GPU time goes: dynamics, bridge, per physics term.
+
+Usage::
+
+    python tools/profile_terms.py --preset ma-t63-l47 --gpu 3
+    python tools/profile_terms.py --preset ma-t63-l47 --gpu 3 --cycles 4
+    python tools/profile_terms.py --preset speedy-t31 --gpu 0 --outdir /tmp/p
+
+Writes ``report.md``, ``result.json`` and the raw trace to
+``<outdir>/<label>/`` and prints the report.
+
+Unlike ``tools/benchmark.py``, which spawns the model as a subprocess and so
+takes a ``--pythonpath``, this runs in-process: to profile a worktree rather
+than the installed package, put it on ``PYTHONPATH`` yourself. The report names
+the ``jcm`` that was actually imported, so check that line before quoting an
+A/B.
+
+Why this exists rather than a stopwatch around each term
+--------------------------------------------------------
+A JCM step is compiled as one XLA module. Dynamics, the spectral/gridpoint
+bridge and all ~60 physics terms are fused into a single stream of kernels
+launched asynchronously, so there is no runtime boundary to time: a
+``perf_counter`` around a term measures Python tracing, not device work, and
+inserting ``block_until_ready`` to force a boundary changes the program being
+measured (it defeats the overlap that makes the real step fast).
+
+What does survive compilation is instruction metadata. ``jcm.profiling`` opens
+a :func:`jax.named_scope` around the dycore call, each bridge direction and
+each physics term, which XLA records as an ``op_name`` prefix on every
+instruction traced inside. A profiler trace reports, per GPU kernel, the HLO
+instruction that produced it. Joining the two attributes measured device time
+back to the component that emitted it, with no instrumentation in the physics
+and without perturbing the compiled program.
+
+Two consequences of measuring a *fused* program, both reported rather than
+hidden:
+
+- A fusion that merges instructions from two scopes is charged whole to its
+  root instruction's scope. The report counts how much device time sits in
+  such mixed kernels; that number is the attribution's error bar, and a run
+  where it is large should not be quoted per-term.
+- Kernels that belong to no scope (the scan plumbing, output assembly, device
+  copies) are reported as ``unattributed`` rather than being spread pro-rata
+  over the components, which would flatter every one of them.
+
+A third consequence is a hard ceiling on the window. The profiler's event
+buffer holds ~1e6 events and a T63L47 JAM step emits ~19,000 kernels, so ~20
+steps is all that fits at that resolution; past it the profiler stops recording
+and the averages silently come out low. The default window is two radiation
+sub-cycles for that reason, and the tool fails rather than reports if the
+buffer overflows. Nothing is lost by the short window: kernel shapes are static
+and the model takes no data-dependent branches, so a step's cost does not vary
+with the state.
+
+Methodology follows the ``jcm-benchmark`` skill: run only on a verified-free
+GPU, discard the compile pass, and quote steady state only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import dataclasses
+import gzip
+import json
+import os
+import pathlib
+import re
+import shutil
+import sys
+import time
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from benchmark import PRESETS  # noqa: E402
+from gpu_util import describe as describe_gpu  # noqa: E402
+from gpu_util import free_indices, gpu_table, is_free  # noqa: E402
+
+DEFAULT_OUTDIR = pathlib.Path("/scr/dwatsonparris/profiles")
+
+# XLA captures the step into a CUDA graph by default, which is faster but
+# collapses every kernel's reported provenance to a single ``command_buffer_N``
+# instruction -- the attribution join then has nothing to join on. Raising the
+# capture threshold above any real module size keeps kernels individually
+# attributable. This is the one way the profiled program differs from the
+# production one: it pays per-kernel launch overhead that a captured graph
+# amortises, so the TOTAL step time here reads slightly high and is not a
+# throughput benchmark (use ``tools/benchmark.py`` for that). The per-component
+# SPLIT, which is what this tool is for, is unaffected.
+_NO_CUDA_GRAPHS = "--xla_gpu_graph_min_graph_size=2147483647"
+
+
+# --------------------------------------------------------------------------
+# HLO parsing
+# --------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class Instruction:
+    """One HLO instruction: its own scope label and the computations it calls."""
+
+    op_name: str
+    calls: tuple[str, ...]
+
+
+def parse_hlo_module(text: str) -> tuple[str, dict[str, Instruction]]:
+    """Index one dumped HLO module by instruction name.
+
+    Parameters
+    ----------
+    text
+        Contents of an XLA ``*_after_optimizations.txt`` dump.
+
+    Returns
+    -------
+    (str, dict)
+        The module name (from the ``HloModule`` header) and a map from
+        instruction name to :class:`Instruction`. Instruction names are unique
+        across a module, so computations are flattened into one namespace; the
+        ``calls`` edges are what preserve the nesting that matters here.
+
+    """
+    module = ""
+    m = re.search(r"^HloModule ([^\s,]+)", text, re.M)
+    if m:
+        module = m.group(1)
+
+    instructions: dict[str, Instruction] = {}
+    for line in text.splitlines():
+        # Instruction lines are indented inside a computation body; the
+        # computation headers and closing braces sit at column 0.
+        if not line.startswith(" "):
+            continue
+        m = re.match(r"\s+(?:ROOT )?%?([\w.\-]+) = ", line)
+        if not m:
+            continue
+        op_name = ""
+        meta = re.search(r'op_name="([^"]*)"', line)
+        if meta:
+            op_name = meta.group(1)
+        # Called computations are always ``%``-prefixed. Anchoring on that is
+        # what stops the match running on into the ``metadata=`` field that
+        # follows, which has no space before it when the metadata is a bare
+        # op_name.
+        calls: tuple[str, ...] = ()
+        callsm = re.search(r"calls=(%[\w.\-]+(?:,\s*%[\w.\-]+)*)", line)
+        if callsm:
+            calls = tuple(
+                c.strip().lstrip("%") for c in callsm.group(1).split(",")
+            )
+        instructions[m.group(1)] = Instruction(op_name=op_name, calls=calls)
+    return module, instructions
+
+
+def _dumped_modules(dump_dir: pathlib.Path) -> set[str]:
+    """Names of the optimized-HLO dumps present, for recompile detection."""
+    return {p.name for p in dump_dir.glob("*after_optimizations.txt")}
+
+
+def prune_dump(dump_dir: pathlib.Path) -> int:
+    """Delete everything in an XLA dump except the optimized HLO text.
+
+    ``--xla_dump_to`` also writes LLVM IR and PTX for every kernel, which for a
+    JAM configuration runs to hundreds of megabytes that nothing here reads.
+    Returns the number of bytes reclaimed.
+    """
+    freed = 0
+    for path in dump_dir.iterdir():
+        if path.is_file() and not path.name.endswith("after_optimizations.txt"):
+            freed += path.stat().st_size
+            path.unlink()
+        elif path.is_dir():
+            freed += sum(f.stat().st_size for f in path.rglob("*")
+                         if f.is_file())
+            shutil.rmtree(path, ignore_errors=True)
+    return freed
+
+
+def index_hlo_dump(
+    dump_dir: pathlib.Path,
+) -> tuple[
+    dict[str, dict[str, Instruction]],
+    dict[str, dict[str, list[str]]],
+    list[str],
+]:
+    """Index every optimized HLO module in an ``--xla_dump_to`` directory.
+
+    Returns the instruction index, the computation-membership index and a list
+    of informational notes. Both indices come from a single read of each file:
+    a JAM step's dump is ~32 MB and there are two of them, so reading twice to
+    build them separately is noticeable.
+
+    A trace identifies a kernel's module by name alone, and the warm-up runs
+    legitimately compile the step more than once, so several dumps can share a
+    name. Files are therefore read in ``module_NNNN`` order and later ones win,
+    which resolves an instruction to the most recent compilation -- the one the
+    traced execution used, given ``profile_run`` proves no compile happened
+    inside the trace.
+    """
+    def module_id(path: pathlib.Path) -> int:
+        m = re.match(r"module_(\d+)", path.name)
+        return int(m.group(1)) if m else -1
+
+    index: dict[str, dict[str, Instruction]] = {}
+    members: dict[str, dict[str, list[str]]] = {}
+    seen: dict[str, str] = {}
+    notes: list[str] = []
+    for path in sorted(dump_dir.glob("*after_optimizations.txt"), key=module_id):
+        text = path.read_text()
+        module, instructions = parse_hlo_module(text)
+        if not module:
+            continue
+        if module in seen:
+            notes.append(
+                f"module {module!r} was compiled more than once "
+                f"({seen[module]} then {path.name}); using the later"
+            )
+        seen[module] = path.name
+        index.setdefault(module, {}).update(instructions)
+        members.setdefault(module, {}).update(
+            parse_hlo_module_computations(text)
+        )
+    return index, members, notes
+
+
+def parse_hlo_module_computations(text: str) -> dict[str, list[str]]:
+    """Map each computation in a dumped module to its instruction names.
+
+    Needed because a GPU kernel is charged to the fusion instruction that
+    launched it, while the scopes that explain the work sit on the instructions
+    *inside* that fusion's computation.
+    """
+    members: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in text.splitlines():
+        if not line.startswith(" ") and line.rstrip().endswith("{"):
+            m = re.match(r"(?:ENTRY )?%?([\w.\-]+)", line)
+            current = m.group(1) if m else None
+            if current is not None:
+                members.setdefault(current, [])
+            continue
+        if line.startswith("}"):
+            current = None
+            continue
+        if current is None or not line.startswith(" "):
+            continue
+        m = re.match(r"\s+(?:ROOT )?%?([\w.\-]+) = ", line)
+        if m:
+            members[current].append(m.group(1))
+    return members
+
+
+# --------------------------------------------------------------------------
+# Trace parsing and attribution
+# --------------------------------------------------------------------------
+
+
+def load_trace_kernels(trace_dir: pathlib.Path) -> list[dict]:
+    """Read GPU kernel events from a ``jax.profiler.trace`` output directory.
+
+    Returns one dict per kernel execution with ``ts``/``dur`` (microseconds),
+    ``module`` and ``op`` (the HLO instruction that produced it).
+    """
+    paths = sorted(trace_dir.glob("**/*.trace.json.gz"))
+    if not paths:
+        raise FileNotFoundError(f"no *.trace.json.gz under {trace_dir}")
+    events = json.load(gzip.open(paths[-1]))["traceEvents"]
+    kernels = []
+    for e in events:
+        args = e.get("args") or {}
+        # ``kernel_details`` is present only on device-side kernel events,
+        # which is what separates them from host-side Python/XLA spans.
+        if e.get("ph") != "X" or "kernel_details" not in args:
+            continue
+        kernels.append({
+            "ts": float(e.get("ts", 0.0)),
+            "dur": float(e.get("dur", 0.0)),
+            "module": args.get("hlo_module", ""),
+            "op": args.get("hlo_op", ""),
+        })
+    if not kernels:
+        # Distinguish this from "the model did no work": the usual cause is the
+        # trace's event budget being consumed by host events before any device
+        # event lands, which otherwise surfaces as a division by zero in the
+        # report rather than as the collection failure it is.
+        raise RuntimeError(
+            f"{paths[-1]} contains {len(events)} events but no GPU kernels. "
+            "The device plane was not collected -- check that host/python "
+            "tracer levels are 0 and that the run really used a GPU."
+        )
+    return kernels
+
+
+def device_span_us(kernels: list[dict]) -> float:
+    """Elapsed device time from the first kernel's start to the last one's end.
+
+    The denominator for occupancy. Preferred over a host ``perf_counter``
+    because it excludes the profiler's own start/stop cost and any host-side
+    setup that happens to fall inside the traced block.
+    """
+    if not kernels:
+        return 0.0
+    return max(k["ts"] + k["dur"] for k in kernels) - min(
+        k["ts"] for k in kernels
+    )
+
+
+@dataclasses.dataclass
+class Attribution:
+    """Device time per component, plus the honesty metrics for the split."""
+
+    per_label: dict[str, float]
+    kernels_per_label: dict[str, int]
+    steps_seen: dict[str, int]
+    mixed_us: float
+    unjoinable_us: float
+    total_us: float
+
+    def as_dict(self) -> dict:
+        """Return a JSON-serialisable view."""
+        return {
+            "per_label_us": self.per_label,
+            "kernels_per_label": self.kernels_per_label,
+            "steps_seen": self.steps_seen,
+            "mixed_us": self.mixed_us,
+            "unjoinable_us": self.unjoinable_us,
+            "total_us": self.total_us,
+        }
+
+
+def attribute(
+    kernels: list[dict],
+    hlo_index: dict[str, dict[str, Instruction]],
+    members: dict[str, dict[str, list[str]]],
+) -> Attribution:
+    """Charge each kernel's device time to the scope that emitted it.
+
+    Parameters
+    ----------
+    kernels
+        Output of :func:`load_trace_kernels`.
+    hlo_index
+        Module name to instruction map, from :func:`index_hlo_dump`.
+    members
+        Module name to computation-membership map, from
+        :func:`parse_hlo_module_computations`.
+
+    Returns
+    -------
+    Attribution
+        ``per_label`` holds the summed microseconds per component, with
+        ``"unattributed"`` collecting kernels traced outside any JCM scope.
+        ``mixed_us`` is the device time in kernels whose fused instructions
+        span more than one component -- the error bar on the split -- and
+        ``unjoinable_us`` the time in kernels whose instruction was not found
+        in the dump at all (a join failure, not a component).
+        ``steps_seen`` is the minimum per-instruction execution count for each
+        component. For the dynamics and bridge scopes it equals the number of
+        steps the trace captured, which is how a truncated trace is detected.
+
+    """
+    from jcm import profiling
+
+    per_label: dict[str, float] = collections.defaultdict(float)
+    counts: dict[str, int] = collections.defaultdict(int)
+    # Executions per (label, instruction), reduced to a MINIMUM per label. For
+    # the dynamics and bridge scopes -- which sit directly in Model's step,
+    # outside every loop and branch -- no instruction can run fewer than once
+    # per step, so that minimum is exactly the number of steps the trace
+    # captured. It is a completeness check, not a cadence measurement: internal
+    # loops and vmaps make the counts within one physics term span three orders
+    # of magnitude, so no summary of them recovers "how often was this term
+    # invoked". Cadence comes from the configuration (see subcycle_steps).
+    op_count: dict[str, dict[str, int]] = collections.defaultdict(
+        lambda: collections.defaultdict(int))
+    mixed_us = 0.0
+    unjoinable_us = 0.0
+    total_us = 0.0
+
+    for k in kernels:
+        total_us += k["dur"]
+        instrs = hlo_index.get(k["module"])
+        instr = instrs.get(k["op"]) if instrs else None
+        if instr is None:
+            unjoinable_us += k["dur"]
+            per_label["unjoinable"] += k["dur"]
+            counts["unjoinable"] += 1
+            continue
+
+        label = profiling.label_from_op_name(instr.op_name)
+        # A fusion's own metadata is its root's; the constituent instructions
+        # can come from more than one scope. Flag that rather than pretend the
+        # root's label covers the whole kernel.
+        inner = set()
+        mod_members = members.get(k["module"], {})
+        for comp in instr.calls:
+            for name in mod_members.get(comp, ()):
+                child = instrs.get(name)
+                if child is not None:
+                    inner.add(profiling.label_from_op_name(child.op_name))
+        inner.discard(None)
+        if len(inner | ({label} if label else set())) > 1:
+            mixed_us += k["dur"]
+        if label is None and len(inner) == 1:
+            # The root is plumbing (a copy, a bitcast) but everything it fuses
+            # came from one component: that component did the work.
+            label = next(iter(inner))
+
+        key = label or "unattributed"
+        per_label[key] += k["dur"]
+        counts[key] += 1
+        op_count[key][k["op"]] += 1
+
+    steps_seen = {key: min(per_op.values())
+                  for key, per_op in op_count.items()}
+
+    return Attribution(
+        per_label=dict(per_label),
+        kernels_per_label=dict(counts),
+        steps_seen=steps_seen,
+        mixed_us=mixed_us,
+        unjoinable_us=unjoinable_us,
+        total_us=total_us,
+    )
+
+
+# --------------------------------------------------------------------------
+# Reporting
+# --------------------------------------------------------------------------
+
+
+def render_report(result: dict) -> str:
+    """Render the markdown report shown to the user and written to disk."""
+    att = result["attribution"]
+    nsteps = result["steps"]
+    total = att["total_us"]
+    span = result["device_span_us"]
+    lines = [
+        f"# Step cost breakdown — {result['preset']}",
+        "",
+        f"- config: `{result['preset']}` — {result['config']}",
+        f"- jcm: `{result.get('jcm_path', '?')}`",
+        f"- GPU: {result['gpu_name']} (index {result['gpu_index']})",
+        f"- steady-state steps profiled: {nsteps} "
+        f"(after two discarded warm-up runs)",
+        f"- radiation sub-cycle: every "
+        f"{result.get('radiation_subcycle_steps', 1)} steps",
+        f"- device elapsed per step: {span / nsteps / 1000:.2f} ms",
+        f"- device busy per step: {total / nsteps / 1000:.2f} ms "
+        f"({100 * total / span:.0f}% occupancy; the rest is launch gaps, "
+        "which shrink with resolution)",
+        "",
+        "``ms/step`` amortises a component over every step of the window and",
+        "is the throughput-relevant number. ``ms/call`` is what it costs on a",
+        "step where it actually runs; the two differ only for the sub-cycled",
+        "radiation term, whose cadence is read from the configuration rather",
+        "than inferred from the trace.",
+        "",
+        "| component | ms/step | % of device | ms/call | kernels/step |",
+        "|---|---:|---:|---:|---:|",
+    ]
+    # Every term is listed, including those that cost nothing measurable: a
+    # term absent from the table would read as "not measured" when what it
+    # actually means is "free", which is the more interesting fact.
+    per_cycle = result.get("radiation_subcycle_steps", 1)
+    subcycled = result.get("subcycled_term")
+    per_label = dict(att["per_label_us"])
+    for name in result.get("terms", ()):
+        per_label.setdefault(name, 0.0)
+    ordered = sorted(per_label.items(), key=lambda kv: -kv[1])
+    for label, us in ordered:
+        pct = 100.0 * us / total if total else 0.0
+        cadence = per_cycle if label == subcycled else 1
+        per_call = us * cadence / nsteps / 1000
+        kernels = att["kernels_per_label"].get(label, 0) / nsteps
+        lines.append(
+            f"| {label} | {us / nsteps / 1000:.2f} | {pct:.1f} "
+            f"| {per_call:.2f} | {kernels:.0f} |"
+        )
+    lines += [
+        "",
+        "## Attribution quality",
+        "",
+        f"- mixed kernels (fusions spanning components, charged whole to "
+        f"their root's component): {100 * att['mixed_us'] / total:.1f}% "
+        "of device time",
+        f"- unjoinable kernels (HLO instruction absent from the dump): "
+        f"{100 * att['unjoinable_us'] / total:.1f}%",
+        "",
+        "A large mixed fraction means the per-component split is soft and "
+        "should not be quoted term by term; the totals remain sound.",
+        "",
+        "Note: CUDA graph capture is disabled so that kernels stay "
+        "individually attributable, so the total step time here reads high "
+        "against `tools/benchmark.py`. Use that tool for throughput.",
+    ]
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------
+# The profiled run
+# --------------------------------------------------------------------------
+
+
+def profile_run(
+    overrides: list[str], steps: int | None, days: float | None, cycles: int,
+    dump_dir: pathlib.Path,
+    trace_dir: pathlib.Path,
+) -> dict:
+    """Build the model, run it three times, and trace the third.
+
+    1. ``jcm.runners.run`` — establishes the initial state from the preset's
+       own ``init`` group and compiles. Discarded.
+    2. ``Model.resume`` with exactly the arguments the traced call will use.
+       Discarded. This second warm-up is not redundant: ``runners.run``
+       dispatches through ``resume`` with its OWN argument set, and any
+       difference (the snapshot arguments, a different ``ForcingData``
+       instance) is a cache miss whose compilation would otherwise happen
+       inside the traced block.
+    3. The same call again, traced. A cache hit, hence steady state.
+
+    Step 3 is ``resume`` rather than a repeat of ``runners.run`` because
+    ``run`` rebuilds the forcing and re-injects the initial profile every time.
+    Both do device work that no timestep pays for, and inside the traced block
+    it would be profiled as step cost.
+
+    A recompile inside the traced block would put XLA's autotuning kernels in
+    the profile, silently inflating whichever components own the fusions being
+    tuned, so the guard below turns that into a hard failure rather than a
+    plausible-looking table.
+    """
+    import hydra
+    import jax
+    from hydra import compose, initialize_config_dir
+
+    import jcm
+    from jcm import runners
+
+    # Locate the config groups through the imported package rather than this
+    # file's own path, so profiling a worktree on PYTHONPATH reads that
+    # worktree's configs and not the installed copy's. (``jcm/config`` is a
+    # data directory with no ``__init__.py``, hence the dir form.)
+    config_dir = pathlib.Path(jcm.__file__).resolve().parent / "config"
+    with initialize_config_dir(config_dir=str(config_dir), version_base=None):
+        cfg = compose(config_name="config", overrides=overrides)
+
+    # One output frame over the whole window and no chunking, so the traced
+    # region is dominated by timestepping rather than by output assembly.
+    time_step_min = float(cfg.run.time_step)
+    steps_were_explicit = steps is not None
+
+    model = runners.build_model(cfg)
+    per_cycle, subcycled_term = subcycle_steps(model, time_step_min)
+
+    if steps is None:
+        steps = (max(1, round(days * 1440.0 / time_step_min))
+                 if days is not None else cycles * per_cycle)
+
+    # The window must span a whole number of radiation sub-cycles, or it
+    # averages in a different number of radiation calls per step than the model
+    # pays -- at the default 2 h cadence, a factor-of-two error on the largest
+    # row. An explicit --steps is honoured or rejected; a duration is rounded
+    # up, since the user asked for a duration, not an exact count.
+    if steps % per_cycle:
+        if steps_were_explicit:
+            raise SystemExit(
+                f"--steps {steps} does not span a whole number of radiation "
+                f"sub-cycles ({per_cycle} steps at radiation_interval / dt). "
+                "The window would average the wrong number of radiation calls "
+                f"per step. Use a multiple of {per_cycle}."
+            )
+        steps += per_cycle - (steps % per_cycle)
+
+    window_days = steps * time_step_min / 1440.0
+    cfg.run.total_time = window_days
+    cfg.run.save_interval = window_days
+    cfg.run.chunk_days = 0
+    cfg.run.output_averages = False
+
+    # Built once, outside the trace, exactly as jcm.runners._run_full does.
+    forcing = runners.build_forcing(
+        cfg, model.coords, dycore=getattr(model, "dycore", None),
+    )
+    forcing = runners._maybe_attach_nudging_target(forcing, cfg, model)
+
+    resume_kwargs = dict(
+        forcing=forcing,
+        save_interval=window_days,
+        total_time=window_days,
+        output_averages=False,
+    )
+
+    # Warm-up 1: initial state + first compile. Warm-up 2: the traced call's
+    # exact signature, so that its compilation (if any) happens here.
+    runners.run(cfg, model=model)
+    jax.block_until_ready(model._final_dycore_state)
+    jax.block_until_ready(model.resume(**resume_kwargs))
+
+    before = _dumped_modules(dump_dir)
+    shutil.rmtree(trace_dir, ignore_errors=True)
+    # Host and Python tracing off. The trace has a fixed event budget, and at
+    # JAM resolution the host-side events exhaust it before a single device
+    # event is recorded -- a T63 JAM trace came back with 1,000,000 host events
+    # and an empty GPU plane. Only device events are read here anyway.
+    options = jax.profiler.ProfileOptions()
+    options.host_tracer_level = 0
+    options.python_tracer_level = 0
+    t0 = time.perf_counter()
+    with jax.profiler.trace(str(trace_dir), profiler_options=options):
+        predictions = model.resume(**resume_kwargs)
+        jax.block_until_ready(predictions)
+    wall_s = time.perf_counter() - t0
+
+    recompiled = _dumped_modules(dump_dir) - before
+    if recompiled:
+        raise RuntimeError(
+            "XLA compiled "
+            f"{', '.join(sorted(recompiled))} inside the traced block, so the "
+            "trace contains autotuning kernels and the breakdown would be "
+            "wrong. The traced call was expected to hit the compilation "
+            "cache warmed immediately before it."
+        )
+
+    terms = [t.name for t in getattr(model.physics, "terms", ())]
+    hydra.core.global_hydra.GlobalHydra.instance().clear()
+    return {
+        "steps": steps,
+        "time_step_min": time_step_min,
+        # The traced block as a whole. Deliberately NOT divided by steps: it
+        # also covers the profiler's start/stop and the output assembly, which
+        # for a short window dwarf the timestepping. Per-step cost comes from
+        # the device timeline instead.
+        "traced_block_wall_s": wall_s,
+        "radiation_subcycle_steps": per_cycle,
+        "subcycled_term": subcycled_term,
+        "terms": terms,
+        # Which checkout was profiled. An editable install shadowing a
+        # worktree is silent otherwise, and the numbers would describe the
+        # wrong code.
+        "jcm_path": str(pathlib.Path(jcm.__file__).resolve().parent),
+        "config": _config_summary(cfg, overrides),
+        "dump_dir": str(dump_dir),
+    }
+
+
+def subcycle_steps(model, time_step_min: float) -> tuple[int, str | None]:
+    """Return (steps between full radiation calls, the radiation term's name).
+
+    Radiation is the only sub-cycled component (``radiation_interval``, 7200 s
+    by default, gated by a ``lax.cond`` in the radiation term) and usually the
+    largest one. Two things depend on knowing its cadence:
+
+    - the profiled window must span a whole number of sub-cycles, or it
+      averages in a different number of radiation calls per step than the model
+      pays -- at the default 2 h cadence, a factor-of-two error on the biggest
+      row;
+    - its cost *on a step where it runs* is its per-step average times this
+      factor.
+
+    The cadence is read from the configuration rather than inferred from the
+    trace on purpose. Kernel execution counts cannot recover it: internal scans
+    and vmaps make the per-instruction counts within a single term span three
+    orders of magnitude (RRTMGP's range from 2 to 2816 over a 20-step window in
+    which it ran exactly twice), so no summary statistic of them is the
+    invocation count.
+
+    Returns ``(1, None)`` when nothing is sub-cycled.
+    """
+    for term in getattr(model.physics, "terms", ()):
+        params = getattr(term, "params", None)
+        value = params.get_value() if params is not None else None
+        interval = getattr(value, "radiation_interval", None)
+        if interval:
+            per_cycle = max(1, round(float(interval) / (time_step_min * 60.0)))
+            return per_cycle, getattr(term, "name", None)
+    return 1, None
+
+
+def _config_summary(cfg, overrides: list[str]) -> str:
+    """One-line description of what was profiled, for the report header."""
+    groups = [o for o in overrides
+              if re.match(r"^(physics|grid|dycore|run|init)=", o)]
+    dt = cfg.run.time_step
+    return f"{' '.join(groups)} dt={dt}min"
+
+
+def main(argv=None) -> int:
+    """Entry point."""
+    p = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--preset", required=True, choices=sorted(PRESETS),
+                   help="configuration to profile (shared with benchmark.py)")
+    p.add_argument("--gpu", type=int, required=True,
+                   help="GPU index; must be free (see tools/gpu_util.py)")
+    # Default: two radiation sub-cycles (20 steps at dt=12 min). Not a whole
+    # simulated day, though that is the intuitive choice, for two reasons.
+    #
+    # It is not needed: every kernel in a step has a static shape and the model
+    # takes no data-dependent branches, so a step's cost does not vary with the
+    # state or the time of day. Once the window spans a whole number of
+    # radiation sub-cycles the per-step average is already exact, and further
+    # steps only reduce timing jitter.
+    #
+    # And it does not fit: the profiler's event buffer holds ~1e6 events, and a
+    # T63L47 JAM step emits ~19,000 kernels, so ~20 steps is the ceiling at
+    # that resolution. A one-day (120-step) window silently recorded 20 steps
+    # and reported a 4x undercount. --days is still available for cheaper
+    # configurations; the run fails loudly if the buffer overflows.
+    p.add_argument("--cycles", type=int, default=2,
+                   help="radiation sub-cycles to trace (default 2)")
+    p.add_argument("--days", type=float, default=None,
+                   help="simulated days to trace; overrides --cycles")
+    p.add_argument("--steps", type=int, default=None,
+                   help="steps to trace; overrides --days and --cycles")
+    p.add_argument("--label", default=None,
+                   help="output subdirectory name (default: the preset)")
+    p.add_argument("--outdir", type=pathlib.Path, default=DEFAULT_OUTDIR)
+    p.add_argument("--extra", nargs="*", default=[],
+                   help="additional Hydra overrides")
+    p.add_argument("--allow-busy-gpu", action="store_true",
+                   help="skip the free-GPU gate (results will be noisy)")
+    args = p.parse_args(argv)
+
+    # Same gate as tools/benchmark.py: a co-tenant on the card perturbs kernel
+    # durations, and this tool reads those durations directly.
+    g = next((x for x in gpu_table() if x["index"] == args.gpu), None)
+    if g is None or not is_free(g):
+        why = describe_gpu(args.gpu)
+        if not args.allow_busy_gpu:
+            print(f"{why}\nProfile on an idle card, or pass --allow-busy-gpu "
+                  f"to proceed anyway. Free now: {free_indices()}",
+                  file=sys.stderr)
+            return 2
+        print(f"warning: {why} -- proceeding because --allow-busy-gpu was "
+              "passed. The resulting split is NOT trustworthy.",
+              file=sys.stderr)
+
+    outdir = args.outdir / (args.label or args.preset)
+    outdir.mkdir(parents=True, exist_ok=True)
+    dump_dir = outdir / "hlo"
+    shutil.rmtree(dump_dir, ignore_errors=True)
+    dump_dir.mkdir()
+
+    # Set before jax is imported anywhere: XLA reads these when the backend is
+    # first initialised, and both are needed for the attribution join to have
+    # anything to join on.
+    os.environ["CUDA_VISIBLE_DEVICES"] = str(args.gpu)
+    os.environ["XLA_FLAGS"] = " ".join(filter(None, [
+        os.environ.get("XLA_FLAGS", ""),
+        f"--xla_dump_to={dump_dir}",
+        "--xla_dump_hlo_pass_re=^$",
+        _NO_CUDA_GRAPHS,
+    ]))
+
+    overrides = [*PRESETS[args.preset], *args.extra]
+    trace_dir = outdir / "trace"
+    result = profile_run(
+        overrides, args.steps, args.days, args.cycles, dump_dir, trace_dir,
+    )
+
+    freed = prune_dump(dump_dir)
+    print(f"pruned {freed / 2**20:.0f} MiB of PTX/LLVM IR from the HLO dump",
+          file=sys.stderr)
+    hlo_index, members, notes = index_hlo_dump(dump_dir)
+    for n in notes:
+        print(f"note: {n}", file=sys.stderr)
+
+    kernels = load_trace_kernels(trace_dir)
+    att = attribute(kernels, hlo_index, members)
+
+    # The profiler's event buffer holds ~1e6 events and a JAM step emits
+    # ~19,000 kernels, so a long enough window silently stops recording partway
+    # instead of erroring -- a 120-step window captured only 20 steps and
+    # reported a 4x undercount that looked entirely plausible.
+    #
+    # The dynamics and bridge scopes sit directly in Model's step function,
+    # outside every loop and conditional, so each of their instructions runs
+    # exactly once per step BY CONSTRUCTION. That makes them the trace's
+    # completeness check. (A physics term is no good for this: internal scans
+    # and vmaps put its per-instruction counts all over the place.)
+    from jcm import profiling
+
+    probes = {profiling.DYNAMICS, profiling.BRIDGE_TO_PHYSICS,
+              profiling.BRIDGE_TO_DYNAMICS}
+    cycle = result.get("radiation_subcycle_steps", 1)
+    seen = [n for label, n in att.steps_seen.items() if label in probes]
+    if seen and max(seen) < result["steps"]:
+        fits = max(cycle, max(seen) // cycle * cycle)
+        raise SystemExit(
+            f"the trace covers only {max(seen)} of the {result['steps']} steps "
+            f"run ({len(kernels)} kernels captured), so the profiler's event "
+            "buffer overflowed and every number would be an undercount. "
+            f"Profile a shorter window: --steps {fits} or fewer."
+        )
+
+    result.update({
+        "preset": args.preset,
+        "overrides": overrides,
+        "gpu_index": args.gpu,
+        "gpu_name": describe_gpu(args.gpu),
+        "device_span_us": device_span_us(kernels),
+        "hlo_index_notes": notes,
+        "attribution": att.as_dict(),
+    })
+    (outdir / "result.json").write_text(json.dumps(result, indent=2))
+    report = render_report(result)
+    (outdir / "report.md").write_text(report)
+    print(report)
+    print(f"\nWritten to {outdir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/profile_terms.py
+++ b/tools/profile_terms.py
@@ -435,6 +435,8 @@ def render_report(result: dict) -> str:
     nsteps = result["steps"]
     total = att["total_us"]
     span = result["device_span_us"]
+    per_cycle = result.get("radiation_subcycle_steps", 1)
+    subcycled = set(result.get("subcycled_terms") or ())
     lines = [
         f"# Step cost breakdown — {result['preset']}",
         "",
@@ -444,7 +446,8 @@ def render_report(result: dict) -> str:
         f"- steady-state steps profiled: {nsteps} "
         f"(after two discarded warm-up runs)",
         f"- radiation sub-cycle: every "
-        f"{result.get('radiation_subcycle_steps', 1)} steps",
+        f"{result.get('radiation_subcycle_steps', 1)} steps, gating "
+        f"{', '.join(sorted(subcycled)) or 'nothing'}",
         f"- device elapsed per step: {span / nsteps / 1000:.2f} ms",
         f"- device busy per step: {total / nsteps / 1000:.2f} ms "
         f"({100 * total / span:.0f}% occupancy; the rest is launch gaps, "
@@ -452,9 +455,9 @@ def render_report(result: dict) -> str:
         "",
         "``ms/step`` amortises a component over every step of the window and",
         "is the throughput-relevant number. ``ms/call`` is what it costs on a",
-        "step where it actually runs; the two differ only for the sub-cycled",
-        "radiation term, whose cadence is read from the configuration rather",
-        "than inferred from the trace.",
+        "step where it actually runs; the two differ for the terms gated to",
+        "the radiation cadence, whose membership and interval are read from",
+        "the configuration rather than inferred from the trace.",
         "",
         "| component | ms/step | % of device | ms/call | kernels/step |",
         "|---|---:|---:|---:|---:|",
@@ -462,15 +465,13 @@ def render_report(result: dict) -> str:
     # Every term is listed, including those that cost nothing measurable: a
     # term absent from the table would read as "not measured" when what it
     # actually means is "free", which is the more interesting fact.
-    per_cycle = result.get("radiation_subcycle_steps", 1)
-    subcycled = result.get("subcycled_term")
     per_label = dict(att["per_label_us"])
     for name in result.get("terms", ()):
         per_label.setdefault(name, 0.0)
     ordered = sorted(per_label.items(), key=lambda kv: -kv[1])
     for label, us in ordered:
         pct = 100.0 * us / total if total else 0.0
-        cadence = per_cycle if label == subcycled else 1
+        cadence = per_cycle if label in subcycled else 1
         per_call = us * cadence / nsteps / 1000
         kernels = att["kernels_per_label"].get(label, 0) / nsteps
         lines.append(
@@ -550,7 +551,7 @@ def profile_run(
     steps_were_explicit = steps is not None
 
     model = runners.build_model(cfg)
-    per_cycle, subcycled_term = subcycle_steps(model, time_step_min)
+    per_cycle, subcycled_terms = subcycle_steps(model, time_step_min)
 
     if steps is None:
         steps = (max(1, round(days * 1440.0 / time_step_min))
@@ -632,7 +633,7 @@ def profile_run(
         # the device timeline instead.
         "traced_block_wall_s": wall_s,
         "radiation_subcycle_steps": per_cycle,
-        "subcycled_term": subcycled_term,
+        "subcycled_terms": sorted(subcycled_terms),
         "terms": terms,
         # Which checkout was profiled. An editable install shadowing a
         # worktree is silent otherwise, and the numbers would describe the
@@ -643,37 +644,52 @@ def profile_run(
     }
 
 
-def subcycle_steps(model, time_step_min: float) -> tuple[int, str | None]:
-    """Return (steps between full radiation calls, the radiation term's name).
+def subcycle_steps(model, time_step_min: float) -> tuple[int, frozenset[str]]:
+    """Return (steps between radiation calls, the names of terms on that gate).
 
-    Radiation is the only sub-cycled component (``radiation_interval``, 7200 s
-    by default, gated by a ``lax.cond`` in the radiation term) and usually the
-    largest one. Two things depend on knowing its cadence:
+    Radiation runs on a ``radiation_interval`` cadence (7200 s by default) and
+    is usually the largest component. Two things depend on knowing that:
 
     - the profiled window must span a whole number of sub-cycles, or it
       averages in a different number of radiation calls per step than the model
       pays -- at the default 2 h cadence, a factor-of-two error on the biggest
       row;
-    - its cost *on a step where it runs* is its per-step average times this
-      factor.
+    - a gated term's cost *on a step where it runs* is its per-step average
+      times this factor.
 
-    The cadence is read from the configuration rather than inferred from the
-    trace on purpose. Kernel execution counts cannot recover it: internal scans
-    and vmaps make the per-instruction counts within a single term span three
+    More than one term rides the gate. ``JamOpticsTerm`` is gated too, because
+    its per-band Mie optics are consumed only by radiation, so recomputing them
+    on intermediate steps would be discarded work. Membership is therefore
+    taken from the codebase's own marker for it -- the ``configure_radiation_gate``
+    method that ``echam_physics`` calls on exactly these terms -- rather than
+    from a hardcoded name, so a future gated term is picked up automatically.
+
+    Cadence is read from the configuration rather than inferred from the trace
+    on purpose. Kernel execution counts cannot recover it: internal scans and
+    vmaps make the per-instruction counts within a single term span three
     orders of magnitude (RRTMGP's range from 2 to 2816 over a 20-step window in
     which it ran exactly twice), so no summary statistic of them is the
     invocation count.
 
-    Returns ``(1, None)`` when nothing is sub-cycled.
+    Returns ``(1, frozenset())`` when nothing is sub-cycled.
     """
+    per_cycle = 1
+    gated: set[str] = set()
     for term in getattr(model.physics, "terms", ()):
         params = getattr(term, "params", None)
         value = params.get_value() if params is not None else None
         interval = getattr(value, "radiation_interval", None)
+        # ``_radiation_interval_s`` is None when the gate is configured off
+        # (interval <= 0), which is what distinguishes "gated" from "merely
+        # gate-aware".
+        if interval is None and hasattr(term, "configure_radiation_gate"):
+            interval = getattr(term, "_radiation_interval_s", None)
         if interval:
             per_cycle = max(1, round(float(interval) / (time_step_min * 60.0)))
-            return per_cycle, getattr(term, "name", None)
-    return 1, None
+            name = getattr(term, "name", None)
+            if name:
+                gated.add(name)
+    return per_cycle, frozenset(gated)
 
 
 def _config_summary(cfg, overrides: list[str]) -> str:
@@ -784,15 +800,21 @@ def main(argv=None) -> int:
 
     probes = {profiling.DYNAMICS, profiling.BRIDGE_TO_PHYSICS,
               profiling.BRIDGE_TO_DYNAMICS}
+    # EVERY probe must be complete, not just the best of them. The probes are
+    # ordered within a step (bridge_to_physics runs before dynamics), so a
+    # buffer that fills partway through the final step leaves the earlier probe
+    # at the full count while a later one is short; taking the max would accept
+    # that trace and then divide short totals by the full step count.
     cycle = result.get("radiation_subcycle_steps", 1)
-    seen = [n for label, n in att.steps_seen.items() if label in probes]
-    if seen and max(seen) < result["steps"]:
-        fits = max(cycle, max(seen) // cycle * cycle)
+    seen = {label: n for label, n in att.steps_seen.items() if label in probes}
+    if seen and min(seen.values()) < result["steps"]:
+        worst = min(seen.values())
+        fits = max(cycle, worst // cycle * cycle)
         raise SystemExit(
-            f"the trace covers only {max(seen)} of the {result['steps']} steps "
-            f"run ({len(kernels)} kernels captured), so the profiler's event "
-            "buffer overflowed and every number would be an undercount. "
-            f"Profile a shorter window: --steps {fits} or fewer."
+            f"the trace covers only {worst} of the {result['steps']} steps run "
+            f"({len(kernels)} kernels captured; per-probe {seen}), so the "
+            "profiler's event buffer overflowed and every number would be an "
+            f"undercount. Profile a shorter window: --steps {fits} or fewer."
         )
 
     result.update({

--- a/tools/profile_terms_test.py
+++ b/tools/profile_terms_test.py
@@ -1,0 +1,359 @@
+"""Tests for the per-component step profiler.
+
+Like ``benchmark_test.py``, these guard a *methodology*: a bug in the HLO parse
+or the attribution join does not crash, it silently charges a term's cost to
+the wrong term. Every test here works on fixed synthetic HLO text and synthetic
+trace events, so it needs neither a GPU nor a model.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import profile_terms as pt  # noqa: E402
+
+# A miniature but structurally faithful dump: an entry computation whose
+# kernels are fusions, plus the fused computations carrying the scope
+# metadata. Mirrors what XLA emits for a step -- including the case that makes
+# attribution hard, ``mixed_fusion``, whose two operands come from different
+# scopes.
+HLO = """HloModule jit__run_from_state, entry_computation_layout={()->()}
+
+%fused_conv (param_0: f32[4]) -> f32[4] {
+  %param_0 = f32[4]{0} parameter(0)
+  %m = f32[4]{0} multiply(%param_0, %param_0), metadata={op_name="jit(_run_from_state)/scan/jcm:bridge_to_dynamics/jcm:tiedtke_convection/mul"}
+  ROOT %a = f32[4]{0} add(%m, %m), metadata={op_name="jit(_run_from_state)/scan/jcm:bridge_to_dynamics/jcm:tiedtke_convection/add"}
+}
+
+%fused_mixed (param_0: f32[4]) -> f32[4] {
+  %param_1 = f32[4]{0} parameter(0)
+  %r = f32[4]{0} sine(%param_1), metadata={op_name="jit(_run_from_state)/scan/jcm:bridge_to_dynamics/jcm:rrtmgp_radiation/sin"}
+  ROOT %c = f32[4]{0} cosine(%r), metadata={op_name="jit(_run_from_state)/scan/jcm:bridge_to_dynamics/jcm:tiedtke_convection/cos"}
+}
+
+%fused_dyn (param_0: f32[4]) -> f32[4] {
+  %param_2 = f32[4]{0} parameter(0)
+  ROOT %d = f32[4]{0} negate(%param_2), metadata={op_name="jit(_run_from_state)/scan/jcm:dynamics/neg"}
+}
+
+ENTRY %main (p: f32[4]) -> f32[4] {
+  %p = f32[4]{0} parameter(0)
+  %conv_fusion = f32[4]{0} fusion(%p), kind=kLoop, calls=%fused_conv, metadata={op_name="jit(_run_from_state)/scan/jcm:bridge_to_dynamics/jcm:tiedtke_convection/add"}
+  %mixed_fusion = f32[4]{0} fusion(%conv_fusion), kind=kLoop, calls=%fused_mixed, metadata={op_name="jit(_run_from_state)/scan/jcm:bridge_to_dynamics/jcm:tiedtke_convection/cos"}
+  %dyn_fusion = f32[4]{0} fusion(%mixed_fusion), kind=kLoop, calls=%fused_dyn, metadata={op_name="jit(_run_from_state)/scan/jcm:dynamics/neg"}
+  %copy = f32[4]{0} copy(%dyn_fusion)
+  ROOT %bridge = f32[4]{0} tanh(%copy), metadata={op_name="jit(_run_from_state)/scan/jcm:bridge_to_physics/tanh"}
+}
+"""
+
+
+@pytest.fixture
+def parsed():
+    """Parse the fixture module into (name, instructions, members)."""
+    module, instructions = pt.parse_hlo_module(HLO)
+    return module, instructions, pt.parse_hlo_module_computations(HLO)
+
+
+def test_parse_module_name_and_instructions(parsed):
+    module, instructions, _ = parsed
+    assert module == "jit__run_from_state"
+    # Instructions from every computation share one namespace.
+    assert {"m", "a", "r", "c", "d", "conv_fusion", "dyn_fusion",
+            "copy", "bridge"} <= set(instructions)
+
+
+def test_parse_extracts_calls_edges(parsed):
+    _, instructions, _ = parsed
+    assert instructions["conv_fusion"].calls == ("fused_conv",)
+    # A plain instruction calls nothing.
+    assert instructions["copy"].calls == ()
+
+
+def test_computation_membership(parsed):
+    _, _, members = parsed
+    # Parameters are members too. They carry no metadata, so they contribute
+    # no label and are harmless to the mixed-kernel check.
+    assert members["fused_conv"] == ["param_0", "m", "a"]
+    assert set(members["main"]) == {
+        "p", "conv_fusion", "mixed_fusion", "dyn_fusion", "copy", "bridge",
+    }
+
+
+def test_label_extraction_is_innermost():
+    """A term nested inside the enclosing physics scope wins over it."""
+    from jcm import profiling
+    assert profiling.label_from_op_name(
+        "jit(f)/scan/jcm:bridge_to_dynamics/jcm:tiedtke_convection/mul"
+    ) == "tiedtke_convection"
+    assert profiling.label_from_op_name(
+        "jit(f)/scan/jcm:bridge_to_dynamics/reshape"
+    ) == "bridge_to_dynamics"
+    assert profiling.label_from_op_name("jit(f)/scan/add") is None
+
+
+def _kernels(*specs):
+    """Build trace-shaped kernel events from (op, ts, dur) triples."""
+    return [{"module": "jit__run_from_state", "op": op, "ts": ts, "dur": dur}
+            for op, ts, dur in specs]
+
+
+def _attribute(kernels, parsed):
+    module, instructions, members = parsed
+    return pt.attribute(kernels, {module: instructions}, {module: members})
+
+
+def test_attribution_charges_each_kernel_to_its_scope(parsed):
+    att = _attribute(_kernels(
+        ("conv_fusion", 0.0, 10.0),
+        ("dyn_fusion", 10.0, 30.0),
+        ("bridge", 40.0, 5.0),
+    ), parsed)
+    assert att.per_label == {
+        "tiedtke_convection": 10.0, "dynamics": 30.0, "bridge_to_physics": 5.0,
+    }
+    assert att.total_us == 45.0
+
+
+def test_mixed_fusion_is_flagged_but_still_charged(parsed):
+    """A fusion spanning two scopes goes wholly to its root's scope, and is counted."""
+    att = _attribute(_kernels(("mixed_fusion", 0.0, 8.0)), parsed)
+    assert att.per_label == {"tiedtke_convection": 8.0}
+    assert att.mixed_us == 8.0
+
+
+def test_pure_fusion_is_not_flagged_as_mixed(parsed):
+    att = _attribute(_kernels(("conv_fusion", 0.0, 8.0)), parsed)
+    assert att.mixed_us == 0.0
+
+
+def test_unscoped_kernel_is_reported_not_redistributed(parsed):
+    """Plumbing kernels form their own bucket rather than inflating components."""
+    att = _attribute(_kernels(
+        ("copy", 0.0, 4.0), ("dyn_fusion", 4.0, 6.0),
+    ), parsed)
+    assert att.per_label == {"unattributed": 4.0, "dynamics": 6.0}
+
+
+def test_unjoinable_kernel_is_its_own_bucket(parsed):
+    """A kernel whose instruction is missing is a join failure, not a component."""
+    att = _attribute(_kernels(("no_such_instruction", 0.0, 7.0)), parsed)
+    assert att.unjoinable_us == 7.0
+    assert att.per_label == {"unjoinable": 7.0}
+    # It must NOT be silently folded into 'unattributed', which would hide a
+    # broken join behind a plausible-looking number.
+    assert "unattributed" not in att.per_label
+
+
+def test_kernel_from_unknown_module_is_unjoinable(parsed):
+    module, instructions, members = parsed
+    att = pt.attribute(
+        [{"module": "jit_other", "op": "dyn_fusion", "ts": 0.0, "dur": 3.0}],
+        {module: instructions}, {module: members},
+    )
+    assert att.unjoinable_us == 3.0
+
+
+def test_device_span_covers_first_start_to_last_end():
+    span = pt.device_span_us(_kernels(
+        ("a", 100.0, 10.0), ("b", 50.0, 5.0), ("c", 200.0, 25.0),
+    ))
+    assert span == pytest.approx(175.0)  # 225 - 50
+
+
+def test_device_span_of_empty_trace_is_zero():
+    assert pt.device_span_us([]) == 0.0
+
+
+def test_report_lists_zero_cost_terms(parsed):
+    """A term that costs nothing must still appear, as 0.00 rather than absent."""
+    att = _attribute(_kernels(("dyn_fusion", 0.0, 100.0)), parsed)
+    result = {
+        "preset": "fixture", "config": "physics=x dt=12min",
+        "gpu_name": "GPU 0", "gpu_index": 0, "steps": 10,
+        "device_span_us": 200.0, "terms": ["tiedtke_convection", "hines_gwd"],
+        "attribution": att.as_dict(),
+    }
+    report = pt.render_report(result)
+    assert "| hines_gwd | 0.00 |" in report
+    assert "| dynamics | 0.01 |" in report
+    assert "50% occupancy" in report
+
+
+def test_index_warns_when_a_module_name_is_compiled_twice(tmp_path):
+    """Two dumps of one jit function cannot be told apart from the trace."""
+    (tmp_path / "module_0001.jit_f.sm_80_gpu_after_optimizations.txt").write_text(
+        "HloModule jit_f\n\nENTRY %main () -> () {\n  %a = f32[] constant(1)\n}\n"
+    )
+    (tmp_path / "module_0002.jit_f.sm_80_gpu_after_optimizations.txt").write_text(
+        "HloModule jit_f\n\nENTRY %main () -> () {\n  %b = f32[] constant(2)\n}\n"
+    )
+    index, members, notes = pt.index_hlo_dump(tmp_path)
+    assert "jit_f" in index
+    assert "main" in members["jit_f"]
+    assert len(notes) == 1
+    assert "compiled more than once" in notes[0]
+
+
+def test_index_is_quiet_for_distinct_modules(tmp_path):
+    (tmp_path / "module_0001.jit_f.sm_80_gpu_after_optimizations.txt").write_text(
+        "HloModule jit_f\n\nENTRY %main () -> () {\n  %a = f32[] constant(1)\n}\n"
+    )
+    (tmp_path / "module_0002.jit_g.sm_80_gpu_after_optimizations.txt").write_text(
+        "HloModule jit_g\n\nENTRY %main.1 () -> () {\n  %b = f32[] constant(2)\n}\n"
+    )
+    index, members, notes = pt.index_hlo_dump(tmp_path)
+    assert set(index) == {"jit_f", "jit_g"}
+    assert set(members) == {"jit_f", "jit_g"}
+    assert notes == []
+
+
+def test_empty_device_plane_raises_rather_than_dividing_by_zero(tmp_path):
+    """A trace with host events but no kernels is a collection failure."""
+    import gzip
+    import json
+
+    d = tmp_path / "plugins" / "profile" / "run"
+    d.mkdir(parents=True)
+    payload = {"traceEvents": [
+        {"ph": "X", "pid": 701, "name": "host_op", "ts": 0, "dur": 1,
+         "args": {}},
+    ]}
+    with gzip.open(d / "x.trace.json.gz", "wt") as fh:
+        json.dump(payload, fh)
+
+    with pytest.raises(RuntimeError, match="no GPU kernels"):
+        pt.load_trace_kernels(tmp_path)
+
+
+def test_missing_trace_file_is_reported(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        pt.load_trace_kernels(tmp_path)
+
+
+def test_prune_dump_keeps_only_optimized_hlo(tmp_path):
+    """The PTX/LLVM IR that XLA also dumps is hundreds of MiB nothing reads."""
+    (tmp_path / "m.sm_80_gpu_after_optimizations.txt").write_text("HloModule m")
+    (tmp_path / "m.ptx").write_text("x" * 100)
+    (tmp_path / "m.ll").write_text("y" * 50)
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "more.ptx").write_text("z" * 10)
+
+    freed = pt.prune_dump(tmp_path)
+
+    assert freed == 160
+    assert [p.name for p in tmp_path.iterdir()] == [
+        "m.sm_80_gpu_after_optimizations.txt"
+    ]
+
+
+def test_every_preset_is_profilable():
+    """The tool's --preset choices stay in step with benchmark.py's registry."""
+    assert "ma-t63-l47" in pt.PRESETS
+    assert all(isinstance(v, list) for v in pt.PRESETS.values())
+
+
+def test_steps_seen_counts_the_steps_captured(parsed):
+    """The completeness probe counts how many steps the trace actually holds."""
+    att = _attribute(_kernels(
+        ("dyn_fusion", 0.0, 1.0), ("dyn_fusion", 1.0, 1.0),
+        ("dyn_fusion", 2.0, 1.0), ("dyn_fusion", 3.0, 1.0),
+        ("conv_fusion", 4.0, 50.0), ("conv_fusion", 5.0, 50.0),
+    ), parsed)
+    assert att.steps_seen["dynamics"] == 4
+    assert att.steps_seen["tiedtke_convection"] == 2
+
+
+def test_steps_seen_is_robust_to_inner_loop_instructions(parsed):
+    """One instruction running many times per step must not skew the probe.
+
+    This is the failure that made the previous estimator wrong: RRTMGP's
+    per-instruction counts ranged from 2 to 2816 over a window in which it ran
+    exactly twice, so max and "dominant instruction" were both far off.
+    """
+    kernels = _kernels(*[("dyn_fusion", float(i), 1.0) for i in range(5)])
+    kernels += _kernels(*[("copy", float(i), 0.1) for i in range(5)])
+    # 'd' lives inside %fused_dyn, so it carries the dynamics label too, and
+    # here it fires 40 times -- eight per step.
+    kernels += _kernels(*[("d", float(i), 0.1) for i in range(40)])
+    att = _attribute(kernels, parsed)
+    assert att.steps_seen["dynamics"] == 5
+
+
+def test_report_uses_the_configured_cadence_for_ms_per_call(parsed):
+    """ms/call for the sub-cycled term is ms/step times its configured rate."""
+    att = _attribute(_kernels(
+        ("conv_fusion", 0.0, 500.0), ("conv_fusion", 1.0, 500.0),
+    ), parsed)
+    result = {
+        "preset": "fixture", "config": "physics=x dt=12min",
+        "gpu_name": "GPU 0", "gpu_index": 0, "steps": 20,
+        "device_span_us": 2000.0, "terms": [],
+        "radiation_subcycle_steps": 10,
+        "subcycled_term": "tiedtke_convection",
+        "attribution": att.as_dict(),
+    }
+    report = pt.render_report(result)
+    # 1000 us / 20 steps = 0.05 ms/step; x10 for the 1-in-10 cadence.
+    assert "| tiedtke_convection | 0.05 | 100.0 | 0.50 |" in report
+    assert "radiation sub-cycle: every 10 steps" in report
+
+
+def test_report_leaves_every_step_components_alone(parsed):
+    """A component that is not sub-cycled has ms/call equal to ms/step."""
+    att = _attribute(_kernels(("dyn_fusion", 0.0, 1000.0)), parsed)
+    result = {
+        "preset": "fixture", "config": "physics=x dt=12min",
+        "gpu_name": "GPU 0", "gpu_index": 0, "steps": 20,
+        "device_span_us": 2000.0, "terms": [],
+        "radiation_subcycle_steps": 10,
+        "subcycled_term": "rrtmgp_radiation",
+        "attribution": att.as_dict(),
+    }
+    report = pt.render_report(result)
+    assert "| dynamics | 0.05 | 100.0 | 0.05 |" in report
+
+
+class _FakeParam:
+    def __init__(self, value):
+        self._value = value
+
+    def get_value(self):
+        return self._value
+
+
+class _FakeRadiationParams:
+    radiation_interval = 7200.0
+
+
+class _FakeTerm:
+    def __init__(self, params=None, name="term"):
+        self.name = name
+        if params is not None:
+            self.params = _FakeParam(params)
+
+
+class _FakePhysics:
+    def __init__(self, terms):
+        self.terms = terms
+
+
+class _FakeModel:
+    def __init__(self, terms):
+        self.physics = _FakePhysics(terms)
+
+
+def test_subcycle_steps_reads_the_radiation_interval():
+    """7200 s of radiation interval is 10 steps at a 12 minute timestep."""
+    model = _FakeModel([_FakeTerm(), _FakeTerm(_FakeRadiationParams(), "rad")])
+    assert pt.subcycle_steps(model, 12.0) == (10, "rad")
+    assert pt.subcycle_steps(model, 15.0) == (8, "rad")
+
+
+def test_subcycle_steps_defaults_to_every_step():
+    """No radiation term (or no interval) means nothing is sub-cycled."""
+    assert pt.subcycle_steps(_FakeModel([_FakeTerm()]), 12.0) == (1, None)
+    assert pt.subcycle_steps(_FakeModel([]), 12.0) == (1, None)

--- a/tools/profile_terms_test.py
+++ b/tools/profile_terms_test.py
@@ -293,7 +293,7 @@ def test_report_uses_the_configured_cadence_for_ms_per_call(parsed):
         "gpu_name": "GPU 0", "gpu_index": 0, "steps": 20,
         "device_span_us": 2000.0, "terms": [],
         "radiation_subcycle_steps": 10,
-        "subcycled_term": "tiedtke_convection",
+        "subcycled_terms": ["tiedtke_convection"],
         "attribution": att.as_dict(),
     }
     report = pt.render_report(result)
@@ -310,7 +310,7 @@ def test_report_leaves_every_step_components_alone(parsed):
         "gpu_name": "GPU 0", "gpu_index": 0, "steps": 20,
         "device_span_us": 2000.0, "terms": [],
         "radiation_subcycle_steps": 10,
-        "subcycled_term": "rrtmgp_radiation",
+        "subcycled_terms": ["rrtmgp_radiation"],
         "attribution": att.as_dict(),
     }
     report = pt.render_report(result)
@@ -349,11 +349,68 @@ class _FakeModel:
 def test_subcycle_steps_reads_the_radiation_interval():
     """7200 s of radiation interval is 10 steps at a 12 minute timestep."""
     model = _FakeModel([_FakeTerm(), _FakeTerm(_FakeRadiationParams(), "rad")])
-    assert pt.subcycle_steps(model, 12.0) == (10, "rad")
-    assert pt.subcycle_steps(model, 15.0) == (8, "rad")
+    assert pt.subcycle_steps(model, 12.0) == (10, frozenset({"rad"}))
+    assert pt.subcycle_steps(model, 15.0) == (8, frozenset({"rad"}))
 
 
 def test_subcycle_steps_defaults_to_every_step():
     """No radiation term (or no interval) means nothing is sub-cycled."""
-    assert pt.subcycle_steps(_FakeModel([_FakeTerm()]), 12.0) == (1, None)
-    assert pt.subcycle_steps(_FakeModel([]), 12.0) == (1, None)
+    assert pt.subcycle_steps(_FakeModel([_FakeTerm()]), 12.0) == (
+        1, frozenset())
+    assert pt.subcycle_steps(_FakeModel([]), 12.0) == (1, frozenset())
+
+
+class _FakeGatedTerm:
+    """A term riding the radiation gate, like JamOpticsTerm."""
+
+    def __init__(self, interval_s, name="optics"):
+        self.name = name
+        self._radiation_interval_s = interval_s
+
+    def configure_radiation_gate(self, interval_s):
+        self._radiation_interval_s = interval_s if interval_s > 0 else None
+
+
+def test_subcycle_steps_finds_every_gated_term():
+    """Optics rides the radiation gate too, so its ms/call must be scaled.
+
+    Missing this understated the second-largest component by 10x: its
+    per-band Mie optics are consumed only by radiation, so the term is gated
+    to the same cadence rather than running every step.
+    """
+    model = _FakeModel([
+        _FakeTerm(_FakeRadiationParams(), "rad"),
+        _FakeGatedTerm(7200.0, "optics"),
+        _FakeTerm(name="convection"),
+    ])
+    per_cycle, gated = pt.subcycle_steps(model, 12.0)
+    assert per_cycle == 10
+    assert gated == frozenset({"rad", "optics"})
+
+
+def test_subcycle_steps_ignores_a_disabled_gate():
+    """A gate configured off (interval <= 0) means the term runs every step."""
+    model = _FakeModel([
+        _FakeTerm(_FakeRadiationParams(), "rad"),
+        _FakeGatedTerm(None, "optics"),
+    ])
+    _, gated = pt.subcycle_steps(model, 12.0)
+    assert gated == frozenset({"rad"})
+
+
+def test_report_scales_every_gated_term(parsed):
+    """Both gated terms get the cadence, not just the radiation one."""
+    att = _attribute(_kernels(
+        ("conv_fusion", 0.0, 400.0), ("dyn_fusion", 1.0, 100.0),
+    ), parsed)
+    result = {
+        "preset": "fixture", "config": "physics=x dt=12min",
+        "gpu_name": "GPU 0", "gpu_index": 0, "steps": 20,
+        "device_span_us": 1000.0, "terms": [],
+        "radiation_subcycle_steps": 10,
+        "subcycled_terms": ["tiedtke_convection", "dynamics"],
+        "attribution": att.as_dict(),
+    }
+    report = pt.render_report(result)
+    assert "| tiedtke_convection | 0.02 | 80.0 | 0.20 |" in report
+    assert "| dynamics | 0.01 | 20.0 | 0.05 |" in report


### PR DESCRIPTION
Adds a reproducible per-component cost breakdown of a timestep: how much device
time the dynamical core, each direction of the dynamics/physics bridge, and
each individual `PhysicsTerm` account for, in steady state.

## The problem

A step compiles to one XLA module, so the ~60 terms are fused into a single
asynchronous kernel stream with no runtime boundary to time. A `perf_counter`
around a term measures Python tracing; a `block_until_ready` to force a
boundary changes the program being measured. Consequently
`docs/source/design/pyses_performance_review.md` §C has stood open asking for
"one profiled run" to confirm the MAM4 : optics : rest split that motivates its
optimisation levers, because there was no way to get one.

## How it works

`jax.named_scope` survives compilation: XLA records it as an `op_name` prefix on
every HLO instruction traced inside, through all of its optimisation passes. A
profiler trace reports, per GPU kernel, the HLO instruction that produced it.
Joining the two attributes measured device time back to the component that
emitted it.

That needs six lines in the model; `jcm/profiling.py` holds the convention and
the rationale:

- `ComposablePhysics`'s two term loops wrap each call in
  `profiling.scoped(..., term.name)`. The loops, not `PhysicsTerm` itself:
  `__call__` is overridden by every one of the ~60 terms, so a base-class
  wrapper would never run, and this keeps the schemes free of profiling code
  entirely.
- `Model._get_op_split_step_fn`'s `step` scopes the dycore call and both bridge
  directions. The physics call is scoped via the callable rather than at its two
  call sites, so the `auto_axes` sharding branch is untouched.

The scopes are unconditional rather than behind a debug flag. A named scope is
trace-time-only metadata that XLA does not optimise on, so it costs nothing at
runtime, and leaving it on means the profiled build **is** the production build
rather than a near-copy of it.

`tools/profile_terms.py` does the join. It shares `benchmark.py`'s `PRESETS` and
free-GPU gate, runs the preset, and reports ms/step, ms/call and an explicit
error bar.

## Guards, because a bug here reports a plausible wrong number rather than crashing

Every one of these was added after the mistake it prevents actually happened
while developing this, and each is covered by a unit test on synthetic HLO and
trace fixtures:

- **A truncated trace.** The profiler's event buffer holds ~1e6 events and a
  T63L47 JAM step emits ~19,000 kernels, so ~20 steps is the ceiling at that
  resolution. A 120-step window recorded 1,000,013 events, captured 20 of its
  120 steps, divided by 120 anyway, and reported 67.7 ms/step against a true
  264 — a 4x undercount that looked entirely plausible. Detection uses the fact
  that the dynamics and bridge scopes sit directly in `Model`'s step, outside
  every loop and branch, so no instruction of theirs can run fewer than once per
  step: their minimum execution count *is* the number of steps captured.
  Verified to accept the good trace and reject the truncated one.
- **An empty device plane.** The first attempt returned 1,000,000 host events
  and no GPU events at all, which surfaced as a division by zero. Host and
  Python tracing are now off, and an empty device plane is a named error.
- **Autotuning contamination.** A recompile inside the traced block would put
  XLA's autotuning kernels in the profile. `Model.resume` after `runners.run`
  really does recompile — they pass different argument sets — so the tool warms
  up twice, the second time with the traced call's exact signature, and then
  hard-fails if a new HLO module appears during the trace.
- **Radiation sub-cycling.** Radiation is 44% of the average step and runs 1
  step in 10, so a window that is not a whole number of sub-cycles averages in
  the wrong number of radiation calls: up to a factor of two on the largest row.
  The window is therefore specified in sub-cycles (default 2), and a `--days` or
  `--steps` window is rounded up or rejected.
- **Cadence is read from the config, not inferred.** An earlier version of the
  ms/call column estimated invocation counts from kernel execution counts. That
  is not recoverable: internal scans and vmaps make the per-instruction counts
  within one term span three orders of magnitude — RRTMGP's ranged from 2 to
  2816 over a window in which it ran exactly twice — so no summary statistic of
  them is the invocation count. It now comes from `radiation_interval`, which is
  exact.
- **Fusions spanning two components** are charged whole to their root's
  component; the report states what fraction of device time that is (13% here)
  as the error bar on the split. Kernels belonging to no scope are reported as
  `unattributed` rather than spread pro-rata, which would flatter everything.
- **Profiling the wrong checkout.** The report names the `jcm` actually
  imported, since an editable install shadowing a worktree is otherwise silent.

## Validation

- Two independent runs of the same configuration agree to within 0.2%
  (264.25 vs 264.42 ms/step of device-busy time).
- The device-busy total cross-checks against an independent throughput
  measurement: the `jcm-benchmark` skill records T63L47 at 28.3 s/sim-day, which
  at dt = 12 min is 236 ms/step, against 264 ms/step here. The residual is
  expected and documented — the tool disables CUDA graph capture so kernels stay
  individually attributable, which costs per-launch overhead a captured graph
  amortises. This is exactly why the report says its total is not a throughput
  number and points at `benchmark.py` for that.

## Result

`ma-t63-l47` on one A100-80GB, device time per step:

| component | ms/step | % | ms/call |
|---|---:|---:|---:|
| `rrtmgp_radiation` | 116.40 | 44.1 | 1164.04 |
| `jam_optics` | 40.64 | 15.4 | 40.64 |
| `jam_mam4_jax_microphysics` | 36.71 | 13.9 | 36.71 |
| dynamics | 18.96 | 7.2 | 18.96 |
| `tiedtke_convection` | 14.94 | 5.7 | 14.94 |
| bridge, both directions | 1.76 | 0.7 | 1.76 |

§C of `pyses_performance_review.md` is updated with the measurement it asked
for. The inferred ordering holds — optics and MAM4 are the two largest JAM
terms, and the other ten are collectively small — with one correction: RRTMGP
still dominates everything else combined even at a 1-in-10 sub-cycle, at 1.16 s
on each step it runs. That promotes lever B3 (`compute_cre=False`, halving the
RRTMGP work) above the B1/B2 optics and MAM4 work the section was written to
gate. The bridge, sometimes assumed to be a real cost of the composable design,
is under 1% of device time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aqshaa5nDrxcDWgg1FYw8Z
