### PR TITLE
JAM carbonaceous ageing via the mam4-jax core (#721)

### DIFF
--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -13,6 +13,7 @@ JAX-GCM is designed to be a fully differentiable climate model that balances eas
    design/parallelization
    design/pyses_cam_se_dycore
    design/dinosaur_sl_jam_configuration
+   design/jam_carbon_aging
    design/speedy_variable_levels
    design/frontal_gravity_wave_drag
    design/lohmann_2m_column_processes

--- a/docs/source/design/jam_carbon_aging.md
+++ b/docs/source/design/jam_carbon_aging.md
@@ -72,6 +72,8 @@ Ageing is ON by default in every JAM run using the `mam4_jax` core (there
 is no Fortran toggle to mirror; the core's `mdo_pcarbonaging` exists for
 fixture parity only). Expected effects: BC/POA lifetimes drop toward the
 observed 5–8 d range, carbonaceous burdens fall accordingly, and SO4 gains
-a small source from the closed repack leak. The mam4-jax pin also carries a
-float32 fix without which coagulation moved **zero** mass between modes in
-f32 runs (`betaij3` underflow) — see the mam4-jax PR for details.
+a small source from the closed repack leak.
+
+The pinned core is **mam4-jax 0.4.0**, the first release carrying the ageing
+port; it also carries a float32 fix without which coagulation moved **zero**
+mass between modes in f32 runs (`betaij3` underflow).

--- a/docs/source/design/jam_carbon_aging.md
+++ b/docs/source/design/jam_carbon_aging.md
@@ -40,9 +40,12 @@ mode *number* move by `xferfrac`; shell species move wholesale.
 because the references legitimately disagree by an order of magnitude —
 E3SM production hard-codes 8, the MAM4 box harness uses 3, ECHAM-HAM uses 1 —
 and it directly sets the BC/POA lifetime (smaller = faster ageing). Default:
-8.0 (deployed-MAM4). It is trace-time static in the core's process-global
-config, so it is **not** a differentiable parameter; calibrating it means a
-sweep, not a gradient.
+8.0 (deployed-MAM4). Each term instance holds its own value and passes it to
+the core **per call** as a static jit argument (never via the core's
+process-global config, which is read at trace time and would make several
+differently-configured instances in one process order-dependent). Static
+means it is **not** a differentiable parameter; calibrating it means a
+sweep — which the per-instance binding makes safe — not a gradient.
 
 ## Why in-core, not a harness term
 

--- a/docs/source/design/jam_carbon_aging.md
+++ b/docs/source/design/jam_carbon_aging.md
@@ -42,12 +42,18 @@ receives 3 (via `phys_control`, the CAM5/ACME lineage; the oft-quoted 8 in
 `modal_aero_gasaerexch.F90` belongs to E3SM's legacy `modal_aero_coag` ageing
 path), and ECHAM-HAM uses 1 — and it directly sets the BC/POA lifetime
 (smaller = faster ageing). Default: 3.0 (the amicphys reference value, which
-also reproduces the vendored Fortran captures). Each term instance holds its own value and passes it to
-the core **per call** as a static jit argument (never via the core's
-process-global config, which is read at trace time and would make several
-differently-configured instances in one process order-dependent). Static
-means it is **not** a differentiable parameter; calibrating it means a
-sweep — which the per-instance binding makes safe — not a gradient.
+also reproduces the vendored Fortran captures). Each term instance holds its
+own value as an **`nnx.Param` leaf** — a differentiable parameter per the
+repo convention — and passes it to the core per call as a **traced**
+`AmicphysParams` field (never via the core's process-global config, which is
+read at trace time and would make several differently-configured instances in
+one process order-dependent). Consequences: `jax.grad` flows through the
+criterion (piecewise — the gradient is exactly zero once the mode saturates),
+a calibration sweep over the threshold reuses a single compiled step, and the
+gas netprod rates ride the same pytree for future source calibration. The
+`mdo_pcarbonaging` toggle is *not* subsumed by the threshold: 0 monolayers
+means a zero-thickness coating requirement (instant full ageing, not off),
+and no finite threshold suppresses the wholesale shell-species transfer.
 
 ## Why in-core, not a harness term
 

--- a/docs/source/design/jam_carbon_aging.md
+++ b/docs/source/design/jam_carbon_aging.md
@@ -70,9 +70,16 @@ harness-side approximation would have fixed neither.
 
 Ageing is ON by default in every JAM run using the `mam4_jax` core (there
 is no Fortran toggle to mirror; the core's `mdo_pcarbonaging` exists for
-fixture parity only). Expected effects: BC/POA lifetimes drop toward the
-observed 5–8 d range, carbonaceous burdens fall accordingly, and SO4 gains
-a small source from the closed repack leak.
+fixture parity only). Carbonaceous lifetimes and burdens both fall, and SO4
+gains a small source from the closed repack leak. 90-day T63L47
+`echam-jam-aerocom` runs (area-weighted global means over days 45–90,
+τ = burden / (dry + wet removal)) put the threshold's sensitivity at roughly
+a factor of two across the reference spread: at `n = 8` BC sits at 0.22 mg/m²
+with τ ≈ 8.4 d and 56 % of its mass already in accumulation, at the default
+`n = 3` at 0.15 mg/m² with τ ≈ 4.8 d and 68 % in accumulation. Both bracket
+the observed 5–8 d, against ~21 d and 0 % with no ageing at all — so the
+threshold is a first-order tuning handle for carbonaceous lifetime, which is
+why it is exposed and differentiable rather than hard-coded.
 
 The pinned core is **mam4-jax 0.4.0**, the first release carrying the ageing
 port; it also carries a float32 fix without which coagulation moved **zero**

--- a/docs/source/design/jam_carbon_aging.md
+++ b/docs/source/design/jam_carbon_aging.md
@@ -4,27 +4,34 @@
 **Where it runs:** inside the mam4-jax core (`mam_pcarbon_aging_1subarea`
 port), invoked by `Mam4JaxMicrophysics` after coagulation each step.
 
-## The problem it solves
+## Why the process is needed
 
