### PR TITLE
Aerosol mass-budget closure: the in-step gauge + the SL transport mass fixer (#713)

### DIFF
--- a/jcm/dycore/dinosaur/dycore.py
+++ b/jcm/dycore/dinosaur/dycore.py
@@ -773,9 +773,15 @@ class DinosaurDycore(DynamicalCore):
             tiny = jnp.asarray(1e-300, dtype=q_new.dtype) if \
                 q_new.dtype == jnp.float64 else jnp.asarray(1e-30, q_new.dtype)
             ok = (current > tiny) & (target > tiny)
+            # Double-where guard (#558): the masked branch's division must
+            # see benign inputs, or its cotangent (∝ target/current²) blows
+            # up through empty fields — qc/qi start at zero in every
+            # cold-start run and this NaN'd the two-step gradient gate.
+            safe_current = jnp.where(ok, current, 1.0)
+            safe_target = jnp.where(ok, target, 1.0)
             scale = jnp.where(
                 ok,
-                jnp.clip(target / jnp.maximum(current, tiny), 2.0 / 3.0, 1.5),
+                jnp.clip(safe_target / safe_current, 2.0 / 3.0, 1.5),
                 1.0,
             )
             tracers[name] = q_new * scale

--- a/jcm/dycore/dinosaur/dycore.py
+++ b/jcm/dycore/dinosaur/dycore.py
@@ -710,7 +710,76 @@ class DinosaurDycore(DynamicalCore):
         state_next = state_after_dyn
         for f in self._filters:
             state_next = f(state, state_next)
+        if self._nodal_tracers and self._sl_options.get("mass_fixer", True):
+            # SL transport is not mass-conserving (its own validation test
+            # says so) and its quasi-monotone limiter rectifies the error
+            # into systematic CREATION where removal digs sharp minima —
+            # the #713 budget gauge measured it at >10% of the dust
+            # emission rate on dev and unbounded once stronger sinks
+            # sharpened the fields. Restore each nodal tracer's global
+            # mass to its pre-transport value.
+            state_next = self._fix_nodal_tracer_mass(
+                state_after_physics, state_next,
+            )
         return state_next
+
+    def _nodal_tracer_column_weight(self, state) -> jnp.ndarray:
+        """Per-cell air-mass weight ``dp`` [nondim] for nodal-tracer integrals."""
+        ps = jnp.exp(
+            self.coords.horizontal.to_nodal(state.log_surface_pressure)
+        )  # (1, lon, lat)
+        vert = self.coords.vertical
+        if isinstance(vert, HybridCoordinates):
+            a = jnp.asarray(vert.a_boundaries)
+            b = jnp.asarray(vert.b_boundaries)
+            da = (a[1:] - a[:-1])[:, None, None]
+            db = (b[1:] - b[:-1])[:, None, None]
+            return da + db * ps
+        sigma = jnp.asarray(vert.boundaries)
+        return (sigma[1:] - sigma[:-1])[:, None, None] * ps
+
+    def _fix_nodal_tracer_mass(self, state_ref, state_new):
+        """ECMWF-style proportional global mass fixer for the SL tracers (#713).
+
+        Semi-Lagrangian interpolation does not conserve ``∫ q·dp`` — and
+        with the quasi-monotone limiter the error is one-signed wherever a
+        strong sink leaves sharp minima (clipping interpolation
+        undershoots at a minimum can only ADD mass), which is exactly the
+        state strong scavenging/sedimentation produces. Each nodal tracer
+        is therefore rescaled by one global factor per step so its
+        post-transport mass equals the post-physics pre-transport value
+        (Diamantakis & Flemming 2014, the proportional fixer): positivity
+        and the spatial distribution are preserved, and the correction is
+        spread in proportion to the field itself.
+
+        The factor is clipped to [2/3, 1.5]: per-step interpolation error
+        is O(1e-3); a factor outside that band means something other than
+        transport error (a genuinely empty field spinning up, a physics
+        bug) and must surface in the ``budget_dyn_*`` gauge rather than
+        be silently absorbed here.
+        """
+        w = jnp.asarray(self.coords.horizontal.quadrature_weights)
+        dp_ref = self._nodal_tracer_column_weight(state_ref)
+        dp_new = self._nodal_tracer_column_weight(state_new)
+        tracers = dict(state_new.tracers)
+        for name in self._nodal_tracers:
+            q_ref = state_ref.tracers[name]
+            q_new = tracers[name]
+            target = jnp.sum(q_ref * dp_ref * w)
+            current = jnp.sum(q_new * dp_new * w)
+            # A fixer must never manufacture sign: only rescale when both
+            # totals are meaningfully positive (mixing ratios; a cold-start
+            # zero field or a ringing near-zero total passes through).
+            tiny = jnp.asarray(1e-300, dtype=q_new.dtype) if \
+                q_new.dtype == jnp.float64 else jnp.asarray(1e-30, q_new.dtype)
+            ok = (current > tiny) & (target > tiny)
+            scale = jnp.where(
+                ok,
+                jnp.clip(target / jnp.maximum(current, tiny), 2.0 / 3.0, 1.5),
+                1.0,
+            )
+            tracers[name] = q_new * scale
+        return state_new.replace(tracers=tracers)
 
     def sim_time(self, state: State) -> jnp.ndarray:
         return state.sim_time

--- a/jcm/dycore/dinosaur/dycore_test.py
+++ b/jcm/dycore/dinosaur/dycore_test.py
@@ -149,3 +149,99 @@ class OffCenteringDefaultTest(unittest.TestCase):
     def test_sl_options_still_override(self):
         dycore = _small_dycore(sl_options={"off_centering": 0.05})
         self.assertEqual(dycore.off_centering, 0.05)
+
+
+@unittest.skipUnless(_sl_available(), "needs the semi-Lagrangian dinosaur")
+class TracerMassFixerTest(unittest.TestCase):
+    """The SL global mass fixer (#713).
+
+    Semi-Lagrangian transport does not conserve tracer mass; with the
+    quasi-monotone limiter the error is systematically POSITIVE wherever
+    strong sinks leave sharp minima (the limiter can only add mass when it
+    clips an interpolation undershoot at a minimum). The 2026-08 aerosol
+    runaway compounded exactly this. The fixer restores each nodal
+    tracer's global ``integral(q dp)`` to its pre-transport value every
+    step.
+    """
+
+    def _dycore_with_tracer(self):
+        from jcm.physics.physics_term import TracerSpec
+
+        dycore = _small_dycore(
+            tracer_specs={"dust": TracerSpec(name="dust")},
+        )
+        state = dycore.initial_state(None, random_seed=0)
+        return dycore, state
+
+    def _mass(self, dycore, state):
+        import jax.numpy as jnp
+        import numpy as np
+
+        w = np.asarray(dycore.coords.horizontal.quadrature_weights)
+        dp = dycore._nodal_tracer_column_weight(state)
+        return float(jnp.sum(state.tracers["dust"] * dp * w))
+
+    def test_fixer_restores_transport_mass_error(self):
+        import jax.numpy as jnp
+
+        dycore, state = self._dycore_with_tracer()
+        # A rough positive field (the regime where SL leaks).
+        q = 1e-9 * (1.0 + 0.9 * jnp.sin(
+            jnp.arange(state.tracers["dust"].size, dtype=jnp.float64)
+        ).reshape(state.tracers["dust"].shape))
+        state.tracers = {**state.tracers, "dust": jnp.abs(q)}
+        # Fabricate a 1% transport gain on the same state.
+        gained = state.replace(
+            tracers={**state.tracers, "dust": 1.01 * state.tracers["dust"]},
+        )
+        fixed = dycore._fix_nodal_tracer_mass(state, gained)
+        self.assertAlmostEqual(
+            self._mass(dycore, fixed) / self._mass(dycore, state), 1.0,
+            places=10,
+        )
+
+    def test_fixer_guards_empty_fields_and_clips(self):
+        import jax.numpy as jnp
+        import numpy as np
+
+        dycore, state = self._dycore_with_tracer()
+        zero = state.replace(
+            tracers={**state.tracers,
+                     "dust": jnp.zeros_like(state.tracers["dust"])},
+        )
+        # Zero reference AND zero current: passes through untouched.
+        out = dycore._fix_nodal_tracer_mass(zero, zero)
+        np.testing.assert_array_equal(np.asarray(out.tracers["dust"]), 0.0)
+        # A 10x discrepancy is not interpolation error: the clip bounds the
+        # correction at 1.5x rather than silently absorbing a real bug.
+        small = state.replace(
+            tracers={**state.tracers,
+                     "dust": jnp.full_like(state.tracers["dust"], 1e-10)},
+        )
+        big = state.replace(
+            tracers={**state.tracers,
+                     "dust": jnp.full_like(state.tracers["dust"], 1e-9)},
+        )
+        out = dycore._fix_nodal_tracer_mass(big, small)
+        np.testing.assert_allclose(
+            np.asarray(out.tracers["dust"]), 1.5e-10, rtol=1e-6,
+        )
+
+    def test_step_conserves_nodal_tracer_mass(self):
+        import jax.numpy as jnp
+
+        dycore, state = self._dycore_with_tracer()
+        # Sharp positive blob: the hard case for SL conservation.
+        shape = state.tracers["dust"].shape
+        q = jnp.zeros(shape, dtype=jnp.float64)
+        q = q.at[:, 10:14, 20:24].set(1e-8)
+        state.tracers = {**state.tracers, "dust": q}
+        m0 = self._mass(dycore, state)
+        s = state
+        for _ in range(5):
+            s = dycore.step(s, None)
+        m5 = self._mass(dycore, s)
+        # ps evolves, so integral(q dp) is conserved per step against the
+        # step's own reference; over 5 dry adiabatic steps the drift must
+        # be at the clip/roundoff level, not the raw SL leak.
+        self.assertAlmostEqual(m5 / m0, 1.0, places=6)

--- a/jcm/physics/budget_gauge.py
+++ b/jcm/physics/budget_gauge.py
@@ -87,6 +87,18 @@ def gauge_aerosol_budget(
 
     dm = rho * dz                                   # (nlev, ncols) [kg/m²]
     prev_expected = diagnostics.get(CARRY_KEY)
+    # Validity flag rides the carry: ``get_empty_data`` traces this
+    # function and ZERO-FILLS the resulting carry template, and the
+    # initial physics carry hands that template back on the first step —
+    # so ``prev_expected`` is present-but-structural there, and treating
+    # it as a real expectation would report the entire initial burden as
+    # a fictitious dynamics source on step one (harmless from a zero
+    # cold start, badly wrong from a warm start). The flag is written as
+    # 1 by every real step and is 0 exactly when the expectation is the
+    # zero-filled seed.
+    valid = jnp.asarray(0.0, dm.dtype)
+    if prev_expected is not None:
+        valid = prev_expected.get("_valid", valid) * jnp.ones((), dm.dtype)
     out = dict(diagnostics)
     expected: dict[str, jnp.ndarray] = {}
     for sp, names in sorted(by_species.items()):
@@ -102,9 +114,12 @@ def gauge_aerosol_budget(
         out[f"budget_mass_{sp}"] = mass
         out[f"budget_ptend_{sp}"] = ptend
         if prev_expected is not None and sp in prev_expected:
-            out[f"budget_dyn_{sp}"] = (mass - prev_expected[sp]) / dt
+            out[f"budget_dyn_{sp}"] = (
+                valid * (mass - prev_expected[sp]) / dt
+            )
         else:
             out[f"budget_dyn_{sp}"] = jnp.zeros_like(mass)
         expected[sp] = mass + dt * ptend
+    expected["_valid"] = jnp.ones((), dm.dtype)
     out[CARRY_KEY] = expected
     return out

--- a/jcm/physics/budget_gauge.py
+++ b/jcm/physics/budget_gauge.py
@@ -1,0 +1,110 @@
+"""Per-species aerosol mass-budget gauge (#713).
+
+The July-2026 aerosol runaway hid for weeks because a burden drift is a
+small residual of large opposing process fluxes — and the health gates
+(NaN / temperature / humidity) sailed through a ×390 dust explosion with
+the meteorology entirely normal. This gauge closes the budget *in the
+step*, where the pairing between a physics call and the host's transport
+is exact, instead of reconstructing it from time-averaged output:
+
+``budget_mass_<sp>``
+    Column mass of the ADVECTED interstitial tracers (``m_*``) of species
+    ``sp`` at physics entry [kg/m²], per column. The cloud-borne carry is
+    deliberately excluded — the host never transports it, so it cannot
+    contribute to the dynamics residual, and its exchange transfers show
+    up in ``budget_ptend`` (as they should: they are real sources/sinks
+    of advected mass).
+
+``budget_ptend_<sp>``
+    Net physics column tendency [kg/m²/s]: the SUM over every term of the
+    accumulated ``m_*`` tracer tendencies. Unlike the ``emi_*`` /
+    ``wet_*`` / ``dry_*`` ledgers this includes *every* pathway —
+    chemistry production, cloud-borne exchange, convective transport,
+    re-injection — so ``ptend − (emi − wet − dry)`` measures the
+    unledgered physics per species.
+
+``budget_dyn_<sp>``
+    The DYNAMICS residual [kg/m²/s]: ``(mass_now − expected_prev)/dt``
+    with ``expected_prev = mass_prev + dt·ptend_prev`` carried across the
+    step. The host applies exactly ``q += dt·tend`` and then transports
+    (semi-Lagrangian advection, filters, the dynamics→physics positivity
+    projection), so this residual is everything the transport machinery
+    created or destroyed. A conservative core reads ~0; dinosaur's
+    semi-Lagrangian tracer transport is *documented* non-conservative
+    (its own validation test: "semi-Lagrangian transport does not
+    conserve mass exactly"), and this field is where that error becomes
+    visible per species, per column, per step. Zero on the first step
+    (no previous expectation).
+
+All three are per-column 2D fields riding the ordinary diagnostics
+output (time-averaged like everything else under ``output_averages``).
+Global closure: ``d(budget_mass)/dt == budget_ptend + budget_dyn`` by
+construction, so the *global-mean* ``budget_dyn`` is the transport leak
+and ``budget_ptend − ledgers`` the unledgered-physics leak.
+
+The expectation carried between steps lives under the internal
+``_budget_expected`` key (excluded from output).
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+
+#: Internal carry key for the lagged expectation.
+CARRY_KEY = "_budget_expected"
+
+
+def gauge_aerosol_budget(
+    diagnostics: dict,
+    state,
+    tracer_tends: dict,
+    dt: float,
+) -> dict:
+    """Emit the per-species budget fields; thread the lagged expectation.
+
+    No-op (returns ``diagnostics`` unchanged) when the composition carries
+    no aerosol mass tracers or no air-mass diagnostics — both are
+    trace-time-static properties of the physics package, so the carry
+    structure is stable across steps.
+    """
+    rho = diagnostics.get("air_density")
+    dz = diagnostics.get("layer_thickness")
+    if rho is None or dz is None:
+        return diagnostics
+    from jcm.physics.aerosol.jam.emissions.flux_diagnostic import (
+        DEPOSITED_SPECIES,
+        _species_of,
+    )
+    by_species: dict[str, list[str]] = {}
+    for nm in state.tracers:
+        if not nm.startswith("m_"):
+            continue
+        sp = _species_of(nm)
+        if sp in DEPOSITED_SPECIES:
+            by_species.setdefault(sp, []).append(nm)
+    if not by_species:
+        return diagnostics
+
+    dm = rho * dz                                   # (nlev, ncols) [kg/m²]
+    prev_expected = diagnostics.get(CARRY_KEY)
+    out = dict(diagnostics)
+    expected: dict[str, jnp.ndarray] = {}
+    for sp, names in sorted(by_species.items()):
+        mass = sum(
+            jnp.sum(jnp.asarray(state.tracers[nm]) * dm, axis=0)
+            for nm in names
+        )
+        ptend = sum(
+            jnp.sum(tracer_tends[nm] * dm, axis=0)
+            for nm in names if nm in tracer_tends
+        )
+        ptend = ptend + jnp.zeros_like(mass)
+        out[f"budget_mass_{sp}"] = mass
+        out[f"budget_ptend_{sp}"] = ptend
+        if prev_expected is not None and sp in prev_expected:
+            out[f"budget_dyn_{sp}"] = (mass - prev_expected[sp]) / dt
+        else:
+            out[f"budget_dyn_{sp}"] = jnp.zeros_like(mass)
+        expected[sp] = mass + dt * ptend
+    out[CARRY_KEY] = expected
+    return out

--- a/jcm/physics/budget_gauge_test.py
+++ b/jcm/physics/budget_gauge_test.py
@@ -1,0 +1,87 @@
+"""Tests for the #713 per-species aerosol mass-budget gauge."""
+
+import unittest
+
+import jax.numpy as jnp
+import numpy as np
+
+from jcm.physics.budget_gauge import CARRY_KEY, gauge_aerosol_budget
+from jcm.physics_interface import PhysicsState
+
+
+def _make(nlev=4, ncols=3, q=1e-9):
+    state = PhysicsState.zeros((nlev, ncols)).copy(
+        temperature=jnp.full((nlev, ncols), 270.0),
+        tracers={
+            "m_du_acc": jnp.full((nlev, ncols), q),
+            "m_du_cor": jnp.full((nlev, ncols), 2 * q),
+            "n_acc": jnp.full((nlev, ncols), 1e8),   # number: not gauged
+            "qc": jnp.zeros((nlev, ncols)),          # non-aerosol: not gauged
+        },
+    )
+    diagnostics = {
+        "air_density": jnp.ones((nlev, ncols)),
+        "layer_thickness": jnp.full((nlev, ncols), 100.0),
+    }
+    return state, diagnostics
+
+
+class GaugeTest(unittest.TestCase):
+    def test_mass_and_ptend_are_species_sums(self):
+        state, diag = _make()
+        tends = {"m_du_acc": jnp.full((4, 3), 1e-13),
+                 "m_du_cor": jnp.full((4, 3), -2e-13)}
+        out = gauge_aerosol_budget(diag, state, tends, 600.0)
+        # dm = 100 kg/m² per level, 4 levels: mass = (1+2)e-9 * 400.
+        np.testing.assert_allclose(out["budget_mass_du"], 3e-9 * 400.0)
+        np.testing.assert_allclose(out["budget_ptend_du"],
+                                   (1e-13 - 2e-13) * 400.0)
+        # First call: no expectation yet -> dynamics residual is zero.
+        np.testing.assert_array_equal(out["budget_dyn_du"], 0.0)
+        self.assertIn(CARRY_KEY, out)
+
+    def test_dynamics_residual_closes_and_detects_a_leak(self):
+        dt = 600.0
+        state, diag = _make()
+        tends = {"m_du_acc": jnp.full((4, 3), 1e-13),
+                 "m_du_cor": jnp.zeros((4, 3))}
+        out = gauge_aerosol_budget(diag, state, tends, dt)
+
+        # A CONSERVATIVE host applies exactly q += dt*tend: residual 0.
+        conserved = state.copy(tracers={
+            **state.tracers,
+            "m_du_acc": state.tracers["m_du_acc"] + dt * tends["m_du_acc"],
+        })
+        out2 = gauge_aerosol_budget(dict(out), conserved, tends, dt)
+        np.testing.assert_allclose(np.asarray(out2["budget_dyn_du"]), 0.0,
+                                   atol=1e-22)
+
+        # A LEAKY host (transport created 10% extra acc mass): residual
+        # equals exactly the created column mass per unit time.
+        leaky = state.copy(tracers={
+            **state.tracers,
+            "m_du_acc": 1.1 * (state.tracers["m_du_acc"]
+                               + dt * tends["m_du_acc"]),
+        })
+        out3 = gauge_aerosol_budget(dict(out), leaky, tends, dt)
+        created = 0.1 * float(
+            (state.tracers["m_du_acc"][0, 0] + dt * 1e-13) * 400.0)
+        np.testing.assert_allclose(np.asarray(out3["budget_dyn_du"]),
+                                   created / dt, rtol=1e-5)
+
+    def test_noop_without_airmass_or_aerosols(self):
+        state, diag = _make()
+        # No air-mass diagnostics -> untouched dict.
+        out = gauge_aerosol_budget({}, state, {}, 600.0)
+        self.assertEqual(out, {})
+        # No aerosol tracers -> untouched dict.
+        bare = PhysicsState.zeros((4, 3)).copy(
+            temperature=jnp.full((4, 3), 270.0),
+            tracers={"qc": jnp.zeros((4, 3))},
+        )
+        out = gauge_aerosol_budget(dict(diag), bare, {}, 600.0)
+        self.assertNotIn("budget_mass_du", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jcm/physics/budget_gauge_test.py
+++ b/jcm/physics/budget_gauge_test.py
@@ -69,6 +69,29 @@ class GaugeTest(unittest.TestCase):
         np.testing.assert_allclose(np.asarray(out3["budget_dyn_du"]),
                                    created / dt, rtol=1e-5)
 
+    def test_zero_filled_template_expectation_reads_as_invalid(self):
+        # get_empty_data traces the gauge and ZERO-FILLS the carry, and
+        # the initial physics carry hands that template back on step 1 —
+        # a warm start (nonzero burden) must NOT report its entire
+        # initial mass as a fictitious dynamics source (Codex P2 on
+        # #720). The zero-filled _valid flag marks the seed structural.
+        import jax
+
+        dt = 600.0
+        state, diag = _make(q=5e-9)     # warm start: real burden
+        tends = {"m_du_acc": jnp.zeros((4, 3)), "m_du_cor": jnp.zeros((4, 3))}
+        real = gauge_aerosol_budget(dict(diag), state, tends, dt)
+        # Simulate the template: zero-fill the carried expectation.
+        template = jax.tree_util.tree_map(
+            jnp.zeros_like, real[CARRY_KEY])
+        seeded = {**diag, CARRY_KEY: template}
+        out = gauge_aerosol_budget(seeded, state, tends, dt)
+        np.testing.assert_array_equal(np.asarray(out["budget_dyn_du"]), 0.0)
+        # The step it emits is valid, so the NEXT step measures normally.
+        out2 = gauge_aerosol_budget(dict(out), state, tends, dt)
+        np.testing.assert_allclose(np.asarray(out2["budget_dyn_du"]), 0.0,
+                                   atol=1e-22)
+
     def test_noop_without_airmass_or_aerosols(self):
         state, diag = _make()
         # No air-mass diagnostics -> untouched dict.

--- a/jcm/physics/composable_physics.py
+++ b/jcm/physics/composable_physics.py
@@ -31,6 +31,7 @@ from jcm import profiling
 from jcm.physics_interface import Physics, PhysicsState, PhysicsTendency
 from jcm.forcing import ForcingData
 from jcm.terrain import TerrainData
+from jcm.physics.budget_gauge import gauge_aerosol_budget
 from jcm.physics.physics_term import PhysicsTerm, TracerSpec
 from jcm.physics.radiation.band_config import RadiationBandConfig
 
@@ -377,6 +378,15 @@ class ComposablePhysics(nnx.Module, Physics):
             "q_tendency": acc["specific_humidity"],
         }
 
+        # Per-species aerosol mass-budget gauge (#713): entry mass, net
+        # physics tendency, and the lagged DYNAMICS residual — the
+        # in-step budget closure that makes a transport leak or an
+        # unledgered physics source visible in one save window instead
+        # of after months of compounding. No-op without aerosol tracers.
+        diagnostics = gauge_aerosol_budget(
+            diagnostics, vectorized_state, acc["tracers"], self.dt_seconds,
+        )
+
         # Keep the accumulated tendencies column-sharded before the lon-major
         # un-flatten, so the (nlev, ncols) -> (nlev, nlon, nlat) reshape lands
         # back in the physics 3D sharding rather than triggering a gather.
@@ -531,6 +541,9 @@ class ComposablePhysics(nnx.Module, Physics):
         # Cross-step (q, dq/dt) handoff for the lagged dynamics-tendency
         # reconstruction (#699) — carry plumbing, not an output field.
         "_prev_step",
+        # Cross-step per-species mass expectation for the #713 budget
+        # gauge — carry plumbing, not an output field.
+        "_budget_expected",
         "aerosol.aod_sw_per_band",
         "aerosol.ssa_sw_per_band",
         "aerosol.asy_sw_per_band",

--- a/jcm/runners.py
+++ b/jcm/runners.py
@@ -2023,6 +2023,37 @@ def run_chunked(
         reports.append(report)
         print_report(report)
 
+        # #713: one greppable aerosol-budget line per species per chunk.
+        # The gauge fields close d(mass)/dt = ptend + dyn in-step, so the
+        # chunk means printed here attribute any drift on the spot:
+        # ``dyn`` is the transport (SL/filters) creation, ``ptend-ledger``
+        # the unledgered physics. All float64 global means — a drift that
+        # takes months to show in burdens is visible in one chunk here.
+        budget_species = sorted(
+            k[len("budget_dyn_"):] for k in ds.data_vars
+            if k.startswith("budget_dyn_"))
+        if budget_species:
+            import numpy as _np
+            _w = _np.cos(_np.deg2rad(_np.asarray(ds.lat, dtype=_np.float64)))
+            def _gm(name):
+                v = _np.asarray(ds[name], dtype=_np.float64)
+                # (time, lon, lat) -> weighted global+time mean
+                return float(
+                    (v * _w[None, None, :]).sum(axis=(-1, -2)).mean()
+                    / (_w.sum() * v.shape[-2]))
+            for sp in budget_species:
+                mass = _gm(f"budget_mass_{sp}")
+                ptend = _gm(f"budget_ptend_{sp}")
+                dyn = _gm(f"budget_dyn_{sp}")
+                ledger = 0.0
+                for fam, sgn in (("emi", 1.0), ("wet", -1.0), ("dry", -1.0)):
+                    key = f"{fam}_{sp}"
+                    if key in ds:
+                        ledger += sgn * _gm(key)
+                print(f"  budget {sp:4s}: mass={mass*1e6:10.3f} mg/m2  "
+                      f"ptend={ptend*1e12:+10.2f} dyn={dyn*1e12:+10.2f} "
+                      f"unledgered={(ptend-ledger)*1e12:+10.2f} ng/m2/s")
+
         nc_path = f"{output_prefix}_day{int(elapsed_sim_days)}.nc"
         ds.attrs.update(provenance.attrs())
         ds.attrs["jcm_prov_chunk_wall_seconds"] = round(chunk_wall, 1)

--- a/jcm/runners.py
+++ b/jcm/runners.py
@@ -2056,6 +2056,22 @@ def run_chunked(
                 return float(
                     (v * _w[None, None, :]).sum(axis=(-1, -2)).mean()
                     / (_w.sum() * v.shape[-2]))
+            # Closure floor: the gauge's carried expectation quantizes at
+            # the model dtype's epsilon of the column mass each step, so a
+            # |dyn| below eps*mass/dt is rounding, not leak. At float64
+            # (eps ~ 2e-16) the floor is far below anything physical; at
+            # float32 (eps ~ 1.2e-7) it reaches O(0.1-1) ng/m2/s at real
+            # burdens — flag those lines rather than let a noise-level
+            # residual read as either "closed" or "leaking".
+            _eps = float(jnp.finfo(
+                ds[f"budget_dyn_{budget_species[0]}"].dtype).eps)
+            # pySES presets omit run.time_step (the Model adopts the
+            # dycore's dt); the floor is an order-of-magnitude guide, so
+            # a nominal 900 s stands in rather than reaching into the
+            # dycore from here.
+            _dt_cfg = cfg.get("run", {}).get("time_step", None)
+            _dt_s = float(_dt_cfg) * 60.0 if _dt_cfg else 900.0
+            f32_noted = False
             for sp in budget_species:
                 mass = _gm(f"budget_mass_{sp}")
                 ptend = _gm(f"budget_ptend_{sp}")
@@ -2065,9 +2081,19 @@ def run_chunked(
                     key = f"{fam}_{sp}"
                     if key in ds:
                         ledger += sgn * _gm(key)
+                floor = _eps * abs(mass) / _dt_s
+                caveat = ""
+                if _eps > 1e-10 and abs(dyn) <= floor:
+                    caveat = f"  [<f32 floor {floor*1e12:.2f} — inconclusive]"
+                    f32_noted = True
                 print(f"  budget {sp:4s}: mass={mass*1e6:10.3f} mg/m2  "
                       f"ptend={ptend*1e12:+10.2f} dyn={dyn*1e12:+10.2f} "
-                      f"unledgered={(ptend-ledger)*1e12:+10.2f} ng/m2/s")
+                      f"unledgered={(ptend-ledger)*1e12:+10.2f} ng/m2/s"
+                      + caveat)
+            if f32_noted:
+                print("  budget note: float32 run — dyn below the per-species "
+                      "floor is precision noise; closure can only be claimed "
+                      "down to that floor (run float64 to verify further).")
 
         nc_path = f"{output_prefix}_day{int(elapsed_sim_days)}.nc"
         ds.attrs.update(provenance.attrs())

--- a/jcm/runners.py
+++ b/jcm/runners.py
@@ -2034,7 +2034,22 @@ def run_chunked(
             if k.startswith("budget_dyn_"))
         if budget_species:
             import numpy as _np
-            _w = _np.cos(_np.deg2rad(_np.asarray(ds.lat, dtype=_np.float64)))
+            _lat = _np.asarray(ds.lat, dtype=_np.float64)
+            # Exact Gaussian quadrature weights when the output grid is
+            # Gauss-Legendre (dinosaur): match the nodes by sin(lat) and
+            # use their weights, so a transport residual whose quadrature
+            # integral should cancel actually reads zero. cos(lat) is
+            # only the leading approximation of those weights and biases
+            # meridionally structured fields. Non-Gaussian grids fall
+            # back to cosine weighting.
+            _nodes, _gw = _np.polynomial.legendre.leggauss(_lat.size)
+            _order = _np.argsort(_np.sin(_np.deg2rad(_lat)))
+            if _np.allclose(_np.sin(_np.deg2rad(_lat))[_order], _nodes,
+                            atol=1e-6):
+                _w = _np.empty_like(_gw)
+                _w[_order] = _gw
+            else:
+                _w = _np.cos(_np.deg2rad(_lat))
             def _gm(name):
                 v = _np.asarray(ds[name], dtype=_np.float64)
                 # (time, lon, lat) -> weighted global+time mean


### PR DESCRIPTION
Closes #713. Refs #658, #660, #714.

**The finding this delivers**: dinosaur's semi-Lagrangian tracer transport — documented non-conservative by its own validation test — has been *creating* aerosol mass at a climate-relevant rate on `dev`: **dust +61–67 ng/m²/s (~20% of the emission flux), steadily**, sea salt's *entire* net budget balance (+5.4 vs physics −5.0), few-% for SO4/BC/POA. The quasi-monotone limiter rectifies the interpolation error — clipping an undershoot at a minimum can only add mass — so the sharper the sinks make the fields, the more it creates. That is (a) why dev's dust burden creeps, (b) why dust and sea salt "were fine" before the recent cloud-fix PRs strengthened removal, and (c) the engine of the #660/#714 runaway: stronger sinks → sharper minima → more creation → more burden, exponential once past threshold (dust ×390/30 days).

## Commit 1 — the in-step budget gauge (#713 items 1+2)

`budget_mass_<sp>` / `budget_ptend_<sp>` / `budget_dyn_<sp>` per aerosol species: advected column mass at physics entry, net physics tendency over **all** pathways, and the lagged dynamics residual — the host applies exactly `q += dt·tend` before transporting, so `dyn` is precisely what the transport machinery created or destroyed. Closure `d(mass)/dt = ptend + dyn` holds by construction; `ptend − (emi − wet − dry)` isolates unledgered physics (measured: the cloud-borne exchange's into-carry flux and SO4 chemistry production — both legitimate). Plus one greppable float64 `budget <sp>: …` line per species per chunk in the runner, so a drift that once took 9 sim-months to surface in burdens is visible — and attributed — in a single 15-day chunk. The gauge named the SL leak on its first run.

## Commit 2 — the proportional SL mass fixer

ECMWF-style (Diamantakis & Flemming 2014): each nodal tracer rescaled by one global factor per step so post-transport `∫q·dp` equals its post-physics value. Positivity and spatial structure preserved; factor clipped to [2/3, 1.5] so anything bigger surfaces in `budget_dyn_*` instead of being absorbed; sign-guarded (empty/ringing fields pass through); `sl_options {'mass_fixer': False}` opts out. **This also covers `qc`/`qi`** (declared tracers ride nodal transport), so cloud-condensate advection becomes conserving too — a deliberate behaviour change.

## Commit 3 — #558-class gradient guard

The fixer's scale division needed the double-where guard (cotangent ∝ `target/current²` through cold-start-empty fields NaN'd the two-step gradient gate; caught by the local slow suite, fixed, both macv2sp configs pass).

## Validation (90-day T63L47 `echam-jam-aerocom`, production emissions; logs + outputs in `/scr/dwatsonparris/jam_scav_ab/`)

| run | dust `dyn` [ng/m²/s] | dust burden day 60 [mg/m²] |
|---|---|---|
| dev, unfixed | +61…+67 | 203 (leak-sustained) |
| dev + fixer | **+0.02…+0.15** | ~154 (emission-driven, closed) |
| #660+#714 stack, unfixed | +26…+35 → runaway | **16,294 and exploding** |
| stack + fixer | **−0.02…+0.08** | **50.8, stable** |

Every species' budget line closes to ±0.2 ng/m²/s through day 75+ (day-90 finals land in this thread); zero NaN vars throughout; fast suite 1925 @ 94.8%, slow 86 @ 84.7%, ruff clean.

**Merge-order note**: this PR is the unblocker — #660 and #714 both sit on top of a transport leak their stronger sinks amplify into the runaway documented on #660. With this merged first, their physics can be re-validated on a closed budget (the moment-weighted settling and the ledger-keyed scavenging are both physically right and both looked "explosive" only because the dycore was manufacturing the mass they removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFu9rxRPLQ7qj3hwZf6zRE