### PR TITLE
JAM wet scavenging keys to the microphysics' process-time ledger (#708)

### DIFF
--- a/docs/source/design/lohmann_2m_column_processes.md
+++ b/docs/source/design/lohmann_2m_column_processes.md
@@ -1,8 +1,6 @@
 # The Lohmann 2M scheme is ECHAM's `column_processes` loop
 
-*(2026-08; issues #662, #667, #685, #686, #687, #688, #689; parent audit #614)*
-
-## The decision
+## The design
 
 `cloud_microphysics_2m` runs the **entire** two-moment process chain inside one
 top-down `lax.scan`, one scan step per level, in the section order of ECHAM's
@@ -10,32 +8,20 @@ top-down `lax.scan`, one scan step per level, in the section order of ECHAM's
 ledger, `update_tendencies_and_important_vars`) has no cross-level coupling and
 runs vectorized on the stacked per-level outputs afterwards.
 
-The previous layout split the chain: "level-independent" processes
-(condensation partition, freezing, WBF, warm/cold precipitation formation) ran
-vectorized outside the sweep, and only sedimentation/melting/sublimation ran
-inside it. That looked like a harmless performance-friendly factorization. It
-was not, because in the reference **every process at level `jk` consumes the
-precipitation state the levels above produced *this step*** — the rain/snow
-fluxes (`prfl`/`pssfl`), the precipitation cover (`zclcpre`), and the falling
-ice flux (`zxiflux`) are loop-carried. Splitting the chain silently severed
-those couplings:
-
-- accretion by rain/snow from above read `qr`/`qs` tracers that no term
-  declared any more — both identically zero, so the pathway was dead code and
-  precipitation formation was understated ~3× (#662 finding 5, and through
-  `rate_cb = p_form/(qc+qi)` the leading suspect for the cloud-borne aerosol
-  drainage failure in #658);
-- the cloud∩precipitation overlap `zclcstar = min(paclc, zclcpre)` could not
-  be formed, so accretion geometry fell back to `paclc` (#685);
-- ice created mid-step (deposition, freezing, WBF) never met its
-  aggregation/riming sink that step (#686);
-- warm rain ran *first*, before condensation and activation, matching neither
-  ECHAM nor CAM (#667 finding 4).
-
-The restructure is therefore not an optimization choice reversed — it is the
-minimal faithful shape. Wall-clock cost is unchanged at leading order: the
-same arithmetic moves from a `(nlev,)`-vectorized context into the scan body,
-and the scan already existed.
+The monolithic sweep is forced by the reference's data flow: every process at
+level `jk` consumes the precipitation state the levels above produced *this
+step* — the rain/snow fluxes (`prfl`/`pssfl`), the precipitation cover
+(`zclcpre`), and the falling ice flux (`zxiflux`) are loop-carried. Lifting
+apparently "level-independent" processes (the condensation partition,
+freezing, WBF, precipitation formation) out of the sweep severs those
+couplings: accretion by rain and snow from above loses its collector fluxes,
+the cloud∩precipitation overlap `zclcstar = min(paclc, zclcpre)` cannot be
+formed, ice created mid-step (by deposition, freezing, or WBF) never meets
+its aggregation/riming sink that step, and warm rain cannot run after
+condensation and activation, which is where both ECHAM and CAM place it. The
+whole chain therefore lives in the scan. Wall-clock cost is unchanged at
+leading order: the same arithmetic runs inside the scan body rather than in a
+`(nlev,)`-vectorized context.
 
 ## What the sweep does per level
 
@@ -48,10 +34,26 @@ geometry (`zclcstar`, `zauloc`, the Marshall–Palmer inversions
 `zxrp1`/`zxsp1`) → 7.1 warm rain → 7.2 cold precipitation → 7.3 flux update.
 
 One deliberate deviation, reviewed and kept: sedimentation runs **before**
-melting (MG/PUMAS order, `micro_pumas_v1.F90`), with the running ice tendency
-threaded through the melt routine so the two sinks cannot claim the same mass
-(#662 finding 2). ECHAM melts first; both orderings are internally consistent
+melting (the MG/PUMAS order, `micro_pumas_v1.F90`), with the running ice
+tendency threaded through the melt routine so the two sinks cannot claim the
+same mass. ECHAM melts first; both orderings are internally consistent
 ledgers.
+
+Formulation choices inside the sweep, for provenance:
+
+- Grid-scale condensation/evaporation is the section-5 `zqcdif` closure with
+  ECHAM's Newton saturation damper (`zqcon`; 0.36–0.93 through the
+  troposphere), so no external saturation adjustment is composed alongside
+  the scheme and no supersaturation survives a step.
+- Clear-sky condensate — including cells whose cover reached zero this step —
+  evaporates through `zxlevap`/`zxievap` verbatim.
+- Accretion by rain and snow from above converts the loop-carried fluxes to
+  local mixing ratios with the Marshall–Palmer inversions (`zxrp1`/`zxsp1`).
+- The WBF threshold updraft `peta` is ECHAM's diffusional-growth ζ
+  (`mo_cloud_micro_2m.f90` line 856), recomputed after freezing so the
+  post-freezing crystal population sets the threshold.
+- Diagnostic cirrus ICNC (`nic_cirrus = 1`) uses the Schumann volume-mean
+  radius, in metres.
 
 ## The state-splitting convention
 
@@ -75,18 +77,6 @@ The ledger reconstruction is identical either way:
 guard bounds the true end-of-step state and the host's tendency sum
 telescopes exactly as ECHAM's INOUT accumulation.
 
-## What this made live (previously inert or miscalibrated)
-
-| pathway | before | after |
-|---|---|---|
-| internal saturation adjustment | `zqcon ≈ 1/50…1/650` (zdqsdt ×1000; #667.1) | Newton damper 0.36–0.93; 10 % supersat → 1 % in one step |
-| grid-scale condensation | external Sundqvist bolt-on (double-adjustment risk) | ECHAM section-5 `zqcdif` closure in-scheme; bolt-on removed |
-| clear-sky condensate sink | none (`pxlevap = pxievap = 0`) | `zxlevap`/`zxievap` verbatim; cf=0 cells evaporate in one step |
-| rain/snow-from-above accretion | dead (`qr`/`qs` ≡ 0) | Marshall–Palmer inversion of carry fluxes |
-| WBF threshold updraft | fed a 0–1 clip as `peta` | ECHAM's diffusional-growth ζ (line 856); recomputed post-freezing |
-| diagnostic ICNC (`nic_cirrus=1`) | `prid` in µm (r³ off by 10¹⁸) → pinned at floor | Schumann volume-mean radius in metres |
-| cold-chain gate | step-start `qi > ccwmin` | `ll_cc` + in-scan `zxib > cqtmin` (#686) |
-
 ## Deliberate omissions (tracked)
 
 - **Large-scale vertical velocity is not plumbed** (`zvervx` is TKE-only; the
@@ -105,52 +95,52 @@ telescopes exactly as ECHAM's INOUT accumulation.
 (modelled on CAM's `check_energy_chng`) close the water and enthalpy budgets
 against the surface fluxes for warm-liquid, WBF, cold-fallout, and
 melt-in-place fixtures. `TestSaturationGate2M` pins that no supersaturation
-survives a step (the property whose absence let the double adjustment hide);
-`TestColdChainSameStepCoupling2M` pins that a deck glaciating via WBF exports
-a frozen flux the same step. Budget tests pin the ledger's self-consistency —
-a defect that mis-states the in-cloud state on both sides of a transfer needs
-a *state* assertion, which is why the het-INP test bounds the per-level
-fusion heat from below rather than trusting closure alone.
+survives a step; `TestColdChainSameStepCoupling2M` pins that a deck
+glaciating via WBF exports a frozen flux the same step. Budget tests pin the
+ledger's self-consistency — a defect that mis-states the in-cloud state on
+both sides of a transfer needs a *state* assertion, which is why the het-INP
+test bounds the per-level fusion heat from below rather than trusting closure
+alone.
 
-`clouds.cloud_fraction` now means the post-microphysics cover under both the
-1M and 2M schemes (#687; documented on `CloudData`), and the 2M
-negative-mass repair is exported as `clouds.negative_mass_repair` [W/m²]
-(#689) so its sign-definite heating is measurable in any run.
+`clouds.cloud_fraction` is the post-microphysics cover under both the 1M and
+2M schemes (documented on `CloudData`), and the 2M negative-mass repair is
+exported as `clouds.negative_mass_repair` [W/m²] so its sign-definite heating
+is measurable in any run.
 
-## The wet-scavenging interface (#708)
+## The wet-scavenging interface
 
-ECHAM-HAM does not reconstruct aerosol scavenging from cover × grid-mean
-state: after `column_processes`, `cloud_subm_2` receives the ledger the
-microphysics itself integrated — `zmlwc`/`zmiwc` (in-cloud condensate
-captured at section 7, before precipitation formation depletes it), the
-in-cloud formation rates `zmratepr`/`zmrateps`/`zmsnowacl` (with `zmrateps`
-seeded from `sedimentation_ice`: sedimenting ice **is** a scavenging carrier
-in ECHAM-HAM), and `paclc`. The scan already computed all of these; they are
-now published on `CloudData` (`incloud_*`, `process_cloud_fraction`,
-`condensate_evaporation_rate` — see `ScavengingLedger` in
-`lohmann_2m/types.py`) and the JAM wet-deposition and cloud-borne exchange
-terms key to them:
+The scheme publishes the same process-time ledger that ECHAM-HAM's
+`cloud_subm_2` receives from `column_processes`: `zmlwc`/`zmiwc` (in-cloud
+condensate captured at section 7, before precipitation formation depletes
+it), the in-cloud formation rates `zmratepr`/`zmrateps`/`zmsnowacl`
+(`zmrateps` seeded from `sedimentation_ice`: sedimenting ice **is** a
+scavenging carrier in ECHAM-HAM), the cover the processes ran under, and the
+condensate-evaporation ledger (`zxlevap + zxievap`). These appear on
+`CloudData` as `incloud_*`, `process_cloud_fraction`, and
+`condensate_evaporation_rate` (see `ScavengingLedger` in
+`lohmann_2m/types.py`), and the JAM wet-deposition and cloud-borne exchange
+terms key to them — the ledger is why `aerosol_module="jam"` requires the 2M
+scheme:
 
 - **In-cloud removal** is HAMMOZ `prep_wetdep_hydro`'s
   `peffwat = (zmratepr+zmsnowacl)·Δt/zmlwc` and `peffice = zmrateps·Δt/zmiwc`
   (clipped to [0, 1]), split by the in-cloud ice mass fraction. Numerator and
   denominator are both captured at process time, so the fraction is bounded
-  by construction — no unbounded rate ratio, no floor being "accidentally
-  correct" in near-empty cells.
+  by construction in every cell, including near-empty ones.
 - **Resuspension** of cloud-borne aerosol keys to the condensate-evaporation
-  ledger (`zxlevap + zxievap`): a sky cleared by evaporation releases the
-  reservoir in one step, a sky cleared by rainout releases nothing (that
-  aerosol leaves with the precip), and the same step's rainout claim caps the
-  released share so the two sinks cannot jointly overdraw. Cover alone
-  cannot make this distinction — both endings read `cloud_fraction = 0`.
+  ledger: a sky cleared by evaporation releases the reservoir in one step, a
+  sky cleared by rainout releases nothing (that aerosol leaves with the
+  precip), and the same step's rainout claim caps the released share so the
+  two sinks cannot jointly overdraw. The end-of-step cover cannot make this
+  distinction — both endings read `cloud_fraction = 0` — which is why the
+  ledger, not the cover, is the interface.
 
 One documented deviation from the reference: ECHAM-HAM zeroes `zmlwc`/`zmiwc`
 *after* the `paclc` write-back (mo_cloud_micro_2m.f90:3655 → 3660), so a cell
 whose condensate fully converted to precipitation reaches `cloud_subm_2` with
 a zero pool, `peffwat = 0`, and **no scavenging in exactly the step with the
 largest removal** — the reference has the dead zone itself. jcm keeps the
-faithful zeroing (the marker is information: zero pool + positive formation
-identifies the fully-converting cell) but maps the marker to scavenged
-fraction **1**, not 0. The 1M scheme does not publish the ledger yet (#712);
-the factory statically wires the JAM terms back to the legacy cover-keyed
-reconstruction under `cloud_scheme: 1m`.
+faithful zeroing, because the marker is information — a zero pool with a
+positive formation rate identifies the fully-converting cell — but maps the
+marker to scavenged fraction **1**, not 0: the droplets became precipitation,
+and everything they carried went with them.

--- a/docs/source/design/lohmann_2m_column_processes.md
+++ b/docs/source/design/lohmann_2m_column_processes.md
@@ -116,3 +116,41 @@ fusion heat from below rather than trusting closure alone.
 1M and 2M schemes (#687; documented on `CloudData`), and the 2M
 negative-mass repair is exported as `clouds.negative_mass_repair` [W/m²]
 (#689) so its sign-definite heating is measurable in any run.
+
+## The wet-scavenging interface (#708)
+
+ECHAM-HAM does not reconstruct aerosol scavenging from cover × grid-mean
+state: after `column_processes`, `cloud_subm_2` receives the ledger the
+microphysics itself integrated — `zmlwc`/`zmiwc` (in-cloud condensate
+captured at section 7, before precipitation formation depletes it), the
+in-cloud formation rates `zmratepr`/`zmrateps`/`zmsnowacl` (with `zmrateps`
+seeded from `sedimentation_ice`: sedimenting ice **is** a scavenging carrier
+in ECHAM-HAM), and `paclc`. The scan already computed all of these; they are
+now published on `CloudData` (`incloud_*`, `process_cloud_fraction`,
+`condensate_evaporation_rate` — see `ScavengingLedger` in
+`lohmann_2m/types.py`) and the JAM wet-deposition and cloud-borne exchange
+terms key to them:
+
+- **In-cloud removal** is HAMMOZ `prep_wetdep_hydro`'s
+  `peffwat = (zmratepr+zmsnowacl)·Δt/zmlwc` and `peffice = zmrateps·Δt/zmiwc`
+  (clipped to [0, 1]), split by the in-cloud ice mass fraction. Numerator and
+  denominator are both captured at process time, so the fraction is bounded
+  by construction — no unbounded rate ratio, no floor being "accidentally
+  correct" in near-empty cells.
+- **Resuspension** of cloud-borne aerosol keys to the condensate-evaporation
+  ledger (`zxlevap + zxievap`): a sky cleared by evaporation releases the
+  reservoir in one step, a sky cleared by rainout releases nothing (that
+  aerosol leaves with the precip), and the same step's rainout claim caps the
+  released share so the two sinks cannot jointly overdraw. Cover alone
+  cannot make this distinction — both endings read `cloud_fraction = 0`.
+
+One documented deviation from the reference: ECHAM-HAM zeroes `zmlwc`/`zmiwc`
+*after* the `paclc` write-back (mo_cloud_micro_2m.f90:3655 → 3660), so a cell
+whose condensate fully converted to precipitation reaches `cloud_subm_2` with
+a zero pool, `peffwat = 0`, and **no scavenging in exactly the step with the
+largest removal** — the reference has the dead zone itself. jcm keeps the
+faithful zeroing (the marker is information: zero pool + positive formation
+identifies the fully-converting cell) but maps the marker to scavenged
+fraction **1**, not 0. The 1M scheme does not publish the ledger yet (#712);
+the factory statically wires the JAM terms back to the legacy cover-keyed
+reconstruction under `cloud_scheme: 1m`.

--- a/jcm/physics/aerosol/jam/cloud_borne.py
+++ b/jcm/physics/aerosol/jam/cloud_borne.py
@@ -15,13 +15,17 @@ number fraction) define the grid-mean equilibrium cloud-borne amount
     q_cb* = cloud_fraction · f_act · (q_int + q_cb)
 
 and the pair relaxes toward it with a tunable timescale, activation and
-resuspension each getting their own knob. Both directions come out of the one
-expression: a growing or persistent cloud pulls ``q_cb`` up toward the
-activated partition, and a cleared sky (``cloud_fraction → 0``) returns the
-whole reservoir to interstitial. The per-step transfer uses the exponential
-relaxation factor ``1 − exp(−Δt/τ)``, so it is unconditionally bounded by the
-donor phase's content and exactly conserving (the two tendencies are equal
-and opposite).
+resuspension each getting their own knob. A growing or persistent cloud pulls
+``q_cb`` up toward the activated partition; the downward direction is keyed
+to the microphysics' condensate-evaporation ledger (#708): the reservoir
+share released each step is the share of the droplet population that
+EVAPORATED — a sky cleared by evaporation resuspends everything, a sky
+cleared by rainout resuspends nothing (that aerosol leaves with the precip,
+removed by the wetdep term running just after this one), and only cells with
+no cloud process at all (advected-in ``q_cb`` in clear air) fall back to the
+slow ``resuspension_timescale`` drain. Every per-step transfer factor lies in
+[0, 1], so the move is unconditionally bounded by the donor phase's content
+and exactly conserving (the two tendencies are equal and opposite).
 
 This is deliberately simpler than CAM's ``dropmixnuc``, which couples the
 transfer to an implicit turbulent-mixing solve; jcm has no physics-side
@@ -65,6 +69,9 @@ from jcm.physics.aerosol.jam.cloud_borne_store import (
     carry_mode,
     tracer_view,
 )
+from jcm.physics.aerosol.jam.wetdep.wetdep_term import (
+    incloud_scavenged_fractions,
+)
 from jcm.physics.aerosol.jam.microphysics.mam4_data import MAM4_SPEC
 from jcm.physics.aerosol.jam.population import ModalAerosolSpec
 from jcm.physics.aerosol.jam.tracer_layout import mass_name, number_name
@@ -76,6 +83,13 @@ from jcm.physics_interface import PhysicsTendency
 #: cloud-borne reservoir drains. Also floors the 1/cf stretch of the activation
 #: timescale, so a vanishingly thin cloud cannot make it infinite.
 _MIN_CLOUD_FRACTION = 1.0e-3
+
+#: Grid-mean condensate floor [kg/kg] deciding whether the cell saw any cloud
+#: process this step (evaporation + surviving pool + formation); below it the
+#: evaporation-ledger keying falls back to the slow timescale drain. Physical
+#: floor, not an epsilon, for the same f32 VJP reason as wetdep's
+#: ``_CONDENSATE_FLOOR``.
+_PROCESS_FLOOR = 1.0e-12
 
 
 @tree_math.struct
@@ -109,12 +123,29 @@ class CloudBorneExchange(PhysicsTerm):
         params: CloudBorneExchangeParameters | None = None,
         *,
         spec: ModalAerosolSpec | None = None,
+        evaporation_ledger: bool = True,
     ):
-        """Hold params and the population (which must prognose the phase)."""
+        """Hold params and the population (which must prognose the phase).
+
+        ``evaporation_ledger`` (#708): key resuspension to the cloud
+        scheme's condensate-evaporation ledger — the physical
+        discriminator between "the cloud evaporated, release the aerosol"
+        and "the cloud rained out, the aerosol left with it" — instead of
+        draining on ``resuspension_timescale`` whenever the
+        post-microphysics cover reads 0. The cover cannot distinguish the
+        two: a fully-rained-out cell also ends with cover 0, and the
+        timescale drain there races the same step's rainout (with this
+        term running before wetdep, up to ``1-exp(-dt/τ)`` ≈ 86% at
+        Δt=1800 s of the reservoir escaped scavenging through exactly the
+        cells with the largest removal). Static because it must match
+        what the composed cloud scheme publishes (2M writes the ledger,
+        1M does not yet) — wired by the factory, never per-cell.
+        """
         self.params = nnx.Param(
             params or CloudBorneExchangeParameters.default()
         )
         self._spec = spec or MAM4_SPEC
+        self._evaporation_ledger = evaporation_ledger
         if not self._spec.cloud_borne:
             # Composed against a population without the mirror tracers, the
             # ``mc_*``/``nc_*`` tendencies would be silently dropped by the
@@ -200,14 +231,62 @@ class CloudBorneExchange(PhysicsTerm):
             jnp.stack(fracs) * (q_int_arr + q_cb_arr),
             0.0,
         )
-        tau = jnp.where(
-            target > q_cb_arr,
-            params.activation_timescale / cloudy_cf,
-            params.resuspension_timescale,
+        phi_up = -jnp.expm1(
+            -dt / jnp.maximum(params.activation_timescale / cloudy_cf, 1.0)
         )
-        # 1 − exp(−Δt/τ) ∈ [0, 1]: the move never overshoots the target, so
-        # neither phase can go negative (|Δ| ≤ |target − q_cb| ≤ donor).
-        phi = -jnp.expm1(-dt / jnp.maximum(tau, 1.0))
+        phi_slow = -jnp.expm1(
+            -dt / jnp.maximum(params.resuspension_timescale, 1.0)
+        )
+        if self._evaporation_ledger:
+            # Resuspension keyed to the microphysics' own evaporation
+            # ledger (#708). The per-step fraction of the droplet
+            # population that evaporated is E/(E + pool): E is the
+            # grid-mean condensate returned to vapour this step
+            # (zxlevap+zxievap) and pool the grid-mean in-cloud condensate
+            # that survived to the precipitation-formation stage — that
+            # fraction of the cloud-borne reservoir is released. The
+            # rainout claim of the SAME step (the formation-ledger
+            # fraction wetdep removes, running after this term) caps it,
+            # so the two sinks cannot jointly overdraw the reservoir:
+            # evaporated + rained fractions of one droplet population sum
+            # to at most 1. WBF and freezing move condensate between
+            # phases WITHIN the pool, so they neither evaporate nor rain
+            # out cloud-borne aerosol here — the aerosol rides into the
+            # ice and meets the snow pathway (#686) in the ledger instead.
+            e_gm = jnp.maximum(clouds.condensate_evaporation_rate, 0.0) * dt
+            cf_proc = jnp.clip(clouds.process_cloud_fraction, 0.0, 1.0)
+            pool_gm = cf_proc * (
+                jnp.maximum(clouds.incloud_liquid, 0.0)
+                + jnp.maximum(clouds.incloud_ice, 0.0)
+            )
+            formed_gm = cf_proc * dt * jnp.maximum(
+                clouds.incloud_rain_formation + clouds.incloud_riming
+                + clouds.incloud_snow_formation, 0.0,
+            )
+            f_wat, f_ice, pice = incloud_scavenged_fractions(clouds, dt)
+            f_form = (1.0 - pice) * f_wat + pice * f_ice
+            live = (e_gm + pool_gm + formed_gm) > _PROCESS_FLOOR
+            f_evap = jnp.where(
+                live,
+                e_gm / jnp.maximum(e_gm + pool_gm, _PROCESS_FLOOR),
+                0.0,
+            )
+            # Cells with NO cloud process this step (advected-in q_cb in
+            # clear air: nothing evaporated, nothing formed) keep the slow
+            # CAM-style timescale drain; everywhere else the ledger says
+            # exactly which share to release. A fully-rained-out cell is
+            # ``live`` through its formation ledger with f_evap ≈ 0 — no
+            # resuspension racing the rainout.
+            phi_down = jnp.where(
+                live,
+                jnp.minimum(f_evap, jnp.maximum(1.0 - f_form, 0.0)),
+                phi_slow,
+            )
+        else:
+            phi_down = phi_slow
+        # phi ∈ [0, 1]: the move never overshoots the target, so neither
+        # phase can go negative (|Δ| ≤ |target − q_cb| ≤ donor).
+        phi = jnp.where(target > q_cb_arr, phi_up, phi_down)
         transfer = (target - q_cb_arr) * phi / dt   # [.../s], + toward cloud-borne
 
         # Cloud-borne side to the active store (carry mode integrates it

--- a/jcm/physics/aerosol/jam/cloud_borne.py
+++ b/jcm/physics/aerosol/jam/cloud_borne.py
@@ -123,29 +123,25 @@ class CloudBorneExchange(PhysicsTerm):
         params: CloudBorneExchangeParameters | None = None,
         *,
         spec: ModalAerosolSpec | None = None,
-        evaporation_ledger: bool = True,
     ):
         """Hold params and the population (which must prognose the phase).
 
-        ``evaporation_ledger`` (#708): key resuspension to the cloud
-        scheme's condensate-evaporation ledger — the physical
-        discriminator between "the cloud evaporated, release the aerosol"
-        and "the cloud rained out, the aerosol left with it" — instead of
-        draining on ``resuspension_timescale`` whenever the
-        post-microphysics cover reads 0. The cover cannot distinguish the
-        two: a fully-rained-out cell also ends with cover 0, and the
-        timescale drain there races the same step's rainout (with this
-        term running before wetdep, up to ``1-exp(-dt/τ)`` ≈ 86% at
-        Δt=1800 s of the reservoir escaped scavenging through exactly the
-        cells with the largest removal). Static because it must match
-        what the composed cloud scheme publishes (2M writes the ledger,
-        1M does not yet) — wired by the factory, never per-cell.
+        Resuspension keys to the cloud scheme's condensate-evaporation
+        ledger (#708) — the physical discriminator between "the cloud
+        evaporated, release the aerosol" and "the cloud rained out, the
+        aerosol left with it". Cover alone cannot distinguish the two: a
+        fully-rained-out cell also ends with cover 0, and a timescale
+        drain there would race the same step's rainout (with this term
+        running before wetdep, up to ``1-exp(-dt/τ)`` ≈ 86% at Δt=1800 s
+        of the reservoir would escape scavenging through exactly the
+        cells with the largest removal). This term therefore requires a
+        cloud scheme that publishes the ``CloudData`` ledger fields; the
+        physics factory enforces that at compose time.
         """
         self.params = nnx.Param(
             params or CloudBorneExchangeParameters.default()
         )
         self._spec = spec or MAM4_SPEC
-        self._evaporation_ledger = evaporation_ledger
         if not self._spec.cloud_borne:
             # Composed against a population without the mirror tracers, the
             # ``mc_*``/``nc_*`` tendencies would be silently dropped by the
@@ -237,68 +233,56 @@ class CloudBorneExchange(PhysicsTerm):
         phi_slow = -jnp.expm1(
             -dt / jnp.maximum(params.resuspension_timescale, 1.0)
         )
-        if self._evaporation_ledger:
-            # Resuspension keyed to the microphysics' own evaporation
-            # ledger (#708). The per-step fraction of the droplet
-            # population that evaporated is E/(E + pool): E is the
-            # grid-mean condensate returned to vapour this step
-            # (zxlevap+zxievap) and pool the grid-mean in-cloud condensate
-            # that survived to the precipitation-formation stage — that
-            # fraction of the cloud-borne reservoir is released. The
-            # rainout claim of the SAME step (the formation-ledger
-            # fraction wetdep removes, running after this term) caps it,
-            # so the two sinks cannot jointly overdraw the reservoir:
-            # evaporated + rained fractions of one droplet population sum
-            # to at most 1. WBF and freezing move condensate between
-            # phases WITHIN the pool, so they neither evaporate nor rain
-            # out cloud-borne aerosol here — the aerosol rides into the
-            # ice and meets the snow pathway (#686) in the ledger instead.
-            e_gm = jnp.maximum(clouds.condensate_evaporation_rate, 0.0) * dt
-            cf_proc = jnp.clip(clouds.process_cloud_fraction, 0.0, 1.0)
-            pool_gm = cf_proc * (
-                jnp.maximum(clouds.incloud_liquid, 0.0)
-                + jnp.maximum(clouds.incloud_ice, 0.0)
-            )
-            formed_gm = cf_proc * dt * jnp.maximum(
-                clouds.incloud_rain_formation + clouds.incloud_riming
-                + clouds.incloud_snow_formation, 0.0,
-            )
-            f_wat, f_ice, pice = incloud_scavenged_fractions(clouds, dt)
-            f_form = (1.0 - pice) * f_wat + pice * f_ice
-            live = (e_gm + pool_gm + formed_gm) > _PROCESS_FLOOR
-            f_evap = jnp.where(
-                live,
-                e_gm / jnp.maximum(e_gm + pool_gm, _PROCESS_FLOOR),
-                0.0,
-            )
-            # The ledger keying applies ONLY where the sky has cleared
-            # (cf < _MIN_CLOUD_FRACTION, i.e. target = 0) — the branch the
-            # #708 race lived in: a rained-out cell is ``live`` through
-            # its formation ledger with f_evap ≈ 0 (no resuspension racing
-            # the rainout), an evaporated cell releases everything in one
-            # step, and a no-process cell (advected-in q_cb in clear air)
-            # keeps the slow CAM-style timescale drain.
-            #
-            # Where cloud PERSISTS, the downward direction is the
-            # equilibrium relaxation toward the (nonzero) target and MUST
-            # keep its timescale: keying it to the evaporation ledger
-            # zeroes it in any non-evaporating cloudy cell, which turns
-            # the reservoir into a ratchet — q_cb can rise toward the
-            # activation target but never fall. A 60-day T63 run with that
-            # form loaded the cloud-borne accumulation mode ~1e4x at cloud
-            # levels and blew every activatable species up exponentially
-            # from day ~32 (dust x390 in 30 days); restoring the under-
-            # cloud relaxation is what bounds the reservoir by the
-            # activation equilibrium.
-            cleared = cf <= _MIN_CLOUD_FRACTION
-            phi_ledger = jnp.where(
-                live,
-                jnp.minimum(f_evap, jnp.maximum(1.0 - f_form, 0.0)),
-                phi_slow,
-            )
-            phi_down = jnp.where(cleared, phi_ledger, phi_slow)
-        else:
-            phi_down = phi_slow
+        # Resuspension keyed to the microphysics' own evaporation ledger
+        # (#708). The per-step fraction of the droplet population that
+        # evaporated is E/(E + pool): E is the grid-mean condensate
+        # returned to vapour this step (zxlevap+zxievap) and pool the
+        # grid-mean in-cloud condensate that survived to the
+        # precipitation-formation stage — that fraction of the cloud-borne
+        # reservoir is released. The rainout claim of the SAME step (the
+        # formation-ledger fraction wetdep removes, running after this
+        # term) caps it, so the two sinks cannot jointly overdraw the
+        # reservoir: evaporated + rained fractions of one droplet
+        # population sum to at most 1. WBF and freezing move condensate
+        # between phases WITHIN the pool, so they neither evaporate nor
+        # rain out cloud-borne aerosol here — the aerosol rides into the
+        # ice and meets the snow pathway (#686) in the ledger instead.
+        e_gm = jnp.maximum(clouds.condensate_evaporation_rate, 0.0) * dt
+        cf_proc = jnp.clip(clouds.process_cloud_fraction, 0.0, 1.0)
+        pool_gm = cf_proc * (
+            jnp.maximum(clouds.incloud_liquid, 0.0)
+            + jnp.maximum(clouds.incloud_ice, 0.0)
+        )
+        formed_gm = cf_proc * dt * jnp.maximum(
+            clouds.incloud_rain_formation + clouds.incloud_riming
+            + clouds.incloud_snow_formation, 0.0,
+        )
+        f_wat, f_ice, pice = incloud_scavenged_fractions(clouds, dt)
+        f_form = (1.0 - pice) * f_wat + pice * f_ice
+        live = (e_gm + pool_gm + formed_gm) > _PROCESS_FLOOR
+        f_evap = jnp.where(
+            live,
+            e_gm / jnp.maximum(e_gm + pool_gm, _PROCESS_FLOOR),
+            0.0,
+        )
+        # The ledger keying applies ONLY where the sky has cleared
+        # (cf < _MIN_CLOUD_FRACTION, i.e. target = 0): a rained-out cell
+        # is ``live`` through its formation ledger with f_evap ≈ 0 (no
+        # resuspension racing the rainout), an evaporated cell releases
+        # everything in one step, and a no-process cell (advected-in q_cb
+        # in clear air) keeps the slow CAM-style timescale drain.
+        #
+        # Where cloud PERSISTS, the downward direction is the equilibrium
+        # relaxation toward the (nonzero) target and MUST keep its
+        # timescale: keying it to the evaporation ledger zeroes it in any
+        # non-evaporating cloudy cell, which turns the reservoir into a
+        # ratchet — q_cb can rise toward the activation target but never
+        # fall, loading the cloud-borne phase without bound at cloud
+        # levels. The under-cloud relaxation is what bounds the reservoir
+        # by the activation equilibrium.
+        cleared = cf <= _MIN_CLOUD_FRACTION
+        release = jnp.minimum(f_evap, jnp.maximum(1.0 - f_form, 0.0))
+        phi_down = jnp.where(cleared & live, release, phi_slow)
         # phi ∈ [0, 1]: the move never overshoots the target, so neither
         # phase can go negative (|Δ| ≤ |target − q_cb| ≤ donor).
         phi = jnp.where(target > q_cb_arr, phi_up, phi_down)

--- a/jcm/physics/aerosol/jam/cloud_borne.py
+++ b/jcm/physics/aerosol/jam/cloud_borne.py
@@ -271,17 +271,32 @@ class CloudBorneExchange(PhysicsTerm):
                 e_gm / jnp.maximum(e_gm + pool_gm, _PROCESS_FLOOR),
                 0.0,
             )
-            # Cells with NO cloud process this step (advected-in q_cb in
-            # clear air: nothing evaporated, nothing formed) keep the slow
-            # CAM-style timescale drain; everywhere else the ledger says
-            # exactly which share to release. A fully-rained-out cell is
-            # ``live`` through its formation ledger with f_evap ≈ 0 — no
-            # resuspension racing the rainout.
-            phi_down = jnp.where(
+            # The ledger keying applies ONLY where the sky has cleared
+            # (cf < _MIN_CLOUD_FRACTION, i.e. target = 0) — the branch the
+            # #708 race lived in: a rained-out cell is ``live`` through
+            # its formation ledger with f_evap ≈ 0 (no resuspension racing
+            # the rainout), an evaporated cell releases everything in one
+            # step, and a no-process cell (advected-in q_cb in clear air)
+            # keeps the slow CAM-style timescale drain.
+            #
+            # Where cloud PERSISTS, the downward direction is the
+            # equilibrium relaxation toward the (nonzero) target and MUST
+            # keep its timescale: keying it to the evaporation ledger
+            # zeroes it in any non-evaporating cloudy cell, which turns
+            # the reservoir into a ratchet — q_cb can rise toward the
+            # activation target but never fall. A 60-day T63 run with that
+            # form loaded the cloud-borne accumulation mode ~1e4x at cloud
+            # levels and blew every activatable species up exponentially
+            # from day ~32 (dust x390 in 30 days); restoring the under-
+            # cloud relaxation is what bounds the reservoir by the
+            # activation equilibrium.
+            cleared = cf <= _MIN_CLOUD_FRACTION
+            phi_ledger = jnp.where(
                 live,
                 jnp.minimum(f_evap, jnp.maximum(1.0 - f_form, 0.0)),
                 phi_slow,
             )
+            phi_down = jnp.where(cleared, phi_ledger, phi_slow)
         else:
             phi_down = phi_slow
         # phi ∈ [0, 1]: the move never overshoots the target, so neither

--- a/jcm/physics/aerosol/jam/cloud_borne_store_test.py
+++ b/jcm/physics/aerosol/jam/cloud_borne_store_test.py
@@ -203,7 +203,17 @@ class CarryModeExchangeTest(unittest.TestCase):
         )
 
         class _Clouds:
+            # Cover plus all-zero #708 ledger fields: "no cloud process
+            # this step" routes resuspension to the timescale drain these
+            # tests were written against.
             cloud_fraction = jnp.full(shape, cf)
+            incloud_liquid = jnp.zeros(shape)
+            incloud_ice = jnp.zeros(shape)
+            incloud_rain_formation = jnp.zeros(shape)
+            incloud_snow_formation = jnp.zeros(shape)
+            incloud_riming = jnp.zeros(shape)
+            process_cloud_fraction = jnp.zeros(shape)
+            condensate_evaporation_rate = jnp.zeros(shape)
 
         diagnostics = {
             CARRY_KEY: {

--- a/jcm/physics/aerosol/jam/cloud_borne_test.py
+++ b/jcm/physics/aerosol/jam/cloud_borne_test.py
@@ -357,6 +357,38 @@ class CloudBorneExchangeTest(unittest.TestCase):
             np.asarray(diagnostics[CARRY_KEY][nm]), rtol=1e-7,
         )
 
+    def test_persistent_cloud_still_relaxes_excess_down(self):
+        # THE anti-ratchet gate: under PERSISTENT cloud (target > 0) the
+        # downward direction is the equilibrium relaxation and must keep
+        # its timescale even when nothing evaporated this step. Keying it
+        # to the evaporation ledger zeroed it in every non-evaporating
+        # cloudy cell, making the reservoir a ratchet (rise toward the
+        # activation target, never fall) — measured blowing up every
+        # activatable species exponentially in a 60-day T63 run.
+        state, diagnostics = self._setup(
+            cloud_fraction=0.5, q_cb=1.0e-9, n_cb=1.0e8,
+            q_int=1.0e-12, n_int=1.0e3,   # target << q_cb
+        )
+        shape = state.temperature.shape
+        clouds = diagnostics["clouds"]
+        # Persistent, non-evaporating, non-precipitating cloud.
+        clouds.incloud_liquid = jnp.full(shape, 1.0e-3)
+        clouds.process_cloud_fraction = jnp.full(shape, 0.5)
+        _, out = CloudBorneExchange()(state, diagnostics, None, None)
+        nm = mass_name("so4", "acc", cloud_borne=True)
+        q0 = np.asarray(diagnostics[CARRY_KEY][nm])
+        q1 = np.asarray(out[CARRY_KEY][nm])
+        # Excess above target must relax by the 900 s fraction
+        # (phi = 1 - exp(-1800/900) ~ 0.86) toward the activation target
+        # (0.9 x q_tot here), not stay ratcheted (phi_down = 0).
+        q_int0 = 1.0e-12
+        target = 0.9 * (q_int0 + q0)
+        phi = -np.expm1(-1800.0 / 900.0)
+        expected = q0 + (target - q0) * phi
+        np.testing.assert_allclose(q1, expected, rtol=1e-3)
+        self.assertTrue((q1 < 0.999 * q0).all(),
+                        f"reservoir ratcheted: {q1.max()} vs {q0.max()}")
+
     def test_phase_transfer_is_not_evaporation(self):
         # WBF / freezing move condensate between phases WITHIN the pool
         # (liquid pool empty, ice pool full, no evaporation ledger): the

--- a/jcm/physics/aerosol/jam/cloud_borne_test.py
+++ b/jcm/physics/aerosol/jam/cloud_borne_test.py
@@ -40,8 +40,8 @@ class _Clouds:
     """CloudData stub: cover plus the #708 scavenging-ledger fields.
 
     All-zero ledger fields mean "no cloud process this step", which routes
-    the exchange term's downward direction to the slow timescale drain —
-    the pre-#708 behaviour the legacy tests were written against.
+    the exchange term's downward direction to the slow timescale drain,
+    so tests of the timescale relaxation can leave them defaulted.
     """
 
     def __init__(self, cloud_fraction, **ledger):

--- a/jcm/physics/aerosol/jam/cloud_borne_test.py
+++ b/jcm/physics/aerosol/jam/cloud_borne_test.py
@@ -37,8 +37,20 @@ class TracerLayoutSwitchTest(unittest.TestCase):
 
 
 class _Clouds:
-    def __init__(self, cloud_fraction):
+    """CloudData stub: cover plus the #708 scavenging-ledger fields.
+
+    All-zero ledger fields mean "no cloud process this step", which routes
+    the exchange term's downward direction to the slow timescale drain —
+    the pre-#708 behaviour the legacy tests were written against.
+    """
+
+    def __init__(self, cloud_fraction, **ledger):
         self.cloud_fraction = cloud_fraction
+        zeros = jnp.zeros_like(cloud_fraction)
+        for f in ("incloud_liquid", "incloud_ice", "incloud_rain_formation",
+                  "incloud_snow_formation", "incloud_riming",
+                  "process_cloud_fraction", "condensate_evaporation_rate"):
+            setattr(self, f, ledger.get(f, zeros))
 
 
 class CloudBorneExchangeTest(unittest.TestCase):
@@ -276,6 +288,90 @@ class CloudBorneExchangeTest(unittest.TestCase):
         self.assertNotEqual(float(g), 0.0)
 
 
+    # ----- The evaporation-ledger keying (#708) ------------------------
+
+    def _ledger_setup(self, *, e_gm=0.0, pool_ic=0.0, form_ic=0.0,
+                      cf_proc=0.5, q_cb=1.0e-10, n_cb=1.0e7):
+        """Clear post-microphysics sky (cf=0) with a chosen process ledger."""
+        state, diagnostics = self._setup(
+            cloud_fraction=0.0, q_cb=q_cb, n_cb=n_cb,
+        )
+        shape = state.temperature.shape
+        dt = 1800.0
+        clouds = diagnostics["clouds"]
+        clouds.condensate_evaporation_rate = jnp.full(shape, e_gm / dt)
+        clouds.incloud_liquid = jnp.full(shape, pool_ic)
+        clouds.incloud_rain_formation = jnp.full(shape, form_ic / dt)
+        clouds.process_cloud_fraction = jnp.full(shape, cf_proc)
+        return state, diagnostics
+
+    def test_rained_out_cell_does_not_resuspend(self):
+        # A cell whose condensate fully converted to precipitation ends
+        # with cover 0 AND a zeroed pool — indistinguishable from an
+        # evaporated cell by cover alone. The formation ledger marks it
+        # live with f_evap = 0: the exchange term must leave q_cb for the
+        # wetdep term (running just after) to rain out, instead of
+        # resuspending ~86% of it into the interstitial phase in the same
+        # step (the #708 race).
+        state, diagnostics = self._ledger_setup(form_ic=1.0e-4)
+        _, out = CloudBorneExchange()(state, diagnostics, None, None)
+        nm = mass_name("so4", "acc", cloud_borne=True)
+        np.testing.assert_allclose(
+            np.asarray(out[CARRY_KEY][nm]),
+            np.asarray(diagnostics[CARRY_KEY][nm]), rtol=1e-7,
+        )
+
+    def test_evaporated_cell_resuspends_fully(self):
+        # A cell cleared by evaporation (positive evaporation ledger,
+        # nothing formed, pool gone) releases the WHOLE reservoir in one
+        # step — CAM's instant resuspension, not a 900 s relaxation.
+        state, diagnostics = self._ledger_setup(e_gm=5.0e-4)
+        _, out = CloudBorneExchange()(state, diagnostics, None, None)
+        nm = mass_name("so4", "acc", cloud_borne=True)
+        q1 = np.asarray(out[CARRY_KEY][nm])
+        self.assertLess(q1.max(), 1e-6 * 1.0e-10)
+
+    def test_partial_evaporation_releases_that_share(self):
+        # E = pool: half the droplet population evaporated, half persists
+        # -> release half the reservoir (target 0 under cf=0).
+        state, diagnostics = self._ledger_setup(
+            e_gm=1.0e-4, pool_ic=2.0e-4, cf_proc=0.5,
+        )
+        _, out = CloudBorneExchange()(state, diagnostics, None, None)
+        nm = mass_name("so4", "acc", cloud_borne=True)
+        q1 = np.asarray(out[CARRY_KEY][nm])
+        np.testing.assert_allclose(q1, 0.5e-10, rtol=1e-5)
+
+    def test_rainout_claim_caps_resuspension(self):
+        # Evaporation and rainout both claimed condensate this step; the
+        # rainout fraction (which wetdep will remove right after) caps the
+        # released share so the two sinks cannot jointly overdraw:
+        # f_evap = 0.5 but f_form = 1 -> nothing resuspends.
+        state, diagnostics = self._ledger_setup(
+            e_gm=1.0e-4, pool_ic=2.0e-4, form_ic=4.0e-4, cf_proc=0.5,
+        )
+        _, out = CloudBorneExchange()(state, diagnostics, None, None)
+        nm = mass_name("so4", "acc", cloud_borne=True)
+        np.testing.assert_allclose(
+            np.asarray(out[CARRY_KEY][nm]),
+            np.asarray(diagnostics[CARRY_KEY][nm]), rtol=1e-7,
+        )
+
+    def test_phase_transfer_is_not_evaporation(self):
+        # WBF / freezing move condensate between phases WITHIN the pool
+        # (liquid pool empty, ice pool full, no evaporation ledger): the
+        # aerosol rides into the ice — no resuspension, even at cover 0.
+        state, diagnostics = self._ledger_setup()
+        shape = state.temperature.shape
+        diagnostics["clouds"].incloud_ice = jnp.full(shape, 2.0e-4)
+        _, out = CloudBorneExchange()(state, diagnostics, None, None)
+        nm = mass_name("so4", "acc", cloud_borne=True)
+        np.testing.assert_allclose(
+            np.asarray(out[CARRY_KEY][nm]),
+            np.asarray(diagnostics[CARRY_KEY][nm]), rtol=1e-7,
+        )
+
+
 class FactorySwitchTest(unittest.TestCase):
     def test_default_composes_exchange_and_store(self):
         from jcm.physics.aerosol.jam import jam_aerosol_physics
@@ -322,7 +418,6 @@ class FactorySwitchTest(unittest.TestCase):
         self.assertIn(
             "jam_cloud_borne_store", [t.name for t in terms],
         )
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/jcm/physics/aerosol/jam/jam_terms.py
+++ b/jcm/physics/aerosol/jam/jam_terms.py
@@ -162,7 +162,6 @@ def jam_aerosol_physics(
     tracer_diffusion: TracerDiffusionParameters | None = None,
     convective_transport: bool = True,
     conv_transport: ConvTransportParameters | None = None,
-    scavenging_ledger: bool = True,
 ) -> list[PhysicsTerm]:
     """Build the ordered JAM harness term list.
 
@@ -217,14 +216,12 @@ def jam_aerosol_physics(
             is entangled with convective scavenging and neither reference
             model transports a stratiform cloud-borne phase convectively.
             On by default.
-        scavenging_ledger: key stratiform in-cloud wet removal and
-            cloud-borne resuspension to the cloud scheme's process-time
-            scavenging ledger (#708 — the ECHAM-HAM ``cloud_subm``
-            interface). Requires a cloud scheme that publishes the
-            ``CloudData`` ledger fields (the 2M scheme); set False for the
-            1M scheme, which does not yet (#712), so both terms fall back to the
-            legacy cover-keyed reconstruction. Static by design — the
-            fallback must never be a silent per-cell branch.
+
+    Stratiform in-cloud wet removal and cloud-borne resuspension key to
+    the cloud scheme's process-time scavenging ledger (#708 — the
+    ECHAM-HAM ``cloud_subm`` interface), so the harness requires a cloud
+    scheme that publishes the ``CloudData`` ledger fields (the 2M
+    scheme); ``echam_physics`` enforces this at compose time.
 
     Returns:
         The ordered term list: natural emissions, prescribed oxidants and
@@ -334,7 +331,7 @@ def jam_aerosol_physics(
     post_core = [
         ArgActivation(params=activation, spec=spec, variant=arg_variant),
         # Heterogeneous ice nucleation on dust/BC → ``ice_nuclei`` for the 2M
-        # cloud scheme (#494). Harmless with the 1M scheme (diagnostic unused).
+        # cloud scheme (#494).
         IceNucleation(
             params=ice_nucleation_params, spec=spec, scheme=ice_scheme,
         ),
@@ -345,15 +342,13 @@ def jam_aerosol_physics(
         # post-cloud block, before the aqueous chemistry that splits its
         # product by cloud-borne number and the scavenging that drains the
         # reservoir. Only composed when the population prognoses the phase.
-        *([CloudBorneExchange(params=cloud_borne_exchange, spec=spec,
-                              evaporation_ledger=scavenging_ledger)]
+        *([CloudBorneExchange(params=cloud_borne_exchange, spec=spec)]
           if spec.cloud_borne else []),
         # In-cloud aqueous SO2 oxidation → cloud-borne sulfate; runs in the
         # post-cloud block (needs current clouds), just before wet scavenging.
         AqueousSulfur(params=aqueous, spec=spec, scheme=aqueous_scheme),
         WetScavenging(params=wetdep, spec=spec,
-                      in_plume_convective=convective_transport,
-                      formation_ledger=scavenging_ledger),
+                      in_plume_convective=convective_transport),
     ]
     terms = [*pre_core, core, *optics_terms, *post_core]
     return terms

--- a/jcm/physics/aerosol/jam/jam_terms.py
+++ b/jcm/physics/aerosol/jam/jam_terms.py
@@ -222,7 +222,7 @@ def jam_aerosol_physics(
             scavenging ledger (#708 — the ECHAM-HAM ``cloud_subm``
             interface). Requires a cloud scheme that publishes the
             ``CloudData`` ledger fields (the 2M scheme); set False for the
-            1M scheme, which does not yet, so both terms fall back to the
+            1M scheme, which does not yet (#712), so both terms fall back to the
             legacy cover-keyed reconstruction. Static by design — the
             fallback must never be a silent per-cell branch.
 

--- a/jcm/physics/aerosol/jam/jam_terms.py
+++ b/jcm/physics/aerosol/jam/jam_terms.py
@@ -162,6 +162,7 @@ def jam_aerosol_physics(
     tracer_diffusion: TracerDiffusionParameters | None = None,
     convective_transport: bool = True,
     conv_transport: ConvTransportParameters | None = None,
+    scavenging_ledger: bool = True,
 ) -> list[PhysicsTerm]:
     """Build the ordered JAM harness term list.
 
@@ -216,6 +217,14 @@ def jam_aerosol_physics(
             is entangled with convective scavenging and neither reference
             model transports a stratiform cloud-borne phase convectively.
             On by default.
+        scavenging_ledger: key stratiform in-cloud wet removal and
+            cloud-borne resuspension to the cloud scheme's process-time
+            scavenging ledger (#708 — the ECHAM-HAM ``cloud_subm``
+            interface). Requires a cloud scheme that publishes the
+            ``CloudData`` ledger fields (the 2M scheme); set False for the
+            1M scheme, which does not yet, so both terms fall back to the
+            legacy cover-keyed reconstruction. Static by design — the
+            fallback must never be a silent per-cell branch.
 
     Returns:
         The ordered term list: natural emissions, prescribed oxidants and
@@ -336,13 +345,15 @@ def jam_aerosol_physics(
         # post-cloud block, before the aqueous chemistry that splits its
         # product by cloud-borne number and the scavenging that drains the
         # reservoir. Only composed when the population prognoses the phase.
-        *([CloudBorneExchange(params=cloud_borne_exchange, spec=spec)]
+        *([CloudBorneExchange(params=cloud_borne_exchange, spec=spec,
+                              evaporation_ledger=scavenging_ledger)]
           if spec.cloud_borne else []),
         # In-cloud aqueous SO2 oxidation → cloud-borne sulfate; runs in the
         # post-cloud block (needs current clouds), just before wet scavenging.
         AqueousSulfur(params=aqueous, spec=spec, scheme=aqueous_scheme),
         WetScavenging(params=wetdep, spec=spec,
-                      in_plume_convective=convective_transport),
+                      in_plume_convective=convective_transport,
+                      formation_ledger=scavenging_ledger),
     ]
     terms = [*pre_core, core, *optics_terms, *post_core]
     return terms

--- a/jcm/physics/aerosol/jam/jam_terms_test.py
+++ b/jcm/physics/aerosol/jam/jam_terms_test.py
@@ -102,11 +102,14 @@ class EchamPhysicsWiringTest(unittest.TestCase):
             cats.index("aerosol_activation"), cats.index("clouds")
         )
 
-    def test_jam_module_builds_with_1m(self):
+    def test_jam_module_rejects_1m(self):
+        # JAM's scavenging/resuspension terms read the process-time ledger
+        # only the 2M scheme publishes; the combination must fail loudly
+        # at compose time rather than silently scavenge nothing.
         from jcm.physics.echam.echam_terms import echam_physics
 
-        phys = echam_physics(aerosol_module="jam", cloud_scheme="1m")
-        self.assertIn("aerosol_microphysics", [t.category for t in phys.terms])
+        with self.assertRaisesRegex(ValueError, "cloud_scheme='2m'"):
+            echam_physics(aerosol_module="jam", cloud_scheme="1m")
 
     def test_default_is_macv2sp_only(self):
         from jcm.physics.echam.echam_terms import echam_physics

--- a/jcm/physics/aerosol/jam/wetdep/__init__.py
+++ b/jcm/physics/aerosol/jam/wetdep/__init__.py
@@ -4,7 +4,6 @@ from jcm.physics.aerosol.jam.wetdep.wetdep_term import (
     WetScavenging,
     WetDepParameters,
     below_cloud_rate,
-    in_cloud_rate,
     reinjection_budget,
 )
 
@@ -12,6 +11,5 @@ __all__ = [
     "WetScavenging",
     "WetDepParameters",
     "reinjection_budget",
-    "in_cloud_rate",
     "below_cloud_rate",
 ]

--- a/jcm/physics/aerosol/jam/wetdep/wetdep_term.py
+++ b/jcm/physics/aerosol/jam/wetdep/wetdep_term.py
@@ -16,11 +16,7 @@ treatment):
   removed at the fraction cloud condensate converted to precipitation this
   step, read from the cloud scheme's process-time scavenging ledger
   (``incloud_scavenged_fractions`` — HAMMOZ's ``peffwat``/``peffice``, #708),
-  which stays alive in cells the microphysics emptied. The legacy
-  reconstruction ``precip_formation_rate / (qc + qi)`` (grid-mean, cover
-  cancelling in the ratio) remains for cloud schemes that publish no
-  ledger (``formation_ledger=False``, wired by the factory for the 1M
-  scheme).
+  which stays alive in cells the microphysics emptied.
 * **Below-cloud impaction scavenging** — precipitation falling through a
   layer collects aerosol in its clear-air part, with a size-dependent
   (∝ r²) collection efficiency. The stratiform contribution uses the
@@ -110,13 +106,6 @@ class WetDepParameters:
         )
 
 
-#: Physical condensate floor for the in-cloud rate [kg/kg]. A cell with less
-#: than this holds no cloud worth scavenging in; it is also what keeps the
-#: division's VJP clear of the float32 squared-underflow window (a 1e-30
-#: epsilon guard here gave a verified NaN gradient in every clear f32 cell:
-#: the cotangent forms p_form/condensate², and 1e-60 flushes to zero).
-_CONDENSATE_FLOOR = 1.0e-12
-
 #: HAMMOZ ``prep_wetdep_hydro``'s pool floor (``zmin = 1e-10``): below it a
 #: ledger pool counts as absent and the scavenged fraction comes from the
 #: formation-ledger marker instead of the division.
@@ -126,23 +115,6 @@ _LEDGER_POOL_MIN = 1.0e-10
 #: while the batched ``1 - exp(-rate*dt)`` still removes >0.999999 of the
 #: tracer in fully-converting cells.
 _FRACTION_CAP = 1.0 - 1.0e-6
-
-
-def in_cloud_rate(
-    activated_fraction: jnp.ndarray,
-    p_form: jnp.ndarray,
-    qc: jnp.ndarray,
-) -> jnp.ndarray:
-    """Legacy in-cloud scavenging rate [1/s] applied to in-droplet aerosol.
-
-    The condensate-ratio reconstruction (grid-mean formation over
-    grid-mean END-OF-STEP condensate). Kept only for cloud schemes that
-    do not publish the process-time scavenging ledger (the 1M scheme —
-    see the factory wiring); with a ledger the bounded
-    :func:`incloud_scavenged_fractions` replaces it (#708).
-    """
-    rate = activated_fraction * p_form / jnp.maximum(qc, _CONDENSATE_FLOOR)
-    return jnp.where(qc > _CONDENSATE_FLOOR, rate, 0.0)
 
 
 def incloud_scavenged_fractions(
@@ -252,7 +224,8 @@ def conv_in_cloud_rate(
 ) -> jnp.ndarray:
     """Convective in-cloud (nucleation) scavenging rate [1/s].
 
-    The convective mirror of ``in_cloud_rate``: scavenging ratio × (local
+    The convective mirror of the stratiform in-cloud pathway: scavenging
+    ratio × (local
     condensate→precip conversion rate / in-updraft condensate), with the
     per-layer formation flux converted to a mixing-ratio rate by ρ·Δz.
     Zero wherever the updraft carries no condensate.
@@ -324,7 +297,6 @@ class WetScavenging(PhysicsTerm):
         *,
         spec: ModalAerosolSpec | None = None,
         in_plume_convective: bool = False,
-        formation_ledger: bool = True,
     ):
         """Hold params and the population.
 
@@ -336,19 +308,14 @@ class WetScavenging(PhysicsTerm):
         (impaction) pathway — and folds the transport term's published
         surface fluxes into the AeroCom ``wet_*`` ledger.
 
-        ``formation_ledger`` (#708): key the stratiform in-cloud pathways
-        to the cloud scheme's process-time scavenging ledger
+        The stratiform in-cloud pathways read the cloud scheme's
+        process-time scavenging ledger from ``CloudData``
         (``incloud_scavenged_fractions`` — the HAMMOZ ``cloud_subm``
-        interface, bounded by construction and alive in cells the
-        microphysics emptied) instead of the legacy cover x
-        p_form/condensate reconstruction. Static because it must match
-        what the composed cloud scheme publishes: the 2M scheme writes
-        the ledger, the 1M scheme does not yet (#712 tracks the mo_cloud
-        port) — the factory wires this to ``cloud_scheme``.
+        interface), so this term requires a cloud scheme that publishes
+        it; the physics factory enforces that at compose time.
         """
         self.params = nnx.Param(params or WetDepParameters.default())
         self._in_plume_convective = in_plume_convective
-        self._formation_ledger = formation_ledger
         self._spec = spec or MAM4_SPEC
         if carry_mode(self._spec):
             # In carry mode the store term must run upstream each step
@@ -369,10 +336,6 @@ class WetScavenging(PhysicsTerm):
 
         clouds = diagnostics["clouds"]
         cloud_fraction = clouds.cloud_fraction
-        # Total cloud condensate: the formation ledger spans both the rain
-        # (from qc) and snow (from qc and qi) pathways, so the in-droplet
-        # residence pool is liquid + ice.
-        condensate = jnp.maximum(clouds.qc, 0.0) + jnp.maximum(clouds.qi, 0.0)
         # Per-level stratiform process rates from the cloud scheme (#499):
         # the true local condensate→precip conversion and the falling-precip
         # evaporation. The carrier flux for impaction and the re-evap ledger
@@ -440,37 +403,26 @@ class WetScavenging(PhysicsTerm):
                 # No pressure diagnostic: column-wide washout, not none.
                 conv_below = jnp.ones_like(state.temperature)
 
-        # Stratiform in-cloud (nucleation) scavenging rates. With the
-        # process-time ledger (#708) the per-step scavenged fraction of an
+        # Stratiform in-cloud (nucleation) scavenging rates from the
+        # process-time ledger (#708): the per-step scavenged fraction of an
         # in-droplet tracer is HAMMOZ's peffwat/peffice split by the phase
         # mass fraction — bounded by construction, and alive in cells the
-        # microphysics emptied (post-write-back cover 0), where the legacy
-        # reconstruction below reads cover 0 x end-of-step condensate 0
-        # and silently skips the largest-removal step. The in-droplet
+        # microphysics emptied (post-write-back cover 0). The in-droplet
         # SHARE of interstitial aerosol is keyed to the cover the
         # processes actually ran under (process_cloud_fraction), not the
-        # post-write-back cover, for the same reason. ``in_cloud_rate`` is
+        # post-write-back cover, for the same reason. The removal is
         # linear in the activated fraction, so keep the unit-fraction base
         # and apply per-mode, per-quantity fractions below: ARG's number
         # and mass fractions differ a lot (large particles activate
         # preferentially) and vary by mode. The aggregate fraction is kept
         # only as a fallback for standalone composition without ARG
         # upstream.
-        if self._formation_ledger:
-            f_wat, f_ice, pice = incloud_scavenged_fractions(clouds, dt)
-            f_comb = (1.0 - pice) * f_wat + pice * f_ice
-            rate_ledger = fraction_to_rate(f_comb, dt)
-            cf_proc = jnp.clip(clouds.process_cloud_fraction, 0.0, 1.0)
-            rate_ic_unit = params.incloud_scale * cf_proc * rate_ledger
-            rate_cb = params.incloud_scale * rate_ledger
-        else:
-            cf_clip = jnp.clip(cloud_fraction, 0.0, 1.0)
-            rate_ic_unit = params.incloud_scale * cf_clip * in_cloud_rate(
-                jnp.ones_like(state.temperature), p_form, condensate,
-            )
-            rate_cb = params.incloud_scale * in_cloud_rate(
-                jnp.ones_like(state.temperature), p_form, condensate,
-            )
+        f_wat, f_ice, pice = incloud_scavenged_fractions(clouds, dt)
+        f_comb = (1.0 - pice) * f_wat + pice * f_ice
+        rate_ledger = fraction_to_rate(f_comb, dt)
+        cf_proc = jnp.clip(clouds.process_cloud_fraction, 0.0, 1.0)
+        rate_ic_unit = params.incloud_scale * cf_proc * rate_ledger
+        rate_cb = params.incloud_scale * rate_ledger
         jam_act = diagnostics.get("_jam_activation")
 
         # Build per-tracer scavenging rates and stack with the matching

--- a/jcm/physics/aerosol/jam/wetdep/wetdep_term.py
+++ b/jcm/physics/aerosol/jam/wetdep/wetdep_term.py
@@ -13,9 +13,14 @@ weighted by its per-mode activated fractions (the implicit M7/TOMAS-style
 treatment):
 
 * **In-cloud nucleation scavenging** — aerosol residing in cloud droplets is
-  removed at the local rate cloud condensate converts to precipitation,
-  ``precip_formation_rate / (qc + qi)`` (both grid-mean, so the cloudy-area
-  factor cancels inside the ratio).
+  removed at the fraction cloud condensate converted to precipitation this
+  step, read from the cloud scheme's process-time scavenging ledger
+  (``incloud_scavenged_fractions`` — HAMMOZ's ``peffwat``/``peffice``, #708),
+  which stays alive in cells the microphysics emptied. The legacy
+  reconstruction ``precip_formation_rate / (qc + qi)`` (grid-mean, cover
+  cancelling in the ratio) remains for cloud schemes that publish no
+  ledger (``formation_ledger=False``, wired by the factory for the 1M
+  scheme).
 * **Below-cloud impaction scavenging** — precipitation falling through a
   layer collects aerosol in its clear-air part, with a size-dependent
   (∝ r²) collection efficiency. The stratiform contribution uses the
@@ -112,15 +117,106 @@ class WetDepParameters:
 #: the cotangent forms p_form/condensate², and 1e-60 flushes to zero).
 _CONDENSATE_FLOOR = 1.0e-12
 
+#: HAMMOZ ``prep_wetdep_hydro``'s pool floor (``zmin = 1e-10``): below it a
+#: ledger pool counts as absent and the scavenged fraction comes from the
+#: formation-ledger marker instead of the division.
+_LEDGER_POOL_MIN = 1.0e-10
+#: Cap on a per-step scavenged fraction before converting it to an
+#: equivalent decay rate via -log1p(-f)/dt: keeps the rate finite (~14/dt)
+#: while the batched ``1 - exp(-rate*dt)`` still removes >0.999999 of the
+#: tracer in fully-converting cells.
+_FRACTION_CAP = 1.0 - 1.0e-6
+
 
 def in_cloud_rate(
     activated_fraction: jnp.ndarray,
     p_form: jnp.ndarray,
     qc: jnp.ndarray,
 ) -> jnp.ndarray:
-    """In-cloud scavenging rate [1/s] applied to in-droplet aerosol."""
+    """Legacy in-cloud scavenging rate [1/s] applied to in-droplet aerosol.
+
+    The condensate-ratio reconstruction (grid-mean formation over
+    grid-mean END-OF-STEP condensate). Kept only for cloud schemes that
+    do not publish the process-time scavenging ledger (the 1M scheme —
+    see the factory wiring); with a ledger the bounded
+    :func:`incloud_scavenged_fractions` replaces it (#708).
+    """
     rate = activated_fraction * p_form / jnp.maximum(qc, _CONDENSATE_FLOOR)
     return jnp.where(qc > _CONDENSATE_FLOOR, rate, 0.0)
+
+
+def incloud_scavenged_fractions(
+    clouds, dt: jnp.ndarray,
+) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    """Per-step in-cloud scavenged fractions from the process-time ledger.
+
+    The port of HAMMOZ ``prep_wetdep_hydro`` (mo_hammoz_wetdep.f90:405-440):
+
+    * ``f_wat = clip((zmratepr + zmsnowacl)·dt / zmlwc, 0, 1)`` — the
+      fraction of the in-cloud liquid pool converted to precipitation
+      this step (rain formation plus droplets rimed onto falling snow),
+    * ``f_ice = clip(zmrateps·dt / zmiwc, 0, 1)`` — same for ice into
+      snow (including the sedimenting-ice carrier ECHAM-HAM seeds it
+      with),
+    * ``pice`` — the ice mass fraction of the in-cloud pool, splitting a
+      phase-agnostic tracer between the two fractions.
+
+    Both numerator and denominator are captured at process time (the
+    denominator BEFORE formation depletes it), so each fraction is
+    bounded by construction — no unbounded rate ratio, no reliance on a
+    floor to be "accidentally correct" in near-empty cells.
+
+    One documented deviation from HAMMOZ (#708): where the pool is below
+    HAMMOZ's ``zmin`` but the formation ledger is positive, HAMMOZ maps
+    the fraction to 0 — missing the removal in exactly the cells the
+    step fully converted to precipitation (the assembly zeroes
+    zmlwc/zmiwc where the post-write-back cover fell below ``clc_min``).
+    Here that marker maps to fraction 1: the droplets became rain, so
+    everything they carried went with them. ``pice`` falls back to the
+    formation-ledger split in the same cells.
+    """
+    il = jnp.maximum(clouds.incloud_liquid, 0.0)
+    ii = jnp.maximum(clouds.incloud_ice, 0.0)
+    form_wat = jnp.maximum(
+        clouds.incloud_rain_formation + clouds.incloud_riming, 0.0) * dt
+    form_ice = jnp.maximum(clouds.incloud_snow_formation, 0.0) * dt
+
+    live_w = il > _LEDGER_POOL_MIN
+    f_wat = jnp.where(
+        live_w,
+        jnp.clip(form_wat / jnp.maximum(il, _LEDGER_POOL_MIN), 0.0, 1.0),
+        jnp.where(form_wat > 0.0, 1.0, 0.0),
+    )
+    live_i = ii > _LEDGER_POOL_MIN
+    f_ice = jnp.where(
+        live_i,
+        jnp.clip(form_ice / jnp.maximum(ii, _LEDGER_POOL_MIN), 0.0, 1.0),
+        jnp.where(form_ice > 0.0, 1.0, 0.0),
+    )
+
+    pool = il + ii
+    form = form_wat + form_ice
+    pice = jnp.where(
+        pool > _LEDGER_POOL_MIN,
+        ii / jnp.maximum(pool, _LEDGER_POOL_MIN),
+        jnp.where(
+            form > _LEDGER_POOL_MIN,
+            form_ice / jnp.maximum(form, _LEDGER_POOL_MIN),
+            0.0,
+        ),
+    )
+    return f_wat, f_ice, pice
+
+
+def fraction_to_rate(fraction: jnp.ndarray, dt: jnp.ndarray) -> jnp.ndarray:
+    """Equivalent first-order decay rate removing ``fraction`` over ``dt``.
+
+    The batched scavenging update applies ``1 - exp(-rate·dt)``, so the
+    exact inverse is ``-log1p(-f)/dt``; the cap keeps it finite at f = 1
+    (fully-converting cells) while still removing >0.999999 of the tracer.
+    """
+    f = jnp.clip(fraction, 0.0, _FRACTION_CAP)
+    return -jnp.log1p(-f) / dt
 
 
 def below_cloud_rate(
@@ -228,6 +324,7 @@ class WetScavenging(PhysicsTerm):
         *,
         spec: ModalAerosolSpec | None = None,
         in_plume_convective: bool = False,
+        formation_ledger: bool = True,
     ):
         """Hold params and the population.
 
@@ -238,9 +335,20 @@ class WetScavenging(PhysicsTerm):
         keeping convective below-cloud washout, which is a distinct
         (impaction) pathway — and folds the transport term's published
         surface fluxes into the AeroCom ``wet_*`` ledger.
+
+        ``formation_ledger`` (#708): key the stratiform in-cloud pathways
+        to the cloud scheme's process-time scavenging ledger
+        (``incloud_scavenged_fractions`` — the HAMMOZ ``cloud_subm``
+        interface, bounded by construction and alive in cells the
+        microphysics emptied) instead of the legacy cover x
+        p_form/condensate reconstruction. Static because it must match
+        what the composed cloud scheme publishes: the 2M scheme writes
+        the ledger, the 1M scheme does not yet (its own issue tracks the
+        mo_cloud port) — the factory wires this to ``cloud_scheme``.
         """
         self.params = nnx.Param(params or WetDepParameters.default())
         self._in_plume_convective = in_plume_convective
+        self._formation_ledger = formation_ledger
         self._spec = spec or MAM4_SPEC
         if carry_mode(self._spec):
             # In carry mode the store term must run upstream each step
@@ -332,20 +440,37 @@ class WetScavenging(PhysicsTerm):
                 # No pressure diagnostic: column-wide washout, not none.
                 conv_below = jnp.ones_like(state.temperature)
 
-        # The implicit stratiform rate is weighted by the cloudy area
-        # fraction: the grid-mean p_form/condensate ratio is the IN-CLOUD
-        # conversion rate (cf cancels between them), but only cf·af of the
-        # grid-mean interstitial tracer is in droplets. ``in_cloud_rate`` is
+        # Stratiform in-cloud (nucleation) scavenging rates. With the
+        # process-time ledger (#708) the per-step scavenged fraction of an
+        # in-droplet tracer is HAMMOZ's peffwat/peffice split by the phase
+        # mass fraction — bounded by construction, and alive in cells the
+        # microphysics emptied (post-write-back cover 0), where the legacy
+        # reconstruction below reads cover 0 x end-of-step condensate 0
+        # and silently skips the largest-removal step. The in-droplet
+        # SHARE of interstitial aerosol is keyed to the cover the
+        # processes actually ran under (process_cloud_fraction), not the
+        # post-write-back cover, for the same reason. ``in_cloud_rate`` is
         # linear in the activated fraction, so keep the unit-fraction base
-        # and apply per-mode, per-quantity fractions below: ARG's number and
-        # mass fractions differ a lot (large particles activate
+        # and apply per-mode, per-quantity fractions below: ARG's number
+        # and mass fractions differ a lot (large particles activate
         # preferentially) and vary by mode. The aggregate fraction is kept
         # only as a fallback for standalone composition without ARG
         # upstream.
-        cf_clip = jnp.clip(cloud_fraction, 0.0, 1.0)
-        rate_ic_unit = params.incloud_scale * cf_clip * in_cloud_rate(
-            jnp.ones_like(state.temperature), p_form, condensate,
-        )
+        if self._formation_ledger:
+            f_wat, f_ice, pice = incloud_scavenged_fractions(clouds, dt)
+            f_comb = (1.0 - pice) * f_wat + pice * f_ice
+            rate_ledger = fraction_to_rate(f_comb, dt)
+            cf_proc = jnp.clip(clouds.process_cloud_fraction, 0.0, 1.0)
+            rate_ic_unit = params.incloud_scale * cf_proc * rate_ledger
+            rate_cb = params.incloud_scale * rate_ledger
+        else:
+            cf_clip = jnp.clip(cloud_fraction, 0.0, 1.0)
+            rate_ic_unit = params.incloud_scale * cf_clip * in_cloud_rate(
+                jnp.ones_like(state.temperature), p_form, condensate,
+            )
+            rate_cb = params.incloud_scale * in_cloud_rate(
+                jnp.ones_like(state.temperature), p_form, condensate,
+            )
         jam_act = diagnostics.get("_jam_activation")
 
         # Build per-tracer scavenging rates and stack with the matching
@@ -385,9 +510,6 @@ class WetScavenging(PhysicsTerm):
         # out). Without it, the implicit treatment stands — the interstitial
         # tracers are scavenged by their per-mode activated fractions.
         explicit_cb = self._spec.cloud_borne
-        rate_cb = params.incloud_scale * in_cloud_rate(
-            jnp.ones_like(state.temperature), p_form, condensate,
-        )
         for i, mode in enumerate(self._spec.modes):
             below_strat = below_cloud_rate(
                 flux_in, cloud_fraction, aer.r_wet[i], params,

--- a/jcm/physics/aerosol/jam/wetdep/wetdep_term.py
+++ b/jcm/physics/aerosol/jam/wetdep/wetdep_term.py
@@ -343,8 +343,8 @@ class WetScavenging(PhysicsTerm):
         microphysics emptied) instead of the legacy cover x
         p_form/condensate reconstruction. Static because it must match
         what the composed cloud scheme publishes: the 2M scheme writes
-        the ledger, the 1M scheme does not yet (its own issue tracks the
-        mo_cloud port) — the factory wires this to ``cloud_scheme``.
+        the ledger, the 1M scheme does not yet (#712 tracks the mo_cloud
+        port) — the factory wires this to ``cloud_scheme``.
         """
         self.params = nnx.Param(params or WetDepParameters.default())
         self._in_plume_convective = in_plume_convective

--- a/jcm/physics/aerosol/jam/wetdep/wetdep_test.py
+++ b/jcm/physics/aerosol/jam/wetdep/wetdep_test.py
@@ -11,7 +11,6 @@ from jcm.physics.aerosol.jam.wetdep.wetdep_term import (
     WetDepParameters,
     below_cloud_rate,
     conv_in_cloud_rate,
-    in_cloud_rate,
     reinjection_budget,
 )
 
@@ -61,13 +60,6 @@ class ScavengingFunctionTest(unittest.TestCase):
         reinjected, surface = reinjection_budget(none, formed, evap_frac)
         np.testing.assert_allclose(np.asarray(reinjected), 0.0)
         np.testing.assert_allclose(np.asarray(surface[0, 0]), 1.0)
-
-    def test_in_cloud_rate_scales_with_activation(self):
-        pf = jnp.full((1, 1), 1.0e-6)
-        qc = jnp.full((1, 1), 1.0e-3)
-        lo = in_cloud_rate(jnp.full((1, 1), 0.2), pf, qc)
-        hi = in_cloud_rate(jnp.full((1, 1), 0.9), pf, qc)
-        self.assertGreater(float(hi[0, 0]), float(lo[0, 0]))
 
     def test_below_cloud_size_dependence(self):
         precip = jnp.full((1, 1), 1.0e-4)
@@ -702,8 +694,8 @@ class FormationLedgerTest(unittest.TestCase):
     cell whose condensate fully converted to precipitation — which ends
     the step with cover 0, condensate 0, and a ZEROED in-cloud pool but a
     positive formation ledger — still scavenges, in exactly the step with
-    the largest removal. The legacy cover x p_form/condensate path reads
-    zero there (the dead zone this issue was about).
+    the largest removal (a cover-keyed reconstruction would read zero
+    there — the dead zone the ledger interface exists to close).
     """
 
     @staticmethod
@@ -787,14 +779,6 @@ class FormationLedgerTest(unittest.TestCase):
         self.assertLess(q1[1].max(), 2e-6 * q0[1].max())
         # ...and untouched levels keep theirs.
         np.testing.assert_allclose(q1[0], q0[0], rtol=1e-6)
-
-        # The legacy reconstruction reads cover 0 x condensate 0 there and
-        # removes nothing — the documented dead zone this path replaces.
-        _, out_legacy = WetScavenging(
-            params=params, formation_ledger=False)(
-            state, diagnostics, None, None)
-        np.testing.assert_allclose(
-            np.asarray(out_legacy[CARRY_KEY][cb_key]), q0, rtol=1e-6)
 
     def test_interstitial_share_keys_to_process_cover(self):
         # The implicit (no explicit phase) pathway must weight by the

--- a/jcm/physics/aerosol/jam/wetdep/wetdep_test.py
+++ b/jcm/physics/aerosol/jam/wetdep/wetdep_test.py
@@ -152,6 +152,13 @@ class WetDepTermTest(unittest.TestCase):
             precip_rain=jnp.full((ncols,), precip),
             precip_formation_rate=form,
             rain_flux=rain_flux,
+            # The process-time scavenging ledger (#708), consistent with
+            # the grid-mean fields above: in-cloud pool = qc/cf, in-cloud
+            # formation = grid-mean formation/cf, and the process cover
+            # equal to the published cover (nothing emptied here).
+            incloud_liquid=jnp.full((nlev, ncols), 1.0e-3 / 0.6),
+            incloud_rain_formation=form / 0.6,
+            process_cloud_fraction=jnp.full((nlev, ncols), 0.6),
         )
         diagnostics = {
             CARRY_KEY: carry,
@@ -429,6 +436,11 @@ class WetDepTermTest(unittest.TestCase):
             qc=jnp.zeros((nlev, ncols)).at[0:2].set(1.0e-3),
             precip_formation_rate=form,
             precip_evaporation_rate=evap,
+            # Ledger fields (#708) consistent with the grid-mean ones.
+            incloud_liquid=jnp.zeros((nlev, ncols)).at[0:2].set(
+                1.0e-3 / 0.6),
+            incloud_rain_formation=form / 0.6,
+            process_cloud_fraction=cf,
         )
         # Isolate the in-cloud pathway: no impaction.
         params = WetDepParameters(
@@ -680,3 +692,156 @@ class WetDepTermTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class FormationLedgerTest(unittest.TestCase):
+    """The process-time scavenging ledger pathway (#708).
+
+    The in-cloud removal keys to the cloud scheme's HAMMOZ-interface
+    ledger (bounded per-step fractions captured at process time), so a
+    cell whose condensate fully converted to precipitation — which ends
+    the step with cover 0, condensate 0, and a ZEROED in-cloud pool but a
+    positive formation ledger — still scavenges, in exactly the step with
+    the largest removal. The legacy cover x p_form/condensate path reads
+    zero there (the dead zone this issue was about).
+    """
+
+    @staticmethod
+    def _emptied_cell():
+        """Build a one-step full conversion: ledger positive, pools zero."""
+        from jcm.physics.clouds.cloud_data import CloudData
+        from jcm.physics.aerosol.jam.cloud_borne_store import CARRY_KEY
+        from jcm.physics.aerosol.jam.microphysics.mam4_data import MAM4_SPEC
+        from jcm.physics.aerosol.jam.tracer_layout import (
+            mass_name, number_name)
+        from jcm.physics_interface import PhysicsState
+        from jcm.physics.aerosol.jam.jam_state import JamAerosolState
+
+        nlev, ncols = 4, 2
+        spec = MAM4_SPEC
+        tracers, carry = {}, {}
+        for mode in spec.modes:
+            tracers[number_name(mode.short)] = jnp.full(
+                (nlev, ncols), 1e8)
+            carry[number_name(mode.short, cloud_borne=True)] = jnp.full(
+                (nlev, ncols), 1e7)
+            for sp in mode.species:
+                tracers[mass_name(sp, mode.short)] = jnp.full(
+                    (nlev, ncols), 1e-9)
+                carry[mass_name(sp, mode.short, cloud_borne=True)] = (
+                    jnp.full((nlev, ncols), 1e-10))
+        state = PhysicsState.zeros((nlev, ncols)).copy(
+            temperature=jnp.full((nlev, ncols), 275.0), tracers=tracers)
+        shape = (spec.n_modes(), nlev, ncols)
+        aer = JamAerosolState(
+            r_dry=jnp.full(shape, 0.1e-6),
+            r_wet=jnp.full(shape, 0.2e-6),
+            rho=jnp.full(shape, 1800.0),
+            kappa=jnp.full(shape, 0.5),
+            mass=jnp.full(shape, 1e-9),
+            number=jnp.full(shape, 1.0e8),
+        )
+        form_gm = jnp.zeros((nlev, ncols)).at[1].set(1.0e-7)
+        clouds = CloudData.zeros((ncols,), nlev).copy(
+            # POST-microphysics state of the emptied cell: no cover, no
+            # condensate, zeroed pools — only the formation ledger and
+            # the process-time cover remember what happened.
+            precip_formation_rate=form_gm,
+            rain_flux=jnp.cumsum(form_gm * 200.0, axis=0),
+            precip_rain=(form_gm * 200.0).sum(axis=0),
+            incloud_rain_formation=form_gm / 0.5,
+            process_cloud_fraction=jnp.zeros(
+                (nlev, ncols)).at[1].set(0.5),
+        )
+        diagnostics = {
+            CARRY_KEY: carry,
+            "_jam_state": aer,
+            "activated_fraction": jnp.full((nlev, ncols), 0.7),
+            "air_density": jnp.full((nlev, ncols), 1.0),
+            "layer_thickness": jnp.full((nlev, ncols), 200.0),
+            "clouds": clouds,
+            "_dt_seconds": 1800.0,
+        }
+        return state, diagnostics, spec
+
+    def test_emptied_cell_still_scavenges_cloud_borne(self):
+        from jcm.physics.aerosol.jam.cloud_borne_store import CARRY_KEY
+        from jcm.physics.aerosol.jam.tracer_layout import mass_name
+
+        state, diagnostics, spec = self._emptied_cell()
+        params = WetDepParameters(
+            incloud_scale=jnp.asarray(1.0),
+            below_coeff=jnp.asarray(0.0),        # isolate in-cloud
+            below_radius_ref=jnp.asarray(1.0e-7),
+            conv_scav_ratio=jnp.asarray(0.99),
+        )
+        cb_key = mass_name(spec.modes[0].species[0], spec.modes[0].short,
+                           cloud_borne=True)
+        q0 = np.asarray(diagnostics[CARRY_KEY][cb_key])
+
+        _, out = WetScavenging(params=params)(
+            state, diagnostics, None, None)
+        q1 = np.asarray(out[CARRY_KEY][cb_key])
+        # Fraction-1 marker: essentially ALL cloud-borne mass in the
+        # emptied level leaves with the precip it formed...
+        self.assertLess(q1[1].max(), 2e-6 * q0[1].max())
+        # ...and untouched levels keep theirs.
+        np.testing.assert_allclose(q1[0], q0[0], rtol=1e-6)
+
+        # The legacy reconstruction reads cover 0 x condensate 0 there and
+        # removes nothing — the documented dead zone this path replaces.
+        _, out_legacy = WetScavenging(
+            params=params, formation_ledger=False)(
+            state, diagnostics, None, None)
+        np.testing.assert_allclose(
+            np.asarray(out_legacy[CARRY_KEY][cb_key]), q0, rtol=1e-6)
+
+    def test_interstitial_share_keys_to_process_cover(self):
+        # The implicit (no explicit phase) pathway must weight by the
+        # PROCESS-TIME cover: post-write-back cover is 0 in the emptied
+        # cell, so keying to it would zero the removal.
+        import dataclasses
+        from jcm.physics.aerosol.jam.microphysics.mam4_data import MAM4_SPEC
+        from jcm.physics.aerosol.jam.tracer_layout import mass_name
+
+        state, diagnostics, spec = self._emptied_cell()
+        params = WetDepParameters(
+            incloud_scale=jnp.asarray(1.0),
+            below_coeff=jnp.asarray(0.0),
+            below_radius_ref=jnp.asarray(1.0e-7),
+            conv_scav_ratio=jnp.asarray(0.99),
+        )
+        implicit = WetScavenging(
+            params=params,
+            spec=dataclasses.replace(MAM4_SPEC, cloud_borne=False),
+        )
+        tend, _ = implicit(state, diagnostics, None, None)
+        key = mass_name(spec.modes[0].species[0], spec.modes[0].short)
+        dq = np.asarray(tend.tracers[key])
+        self.assertLess(dq[1].max(), 0.0)          # removal in the cell
+        np.testing.assert_array_equal(dq[0], 0.0)  # none where no process
+
+    def test_ledger_fractions_bounded(self):
+        from types import SimpleNamespace
+        from jcm.physics.aerosol.jam.wetdep.wetdep_term import (
+            incloud_scavenged_fractions)
+
+        dt = 1800.0
+        shape = (5,)
+        clouds = SimpleNamespace(
+            incloud_liquid=jnp.array([1e-3, 1e-3, 0.0, 0.0, 1e-15]),
+            incloud_ice=jnp.array([0.0, 1e-4, 0.0, 1e-4, 0.0]),
+            # Formation far exceeding the pool per step must clip at 1.
+            incloud_rain_formation=jnp.array([1e-2, 1e-7, 1e-7, 0.0, 0.0]) / dt,
+            incloud_snow_formation=jnp.array([0.0, 1e-5, 0.0, 1e-3, 0.0]) / dt,
+            incloud_riming=jnp.zeros(shape),
+        )
+        f_wat, f_ice, pice = incloud_scavenged_fractions(clouds, dt)
+        for arr in (f_wat, f_ice, pice):
+            self.assertTrue(bool(jnp.all((arr >= 0.0) & (arr <= 1.0))))
+        self.assertAlmostEqual(float(f_wat[0]), 1.0)   # clipped
+        self.assertAlmostEqual(float(f_wat[2]), 1.0)   # emptied-pool marker
+        self.assertAlmostEqual(float(f_ice[3]), 1.0)   # ice clip
+        self.assertAlmostEqual(float(f_wat[4]), 0.0)   # sub-floor pool, no formation
+        # Phase split falls back to the formation ledger in emptied cells.
+        self.assertAlmostEqual(float(pice[2]), 0.0)

--- a/jcm/physics/clouds/cloud_data.py
+++ b/jcm/physics/clouds/cloud_data.py
@@ -83,7 +83,7 @@ class CloudData:
 
     # The ECHAM-HAM wet-scavenging interface (#708): the process-time
     # ledger ``cloud_subm_2`` receives, written by the 2M scheme (zero
-    # under 1M — a gap tracked by its own issue; the JAM terms that read
+    # under 1M — the mo_cloud ledger port is #712; the JAM terms that read
     # these are wired by the factory to fall back to the condensate-ratio
     # pathway under 1M). ``incloud_liquid``/``incloud_ice`` are ECHAM's
     # zmlwc/zmiwc — IN-CLOUD condensate captured before precipitation

--- a/jcm/physics/clouds/cloud_data.py
+++ b/jcm/physics/clouds/cloud_data.py
@@ -81,6 +81,33 @@ class CloudData:
     # tendencies. Zero under the 1M scheme.
     negative_mass_repair: jnp.ndarray  # (ncols,)
 
+    # The ECHAM-HAM wet-scavenging interface (#708): the process-time
+    # ledger ``cloud_subm_2`` receives, written by the 2M scheme (zero
+    # under 1M — a gap tracked by its own issue; the JAM terms that read
+    # these are wired by the factory to fall back to the condensate-ratio
+    # pathway under 1M). ``incloud_liquid``/``incloud_ice`` are ECHAM's
+    # zmlwc/zmiwc — IN-CLOUD condensate captured before precipitation
+    # formation, zeroed (faithfully) where the post-write-back cover fell
+    # below clc_min; a zeroed pool with a positive formation rate marks a
+    # cell fully converted to precipitation, which consumers must read as
+    # scavenged-fraction 1 (see ScavengingLedger in lohmann_2m/types.py).
+    # The formation rates are IN-CLOUD [kg/kg/s]: rain formation
+    # (zmratepr), snow formation (zmrateps, including the ice-
+    # sedimentation carrier), and riming of droplets by snow (zmsnowacl,
+    # a LIQUID sink into frozen precip). ``process_cloud_fraction`` is
+    # the cover the processes ran under (nonzero in cells the write-back
+    # cleared). ``condensate_evaporation_rate`` is the grid-mean
+    # cloud-condensate evaporation ledger (zxlevap+zxievap) — the
+    # resuspension key: evaporated droplets release their aerosol,
+    # rained-out ones do not.
+    incloud_liquid: jnp.ndarray             # (nlev, ncols) [kg/kg]
+    incloud_ice: jnp.ndarray                # (nlev, ncols) [kg/kg]
+    incloud_rain_formation: jnp.ndarray     # (nlev, ncols) [kg/kg/s]
+    incloud_snow_formation: jnp.ndarray     # (nlev, ncols) [kg/kg/s]
+    incloud_riming: jnp.ndarray             # (nlev, ncols) [kg/kg/s]
+    process_cloud_fraction: jnp.ndarray     # (nlev, ncols) [1]
+    condensate_evaporation_rate: jnp.ndarray  # (nlev, ncols) [kg/kg/s]
+
     # Cloud properties
     droplet_number: jnp.ndarray  # Droplet number concentration [1/m³] (nlev, ncols)
 
@@ -127,6 +154,13 @@ class CloudData:
             rain_formation_warm=jnp.zeros(nodal_shape),
             rain_from_melt=jnp.zeros(nodal_shape),
             negative_mass_repair=jnp.zeros(nodal_shape),
+            incloud_liquid=jnp.zeros((nlev,) + nodal_shape),
+            incloud_ice=jnp.zeros((nlev,) + nodal_shape),
+            incloud_rain_formation=jnp.zeros((nlev,) + nodal_shape),
+            incloud_snow_formation=jnp.zeros((nlev,) + nodal_shape),
+            incloud_riming=jnp.zeros((nlev,) + nodal_shape),
+            process_cloud_fraction=jnp.zeros((nlev,) + nodal_shape),
+            condensate_evaporation_rate=jnp.zeros((nlev,) + nodal_shape),
             droplet_number=jnp.zeros((nlev,) + nodal_shape),
             r_eff_liq=jnp.zeros((nlev,) + nodal_shape),
             r_eff_ice=jnp.zeros((nlev,) + nodal_shape),
@@ -152,6 +186,13 @@ class CloudData:
             'rain_formation_warm': self.rain_formation_warm,
             'rain_from_melt': self.rain_from_melt,
             'negative_mass_repair': self.negative_mass_repair,
+            'incloud_liquid': self.incloud_liquid,
+            'incloud_ice': self.incloud_ice,
+            'incloud_rain_formation': self.incloud_rain_formation,
+            'incloud_snow_formation': self.incloud_snow_formation,
+            'incloud_riming': self.incloud_riming,
+            'process_cloud_fraction': self.process_cloud_fraction,
+            'condensate_evaporation_rate': self.condensate_evaporation_rate,
             'droplet_number': self.droplet_number,
             'r_eff_liq': self.r_eff_liq,
             'r_eff_ice': self.r_eff_ice,

--- a/jcm/physics/clouds/cloud_data.py
+++ b/jcm/physics/clouds/cloud_data.py
@@ -82,10 +82,11 @@ class CloudData:
     negative_mass_repair: jnp.ndarray  # (ncols,)
 
     # The ECHAM-HAM wet-scavenging interface (#708): the process-time
-    # ledger ``cloud_subm_2`` receives, written by the 2M scheme (zero
-    # under 1M — the mo_cloud ledger port is #712; the JAM terms that read
-    # these are wired by the factory to fall back to the condensate-ratio
-    # pathway under 1M). ``incloud_liquid``/``incloud_ice`` are ECHAM's
+    # ledger ``cloud_subm_2`` receives, written by the 2M scheme. The 1M
+    # scheme leaves these zero, which is why the factory rejects
+    # aerosol_module='jam' with cloud_scheme='1m' — the JAM terms that
+    # read them would silently scavenge nothing.
+    # ``incloud_liquid``/``incloud_ice`` are ECHAM's
     # zmlwc/zmiwc — IN-CLOUD condensate captured before precipitation
     # formation, zeroed (faithfully) where the post-write-back cover fell
     # below clc_min; a zeroed pool with a positive formation rate marks a

--- a/jcm/physics/clouds/lohmann_2m/scheme.py
+++ b/jcm/physics/clouds/lohmann_2m/scheme.py
@@ -31,7 +31,7 @@ from ..cloud_utils import (
     minimum_CDNC,
     threshold_vert_vel,
 )
-from .types import MicrophysicsTendencies_2M
+from .types import MicrophysicsTendencies_2M, ScavengingLedger
 from .sedimentation_melt import melting_snow_and_ice, sedimentation_ice
 from .deposition_freezing import (
     demott2010_inp,
@@ -330,7 +330,7 @@ def cloud_microphysics_2m(
         # Acts on the provisional grid-mean ice (ECHAM zxip1 = pxim1 +
         # ztmst·pxite, with the upstream increments folded into qi here).
         (zxip1, icnc_sedi, ice_flux, ice_flux_n, falling_ice_frac,
-         _sedi_rate) = sedimentation_ice(
+         mrateps_sedi_k) = sedimentation_ice(
             cf_k, adc_k, dp_k, rho_k, inv_rho_k,
             jnp.maximum(qi_run_k, 0.0), icnc0_k,
             ice_flux, ice_flux_n, falling_ice_frac,
@@ -659,7 +659,7 @@ def cloud_microphysics_2m(
             & (zxlb > params.cqtmin)
             & (cdnc_w >= cdnc_min_k)
         )
-        (cdnc_p, zxlb, _mratepr, zrpr, _rprn,
+        (cdnc_p, zxlb, mratepr_k, zrpr, _rprn,
          auto_only_k, accr_only_k) = precip_formation_warm(
             ll_warm,
             zauloc,
@@ -679,8 +679,8 @@ def cloud_microphysics_2m(
         # ``zxib > cqtmin`` check runs on the CURRENT in-cloud ice, so
         # ice deposited/frozen/WBF-transferred THIS step meets its
         # aggregation and riming sinks in the same step (#686).
-        (icnc_c, cdnc_c, _mrateps, zxib, zxlb,
-         _sprn, zsacl, _sacln, _msnowacl, zspr) = precip_formation_cold(
+        (icnc_c, cdnc_c, mrateps_k, zxib, zxlb,
+         _sprn, zsacl, _sacln, msnowacl_k, zspr) = precip_formation_cold(
             cloud_flag,
             zauloc,
             paclc,
@@ -694,7 +694,12 @@ def cloud_microphysics_2m(
             cdnc_min_k,
             icnc_het,
             cdnc_p,
-            zero_s,
+            # zmrateps INOUT seed: the in-cloud sedimented-ice amount from
+            # section 4 (ECHAM 1243 → 1703) — ECHAM-HAM counts sedimenting
+            # ice as a scavenging carrier via this ledger entry. Where the
+            # cold chain runs it OVERWRITES the seed (Fortran MERGE at
+            # 3310); elsewhere the seed survives to ``cloud_subm_2``.
+            mrateps_sedi_k,
             zxib, zxlb,
             dt,
             params,
@@ -741,6 +746,7 @@ def cloud_microphysics_2m(
             ice_tend_k, wbf_liq_tend, wbf_ice_tend, wbf_dtedt,
             zxib, zxlb, paclc, icnc_c, cdnc_c, cdnc_min_k, ztp1tmp,
             zmlwc_k, zmiwc_k,
+            mratepr_k, mrateps_k, msnowacl_k,
             auto_only_k, accr_only_k,
             rain_flux, frozen_flux_k,
             wbf_transfer_k, ll_liqcl_k, ll_icecl_k,
@@ -776,6 +782,7 @@ def cloud_microphysics_2m(
      in_cloud_ice_final, in_cloud_liquid_final, paclc_final,
      icnc_final, cdnc_final, cdnc_min_final, ztp1tmp_all,
      zmlwc, zmiwc,
+     zmratepr, zmrateps, zmsnowacl,
      autoconv_only, accretion_only,
      rain_flux_profile, snow_flux_profile,
      wbf_transfer, ll_liqcl, ll_icecl) = scan_outs
@@ -792,7 +799,7 @@ def cloud_microphysics_2m(
         cloud_fraction_final,
         dqdt, dtedt, dqidt, dqcdt,
         dqncdt_perkg, dqnidt_perkg,
-        _incloud_liq, _incloud_ice,
+        incloud_liq_scav, incloud_ice_scav,
         liq_eff_radius, ice_eff_radius,
         zdxlcor, zdxicor,
     ) = update_tendencies_and_important_vars(
@@ -940,6 +947,25 @@ def cloud_microphysics_2m(
     negative_mass_repair = jnp.sum(
         (c.alhc * zdxlcor + c.alhs * zdxicor) * air_mass)
 
+    # The ECHAM-HAM wet-scavenging interface (#708): the process-time
+    # ledger cloud_subm_2 receives, published for the JAM wetdep and
+    # cloud-borne terms (see ScavengingLedger). The pools are the
+    # POST-assembly zmlwc/zmiwc (the Fortran passes them INOUT through
+    # update_tendencies_2, which zeroes them in emptied cells — a zeroed
+    # pool with a positive formation rate is the fraction=1 marker). The
+    # process cover is clipped to the incoming Sundqvist cover for the
+    # same reason the published cloud_fraction is: the RH-raising branch
+    # of update_in_cloud_water is a closure this stack does not use.
+    scav_ledger = ScavengingLedger(
+        incloud_liquid=incloud_liq_scav,
+        incloud_ice=incloud_ice_scav,
+        rain_formation=zmratepr / dt,
+        snow_formation=zmrateps / dt,
+        liquid_riming=zmsnowacl / dt,
+        process_cloud_fraction=jnp.minimum(paclc_final, cloud_fraction_in),
+        condensate_evaporation=(xlevap + xievap) / dt,
+    )
+
     # NOTE the (nlev,) rain / frozen flux profiles stay LAST: call sites and
     # tests unpack them positionally from the end (``*_, rain_b, snow_b``),
     # so new outputs are inserted before them, not appended.
@@ -947,7 +973,7 @@ def cloud_microphysics_2m(
         liq_eff_radius, ice_eff_radius, rain_formation_warm, rain_from_melt, \
         autoconv_rate_col, accretion_rate_col, wbf_rate_col, \
         precip_formation_rate, precip_evaporation_rate, cloud_fraction_final, \
-        negative_mass_repair, \
+        negative_mass_repair, scav_ledger, \
         rain_flux_profile, snow_flux_profile
 
 
@@ -1122,12 +1148,12 @@ class Lohmann2MMicrophysics(PhysicsTerm):
          r_eff_liq_all, r_eff_ice_all, rain_formation_warm, rain_from_melt,
          autoconv_all, accretion_all, wbf_all,
          precip_form_all, precip_evap_all, cloud_fraction_all,
-         negative_mass_repair_all,
+         negative_mass_repair_all, scav_ledger_all,
          rain_flux_all, snow_flux_all) = jax.vmap(
             cloud_microphysics_2m,
             in_axes=(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                      None, None, 1, 1, 1, 1),
-            out_axes=(0,) * 16,
+            out_axes=(0,) * 17,
         )(
             temperature_in, specific_humidity_in, pressure_full,
             qc_interim, qi_interim, qnc, qni,
@@ -1186,6 +1212,18 @@ class Lohmann2MMicrophysics(PhysicsTerm):
             # repair [W/m²] (#689): sign-definite spurious warming from
             # returning sub-ccwmin/negative condensate to vapour.
             negative_mass_repair=negative_mass_repair_all,
+            # The ECHAM-HAM wet-scavenging ledger (#708): the process-time
+            # quantities cloud_subm_2 receives, for the JAM wetdep and
+            # cloud-borne terms (see ScavengingLedger in types.py). The
+            # vmap puts the column axis first — transpose like the rest.
+            incloud_liquid=scav_ledger_all.incloud_liquid.T,
+            incloud_ice=scav_ledger_all.incloud_ice.T,
+            incloud_rain_formation=scav_ledger_all.rain_formation.T,
+            incloud_snow_formation=scav_ledger_all.snow_formation.T,
+            incloud_riming=scav_ledger_all.liquid_riming.T,
+            process_cloud_fraction=scav_ledger_all.process_cloud_fraction.T,
+            condensate_evaporation_rate=(
+                scav_ledger_all.condensate_evaporation.T),
         )
         # Advance the running condensate view so terms downstream (the
         # satellite simulators and the AeroCom diagnostics) describe the

--- a/jcm/physics/clouds/lohmann_2m/types.py
+++ b/jcm/physics/clouds/lohmann_2m/types.py
@@ -27,6 +27,56 @@ class MicrophysicsTendencies_2M(NamedTuple):
     dqrdt: jnp.ndarray          # Rain water tendency (kg/kg/s)
     dqsdt: jnp.ndarray          # Snow tendency (kg/kg/s)
 
+class ScavengingLedger(NamedTuple):
+    """The ECHAM-HAM wet-scavenging interface (``cloud_subm_2``, #708).
+
+    ECHAM-HAM does not reconstruct aerosol scavenging from cover x
+    grid-mean state: ``cloud_subm_2`` receives the process-time ledger the
+    microphysics itself integrated. These are its per-level equivalents,
+    per column (each field is ``(nlev,)`` inside the scheme, stacked to
+    ``(nlev, ncols)`` by the term's vmap). Published on ``CloudData`` for
+    the JAM wet-deposition and cloud-borne exchange terms.
+
+    ``incloud_liquid`` / ``incloud_ice`` are ECHAM's ``zmlwc``/``zmiwc``:
+    the IN-CLOUD condensate captured just before precipitation formation
+    (section 7), after the assembly's faithful zeroing (cells whose
+    post-write-back cover fell below ``clc_min``, or whose value is below
+    1e-20, carry zero — mo_cloud_micro_2m.f90:3660-3665). A zeroed pool
+    with a positive formation rate therefore marks a cell the step fully
+    converted to precipitation; consumers must treat that as
+    scavenged-fraction 1, not 0 (the one documented deviation from
+    HAMMOZ's ``prep_wetdep_hydro``, which maps it to 0 and misses the
+    removal — the #708 dead zone).
+
+    The formation rates are IN-CLOUD [kg/kg/s]: ``rain_formation`` is
+    ``zmratepr`` (KK2000 autoconversion + both accretion pathways),
+    ``snow_formation`` is ``zmrateps`` (ice-sedimentation seed per ECHAM
+    1243, overwritten by aggregation + ice accretion where the cold chain
+    runs, per the Fortran MERGE at 3310), and ``liquid_riming`` is
+    ``zmsnowacl`` (cloud droplets collected by falling snow — a LIQUID
+    sink into the frozen precip).
+
+    ``process_cloud_fraction`` is the cover the processes actually ran
+    under (pre-write-back ``paclc``): the in-droplet share of interstitial
+    aerosol during the step, where the post-microphysics
+    ``CloudData.cloud_fraction`` is already 0 in emptied cells.
+
+    ``condensate_evaporation`` is the grid-mean cloud-condensate
+    evaporation ledger [kg/kg/s] (``zxlevap + zxievap``, #707): condensate
+    in cloud-free cells plus the clear-sky share of positive increments
+    returned to vapour. This is the resuspension key — a droplet that
+    evaporates releases its aerosol; one that rains out does not.
+    """
+
+    incloud_liquid: jnp.ndarray            # zmlwc [kg/kg, in-cloud]
+    incloud_ice: jnp.ndarray               # zmiwc [kg/kg, in-cloud]
+    rain_formation: jnp.ndarray            # zmratepr/dt [kg/kg/s, in-cloud]
+    snow_formation: jnp.ndarray            # zmrateps/dt [kg/kg/s, in-cloud]
+    liquid_riming: jnp.ndarray             # zmsnowacl/dt [kg/kg/s, in-cloud]
+    process_cloud_fraction: jnp.ndarray    # paclc at process time [1]
+    condensate_evaporation: jnp.ndarray    # (zxlevap+zxievap)/dt [kg/kg/s]
+
+
 def microphysics_dt_constants(dt: jnp.ndarray, params: CloudParams2M) -> tuple[jnp.ndarray, jnp.ndarray]:
     """Constants that depend on the microphysics timestep. Here for consistency with ECHAM6,
     where they cannot be parameters.

--- a/jcm/physics/clouds/lohmann_2m_test.py
+++ b/jcm/physics/clouds/lohmann_2m_test.py
@@ -1483,7 +1483,7 @@ class TestColumnWaterConservation2M:
         params = CloudParams2M.default()
 
         (tend, rain_sfc, snow_sfc, _rl, _ri, _rfw, _rfm, _au, _ac, _wbf,
-         form, evap, _cf, _nmr, rain_prof, snow_prof) = cloud_microphysics_2m(
+         form, evap, _cf, _nmr, _ledger, rain_prof, snow_prof) = cloud_microphysics_2m(
             T, q, p, qc, jnp.zeros(nlev), qnc, jnp.zeros(nlev),
             cf, rho, dz,
             jnp.full(nlev, 0.1), jnp.full(nlev, 5e7),
@@ -1533,7 +1533,7 @@ class TestColumnWaterConservation2M:
         params = CloudParams2M.default()
 
         (tend, rain_sfc, snow_sfc, _rl, _ri, _rfw, _rfm, _au, _ac, _wbf,
-         form, evap, _cf, _nmr, _rp, _sp) = cloud_microphysics_2m(
+         form, evap, _cf, _nmr, _ledger, _rp, _sp) = cloud_microphysics_2m(
             T, q, p, jnp.zeros(nlev), qi, jnp.zeros(nlev), qni,
             cf, rho, dz,
             jnp.full(nlev, 0.1), jnp.full(nlev, 5e7),
@@ -2347,3 +2347,106 @@ class TestPrecipFluxProfiles2M:
         for i in range(3):
             assert jnp.allclose(rain_b[i], rain_1, atol=1e-12)
             assert jnp.allclose(snow_b[i], snow_1, atol=1e-12)
+
+
+class TestScavengingLedger2M:
+    """The ECHAM-HAM wet-scavenging ledger (#708).
+
+    The scheme must publish the process-time quantities ``cloud_subm_2``
+    receives — in-cloud pools captured before precipitation formation,
+    the in-cloud formation rates, the process-time cover, and the
+    condensate-evaporation ledger — because the JAM wetdep / cloud-borne
+    terms key their removal and resuspension to them, not to the
+    post-write-back cover.
+    """
+
+    LEDGER_INDEX = 14  # position in the cloud_microphysics_2m return
+
+    @staticmethod
+    def _warm_deck(nlev=16):
+        from jcm.physics.clouds.sundqvist import saturation_specific_humidity
+        T = jnp.linspace(250.0, 295.0, nlev)
+        p = jnp.linspace(3e4, 1e5, nlev)
+        rho = p / (287.0 * T)
+        q = 0.9 * jax.vmap(saturation_specific_humidity)(p, T)
+        qc = jnp.zeros(nlev).at[9:14].set(8e-4)
+        qi = jnp.zeros(nlev)
+        cf = jnp.where(qc > 0, 0.6, 0.0)
+        dz = jnp.full(nlev, 500.0)
+        qnc = jnp.where(qc > 0, 1e8 / rho, 0.0)
+        qni = jnp.zeros(nlev)
+        return T, q, p, qc, qi, qnc, qni, cf, rho, dz
+
+    def _run(self, column, dt=900.0):
+        from jcm.physics.clouds.lohmann_2m import cloud_microphysics_2m
+        T, q, p, qc, qi, qnc, qni, cf, rho, dz = column
+        nlev = T.shape[0]
+        return cloud_microphysics_2m(
+            T, q, p, qc, qi, qnc, qni, cf, rho, dz,
+            jnp.full(nlev, 0.1), jnp.full(nlev, 1e8),
+            jnp.zeros(nlev), jnp.zeros(nlev), dt, CloudParams2M.default(),
+        )
+
+    def test_incloud_pool_is_condensate_over_cover(self):
+        """zmlwc is IN-CLOUD: ~qc/cf in the deck, not the grid mean."""
+        column = self._warm_deck()
+        out = self._run(column)
+        ledger = out[self.LEDGER_INDEX]
+        qc, cf = column[3], column[7]
+        deck = np.asarray(qc) > 0
+        il = np.asarray(ledger.incloud_liquid)[deck]
+        # The pool is captured after evaporation/condensation adjustments,
+        # so require the right scale (qc/cf = 1.33e-3), not equality.
+        assert (il > 1.0e-3).all() and (il < 2.0e-3).all()
+        # Cover: process-time cover matches the diagnosed deck cover.
+        pcf = np.asarray(ledger.process_cloud_fraction)
+        assert np.allclose(pcf[deck], 0.6, atol=1e-6)
+        assert np.allclose(pcf[~deck], 0.0, atol=1e-6)
+
+    def test_formation_rate_bounded_by_pool(self):
+        """f = formation*dt / pool is a fraction: the ledger denominator is
+        captured BEFORE the formation depletes it, so f <= 1 wherever the
+        pool survives (the #708 boundedness-by-construction property)."""
+        column = self._warm_deck()
+        dt = 900.0
+        ledger = self._run(column, dt=dt)[self.LEDGER_INDEX]
+        il = np.asarray(ledger.incloud_liquid)
+        form = np.asarray(
+            ledger.rain_formation + ledger.liquid_riming) * dt
+        live = il > 1e-10
+        assert form[live].max() <= il[live].max() + 1e-12
+        assert (form[live] / il[live] <= 1.0 + 1e-6).all()
+        assert form[live].sum() > 0.0  # the deck does rain
+
+    def test_snow_formation_carries_ice_sedimentation(self):
+        """ECHAM seeds zmrateps from sedimentation_ice (1243->1703): a
+        cirrus layer with NO cold-chain aggregation (cloud flag off below,
+        few large crystals falling) must still report a positive in-cloud
+        snow-formation ledger — the sedimenting ice is a scavenging
+        carrier in ECHAM-HAM's cloud_subm_2."""
+        nlev = 16
+        T = jnp.linspace(215.0, 260.0, nlev)   # all below freezing
+        p = jnp.linspace(2e4, 6e4, nlev)
+        rho = p / (287.0 * T)
+        from jcm.physics.clouds.sundqvist import saturation_specific_humidity
+        q = 0.5 * jax.vmap(saturation_specific_humidity)(p, T)  # subsaturated
+        qi = jnp.zeros(nlev).at[3:6].set(5e-4)
+        qc = jnp.zeros(nlev)
+        cf = jnp.where(qi > 0, 0.5, 0.0)
+        dz = jnp.full(nlev, 500.0)
+        qni = jnp.where(qi > 0, 1e2, 0.0)      # few, large -> fast fallout
+        qnc = jnp.zeros(nlev)
+        ledger = self._run(
+            (T, q, p, qc, qi, qnc, qni, cf, rho, dz)
+        )[self.LEDGER_INDEX]
+        assert float(jnp.sum(ledger.snow_formation)) > 0.0
+
+    def test_term_publishes_ledger_to_cloud_data(self):
+        """The composable term must write all seven ledger fields."""
+        from jcm.physics.clouds.cloud_data import CloudData
+        nlev, ncols = 12, 3
+        zeros = CloudData.zeros((ncols,), nlev)
+        for f in ("incloud_liquid", "incloud_ice", "incloud_rain_formation",
+                  "incloud_snow_formation", "incloud_riming",
+                  "process_cloud_fraction", "condensate_evaporation_rate"):
+            assert getattr(zeros, f).shape == (nlev, ncols)

--- a/jcm/physics/clouds/lohmann_2m_test.py
+++ b/jcm/physics/clouds/lohmann_2m_test.py
@@ -2388,11 +2388,11 @@ class TestScavengingLedger2M:
         )
 
     def test_incloud_pool_is_condensate_over_cover(self):
-        """zmlwc is IN-CLOUD: ~qc/cf in the deck, not the grid mean."""
+        """Zmlwc is IN-CLOUD: ~qc/cf in the deck, not the grid mean."""
         column = self._warm_deck()
         out = self._run(column)
         ledger = out[self.LEDGER_INDEX]
-        qc, cf = column[3], column[7]
+        qc = column[3]
         deck = np.asarray(qc) > 0
         il = np.asarray(ledger.incloud_liquid)[deck]
         # The pool is captured after evaporation/condensation adjustments,
@@ -2404,9 +2404,10 @@ class TestScavengingLedger2M:
         assert np.allclose(pcf[~deck], 0.0, atol=1e-6)
 
     def test_formation_rate_bounded_by_pool(self):
-        """f = formation*dt / pool is a fraction: the ledger denominator is
+        """F = formation*dt / pool is a fraction: the ledger denominator is
         captured BEFORE the formation depletes it, so f <= 1 wherever the
-        pool survives (the #708 boundedness-by-construction property)."""
+        pool survives (the #708 boundedness-by-construction property).
+        """
         column = self._warm_deck()
         dt = 900.0
         ledger = self._run(column, dt=dt)[self.LEDGER_INDEX]
@@ -2423,7 +2424,8 @@ class TestScavengingLedger2M:
         cirrus layer with NO cold-chain aggregation (cloud flag off below,
         few large crystals falling) must still report a positive in-cloud
         snow-formation ledger — the sedimenting ice is a scavenging
-        carrier in ECHAM-HAM's cloud_subm_2."""
+        carrier in ECHAM-HAM's cloud_subm_2.
+        """
         nlev = 16
         T = jnp.linspace(215.0, 260.0, nlev)   # all below freezing
         p = jnp.linspace(2e4, 6e4, nlev)

--- a/jcm/physics/echam/echam_terms.py
+++ b/jcm/physics/echam/echam_terms.py
@@ -357,7 +357,7 @@ def echam_physics(
             # The process-time scavenging ledger (#708) is published by
             # the 2M scheme only; under 1M the wetdep/cloud-borne terms
             # fall back to the legacy cover-keyed reconstruction until the
-            # 1M mo_cloud ledger port lands (tracked in its own issue).
+            # 1M mo_cloud ledger port lands (#712).
             scavenging_ledger=(cloud_scheme == "2m"),
         )
         # The per-band Mie optics are only consumed by the interval-gated

--- a/jcm/physics/echam/echam_terms.py
+++ b/jcm/physics/echam/echam_terms.py
@@ -140,7 +140,11 @@ def echam_physics(
             (two-moment warm-rain).
         aerosol_module: ``"macv2sp"`` (default; prescribed simple plumes) or
             ``"jam"`` (online JAM harness — emissions, microphysics core,
-            ARG activation, deposition, sedimentation; #461). The JAM path
+            ARG activation, deposition, sedimentation; #461). JAM requires
+            ``cloud_scheme="2m"``: its scavenging and resuspension terms
+            read the process-time ledger only the 2M scheme publishes,
+            and only the 2M scheme consumes JAM's activation and
+            ice-nuclei products. The JAM path
             *augments* MACv2-SP rather than replacing it: MACv2-SP is kept for
             the aerosol radiative optics and Twomey factor that radiation and
             the cloud schemes require, while JAM adds the prognostic aerosol
@@ -343,6 +347,20 @@ def echam_physics(
     if aerosol_module == "macv2sp":
         aerosol_terms = [Macv2SpAerosol(params=aerosol_p)]
     elif aerosol_module == "jam":
+        if cloud_scheme != "2m":
+            # The JAM wet-deposition and cloud-borne exchange terms key to
+            # the process-time scavenging ledger only the 2M scheme
+            # publishes on CloudData (#708), and prognostic aerosol without
+            # aerosol-aware microphysics is not a configuration we support:
+            # the 1M scheme would read none of JAM's activation/ice-nuclei
+            # products while the ledger fields stayed all-zero, silently
+            # producing no stratiform in-cloud scavenging.
+            raise ValueError(
+                "aerosol_module='jam' requires cloud_scheme='2m' — the JAM "
+                "scavenging and resuspension terms read the 2M scheme's "
+                f"process-time ledger, and cloud_scheme={cloud_scheme!r} "
+                "does not publish it."
+            )
         from jcm.physics.aerosol.jam.jam_terms import jam_aerosol_physics
         jam_terms = jam_aerosol_physics(
             microphysics=jam_microphysics, cloud_borne=jam_cloud_borne,
@@ -354,11 +372,6 @@ def echam_physics(
             prescribed_speciated=jam_prescribed_speciated,
             convective_transport=jam_convective_transport,
             optics_diagnostics=aerocom_optics,
-            # The process-time scavenging ledger (#708) is published by
-            # the 2M scheme only; under 1M the wetdep/cloud-borne terms
-            # fall back to the legacy cover-keyed reconstruction until the
-            # 1M mo_cloud ledger port lands (#712).
-            scavenging_ledger=(cloud_scheme == "2m"),
         )
         # The per-band Mie optics are only consumed by the interval-gated
         # radiation term, so the optics term skips recomputing them on the

--- a/jcm/physics/echam/echam_terms.py
+++ b/jcm/physics/echam/echam_terms.py
@@ -354,6 +354,11 @@ def echam_physics(
             prescribed_speciated=jam_prescribed_speciated,
             convective_transport=jam_convective_transport,
             optics_diagnostics=aerocom_optics,
+            # The process-time scavenging ledger (#708) is published by
+            # the 2M scheme only; under 1M the wetdep/cloud-borne terms
+            # fall back to the legacy cover-keyed reconstruction until the
+            # 1M mo_cloud ledger port lands (tracked in its own issue).
+            scavenging_ledger=(cloud_scheme == "2m"),
         )
         # The per-band Mie optics are only consumed by the interval-gated
         # radiation term, so the optics term skips recomputing them on the


### PR DESCRIPTION
**#660 has merged** (squashed into `dev` as 7762b53), so this PR now stands alone: the five commits in the diff are all and only this PR's work. The two are the sink half of #658 and were validated together (90-day T63L47 `echam-jam` lifetime A/B against `dev`; results in the thread).

Closes #708. Refs #658, #602, #713 (filed: budget-closure diagnostics for fast drift attribution). #712 (the 1M `mo_cloud` ledger port) was filed by this PR and then closed as moot by the review decision below.

## The problem (#708, Codex P1 on #707 — verified pre-existing, not a regression)

A stratiform cell whose condensate fully converts to precipitation in one step ends it with `cloud_fraction = 0` (the reference-correct `paclc` write-back) and condensate 0. Both JAM consumers read that post-microphysics state:

- `WetScavenging`'s implicit in-cloud rate scaled with the **end-of-step cover** — zero removal in exactly the step with the largest removal;
- `CloudBorneExchange` drained the reservoir toward zero on `resuspension_timescale` whenever cover read 0 — and cover 0 cannot distinguish *evaporated* (release the aerosol) from *rained out* (it left with the precip). Running just before wetdep, the drain let up to `1−exp(−Δt/τ)` ≈ 86% (Δt=1800 s) of the cloud-borne reservoir escape scavenging through exactly the fully-converting cells.

The explicit cloud-borne phase (the CAM/MAM4 `qqcw` inheritance) is **kept** — MAM4's own convention (remove at the conversion fraction, resuspend where cloud water evaporates) is precisely the ledger keying this PR implements, so the fix and the phase point the same direction.

## What changed

**1. The 2M scheme publishes the ECHAM-HAM scavenging interface** (`ScavengingLedger` → seven `CloudData` fields). Everything `cloud_subm_2` receives was already computed in the #707 scan as discarded locals: `zmlwc`/`zmiwc` (in-cloud pools captured *before* formation depletes them, post the faithful emptied-cell zeroing), `zmratepr`/`zmrateps`/`zmsnowacl` (in-cloud formation rates), the process-time cover, and the `zxlevap+zxievap` condensate-evaporation ledger. Two fidelity notes: `zmrateps` is now seeded from `sedimentation_ice` (ECHAM 1243→1703 — sedimenting ice **is** a scavenging carrier in ECHAM-HAM; the cold chain overwrites the seed where it runs, per the Fortran MERGE at 3310), and the evaporation ledger is exported as the resuspension key.

**2. Wetdep in-cloud removal is HAMMOZ `prep_wetdep_hydro`** — `peffwat = (zmratepr+zmsnowacl)·Δt/zmlwc`, `peffice = zmrateps·Δt/zmiwc`, clipped to [0,1] and split by the in-cloud ice mass fraction. Numerator and denominator are captured at process time, so the fraction is bounded **by construction** — no unbounded rate ratio being "accidentally correct" via a floor in near-empty cells. The implicit interstitial in-droplet share keys to the process-time cover.

**3. Cloud-borne resuspension keys to the evaporation ledger.** The released share per step is the share of the droplet population that evaporated, `E/(E+pool)`, capped by `1 − f_form` (the same step's rainout claim) so the two sinks cannot jointly overdraw the reservoir. A sky cleared by evaporation resuspends everything in one step (CAM's instant resuspension); a sky cleared by rainout resuspends nothing; WBF/homogeneous glaciation move condensate within the pool and release nothing — the aerosol rides into the ice and meets the snow pathway (#686) in the ledger. Only cells with no cloud process at all (advected-in `q_cb` in clear air) keep the slow timescale drain.

## The one documented deviation from the reference

ECHAM-HAM zeroes `zmlwc`/`zmiwc` *after* the `paclc` write-back (mo_cloud_micro_2m.f90:3655 → 3660), so `prep_wetdep_hydro` maps the fully-converting cell to `peffwat = 0` — **the reference itself has the dead zone** (one leapfrog step's worth of scavenging missed per full conversion). jcm keeps the faithful zeroing but reads the marker (zero pool + positive formation) as scavenged-fraction **1**, which is what the issue prescribed and what physical bookkeeping requires. Called out in `ScavengingLedger`, `incloud_scavenged_fractions`, and the design doc.

## JAM requires the 2M scheme (review decision)

An earlier revision kept a `scavenging_ledger` constructor switch so JAM could fall back to the legacy cover-keyed reconstruction under the 1M scheme. Review (this thread) ruled JAM+1M an unsupported configuration — prognostic aerosol with aerosol-blind microphysics — so f222619 removes the switch chain and the legacy reconstruction entirely: the ledger pathways are unconditional, and `echam_physics(aerosol_module='jam')` rejects `cloud_scheme='1m'` at compose time. (Verified the combination otherwise constructs and runs — nothing structurally requires 2M, it would just silently scavenge nothing stratiform off the 1M scheme's all-zero ledger fields — so the explicit error is the only guard.)

## Verification

- `ruff` clean; fast suite 1960 passed @ 94.8% (≥90) after f222619; slow tests in the touched areas (aerosol/clouds/echam) 14 passed — all locally at CI parity.
- New gates: `TestScavengingLedger2M` (in-cloud semantics, boundedness-by-construction, the sedimentation seed, term publication), `FormationLedgerTest` (the emptied cell scavenges under the ledger; process-cover keying; fraction bounds incl. the fraction-1 marker), five `CloudBorneExchangeTest` ledger gates (rained-out ≠ evaporated; partial-evaporation share; the rainout cap; phase transfer releases nothing), and `test_jam_module_rejects_1m`.
- All pre-existing wetdep/cloud-borne/2M/1M tests pass.
- 90-day T63L47 `echam-jam-aerocom` A/B (this stack vs `dev`, identical config/init/seeds) in flight for per-species burden/sink-flux/lifetime ratios — thread below when done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFu9rxRPLQ7qj3hwZf6zRE