-JAM emits 100 % of BC and POA into the `primary_carbon` (pcm) mode, which is
-`can_activate=False` by design — structurally excluded from ARG activation,
-stratiform and convective in-cloud scavenging, and the explicit cloud-borne
-phase. That is correct for *fresh* hydrophobic carbon, but with no ageing
-process the exclusion was permanent: the 2-year closed-budget run (PR #720)
-measured a BC lifetime of ~21 days (observed 5–8 d) and a ~2.5× high burden.
-Both reference models age their carbon: MAM4 via `mam_pcarbon_aging_1subarea`
-(E3SM `modal_aero_amicphys.F90:5111-5285`), ECHAM-HAMMOZ via
-`m7_concoag`/`m7_coat` (`mo_ham_m7.f90:3532-3844`).
+JAM emits all BC and POA into the `primary_carbon` (pcm) mode, which is
+`can_activate=False`: structurally excluded from ARG activation, from
+stratiform and convective in-cloud scavenging, and from the explicit
+cloud-borne phase. That exclusion is right for *fresh* hydrophobic carbon and
+wrong for the same particle once a soluble coating has grown on it. Ageing is
+the transfer that ends the exclusion — the only pathway by which carbon
+reaches accumulation, where activation and wet removal can act on it. Without
+it the exclusion is permanent, and BC lifetime is set by dry deposition and
+sedimentation alone: ~21 days against an observed 5–8 d, with a
+correspondingly high burden.
+
+Both reference models age their carbon: MAM4 via
+`mam_pcarbon_aging_1subarea` (E3SM `modal_aero_amicphys.F90:5111-5285`),
+ECHAM-HAMMOZ via `m7_concoag`/`m7_coat` (`mo_ham_m7.f90:3532-3844`).
 
 ## Which reference formulation, and why
 
 Both references implement the same physics — a particle counts as aged once
-condensed + coagulated sulfate (plus SOA as hygroscopicity-equivalent
-"so4") coats its surface with a threshold number of monolayers — but for
-different mode structures. JAM's modes **are** MAM4's (pcm → accumulation is
-the one age-pair), so the MAM4 formulation ports verbatim while HAMMOZ's
-KI/AI/CI→soluble transfers have no direct image here. The HAMMOZ evidence
-establishes the process and brackets the one free parameter.
+condensed + coagulated sulfate (plus SOA as hygroscopicity-equivalent "so4")
+coats its surface with a threshold number of monolayers — but for different
+mode structures. JAM's modes **are** MAM4's, and pcm → accumulation is the one
+age-pair, so the MAM4 formulation ports verbatim. HAMMOZ's KI/AI/CI → soluble
+transfers were considered and have no direct image here: they presuppose a
+soluble/insoluble mode pairing JAM does not have. The HAMMOZ evidence is
+retained for what it does establish — that the process is real, and where the
+one free parameter plausibly sits.
 
 The transferred fraction per step is
 
@@ -36,51 +43,53 @@ with `Δr = 4.76e-10 m` (one bisulfate monolayer), `vol_shell` = so4 + soa
 (soa scaled by κ_soa/κ_so4), `vol_core` = pom + bc + moa. Core species and
 mode *number* move by `xferfrac`; shell species move wholesale.
 
-**The monolayer count `n` is exposed** (`Mam4JaxMicrophysics(n_so4_monolayers=…)`)
-because the references legitimately disagree — the MAM4 *amicphys* path
-receives 3 (via `phys_control`, the CAM5/ACME lineage; the oft-quoted 8 in
-`modal_aero_gasaerexch.F90` belongs to E3SM's legacy `modal_aero_coag` ageing
-path), and ECHAM-HAM uses 1 — and it directly sets the BC/POA lifetime
-(smaller = faster ageing). Default: 3.0 (the amicphys reference value, which
-also reproduces the vendored Fortran captures). Each term instance holds its
-own value as an **`nnx.Param` leaf** — a differentiable parameter per the
-repo convention — and passes it to the core per call as a **traced**
-`AmicphysParams` field (never via the core's process-global config, which is
-read at trace time and would make several differently-configured instances in
-one process order-dependent). Consequences: `jax.grad` flows through the
+## The monolayer threshold is a parameter, not a constant
+
+`n` is exposed as `Mam4JaxMicrophysics(n_so4_monolayers=…)` because the
+references legitimately disagree: the MAM4 *amicphys* path receives 3 (via
+`phys_control`, the CAM5/ACME lineage), ECHAM-HAM's `m7_coat` uses 1, and the
+8 quoted from `modal_aero_gasaerexch.F90` belongs to E3SM's legacy
+`modal_aero_coag` ageing path rather than to amicphys. The spread matters
+because `n` sets carbonaceous lifetime directly — smaller means faster
+ageing. Across the two MAM4 values, 90-day T63L47 `echam-jam-aerocom` runs
+(area-weighted global means over days 45–90, τ = burden / (dry + wet
+removal)) give BC τ ≈ 8.4 d and burden 0.22 mg/m² at `n = 8`, and τ ≈ 4.8 d
+and 0.15 mg/m² at `n = 3`, with 56 % and 68 % of BC mass in accumulation
+respectively. Both bracket the observed 5–8 d; a factor of ~2.7 in the
+parameter moves lifetime by nearly a factor of two.
+
+The default is **3.0** — the amicphys reference value, which also reproduces
+the vendored Fortran captures.
+
+Each term instance holds its own value as an **`nnx.Param` leaf**, a
+differentiable parameter per the repo convention, and passes it to the core
+per call as a **traced** `AmicphysParams` field. It is deliberately not routed
+through the core's process-global config, which is read at trace time: that
+would make several differently-configured instances in one process
+order-dependent. Consequences of the traced form: `jax.grad` flows through the
 criterion (piecewise — the gradient is exactly zero once the mode saturates),
 a calibration sweep over the threshold reuses a single compiled step, and the
-gas netprod rates ride the same pytree for future source calibration. The
-`mdo_pcarbonaging` toggle is *not* subsumed by the threshold: 0 monolayers
-means a zero-thickness coating requirement (instant full ageing, not off),
-and no finite threshold suppresses the wholesale shell-species transfer.
+gas netprod rates ride the same pytree for future source calibration.
+
+`n` does not subsume the `mdo_pcarbonaging` toggle. Zero monolayers is a
+zero-thickness coating requirement — instant full ageing, not off — and no
+finite threshold suppresses the wholesale shell-species transfer. The toggle
+exists for parity against the `skip_pcarbon_aging` reference build; ageing is
+on in every JAM run.
 
 ## Why in-core, not a harness term
 
-The coating criterion needs the sulfate condensed onto pcm *within the
-step*, which exists only inside `amicphys` (the harness never sees per-mode
-condensation increments). It must also run **before** the core's state
-repack: pcm has no so4/soa tracer slots, so condensed shell mass on pcm was
-previously **silently dropped at repack** — a standing per-step sulfur/SOA
-sink proportional to pcm number. Ageing transfers that mass to accumulation
-(which has the slots) and thereby closes the leak by construction. A
-harness-side approximation would have fixed neither.
+The coating criterion needs the sulfate condensed onto pcm *within the step*,
+which exists only inside `amicphys` — the harness never sees per-mode
+condensation increments. It must also run **before** the core's state repack:
+pcm has no so4/soa tracer slots, so shell mass condensed onto pcm has nowhere
+to be written and would be dropped there, a per-step sulfur/SOA sink
+proportional to pcm number. Running ageing first moves that mass to
+accumulation, which does have the slots, so the sink cannot arise. A
+harness-side approximation satisfies neither requirement.
 
-## What changes for users
+## Requirements
 
-Ageing is ON by default in every JAM run using the `mam4_jax` core (there
-is no Fortran toggle to mirror; the core's `mdo_pcarbonaging` exists for
-fixture parity only). Carbonaceous lifetimes and burdens both fall, and SO4
-gains a small source from the closed repack leak. 90-day T63L47
-`echam-jam-aerocom` runs (area-weighted global means over days 45–90,
-τ = burden / (dry + wet removal)) put the threshold's sensitivity at roughly
-a factor of two across the reference spread: at `n = 8` BC sits at 0.22 mg/m²
-with τ ≈ 8.4 d and 56 % of its mass already in accumulation, at the default
-`n = 3` at 0.15 mg/m² with τ ≈ 4.8 d and 68 % in accumulation. Both bracket
-the observed 5–8 d, against ~21 d and 0 % with no ageing at all — so the
-threshold is a first-order tuning handle for carbonaceous lifetime, which is
-why it is exposed and differentiable rather than hard-coded.
-
-The pinned core is **mam4-jax 0.4.0**, the first release carrying the ageing
-port; it also carries a float32 fix without which coagulation moved **zero**
-mass between modes in f32 runs (`betaij3` underflow).
+The core is pinned to **mam4-jax 0.4.0**, the first release carrying the
+ageing port; `Mam4JaxMicrophysics` refuses to construct against a core
+without it.

--- a/docs/source/design/jam_carbon_aging.md
+++ b/docs/source/design/jam_carbon_aging.md
@@ -1,0 +1,66 @@
+# JAM carbonaceous ageing (pcarbon → accumulation)
+
+**Issue:** [#721](https://github.com/climate-analytics-lab/jax-gcm/issues/721).
+**Where it runs:** inside the mam4-jax core (`mam_pcarbon_aging_1subarea`
+port), invoked by `Mam4JaxMicrophysics` after coagulation each step.
+
+## The problem it solves
+
+JAM emits 100 % of BC and POA into the `primary_carbon` (pcm) mode, which is
+`can_activate=False` by design — structurally excluded from ARG activation,
+stratiform and convective in-cloud scavenging, and the explicit cloud-borne
+phase. That is correct for *fresh* hydrophobic carbon, but with no ageing
+process the exclusion was permanent: the 2-year closed-budget run (PR #720)
+measured a BC lifetime of ~21 days (observed 5–8 d) and a ~2.5× high burden.
+Both reference models age their carbon: MAM4 via `mam_pcarbon_aging_1subarea`
+(E3SM `modal_aero_amicphys.F90:5111-5285`), ECHAM-HAMMOZ via
+`m7_concoag`/`m7_coat` (`mo_ham_m7.f90:3532-3844`).
+
+## Which reference formulation, and why
+
+Both references implement the same physics — a particle counts as aged once
+condensed + coagulated sulfate (plus SOA as hygroscopicity-equivalent
+"so4") coats its surface with a threshold number of monolayers — but for
+different mode structures. JAM's modes **are** MAM4's (pcm → accumulation is
+the one age-pair), so the MAM4 formulation ports verbatim while HAMMOZ's
+KI/AI/CI→soluble transfers have no direct image here. The HAMMOZ evidence
+establishes the process and brackets the one free parameter.
+
+The transferred fraction per step is
+
+```
+xferfrac = min( vol_shell · dgn · e^{2.5 ln²σ} / (6 · n · Δr · vol_core),  1 − 10ε )
+```
+
+with `Δr = 4.76e-10 m` (one bisulfate monolayer), `vol_shell` = so4 + soa
+(soa scaled by κ_soa/κ_so4), `vol_core` = pom + bc + moa. Core species and
+mode *number* move by `xferfrac`; shell species move wholesale.
+
+**The monolayer count `n` is exposed** (`Mam4JaxMicrophysics(n_so4_monolayers=…)`)
+because the references legitimately disagree by an order of magnitude —
+E3SM production hard-codes 8, the MAM4 box harness uses 3, ECHAM-HAM uses 1 —
+and it directly sets the BC/POA lifetime (smaller = faster ageing). Default:
+8.0 (deployed-MAM4). It is trace-time static in the core's process-global
+config, so it is **not** a differentiable parameter; calibrating it means a
+sweep, not a gradient.
+
+## Why in-core, not a harness term
+
+The coating criterion needs the sulfate condensed onto pcm *within the
+step*, which exists only inside `amicphys` (the harness never sees per-mode
+condensation increments). It must also run **before** the core's state
+repack: pcm has no so4/soa tracer slots, so condensed shell mass on pcm was
+previously **silently dropped at repack** — a standing per-step sulfur/SOA
+sink proportional to pcm number. Ageing transfers that mass to accumulation
+(which has the slots) and thereby closes the leak by construction. A
+harness-side approximation would have fixed neither.
+
+## What changes for users
+
+Ageing is ON by default in every JAM run using the `mam4_jax` core (there
+is no Fortran toggle to mirror; the core's `mdo_pcarbonaging` exists for
+fixture parity only). Expected effects: BC/POA lifetimes drop toward the
+observed 5–8 d range, carbonaceous burdens fall accordingly, and SO4 gains
+a small source from the closed repack leak. The mam4-jax pin also carries a
+float32 fix without which coagulation moved **zero** mass between modes in
+f32 runs (`betaij3` underflow) — see the mam4-jax PR for details.

--- a/docs/source/design/jam_carbon_aging.md
+++ b/docs/source/design/jam_carbon_aging.md
@@ -37,10 +37,12 @@ with `Δr = 4.76e-10 m` (one bisulfate monolayer), `vol_shell` = so4 + soa
 mode *number* move by `xferfrac`; shell species move wholesale.
 
 **The monolayer count `n` is exposed** (`Mam4JaxMicrophysics(n_so4_monolayers=…)`)
-because the references legitimately disagree by an order of magnitude —
-E3SM production hard-codes 8, the MAM4 box harness uses 3, ECHAM-HAM uses 1 —
-and it directly sets the BC/POA lifetime (smaller = faster ageing). Default:
-8.0 (deployed-MAM4). Each term instance holds its own value and passes it to
+because the references legitimately disagree — the MAM4 *amicphys* path
+receives 3 (via `phys_control`, the CAM5/ACME lineage; the oft-quoted 8 in
+`modal_aero_gasaerexch.F90` belongs to E3SM's legacy `modal_aero_coag` ageing
+path), and ECHAM-HAM uses 1 — and it directly sets the BC/POA lifetime
+(smaller = faster ageing). Default: 3.0 (the amicphys reference value, which
+also reproduces the vendored Fortran captures). Each term instance holds its own value and passes it to
 the core **per call** as a static jit argument (never via the core's
 process-global config, which is read at trace time and would make several
 differently-configured instances in one process order-dependent). Static

--- a/jcm/physics/aerosol/jam/microphysics/mam4_jax.py
+++ b/jcm/physics/aerosol/jam/microphysics/mam4_jax.py
@@ -183,7 +183,11 @@ class Mam4JaxMicrophysics(ModalMicrophysicsTerm):
         reference value). Smaller ages faster ⇒ shorter BC/POA
         lifetime. A differentiable ``nnx.Param`` leaf — the gradient is
         well-defined (piecewise; zero once the mode saturates) and the
-        upstream core takes it as a traced pytree field.
+        upstream core takes it as a traced pytree field. Must be >= 0
+        (validated here for direct construction); optimizer updates
+        that wander negative are clamped to 0 in the core — where the
+        loss surface is flat (saturated branch, zero gradient) — so
+        keep calibration search bounds positive.
 
         ``enable_x64`` controls the GLOBAL model precision. Both backends are
         float32-safe (the coag ``qv12`` underflow was fixed upstream), so
@@ -271,6 +275,13 @@ class Mam4JaxMicrophysics(ModalMicrophysicsTerm):
         # time and would make several differently-configured instances
         # order-dependent (Codex P1 on #726). A calibration sweep over
         # it reuses one compile.
+        if float(n_so4_monolayers) < 0.0:
+            raise ValueError(
+                f"n_so4_monolayers must be >= 0, got {n_so4_monolayers} "
+                "(0 means a zero-thickness coating requirement = instant "
+                "full ageing, NOT off — use the core's mdo_pcarbonaging "
+                "toggle to disable ageing)."
+            )
         self.n_so4_monolayers = nnx.Param(
             jnp.asarray(float(n_so4_monolayers)))
 

--- a/jcm/physics/aerosol/jam/microphysics/mam4_jax.py
+++ b/jcm/physics/aerosol/jam/microphysics/mam4_jax.py
@@ -18,8 +18,10 @@ accumulation mode each step. This is what turns fresh hydrophobic BC/POA
 into wet-scavengable CCN (the pcm mode is ``can_activate=False`` by
 design), and it also closes the core's pcm repack leak (condensed so4/soa
 on pcm has no state slot and was silently dropped). The monolayer
-threshold is the ``n_so4_monolayers`` constructor knob (default 8.0 =
-E3SM production; box harness 3.0; ECHAM-HAM's ``m7_coat`` uses 1.0).
+threshold is the ``n_so4_monolayers`` constructor knob (default 3.0 —
+the amicphys-path reference value, fed via phys_control in
+CAM5/ACME/E3SM; the oft-quoted 8.0 belongs to the legacy
+modal_aero_coag aging path; ECHAM-HAM's ``m7_coat`` uses 1.0).
 
 Tracer adapter
 --------------
@@ -150,7 +152,7 @@ class Mam4JaxMicrophysics(ModalMicrophysicsTerm):
         n_substeps: int = 4,
         enable_x64: bool | None = None,
         core_dtype: str | None = None,
-        n_so4_monolayers: float = 8.0,
+        n_so4_monolayers: float = 3.0,
     ):
         """Import the core, set precision, select the condensation backend.
 
@@ -173,9 +175,9 @@ class Mam4JaxMicrophysics(ModalMicrophysicsTerm):
         (reflective-org/MAM4-JAX#59).
 
         ``n_so4_monolayers`` sets the carbonaceous-ageing coating
-        threshold (see the module docstring; default 8.0 = E3SM
-        production). Smaller ages faster ⇒ shorter BC/POA lifetime.
-        Trace-time static — not a differentiable parameter.
+        threshold (see the module docstring; default 3.0, the amicphys
+        reference value). Smaller ages faster ⇒ shorter BC/POA
+        lifetime. Trace-time static — not a differentiable parameter.
 
         ``enable_x64`` controls the GLOBAL model precision. Both backends are
         float32-safe (the coag ``qv12`` underflow was fixed upstream), so
@@ -250,11 +252,12 @@ class Mam4JaxMicrophysics(ModalMicrophysicsTerm):
                 "onto it is silently dropped at the state repack. Install "
                 "the pinned version: pip install 'jcm[mam4]'."
             )
-        # Monolayer threshold: E3SM production uses 8.0
-        # (modal_aero_gasaerexch.F90:37), the MAM4 box harness 3.0,
-        # ECHAM-HAM's counterpart (m7_coat) 1.0 — an order of magnitude of
-        # legitimate disagreement, and it directly sets the BC/POA
-        # lifetime, so it is exposed here as a calibration knob. Held on
+        # Monolayer threshold: 3.0 is what the MAM4 amicphys path
+        # actually receives (via phys_control; the 8.0 in
+        # modal_aero_gasaerexch.F90 belongs to the legacy
+        # modal_aero_coag path), ECHAM-HAM's counterpart (m7_coat) uses
+        # 1.0 — the spread directly sets the BC/POA lifetime, so it is
+        # exposed here as a calibration knob. Held on
         # the instance and passed PER CALL to the core (a static jit
         # argument) — NOT installed into the core's process-global config,
         # which is read at trace time and would make several

--- a/jcm/physics/aerosol/jam/microphysics/mam4_jax.py
+++ b/jcm/physics/aerosol/jam/microphysics/mam4_jax.py
@@ -10,7 +10,7 @@ harness does **not** duplicate them.
 
 Carbonaceous ageing (jax-gcm#721)
 ---------------------------------
-The core's ``mam_pcarbon_aging_1subarea`` port (mam4-jax ≥ the #721 pin,
+The core's ``mam_pcarbon_aging_1subarea`` port (mam4-jax ≥ 0.4.0,
 ``mdo_pcarbonaging`` on by default) moves the sulfate-coated fraction of
 the primary-carbon mode — number plus pom/bc/mom mass by the
 monolayer-criterion fraction, condensed so4/soa wholesale — into the
@@ -260,7 +260,7 @@ class Mam4JaxMicrophysics(ModalMicrophysicsTerm):
                 "(AmicphysParams): BC/POA would never leave the "
                 "primary-carbon mode (jax-gcm#721) and so4/soa condensed "
                 "onto it is silently dropped at the state repack. Install "
-                "the pinned version: pip install 'jcm[mam4]'."
+                "the pinned version (mam4-jax 0.4.0): pip install 'jcm[mam4]'."
             )
         # Monolayer threshold: 3.0 is what the MAM4 amicphys path
         # actually receives (via phys_control; the 8.0 in

--- a/jcm/physics/aerosol/jam/microphysics/mam4_jax.py
+++ b/jcm/physics/aerosol/jam/microphysics/mam4_jax.py
@@ -21,7 +21,10 @@ on pcm has no state slot and was silently dropped). The monolayer
 threshold is the ``n_so4_monolayers`` constructor knob (default 3.0 —
 the amicphys-path reference value, fed via phys_control in
 CAM5/ACME/E3SM; the oft-quoted 8.0 belongs to the legacy
-modal_aero_coag aging path; ECHAM-HAM's ``m7_coat`` uses 1.0).
+modal_aero_coag aging path; ECHAM-HAM's ``m7_coat`` uses 1.0). It is a
+**differentiable parameter**: an ``nnx.Param`` leaf on the term, passed
+to the core per call as a traced ``AmicphysParams`` leaf, so gradients
+flow and a calibration sweep reuses one compile.
 
 Tracer adapter
 --------------
@@ -73,6 +76,7 @@ from typing import ClassVar
 import jax
 import jax.numpy as jnp
 import numpy as np
+from flax import nnx
 
 from jcm.physics.aerosol.jam.cloud_borne_store import (
     CARRY_KEY,
@@ -177,7 +181,9 @@ class Mam4JaxMicrophysics(ModalMicrophysicsTerm):
         ``n_so4_monolayers`` sets the carbonaceous-ageing coating
         threshold (see the module docstring; default 3.0, the amicphys
         reference value). Smaller ages faster ⇒ shorter BC/POA
-        lifetime. Trace-time static — not a differentiable parameter.
+        lifetime. A differentiable ``nnx.Param`` leaf — the gradient is
+        well-defined (piecewise; zero once the mode saturates) and the
+        upstream core takes it as a traced pytree field.
 
         ``enable_x64`` controls the GLOBAL model precision. Both backends are
         float32-safe (the coag ``qv12`` underflow was fixed upstream), so
@@ -244,10 +250,10 @@ class Mam4JaxMicrophysics(ModalMicrophysicsTerm):
         # leak otherwise). A core without the hook has neither, so refuse
         # it like the gas-netprod guard above rather than silently run
         # 21-day BC lifetimes with a sulfur sink.
-        if not hasattr(_amicphys, "configure_pcarbon_aging"):
+        if not hasattr(_amicphys, "AmicphysParams"):
             raise ImportError(
-                "The installed mam4-jax has no pcarbon aging "
-                "(configure_pcarbon_aging): BC/POA would never leave the "
+                "The installed mam4-jax has no pcarbon aging / params API "
+                "(AmicphysParams): BC/POA would never leave the "
                 "primary-carbon mode (jax-gcm#721) and so4/soa condensed "
                 "onto it is silently dropped at the state repack. Install "
                 "the pinned version: pip install 'jcm[mam4]'."
@@ -256,14 +262,17 @@ class Mam4JaxMicrophysics(ModalMicrophysicsTerm):
         # actually receives (via phys_control; the 8.0 in
         # modal_aero_gasaerexch.F90 belongs to the legacy
         # modal_aero_coag path), ECHAM-HAM's counterpart (m7_coat) uses
-        # 1.0 — the spread directly sets the BC/POA lifetime, so it is
-        # exposed here as a calibration knob. Held on
-        # the instance and passed PER CALL to the core (a static jit
-        # argument) — NOT installed into the core's process-global config,
-        # which is read at trace time and would make several
-        # differently-configured instances in one process order-dependent
-        # (Codex P1 on #726). Trace-time static, so not differentiable.
-        self._n_so4_monolayers = float(n_so4_monolayers)
+        # 1.0 — the spread directly sets the BC/POA lifetime, making it
+        # a key uncertain parameter. Held as an ``nnx.Param`` LEAF (per
+        # the repo's differentiable-parameters convention: numeric
+        # tunables must be visible to jax.grad / optimizers) and passed
+        # to the core per call as a TRACED AmicphysParams leaf — never
+        # via the core's process-global config, which is read at trace
+        # time and would make several differently-configured instances
+        # order-dependent (Codex P1 on #726). A calibration sweep over
+        # it reuses one compile.
+        self.n_so4_monolayers = nnx.Param(
+            jnp.asarray(float(n_so4_monolayers)))
 
         # Precision — applied during construction so the dycore state built
         # afterwards (in bootstrap/run) inherits it; toggling it later would
@@ -459,9 +468,11 @@ class Mam4JaxMicrophysics(ModalMicrophysicsTerm):
             for k, v in core_state.items()
         }
         in_axes = ({k: (None if k == "deltat" else 0) for k in flat_state},)
+        core_params = _amicphys.AmicphysParams(
+            n_so4_monolayers=jnp.asarray(
+                self.n_so4_monolayers.get_value(), cdt))
         one_step = lambda s: amicphys(
-            wateruptake(calcsize(s)),
-            n_so4_monolayers=self._n_so4_monolayers)
+            wateruptake(calcsize(s)), core_params)
         flat_out = jax.vmap(one_step, in_axes=in_axes)(flat_state)
 
         def from_cells(a):

--- a/jcm/physics/aerosol/jam/microphysics/mam4_jax.py
+++ b/jcm/physics/aerosol/jam/microphysics/mam4_jax.py
@@ -254,11 +254,12 @@ class Mam4JaxMicrophysics(ModalMicrophysicsTerm):
         # (modal_aero_gasaerexch.F90:37), the MAM4 box harness 3.0,
         # ECHAM-HAM's counterpart (m7_coat) 1.0 — an order of magnitude of
         # legitimate disagreement, and it directly sets the BC/POA
-        # lifetime, so it is exposed here as a calibration knob. Trace-time
-        # static (a Python float in the core's process-global config), so
-        # NOT differentiable — set before construction, like the backend.
-        _amicphys.configure_pcarbon_aging(
-            n_so4_monolayers=float(n_so4_monolayers))
+        # lifetime, so it is exposed here as a calibration knob. Held on
+        # the instance and passed PER CALL to the core (a static jit
+        # argument) — NOT installed into the core's process-global config,
+        # which is read at trace time and would make several
+        # differently-configured instances in one process order-dependent
+        # (Codex P1 on #726). Trace-time static, so not differentiable.
         self._n_so4_monolayers = float(n_so4_monolayers)
 
         # Precision — applied during construction so the dycore state built
@@ -455,7 +456,9 @@ class Mam4JaxMicrophysics(ModalMicrophysicsTerm):
             for k, v in core_state.items()
         }
         in_axes = ({k: (None if k == "deltat" else 0) for k in flat_state},)
-        one_step = lambda s: amicphys(wateruptake(calcsize(s)))
+        one_step = lambda s: amicphys(
+            wateruptake(calcsize(s)),
+            n_so4_monolayers=self._n_so4_monolayers)
         flat_out = jax.vmap(one_step, in_axes=in_axes)(flat_state)
 
         def from_cells(a):

--- a/jcm/physics/aerosol/jam/microphysics/mam4_jax.py
+++ b/jcm/physics/aerosol/jam/microphysics/mam4_jax.py
@@ -5,8 +5,21 @@ Wraps the MAM4-JAX box model (``reflective-org/MAM4-JAX``) as a JAM
 :class:`PlaceholderMicrophysics` with the actual modal microphysics —
 ``calcsize`` (size redistribution) → ``wateruptake`` (Köhler water) →
 ``amicphys`` (gas–aerosol exchange, rename, binary H₂SO₄ nucleation,
-coagulation). The core owns rename/aging, so the harness does **not**
-duplicate them.
+coagulation, carbonaceous ageing). The core owns rename and ageing, so the
+harness does **not** duplicate them.
+
+Carbonaceous ageing (jax-gcm#721)
+---------------------------------
+The core's ``mam_pcarbon_aging_1subarea`` port (mam4-jax ≥ the #721 pin,
+``mdo_pcarbonaging`` on by default) moves the sulfate-coated fraction of
+the primary-carbon mode — number plus pom/bc/mom mass by the
+monolayer-criterion fraction, condensed so4/soa wholesale — into the
+accumulation mode each step. This is what turns fresh hydrophobic BC/POA
+into wet-scavengable CCN (the pcm mode is ``can_activate=False`` by
+design), and it also closes the core's pcm repack leak (condensed so4/soa
+on pcm has no state slot and was silently dropped). The monolayer
+threshold is the ``n_so4_monolayers`` constructor knob (default 8.0 =
+E3SM production; box harness 3.0; ECHAM-HAM's ``m7_coat`` uses 1.0).
 
 Tracer adapter
 --------------
@@ -85,11 +98,11 @@ from jcm.physics_interface import PhysicsTendency
 # precision per-instance (see ``enable_x64``). If the ``jcm[mam4]`` extra isn't
 # installed this raises ``ImportError`` here, which is the right signal.
 import mam4_jax  # noqa: F401
-from mam4_jax import data
-from mam4_jax.processes import amicphys as _amicphys
-from mam4_jax.processes.amicphys import amicphys
-from mam4_jax.processes.calcsize import calcsize
-from mam4_jax.processes.wateruptake import wateruptake
+from mam4_jax.core import data
+from mam4_jax.coupling import amicphys as _amicphys
+from mam4_jax.coupling.amicphys import amicphys
+from mam4_jax.physics.calcsize import calcsize
+from mam4_jax.physics.wateruptake import wateruptake
 
 # amicphys ``name_gas`` order (igas): 0 = SOA gas, 1 = H₂SO₄. ``data.LMAP_GAS``
 # maps each to its pcnst slot, so jcm's gas tokens resolve to q indices.
@@ -137,6 +150,7 @@ class Mam4JaxMicrophysics(ModalMicrophysicsTerm):
         n_substeps: int = 4,
         enable_x64: bool | None = None,
         core_dtype: str | None = None,
+        n_so4_monolayers: float = 8.0,
     ):
         """Import the core, set precision, select the condensation backend.
 
@@ -157,6 +171,11 @@ class Mam4JaxMicrophysics(ModalMicrophysicsTerm):
 
         Both need a mam4_jax with ``configure_condensation``
         (reflective-org/MAM4-JAX#59).
+
+        ``n_so4_monolayers`` sets the carbonaceous-ageing coating
+        threshold (see the module docstring; default 8.0 = E3SM
+        production). Smaller ages faster ⇒ shorter BC/POA lifetime.
+        Trace-time static — not a differentiable parameter.
 
         ``enable_x64`` controls the GLOBAL model precision. Both backends are
         float32-safe (the coag ``qv12`` underflow was fixed upstream), so
@@ -213,6 +232,34 @@ class Mam4JaxMicrophysics(ModalMicrophysicsTerm):
                 "the pinned version: pip install 'jcm[mam4]'."
             )
         _amicphys.configure_gas_netprod(h2so4=0.0, soa=0.0)
+
+        # Carbonaceous ageing (jax-gcm#721). The core's pcarbon-aging
+        # transfer (mam_pcarbon_aging_1subarea, on by default upstream) is
+        # the ONLY pathway that moves fresh BC/POA out of the
+        # non-activatable pcm mode into accum where wet removal reaches it
+        # — and, mechanically, the routine that rescues so4/soa condensed
+        # onto pcm before the LMAP_AER repack drops it (a per-step sulfur
+        # leak otherwise). A core without the hook has neither, so refuse
+        # it like the gas-netprod guard above rather than silently run
+        # 21-day BC lifetimes with a sulfur sink.
+        if not hasattr(_amicphys, "configure_pcarbon_aging"):
+            raise ImportError(
+                "The installed mam4-jax has no pcarbon aging "
+                "(configure_pcarbon_aging): BC/POA would never leave the "
+                "primary-carbon mode (jax-gcm#721) and so4/soa condensed "
+                "onto it is silently dropped at the state repack. Install "
+                "the pinned version: pip install 'jcm[mam4]'."
+            )
+        # Monolayer threshold: E3SM production uses 8.0
+        # (modal_aero_gasaerexch.F90:37), the MAM4 box harness 3.0,
+        # ECHAM-HAM's counterpart (m7_coat) 1.0 — an order of magnitude of
+        # legitimate disagreement, and it directly sets the BC/POA
+        # lifetime, so it is exposed here as a calibration knob. Trace-time
+        # static (a Python float in the core's process-global config), so
+        # NOT differentiable — set before construction, like the backend.
+        _amicphys.configure_pcarbon_aging(
+            n_so4_monolayers=float(n_so4_monolayers))
+        self._n_so4_monolayers = float(n_so4_monolayers)
 
         # Precision — applied during construction so the dycore state built
         # afterwards (in bootstrap/run) inherits it; toggling it later would

--- a/jcm/physics/aerosol/jam/microphysics/mam4_jax_test.py
+++ b/jcm/physics/aerosol/jam/microphysics/mam4_jax_test.py
@@ -222,8 +222,6 @@ class Mam4JaxAdapterTest(unittest.TestCase):
         the pcm→acc coagulation pathway, so the default-vs-inert difference
         isolates the ageing transfer.
         """
-        from mam4_jax.coupling import amicphys as _amicphys
-
         from jcm.physics.aerosol.jam.microphysics.mam4_jax import (
             Mam4JaxMicrophysics,
         )
@@ -233,12 +231,12 @@ class Mam4JaxAdapterTest(unittest.TestCase):
         # real shell on pcm.
         state = state.copy(tracers={**state.tracers,
                                     "g_h2so4": jnp.full((4, 2), 1.0e-9)})
-        try:
-            aged, _ = Mam4JaxMicrophysics()(state, diagnostics, None, None)
-            inert_term = Mam4JaxMicrophysics(n_so4_monolayers=1.0e9)
-            inert, _ = inert_term(state, diagnostics, None, None)
-        finally:
-            _amicphys.configure_pcarbon_aging(n_so4_monolayers=8.0)
+        # No try/finally needed: the constructor holds the threshold as
+        # an nnx.Param and passes it per call — it never mutates the
+        # core's process-global config, so instances cannot interfere.
+        aged, _ = Mam4JaxMicrophysics()(state, diagnostics, None, None)
+        inert_term = Mam4JaxMicrophysics(n_so4_monolayers=1.0e9)
+        inert, _ = inert_term(state, diagnostics, None, None)
 
         d_bc_pcm = np.asarray(aged.tracers["m_bc_pcm"]
                               - inert.tracers["m_bc_pcm"], np.float64)
@@ -258,6 +256,44 @@ class Mam4JaxAdapterTest(unittest.TestCase):
             d_bc_pcm + d_bc_acc, np.zeros_like(d_bc_pcm),
             atol=1e-6 * float(np.abs(d_bc_pcm).max()),
             err_msg="ageing must conserve BC across pcm+acc")
+
+    def test_aging_threshold_is_a_differentiable_param_leaf(self):
+        """The threshold must be an nnx.Param LEAF (visible to jax.grad /
+        optimizers per the repo's differentiable-parameters rule), and
+        the gradient of a tendency through the term w.r.t. it must be
+        finite and non-zero.
+        """
+        from flax import nnx
+
+        from jcm.physics.aerosol.jam.microphysics.mam4_jax import (
+            Mam4JaxMicrophysics,
+        )
+
+        term = Mam4JaxMicrophysics()
+        leaves = nnx.state(term, nnx.Param)
+        flat = jax.tree.leaves(leaves)
+        assert any(
+            np.asarray(v).shape == () and float(np.asarray(v)) == 3.0
+            for v in flat
+        ), "n_so4_monolayers must appear as a Param leaf (default 3.0)"
+
+        # Moderate H2SO4 so the pcm shell stays SUB-saturated at n=3:
+        # in the saturated regime the criterion clamps and d/dn is
+        # (correctly) exactly zero, which would make this test vacuous.
+        state, diagnostics = _column_state()
+        state = state.copy(tracers={**state.tracers,
+                                    "g_h2so4": jnp.full((4, 2), 1.0e-11)})
+
+        def bc_acc_tendency(n):
+            t = Mam4JaxMicrophysics(n_so4_monolayers=1.0)
+            t.n_so4_monolayers.set_value(n)
+            tend, _ = t(state, diagnostics, None, None)
+            return jnp.sum(tend.tracers["m_bc_acc"])
+
+        g = jax.grad(bc_acc_tendency)(jnp.asarray(3.0))
+        self.assertTrue(np.isfinite(float(g)))
+        self.assertLess(float(g), 0.0,
+                        "thicker required coating must age less BC")
 
     def test_core_dtype_scoped_float32(self):
         # The float32 core runs under a SCOPED x64-off context: the global

--- a/jcm/physics/aerosol/jam/microphysics/mam4_jax_test.py
+++ b/jcm/physics/aerosol/jam/microphysics/mam4_jax_test.py
@@ -295,6 +295,14 @@ class Mam4JaxAdapterTest(unittest.TestCase):
         self.assertLess(float(g), 0.0,
                         "thicker required coating must age less BC")
 
+    def test_negative_threshold_rejected_at_construction(self):
+        from jcm.physics.aerosol.jam.microphysics.mam4_jax import (
+            Mam4JaxMicrophysics,
+        )
+
+        with self.assertRaises(ValueError):
+            Mam4JaxMicrophysics(n_so4_monolayers=-1.0)
+
     def test_core_dtype_scoped_float32(self):
         # The float32 core runs under a SCOPED x64-off context: the global
         # flag (float64 host, e.g. pySES dynamics) must stay untouched, and

--- a/jcm/physics/aerosol/jam/microphysics/mam4_jax_test.py
+++ b/jcm/physics/aerosol/jam/microphysics/mam4_jax_test.py
@@ -19,8 +19,17 @@ import pytest
 # the optional dependency is installed. Each test below re-enables x64 (via the
 # term's lazy import) and restores it in tearDown.
 _x64_at_import = jax.config.read("jax_enable_x64")
-pytest.importorskip("mam4_jax")
-jax.config.update("jax_enable_x64", _x64_at_import)
+# The dotted path also skips (rather than errors) when an OLD pre-0.3
+# mam4-jax layout is installed — the adapter needs the core/coupling/physics
+# package structure plus pcarbon aging (jax-gcm#721); the pinned version has
+# both. The restore MUST be in a finally: importorskip imports the parent
+# ``mam4_jax`` (flipping x64 on) and then raises Skipped when ``coupling``
+# is missing — without the finally, that abandons the whole xdist worker
+# in float64 and unrelated tests' dtype assertions fail.
+try:
+    pytest.importorskip("mam4_jax.coupling")
+finally:
+    jax.config.update("jax_enable_x64", _x64_at_import)
 
 
 def _column_state(nlev=4, ncols=2):
@@ -123,7 +132,7 @@ class Mam4JaxAdapterTest(unittest.TestCase):
         self.assertTrue(np.all(np.asarray(aer.r_dry) > 0.0))
 
     def _assert_backend_runs_finite(self, backend):
-        from mam4_jax.processes import amicphys as _amicphys
+        from mam4_jax.coupling import amicphys as _amicphys
 
         from jcm.physics.aerosol.jam import MAM4_SPEC, mass_name
         from jcm.physics.aerosol.jam.microphysics.mam4_jax import (
@@ -164,7 +173,7 @@ class Mam4JaxAdapterTest(unittest.TestCase):
         self._assert_backend_runs_finite("astem")
 
     def test_default_backend_is_substep(self):
-        from mam4_jax.processes import amicphys as _amicphys
+        from mam4_jax.coupling import amicphys as _amicphys
 
         from jcm.physics.aerosol.jam.microphysics.mam4_jax import (
             Mam4JaxMicrophysics,
@@ -179,7 +188,7 @@ class Mam4JaxAdapterTest(unittest.TestCase):
             _amicphys.configure_condensation(backend="substep")
 
     def test_enable_x64_control(self):
-        from mam4_jax.processes import amicphys as _amicphys
+        from mam4_jax.coupling import amicphys as _amicphys
 
         from jcm.physics.aerosol.jam.microphysics.mam4_jax import (
             Mam4JaxMicrophysics,
@@ -204,6 +213,51 @@ class Mam4JaxAdapterTest(unittest.TestCase):
                 Mam4JaxMicrophysics(condensation_backend="not-a-backend")
         finally:
             _amicphys.configure_condensation(backend="substep")
+
+    def test_carbon_aging_moves_bc_from_pcm_to_accum(self):
+        """Ageing (jax-gcm#721): condensed H2SO4 coats the pcm mode and the
+        core transfers the coated fraction of BC (and pcm number) to accum.
+        Attribution is by monolayer-threshold sensitivity: an absurdly thick
+        required coating (1e9 monolayers) makes ageing inert, leaving only
+        the pcm→acc coagulation pathway, so the default-vs-inert difference
+        isolates the ageing transfer.
+        """
+        from mam4_jax.coupling import amicphys as _amicphys
+
+        from jcm.physics.aerosol.jam.microphysics.mam4_jax import (
+            Mam4JaxMicrophysics,
+        )
+
+        state, diagnostics = _column_state()
+        # A healthy H2SO4 reservoir so within-step condensation builds a
+        # real shell on pcm.
+        state = state.copy(tracers={**state.tracers,
+                                    "g_h2so4": jnp.full((4, 2), 1.0e-9)})
+        try:
+            aged, _ = Mam4JaxMicrophysics()(state, diagnostics, None, None)
+            inert_term = Mam4JaxMicrophysics(n_so4_monolayers=1.0e9)
+            inert, _ = inert_term(state, diagnostics, None, None)
+        finally:
+            _amicphys.configure_pcarbon_aging(n_so4_monolayers=8.0)
+
+        d_bc_pcm = np.asarray(aged.tracers["m_bc_pcm"]
+                              - inert.tracers["m_bc_pcm"], np.float64)
+        d_bc_acc = np.asarray(aged.tracers["m_bc_acc"]
+                              - inert.tracers["m_bc_acc"], np.float64)
+        d_n_pcm = np.asarray(aged.tracers["n_pcm"]
+                             - inert.tracers["n_pcm"], np.float64)
+        self.assertTrue(np.all(d_bc_pcm < 0.0),
+                        "ageing must remove BC from the pcm mode")
+        self.assertTrue(np.all(d_bc_acc > 0.0),
+                        "ageing must deliver BC to the accum mode")
+        self.assertTrue(np.all(d_n_pcm < 0.0),
+                        "ageing must move pcm number out")
+        # BC has no other source/sink in the core: the ageing difference
+        # must conserve BC between the two modes.
+        np.testing.assert_allclose(
+            d_bc_pcm + d_bc_acc, np.zeros_like(d_bc_pcm),
+            atol=1e-6 * float(np.abs(d_bc_pcm).max()),
+            err_msg="ageing must conserve BC across pcm+acc")
 
     def test_core_dtype_scoped_float32(self):
         # The float32 core runs under a SCOPED x64-off context: the global

--- a/jcm/physics/aerosol/jam/microphysics/mam4_jax_test.py
+++ b/jcm/physics/aerosol/jam/microphysics/mam4_jax_test.py
@@ -19,17 +19,8 @@ import pytest
 # the optional dependency is installed. Each test below re-enables x64 (via the
 # term's lazy import) and restores it in tearDown.
 _x64_at_import = jax.config.read("jax_enable_x64")
-# The dotted path also skips (rather than errors) when an OLD pre-0.3
-# mam4-jax layout is installed — the adapter needs the core/coupling/physics
-# package structure plus pcarbon aging (jax-gcm#721); the pinned version has
-# both. The restore MUST be in a finally: importorskip imports the parent
-# ``mam4_jax`` (flipping x64 on) and then raises Skipped when ``coupling``
-# is missing — without the finally, that abandons the whole xdist worker
-# in float64 and unrelated tests' dtype assertions fail.
-try:
-    pytest.importorskip("mam4_jax.coupling")
-finally:
-    jax.config.update("jax_enable_x64", _x64_at_import)
+pytest.importorskip("mam4_jax.coupling")
+jax.config.update("jax_enable_x64", _x64_at_import)
 
 
 def _column_state(nlev=4, ncols=2):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ jcm = [
 mam4 = [
     # Pinned to the main SHA carrying configure_gas_netprod (#642) until
     # the requested upstream release is tagged — then flip to the version.
-    "mam4-jax @ git+https://github.com/reflective-org/MAM4-JAX.git@69540a16f0d34134c4b6f4f43aef9902a5941638",
+    "mam4-jax @ git+https://github.com/reflective-org/MAM4-JAX.git@9c32019570a8b9a88bf95bba0d2d7caabe940221",
 ]
 # jax-cosp satellite simulators (COSP v2 in JAX): CloudSat radar + warm-rain
 # diagnostics via the CloudsatCosp physics term. Apache-2.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ jcm = [
 mam4 = [
     # Pinned to the main SHA carrying configure_gas_netprod (#642) until
     # the requested upstream release is tagged — then flip to the version.
-    "mam4-jax @ git+https://github.com/reflective-org/MAM4-JAX.git@64a49873a87d621a4aa92ffd62169fb82dafb01e",
+    "mam4-jax @ git+https://github.com/reflective-org/MAM4-JAX.git@683b0d6a5b7e04757ba36a77e7fba394ae972ad5",
 ]
 # jax-cosp satellite simulators (COSP v2 in JAX): CloudSat radar + warm-rain
 # diagnostics via the CloudsatCosp physics term. Apache-2.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ jcm = [
 mam4 = [
     # Pinned to the main SHA carrying configure_gas_netprod (#642) until
     # the requested upstream release is tagged — then flip to the version.
-    "mam4-jax @ git+https://github.com/reflective-org/MAM4-JAX.git@9c32019570a8b9a88bf95bba0d2d7caabe940221",
+    "mam4-jax @ git+https://github.com/reflective-org/MAM4-JAX.git@91d945b6e1b61b5ae5c1c2ef7e9cbc0d4aad8938",
 ]
 # jax-cosp satellite simulators (COSP v2 in JAX): CloudSat radar + warm-rain
 # diagnostics via the CloudsatCosp physics term. Apache-2.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,9 @@ mam4 = [
     # top-level namespace does not re-export, and upstream covers only the
     # top-level namespace by semantic versioning — 0.3.0 renamed
     # ``mam4_jax.processes.*`` out of existence with no deprecation. Bumping is
-    # therefore a deliberate act with the JAM adapter tests run behind it.
+    # therefore a deliberate act with the JAM adapter tests run behind it;
+    # #737 tracks relaxing this once upstream re-exports what the adapter
+    # drives (not urgent — the exact pin is a fine steady state).
     # 0.4.0 is the first release with pcarbon aging (#721) and the float32
     # coagulation mass-transfer fix; it also carries configure_gas_netprod
     # (#642).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ jcm = [
 mam4 = [
     # Pinned to the main SHA carrying configure_gas_netprod (#642) until
     # the requested upstream release is tagged — then flip to the version.
-    "mam4-jax @ git+https://github.com/reflective-org/MAM4-JAX.git@2739a99ca7bb32e6d855bb4bc4a4f3f6d6e7c986",
+    "mam4-jax @ git+https://github.com/reflective-org/MAM4-JAX.git@64a49873a87d621a4aa92ffd62169fb82dafb01e",
 ]
 # jax-cosp satellite simulators (COSP v2 in JAX): CloudSat radar + warm-rain
 # diagnostics via the CloudsatCosp physics term. Apache-2.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,17 +39,8 @@ jcm = [
 # opt-in extra so the Apache-2.0 jcm core never bundles GPL code. Pinned to the
 # tagged release. Install with `pip install jcm[mam4]`.
 mam4 = [
-    # Exact version, not a floor: the adapter reaches into submodule paths
-    # (mam4_jax.core.data, .coupling.amicphys, .physics.*) for the pieces the
-    # top-level namespace does not re-export, and upstream covers only the
-    # top-level namespace by semantic versioning — 0.3.0 renamed
-    # ``mam4_jax.processes.*`` out of existence with no deprecation. Bumping is
-    # therefore a deliberate act with the JAM adapter tests run behind it;
-    # #737 tracks relaxing this once upstream re-exports what the adapter
-    # drives (not urgent — the exact pin is a fine steady state).
-    # 0.4.0 is the first release with pcarbon aging (#721) and the float32
-    # coagulation mass-transfer fix; it also carries configure_gas_netprod
-    # (#642).
+    # Exact, not a floor: the adapter imports submodule paths that upstream
+    # excludes from its semver contract (#737).
     "mam4-jax==0.4.0",
 ]
 # jax-cosp satellite simulators (COSP v2 in JAX): CloudSat radar + warm-rain

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,16 @@ jcm = [
 # opt-in extra so the Apache-2.0 jcm core never bundles GPL code. Pinned to the
 # tagged release. Install with `pip install jcm[mam4]`.
 mam4 = [
-    # Pinned to the main SHA carrying configure_gas_netprod (#642) until
-    # the requested upstream release is tagged — then flip to the version.
-    "mam4-jax @ git+https://github.com/reflective-org/MAM4-JAX.git@683b0d6a5b7e04757ba36a77e7fba394ae972ad5",
+    # Exact version, not a floor: the adapter reaches into submodule paths
+    # (mam4_jax.core.data, .coupling.amicphys, .physics.*) for the pieces the
+    # top-level namespace does not re-export, and upstream covers only the
+    # top-level namespace by semantic versioning — 0.3.0 renamed
+    # ``mam4_jax.processes.*`` out of existence with no deprecation. Bumping is
+    # therefore a deliberate act with the JAM adapter tests run behind it.
+    # 0.4.0 is the first release with pcarbon aging (#721) and the float32
+    # coagulation mass-transfer fix; it also carries configure_gas_netprod
+    # (#642).
+    "mam4-jax==0.4.0",
 ]
 # jax-cosp satellite simulators (COSP v2 in JAX): CloudSat radar + warm-rain
 # diagnostics via the CloudsatCosp physics term. Apache-2.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ jcm = [
 mam4 = [
     # Pinned to the main SHA carrying configure_gas_netprod (#642) until
     # the requested upstream release is tagged — then flip to the version.
-    "mam4-jax @ git+https://github.com/reflective-org/MAM4-JAX.git@91d945b6e1b61b5ae5c1c2ef7e9cbc0d4aad8938",
+    "mam4-jax @ git+https://github.com/reflective-org/MAM4-JAX.git@2739a99ca7bb32e6d855bb4bc4a4f3f6d6e7c986",
 ]
 # jax-cosp satellite simulators (COSP v2 in JAX): CloudSat radar + warm-rain
 # diagnostics via the CloudsatCosp physics term. Apache-2.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ jcm = [
 mam4 = [
     # Pinned to the main SHA carrying configure_gas_netprod (#642) until
     # the requested upstream release is tagged — then flip to the version.
-    "mam4-jax @ git+https://github.com/reflective-org/MAM4-JAX.git@5ed465661dcd1b4a858ed92524ac58fc37696cfd",
+    "mam4-jax @ git+https://github.com/reflective-org/MAM4-JAX.git@69540a16f0d34134c4b6f4f43aef9902a5941638",
 ]
 # jax-cosp satellite simulators (COSP v2 in JAX): CloudSat radar + warm-rain
 # diagnostics via the CloudsatCosp physics term. Apache-2.0.


### PR DESCRIPTION
Closes #721.

## What

Enables **carbonaceous ageing** (primary-carbon → accumulation monolayer transfer) in JAM, via the mam4-jax port of MAM4's `mam_pcarbon_aging_1subarea` — the exact counterpart of ECHAM-HAM's `m7_concoag`/`m7_coat` for our (MAM4) mode structure. The full reference analysis, the choice of formulation, and the monolayer-parameter spread (E3SM-legacy 8 / amicphys 3 / HAMMOZ 1) are in #721 and in the new design doc `docs/source/design/jam_carbon_aging.md`.

jcm changes:
- **Adapter targets the mam4-jax 0.3+ package layout** (`core`/`coupling`/`physics`; the old `processes` paths were removed upstream) and the `jcm[mam4]` extra now pins the **released** `mam4-jax==0.4.0` from PyPI rather than a branch SHA.
- **Ageing is required, not optional**: the adapter refuses a core without the pcarbon-aging/params API (same rationale as the #642 gas-netprod guard — a silently-old core means 21-day BC lifetimes *plus* a per-step sulfur sink from the pcm repack leak).
- `n_so4_monolayers` exposed as a constructor knob (default 3.0 = the amicphys-path reference value fed via `phys_control`; the oft-quoted 8.0 belongs to E3SM's legacy `modal_aero_coag` path; ECHAM-HAM's `m7_coat` uses 1.0). It is a **differentiable `nnx.Param` leaf**, passed to the core per call as a traced `AmicphysParams` field — never through the core's process-global config, which is read at trace time and would make several differently-configured instances order-dependent.
- Adapter test: ageing attribution by monolayer-threshold sensitivity (default vs inert 1e9-monolayer configuration) — BC leaves pcm, arrives in accum, pcm number falls, BC conserved across the pair.

## Upstream dependency

reflective-org/MAM4-JAX#75 has **merged** and shipped as **v0.4.0**, published to PyPI, so there is no merge-order constraint left: `jcm[mam4]` installs a real release (`mam4-jax==0.4.0`) instead of a git URL at a feature-branch SHA.

Between the SHA this branch previously pinned and the v0.4.0 tag, the only changes inside `mam4_jax/` are the version string and the `configure_pcarbon_aging` docstring — the physics and the `AmicphysParams` API the adapter calls are identical, and the published wheel's package contents match the tagged tree (verified by diffing the downloaded wheel against the tag). The 90-day validation runs below therefore still characterise the released core.

The pin is exact rather than a floor because the adapter imports `mam4_jax.core.data`, `.coupling.amicphys` and `.physics.{calcsize,wateruptake}` — paths upstream explicitly excludes from its semver contract. That same guarantee retires the `try`/`finally` the test module wrapped its `importorskip` in: it only existed to survive a pre-0.3 layout that could satisfy `import mam4_jax` (flipping x64 on) and then fail on `.coupling`. A pinned version cannot present that layout.

## Validation

- **MAM4-JAX**: full suite green upstream; the ageing port is validated against the canonical *aging-on* `per_process/` Fortran bundle (aerosol tracers ≤2.1 % over 60 steps, at the box capture's n=3 monolayers) plus machine-ε unit tests, conservation, and a sulfur-closure test that reproduces the repack leak with ageing off.
- **jcm local gates** (re-run against the released 0.4.0 core): `ruff check .` clean; all 14 JAM adapter tests pass; fast suite 1929 passed / 15 skipped at **94.75 %** coverage; slow suite green. CI itself installs `pip install -e .` with no extras, so the adapter tests skip there and the pin is exercised only locally.
- **90-day T63L47 `echam-jam-aerocom` production runs with ageing on**, one per reference monolayer value, same recipe as the #713/#720 validation runs. Budget closed every chunk, zero NaNs. Area-weighted global means over days 45–90, τ = burden / (dry + wet removal):

  | `n_so4_monolayers` | BC burden | BC τ | BC in accum | POA burden | POA τ | POA in accum |
  |---|---|---|---|---|---|---|
  | none (#720) | ~2.5× high | ~21 d | 0 % | — | — | 0 % |
  | 8 (E3SM legacy `modal_aero_coag`) | 0.222 mg/m² | 8.4 d | 56 % | 1.39 mg/m² | 11.0 d | 44 % |
  | **3 (amicphys reference — the default)** | **0.148 mg/m²** | **4.8 d** | **68 %** | **0.857 mg/m²** | **5.8 d** | **54 %** |

  Both reference values bracket the observed BC lifetime of 5–8 d, against ~21 d with no ageing; the default puts the BC burden inside the 0.1–0.3 mg/m² climatological anchor range (it was ~2.5× high before). Caveat: BC emission still exceeds removal by ~25 % at day 90, so the burden has not fully spun up and these τ carry that uncertainty — the *relative* threshold sensitivity is the robust result.

## Follow-up

#737 — relax the exact pin once upstream re-exports what the adapter drives (`amicphys`/`calcsize`/`wateruptake`/`configure_condensation` and the MAM4 index tables). Filed as explicitly low priority: 0.4.0 was cut quickly at our request, so an incomplete public API is the expected consequence rather than an oversight, and the exact pin is a fine steady state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFu9rxRPLQ7qj3hwZf6zRE
