### PR TITLE
Provenance: record the parameter values the run actually used (#732)

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -24,7 +24,19 @@ Unreleased — provenance records the parameters
   ``convection_params=`` and stores ``params``), so reproducing one of
   those from the record needs the constructor signature. Arrays over 64
   elements (embedded NN weights) are summarized by shape/dtype/hash;
-  values captured under ``jit``/``grad`` read ``"<traced>"``.
+  values captured under ``jit``/``grad`` read ``"<traced>"``. A record
+  larger than 64 kB is carried compressed in ``jcm_prov_params_zlib`` on
+  the same file rather than dropped; ``jemcal``-style readers should use
+  ``jcm.provenance.read_params(ds.attrs)``, which handles both forms.
+- The dycore filter is per *leaf*, not per attribute, so a backend that
+  mixes tuning knobs and grid data in one container still has its knobs
+  recorded. This matters for pySES, whose ``diffusion_config`` holds
+  ``nu``/``nu_top`` beside a ``nu_ramp`` profile and whose
+  ``timestep_config`` holds the subcycle counts beside per-stage stepper
+  structs: ``hypervis_scale``, ``coupling`` and ``tracer_substeps`` are
+  constructor arguments stored nowhere else, so a container-level rule
+  would have let two materially different pySES models record
+  identically.
 - The record is taken at the model-to-user handoff
   (``ModelPredictions``) and travels on the predictions object, so it is
   stamped by ``to_xarray`` for a bare

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -49,6 +49,14 @@ Unreleased — provenance records the parameters
   7200 s recorded identically until the digest distinguished them. It is
   aggregated per variable rather than per array leaf, which is what keeps
   it affordable where several terms share one cached coordinate object.
+- The term roster is recorded in order as ``physics.term_order``. A term
+  with no attributes and no nnx variables contributes nothing to the
+  walk, so adding or removing one left the record unchanged even though
+  it changes every step (``ResetEmissionFluxes`` is stateless and zeroes
+  the carried ``emi_*`` accumulators). Order belongs in the record for
+  the same reason it is fixed in the configs: the ECHAM composition
+  requires vdiff before convection so the Tiedtke closure reads the
+  same-step moisture tendency.
 - The composition itself is recorded, not only its terms.
   ``ComposablePhysics.band_config`` is injected into every step and read
   by ``Macv2SpAerosol`` for its optics, so two compositions of identical

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,7 +5,7 @@ Unreleased — provenance records the parameters
 ----------------------------------------------
 
 - **Every output now records the parameter values the run actually
-  used**. The composed Hydra config that #591 stamped is not the
+  used** (#732). The composed Hydra config that #591 stamped is not the
   same thing: each scheme's ``params`` block is deliberately absent from
   the shipped yamls so unspecified fields fall back to
   ``Parameters.default()`` in code, so the config recorded the

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -1,6 +1,42 @@
 Release Notes
 =============
 
+Unreleased — provenance records the parameters
+----------------------------------------------
+
+- **Every output now records the parameter values the run actually
+  used**. The composed Hydra config that #591 stamped is not the
+  same thing: each scheme's ``params`` block is deliberately absent from
+  the shipped yamls so unspecified fields fall back to
+  ``Parameters.default()`` in code, so the config recorded the
+  *overrides* and said nothing about the effective values. A model built
+  in Python, or one whose parameters a calibration loop replaced after
+  construction, had no config behind it at all. ``jcm_prov_params``
+  (with ``jcm_prov_params_sha``) now carries every ``nnx.Param`` on
+  every physics term, the scalar dycore knobs (timestep, diffusion
+  filter, transport options) and the physical constants, read off the
+  *built* model rather than the requested config. Keys locate the value
+  as ``<term>.<variable>.<field>``
+  (``tiedtke_convection.params.entrpen``). That matches the Hydra
+  override path minus its ``physics.terms.`` prefix wherever a term's
+  constructor keyword and its stored variable share a name, as the ECHAM
+  terms do; the SPEEDY terms do not (``SpeedyConvection`` takes
+  ``convection_params=`` and stores ``params``), so reproducing one of
+  those from the record needs the constructor signature. Arrays over 64
+  elements (embedded NN weights) are summarized by shape/dtype/hash;
+  values captured under ``jit``/``grad`` read ``"<traced>"``.
+- The record is taken at the model-to-user handoff
+  (``ModelPredictions``) and travels on the predictions object, so it is
+  stamped by ``to_xarray`` for a bare
+  ``model.run(...).to_xarray().to_netcdf(...)`` that never touches the
+  Hydra runners, and a calibration loop that mutates parameters between
+  iterations cannot retroactively change an earlier run's record. It is
+  also readable directly as ``predictions.params``.
+- **``jcm_prov_run_hash`` values change**, because the parameters are now
+  folded into the hash. They have to be: every member of a parameter
+  sweep shares one code state, config and input set, so without them a
+  sweep produced a single run hash for every member.
+
 Unreleased — transient AMIP forcing
 -----------------------------------
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -36,6 +36,15 @@ Unreleased — provenance records the parameters
   larger than 64 kB is carried compressed in ``jcm_prov_params_zlib`` on
   the same file rather than dropped; ``jemcal``-style readers should use
   ``jcm.provenance.read_params(ds.attrs)``, which handles both forms.
+- A term's constructor controls are recorded even when they never reach
+  an nnx variable, keyed off its ``__init__`` signature.
+  ``UpperSponge`` keeps ``sponge_timescale_s``, ``enspodi``,
+  ``damp_temperature`` and ``target_T_K`` as ordinary attributes and
+  turns them into a grid-shaped profile, so a 3600 s and a 7200 s sponge
+  previously recorded identically; RRTMGP's ``base_seed`` and
+  ``compute_cre`` were the same omission. Keying on the signature rather
+  than scanning attributes keeps the coordinate caches and the nnx
+  bookkeeping out, since nobody passed those in.
 - The dycore filter is per *leaf*, not per attribute, so a backend that
   mixes tuning knobs and grid data in one container still has its knobs
   recorded. This matters for pySES, whose ``diffusion_config`` holds

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,95 +4,47 @@ Release Notes
 Unreleased — provenance records the parameters
 ----------------------------------------------
 
-- **Every output now records the parameter values the run actually
-  used** (#732). The composed Hydra config that #591 stamped is not the
-  same thing: each scheme's ``params`` block is deliberately absent from
-  the shipped yamls so unspecified fields fall back to
-  ``Parameters.default()`` in code, so the config recorded the
-  *overrides* and said nothing about the effective values. A model built
-  in Python, or one whose parameters a calibration loop replaced after
-  construction, had no config behind it at all. ``jcm_prov_params``
-  (with ``jcm_prov_params_sha``) now carries every ``nnx.Variable`` on
-  every physics term, the scalar dycore knobs (timestep, diffusion
-  filter, transport options) and the physical constants, read off the
-  *built* model rather than the requested config. Every nnx variable,
-  not only ``nnx.Param``: a parameter block holding a bool cannot be a
-  ``Param``, so ``SpeedySurfaceFlux.surface_params``,
-  ``EchamSurface.params`` and every Held-Suarez tuning constant are
-  plain Variables, and a ``Param``-only filter recorded nothing at all
-  for Held-Suarez. A declared ``nnx.Param`` is recorded in full; a plain
-  Variable only where it is knob-shaped (scalars, 0-d arrays, structs of
-  those), which keeps those parameter blocks while leaving out the
-  coordinate caches terms also hold as Variables. Keys locate the value
-  as ``<term>.<variable>.<field>``
-  (``tiedtke_convection.params.entrpen``). That matches the Hydra
-  override path minus its ``physics.terms.`` prefix wherever a term's
-  constructor keyword and its stored variable share a name, as the ECHAM
-  terms do; the SPEEDY terms do not (``SpeedyConvection`` takes
-  ``convection_params=`` and stores ``params``), so reproducing one of
-  those from the record needs the constructor signature. Arrays over 64
-  elements (embedded NN weights) are summarized by shape/dtype/hash;
-  values captured under ``jit``/``grad`` read ``"<traced>"``. A record
-  larger than 64 kB is carried compressed in ``jcm_prov_params_zlib`` on
-  the same file rather than dropped; ``jemcal``-style readers should use
-  ``jcm.provenance.read_params(ds.attrs)``, which handles both forms.
-- Settings that never reach an nnx variable are recorded too. Terms keep
-  controls as ordinary attributes (``UpperSponge``'s
-  ``sponge_timescale_s``, ``enspodi``, ``damp_temperature``; RRTMGP's
-  ``base_seed``, ``compute_cre`` and the derived ``_aerosol_free``), so
-  every scalar-shaped attribute is taken. Only names with a dunder infix
-  are skipped, being flax bookkeeping and Python name mangling rather
-  than physical settings.
-- A control that survives *only* in derived form is caught by a
-  per-variable ``array_digest``. ``UpperTemperatureRelaxation`` keeps its
-  timescale solely as the grid-shaped ``_inv_tau`` profile, so 3600 s and
-  7200 s recorded identically until the digest distinguished them. It is
-  aggregated per variable rather than per array leaf, which is what keeps
-  it affordable where several terms share one cached coordinate object.
-- The term roster is recorded in order as ``physics.term_order``. A term
-  with no attributes and no nnx variables contributes nothing to the
-  walk, so adding or removing one left the record unchanged even though
-  it changes every step (``ResetEmissionFluxes`` is stateless and zeroes
-  the carried ``emi_*`` accumulators). Order belongs in the record for
-  the same reason it is fixed in the configs: the ECHAM composition
-  requires vdiff before convection so the Tiedtke closure reads the
-  same-step moisture tendency.
-- The composition itself is recorded, not only its terms.
-  ``ComposablePhysics.band_config`` is injected into every step and read
-  by ``Macv2SpAerosol`` for its optics, so two compositions of identical
-  terms with different band centres produce different fields; walking
-  only ``terms`` let them record identically.
-- The dycore filter is per *leaf*, not per attribute, so a backend that
-  mixes tuning knobs and grid data in one container still has its knobs
-  recorded. This matters for pySES, whose ``diffusion_config`` holds
-  ``nu``/``nu_top`` beside a ``nu_ramp`` profile and whose
-  ``timestep_config`` holds the subcycle counts beside per-stage stepper
-  structs: ``hypervis_scale``, ``coupling`` and ``tracer_substeps`` are
-  constructor arguments stored nowhere else, so a container-level rule
-  would have let two materially different pySES models record
-  identically.
+- **Every output now records the physics parameter values the run
+  actually used** (#732). The composed Hydra config that #591 stamped is
+  not the same thing: each scheme's ``params`` block is deliberately
+  absent from the shipped yamls so unspecified fields fall back to
+  ``Parameters.default()`` in code, meaning the config recorded the
+  *overrides* and said nothing about the effective values, and a model
+  built in Python or one whose parameters a calibration loop replaced
+  had no config behind it at all. ``jcm_prov_params`` (with
+  ``jcm_prov_params_sha``) now carries them, read off the *built*
+  physics, keyed as ``<term>.<variable>.<field>``
+  (``tiedtke_convection.params.entrpen``). Read it with
+  ``jcm.provenance.read_params(ds.attrs)``, or off the predictions object
+  as ``predictions.params``. Everything else about a run stays where it
+  was: the term composition, dycore and resolution are already in the
+  config record this sits beside.
+- Both kinds of parameter variable are covered. An ``nnx.Param`` is
+  recorded in full, including tuned arrays such as the MACv2-SP plume
+  shapes. A plain ``nnx.Variable`` is recorded where it is knob-shaped
+  (scalars, 0-d arrays, structs of those), because a parameter block
+  holding a bool cannot be a ``Param`` — ``SpeedySurfaceFlux.surface_params``,
+  ``EchamSurface.params`` and every Held-Suarez tuning constant are plain
+  Variables — while the coordinate caches terms also hold as Variables
+  stay out. Arrays over 64 elements (embedded NN weights) are summarized
+  by shape, dtype and hash; values captured under ``jit``/``grad`` read
+  ``"<traced>"``.
 - **The record is captured at trace time, not from the live module.**
   ``Model._run_from_state`` is jitted with ``self`` static, so parameters
-  are constants inside the compiled executable and changing an
-  ``nnx.Param`` in place afterwards does not reach the computation.
-  Reading the module at the handoff therefore stamped a trajectory with
-  values that never ran. Where the live values now disagree with the
-  compiled ones, the record reports the compiled ones and both a log
-  warning and a ``live_parameters_differ_from_compiled`` key say so:
-  that disagreement means an in-place parameter change did nothing to
-  the run, which is a scientific error rather than a provenance detail.
-  Rebuild the ``Model`` to change parameters.
-- A dycore setting held as a dtype (pySES ``physics_dtype``) is recorded
-  by its canonical name, so float32-physics and float64-physics runs no
-  longer share a record.
-- The record is taken at the model-to-user handoff
-  (``ModelPredictions``) and travels on the predictions object, so it
-  reaches every output stream the object produces (trajectory,
-  snapshots and the per-observer datasets), including a bare
+  are constants inside the compiled executable and changing one in place
+  afterwards does not reach the computation. Reading the module at the
+  handoff would therefore stamp a trajectory with values that never ran.
+  Where the live values disagree with the compiled ones, the record
+  reports the compiled ones and both a log warning and a
+  ``live_parameters_differ_from_compiled`` key say so: that disagreement
+  means an in-place parameter change did nothing to the run. Rebuild the
+  ``Model`` to change parameters.
+- The record travels on the predictions object, so it reaches every
+  output stream that object produces (trajectory, snapshots and the
+  per-observer datasets), including a bare
   ``model.run(...).to_xarray().to_netcdf(...)`` that never touches the
-  Hydra runners, and a calibration loop that mutates parameters between
-  iterations cannot retroactively change an earlier run's record. It is
-  also readable directly as ``predictions.params``.
+  Hydra runners, and a later run cannot retroactively change an earlier
+  one's record.
 - **``jcm_prov_run_hash`` values change**, because the parameters are now
   folded into the hash. They have to be: every member of a parameter
   sweep shares one code state, config and input set, so without them a

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -12,10 +12,18 @@ Unreleased — provenance records the parameters
   *overrides* and said nothing about the effective values. A model built
   in Python, or one whose parameters a calibration loop replaced after
   construction, had no config behind it at all. ``jcm_prov_params``
-  (with ``jcm_prov_params_sha``) now carries every ``nnx.Param`` on
+  (with ``jcm_prov_params_sha``) now carries every ``nnx.Variable`` on
   every physics term, the scalar dycore knobs (timestep, diffusion
   filter, transport options) and the physical constants, read off the
-  *built* model rather than the requested config. Keys locate the value
+  *built* model rather than the requested config. Every nnx variable,
+  not only ``nnx.Param``: a parameter block holding a bool cannot be a
+  ``Param``, so ``SpeedySurfaceFlux.surface_params``,
+  ``EchamSurface.params`` and every Held-Suarez tuning constant are
+  plain Variables, and a ``Param``-only filter recorded nothing at all
+  for Held-Suarez. A declared ``nnx.Param`` is recorded in full; a plain
+  Variable only where it is knob-shaped (scalars, 0-d arrays, structs of
+  those), which keeps those parameter blocks while leaving out the
+  coordinate caches terms also hold as Variables. Keys locate the value
   as ``<term>.<variable>.<field>``
   (``tiedtke_convection.params.entrpen``). That matches the Hydra
   override path minus its ``physics.terms.`` prefix wherever a term's
@@ -38,8 +46,9 @@ Unreleased — provenance records the parameters
   would have let two materially different pySES models record
   identically.
 - The record is taken at the model-to-user handoff
-  (``ModelPredictions``) and travels on the predictions object, so it is
-  stamped by ``to_xarray`` for a bare
+  (``ModelPredictions``) and travels on the predictions object, so it
+  reaches every output stream the object produces (trajectory,
+  snapshots and the per-observer datasets), including a bare
   ``model.run(...).to_xarray().to_netcdf(...)`` that never touches the
   Hydra runners, and a calibration loop that mutates parameters between
   iterations cannot retroactively change an earlier run's record. It is

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -36,15 +36,24 @@ Unreleased — provenance records the parameters
   larger than 64 kB is carried compressed in ``jcm_prov_params_zlib`` on
   the same file rather than dropped; ``jemcal``-style readers should use
   ``jcm.provenance.read_params(ds.attrs)``, which handles both forms.
-- A term's constructor controls are recorded even when they never reach
-  an nnx variable, keyed off its ``__init__`` signature.
-  ``UpperSponge`` keeps ``sponge_timescale_s``, ``enspodi``,
-  ``damp_temperature`` and ``target_T_K`` as ordinary attributes and
-  turns them into a grid-shaped profile, so a 3600 s and a 7200 s sponge
-  previously recorded identically; RRTMGP's ``base_seed`` and
-  ``compute_cre`` were the same omission. Keying on the signature rather
-  than scanning attributes keeps the coordinate caches and the nnx
-  bookkeeping out, since nobody passed those in.
+- Settings that never reach an nnx variable are recorded too. Terms keep
+  controls as ordinary attributes (``UpperSponge``'s
+  ``sponge_timescale_s``, ``enspodi``, ``damp_temperature``; RRTMGP's
+  ``base_seed``, ``compute_cre`` and the derived ``_aerosol_free``), so
+  every scalar-shaped attribute is taken. Only names with a dunder infix
+  are skipped, being flax bookkeeping and Python name mangling rather
+  than physical settings.
+- A control that survives *only* in derived form is caught by a
+  per-variable ``array_digest``. ``UpperTemperatureRelaxation`` keeps its
+  timescale solely as the grid-shaped ``_inv_tau`` profile, so 3600 s and
+  7200 s recorded identically until the digest distinguished them. It is
+  aggregated per variable rather than per array leaf, which is what keeps
+  it affordable where several terms share one cached coordinate object.
+- The composition itself is recorded, not only its terms.
+  ``ComposablePhysics.band_config`` is injected into every step and read
+  by ``Macv2SpAerosol`` for its optics, so two compositions of identical
+  terms with different band centres produce different fields; walking
+  only ``terms`` let them record identically.
 - The dycore filter is per *leaf*, not per attribute, so a backend that
   mixes tuning knobs and grid data in one container still has its knobs
   recorded. This matters for pySES, whose ``diffusion_config`` holds

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -38,7 +38,8 @@ Unreleased — provenance records the parameters
   reports the compiled ones and both a log warning and a
   ``live_parameters_differ_from_compiled`` key say so: that disagreement
   means an in-place parameter change did nothing to the run. Rebuild the
-  ``Model`` to change parameters.
+  ``Model`` to change parameters; making the mutation take effect (or
+  fail loudly) is tracked in #735.
 - The record travels on the predictions object, so it reaches every
   output stream that object produces (trajectory, snapshots and the
   per-observer datasets), including a bare

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -71,6 +71,20 @@ Unreleased — provenance records the parameters
   constructor arguments stored nowhere else, so a container-level rule
   would have let two materially different pySES models record
   identically.
+- **The record is captured at trace time, not from the live module.**
+  ``Model._run_from_state`` is jitted with ``self`` static, so parameters
+  are constants inside the compiled executable and changing an
+  ``nnx.Param`` in place afterwards does not reach the computation.
+  Reading the module at the handoff therefore stamped a trajectory with
+  values that never ran. Where the live values now disagree with the
+  compiled ones, the record reports the compiled ones and both a log
+  warning and a ``live_parameters_differ_from_compiled`` key say so:
+  that disagreement means an in-place parameter change did nothing to
+  the run, which is a scientific error rather than a provenance detail.
+  Rebuild the ``Model`` to change parameters.
+- A dycore setting held as a dtype (pySES ``physics_dtype``) is recorded
+  by its canonical name, so float32-physics and float64-physics runs no
+  longer share a record.
 - The record is taken at the model-to-user handoff
   (``ModelPredictions``) and travels on the predictions object, so it
   reaches every output stream the object produces (trajectory,

--- a/jcm/model.py
+++ b/jcm/model.py
@@ -24,7 +24,7 @@ from dinosaur.scales import units
 from functools import partial
 import logging
 
-from jcm import profiling
+from jcm import profiling, provenance
 from jcm.date import DateData, parse_duration_days
 from jcm.forcing import ForcingData, default_forcing
 from jcm.predictions import ModelPredictions
@@ -460,6 +460,10 @@ class Model:
         self.dt_si = (time_step * units.minute).to(units.second)
 
         self.observers = tuple(observers)
+        # Parameters as bound into each compiled trace, keyed by the static
+        # signature that selects the executable (#733 review). See the
+        # capture in ``_run_from_state`` for why the live values will not do.
+        self._traced_params: dict = {}
         if len({obs.name for obs in self.observers}) != len(self.observers):
             raise ValueError("Observer names must be unique.")
         if self.observers:
@@ -934,6 +938,26 @@ class Model:
         can continue a run across API boundaries without re-seeding (e.g.
         :meth:`Model.resume`).
         """
+        # Capture the parameters HERE, at trace time, not from the live
+        # module afterwards (#733 review). ``self`` is a static argument,
+        # so the parameter values are baked into this executable as
+        # constants; mutating an nnx.Param in place afterwards changes
+        # nothing the compiled function does (see the note on the
+        # decorator). Reading the module at the model-to-user handoff
+        # therefore stamped a trajectory with values that did not produce
+        # it — a calibration loop that mutates in place got a confident,
+        # wrong record. On a cache hit this line does not re-run, which is
+        # exactly right: the reused executable still holds the parameters
+        # captured at its own trace.
+        try:
+            self._traced_params[
+                (save_interval, total_time, output_averages,
+                 snapshot_stride, snapshot_fields)
+            ] = provenance.describe_params(self.physics, self.dycore)
+        except Exception:  # noqa: BLE001 — provenance never fails a run
+            logger.warning("provenance: trace-time parameter capture failed",
+                           exc_info=True)
+
         inner_steps = int(save_interval / self.dt_si.to(units.day).m)
         outer_steps = int(total_time / save_interval)
         # Op-split saves end-of-step states (snapshot mode) or post-step
@@ -1077,6 +1101,9 @@ class Model:
             ModelPredictions(
                 predictions, self.coords, self.physics,
                 dycore=self.dycore,
+                params=self._traced_params.get(
+                    (save_interval_days, total_time_days, output_averages,
+                     snapshot_stride, tuple(snapshot_variables))),
                 observations=observations,
                 observers=self.observers,
                 obs_t0_days=obs_t0_days,

--- a/jcm/model.py
+++ b/jcm/model.py
@@ -39,6 +39,12 @@ from jcm.dycore.dinosaur.dycore import DinosaurDycore
 
 logger = logging.getLogger(__name__)
 
+#: Per-trace parameter records kept for provenance (#732). A model
+#: retraces once per distinct combination of static arguments and dynamic
+#: avals, which is a handful in normal use; the cap bounds the memory a
+#: long-lived model can accumulate. Each record is a few kB.
+_MAX_TRACED_PARAM_RECORDS = 64
+
 
 # ---------------------------------------------------------------------------
 # Explicit-mesh (multi-device) support
@@ -917,6 +923,20 @@ class Model:
 
         return _integrate_fn
 
+    def _remember_traced_params(self, trace_id: int, record: dict) -> None:
+        """Store one trace's parameter record, oldest evicted past the cap.
+
+        Bounded because nothing else here can be: a model that keeps
+        meeting new input shapes retraces indefinitely, and
+        ``jax.clear_caches()`` does not reach this dict (#733 review).
+        Evicting the oldest degrades that executable's record to empty if
+        it is ever run again, which is the safe direction — a missing
+        record, never another executable's values.
+        """
+        self._traced_params[trace_id] = record
+        while len(self._traced_params) > _MAX_TRACED_PARAM_RECORDS:
+            self._traced_params.pop(next(iter(self._traced_params)))
+
     @partial(jax.jit, static_argnums=(0, 4, 5, 6, 8, 9))  # Note: changing fields assumed static won't propagate.
     def _run_from_state(self,
                         initial_state,
@@ -951,8 +971,8 @@ class Model:
         trace_id = self._trace_counter
         self._trace_counter += 1
         try:
-            self._traced_params[trace_id] = provenance.describe_params(
-                self.physics)
+            self._remember_traced_params(
+                trace_id, provenance.describe_params(self.physics))
         except Exception:  # noqa: BLE001 — provenance never fails a run
             logger.warning("provenance: trace-time parameter capture failed",
                            exc_info=True)

--- a/jcm/model.py
+++ b/jcm/model.py
@@ -460,10 +460,11 @@ class Model:
         self.dt_si = (time_step * units.minute).to(units.second)
 
         self.observers = tuple(observers)
-        # Parameters as bound into each compiled trace, keyed by the static
-        # signature that selects the executable (#733 review). See the
+        # Parameters as bound into each compiled trace, keyed by a trace
+        # id that the executable itself carries back (#733 review). See the
         # capture in ``_run_from_state`` for why the live values will not do.
         self._traced_params: dict = {}
+        self._trace_counter: int = 0
         if len({obs.name for obs in self.observers}) != len(self.observers):
             raise ValueError("Observer names must be unique.")
         if self.observers:
@@ -949,11 +950,11 @@ class Model:
         # wrong record. On a cache hit this line does not re-run, which is
         # exactly right: the reused executable still holds the parameters
         # captured at its own trace.
+        trace_id = self._trace_counter
+        self._trace_counter += 1
         try:
-            self._traced_params[
-                (save_interval, total_time, output_averages,
-                 snapshot_stride, snapshot_fields)
-            ] = provenance.describe_params(self.physics, self.dycore)
+            self._traced_params[trace_id] = provenance.describe_params(
+                self.physics, self.dycore)
         except Exception:  # noqa: BLE001 — provenance never fails a run
             logger.warning("provenance: trace-time parameter capture failed",
                            exc_info=True)
@@ -985,8 +986,15 @@ class Model:
         (final_dycore_state, final_physics_state, predictions, observations,
          snapshots) = integrate(initial_state, initial_physics_state)
 
+        # The id rides back as a traced constant, so a cache hit returns
+        # the id of the executable that actually ran. Keying the store on
+        # the static arguments instead was not enough: one static
+        # signature can own several executables (a forcing of a different
+        # shape or dtype retraces), and the later trace overwrote the
+        # earlier one's record.
         return (final_dycore_state, final_physics_state,
-                predictions.replace(times=times), observations, snapshots)
+                predictions.replace(times=times), observations, snapshots,
+                jnp.int32(trace_id))
 
     def run_from_state(self,
                        initial_state,
@@ -1089,7 +1097,7 @@ class Model:
             )
 
         (final_dycore_state, final_physics_state, predictions, observations,
-         snapshots) = self._run_from_state(
+         snapshots, trace_id) = self._run_from_state(
                 initial_state, initial_physics_state, forcing,
                 save_interval_days, total_time_days,
                 output_averages, observer_xs,
@@ -1101,9 +1109,7 @@ class Model:
             ModelPredictions(
                 predictions, self.coords, self.physics,
                 dycore=self.dycore,
-                params=self._traced_params.get(
-                    (save_interval_days, total_time_days, output_averages,
-                     snapshot_stride, tuple(snapshot_variables))),
+                params=self._traced_params.get(int(trace_id)),
                 observations=observations,
                 observers=self.observers,
                 obs_t0_days=obs_t0_days,

--- a/jcm/model.py
+++ b/jcm/model.py
@@ -461,7 +461,7 @@ class Model:
 
         self.observers = tuple(observers)
         # Parameters as bound into each compiled trace, keyed by a trace
-        # id that the executable itself carries back (#733 review). See the
+        # id that the executable itself carries back (#732). See the
         # capture in ``_run_from_state`` for why the live values will not do.
         self._traced_params: dict = {}
         self._trace_counter: int = 0
@@ -940,21 +940,19 @@ class Model:
         :meth:`Model.resume`).
         """
         # Capture the parameters HERE, at trace time, not from the live
-        # module afterwards (#733 review). ``self`` is a static argument,
-        # so the parameter values are baked into this executable as
-        # constants; mutating an nnx.Param in place afterwards changes
-        # nothing the compiled function does (see the note on the
-        # decorator). Reading the module at the model-to-user handoff
-        # therefore stamped a trajectory with values that did not produce
-        # it — a calibration loop that mutates in place got a confident,
-        # wrong record. On a cache hit this line does not re-run, which is
-        # exactly right: the reused executable still holds the parameters
-        # captured at its own trace.
+        # module afterwards (#732). ``self`` is a static argument, so the
+        # parameter values are baked into this executable as constants and
+        # mutating one in place afterwards changes nothing the compiled
+        # function does (see the note on the decorator). Reading the module
+        # at the model-to-user handoff would therefore stamp a trajectory
+        # with values that did not produce it. On a cache hit this does not
+        # re-run, which is right: the reused executable still holds the
+        # parameters captured at its own trace.
         trace_id = self._trace_counter
         self._trace_counter += 1
         try:
             self._traced_params[trace_id] = provenance.describe_params(
-                self.physics, self.dycore)
+                self.physics)
         except Exception:  # noqa: BLE001 — provenance never fails a run
             logger.warning("provenance: trace-time parameter capture failed",
                            exc_info=True)

--- a/jcm/predictions.py
+++ b/jcm/predictions.py
@@ -57,7 +57,7 @@ class ModelPredictions:
         self._snapshot_variables = tuple(snapshot_variables)
         self._snapshot_interval_days = snapshot_interval_days
         # Snapshot the parameters this trajectory was produced with, here
-        # at the model-to-user handoff. Eagerly, not on demand: a
+        # at the model-to-user handoff (#732). Eagerly, not on demand: a
         # calibration loop updates the term parameters in place between
         # runs, so a lazy read through ``self._physics`` would report
         # whichever values the *next* iteration installed rather than the
@@ -78,7 +78,7 @@ class ModelPredictions:
 
     @property
     def params(self):
-        """The parameter values behind this trajectory.
+        """The parameter values behind this trajectory (see #732).
 
         Flat dotted keys under ``physics`` / ``dycore`` / ``constants`` —
         read off the built model at construction, so it reflects what ran
@@ -167,7 +167,7 @@ class ModelPredictions:
         """Convert the full prediction trajectory to an xarray.Dataset.
 
         The parameters the run used are stamped into the dataset's global
-        attributes here, so they survive a bare
+        attributes here (#732), so they survive a bare
         ``model.run(...).to_xarray().to_netcdf(...)`` that never goes near
         the Hydra runners. Wrapping rather than stamping inside
         :meth:`_trajectory_dataset` keeps the per-backend return paths

--- a/jcm/predictions.py
+++ b/jcm/predictions.py
@@ -44,7 +44,7 @@ class ModelPredictions:
                  dycore=None, observations=None, observers=(),
                  obs_t0_days=None, obs_dt_seconds=None,
                  snapshots=None, snapshot_variables=(),
-                 snapshot_interval_days=None):
+                 snapshot_interval_days=None, params=None):
         self._predictions = predictions
         self._coords = coords
         self._physics = physics
@@ -56,25 +56,57 @@ class ModelPredictions:
         self._snapshots = snapshots
         self._snapshot_variables = tuple(snapshot_variables)
         self._snapshot_interval_days = snapshot_interval_days
-        # Snapshot the parameters this trajectory was produced with, here
-        # at the model-to-user handoff (#732). Eagerly, not on demand: a
-        # calibration loop updates the term parameters in place between
-        # runs, so a lazy read through ``self._physics`` would report
-        # whichever values the *next* iteration installed rather than the
-        # ones behind these predictions. Provenance capture must never be
-        # able to fail a completed run, hence the broad guard.
+        # The parameters this trajectory was produced with (#732).
+        #
+        # ``params`` is the record captured at TRACE time by
+        # ``Model._run_from_state`` and is authoritative when present:
+        # ``self`` is a static argument to that jit, so the parameters are
+        # constants inside the executable, and reading the live module here
+        # can report values that never reached the computation (#733
+        # review). Falling back to a live read covers a ModelPredictions
+        # built directly, where there is no trace to have captured.
         #
         # Skipped entirely with no model to read: the pytree unflatten
         # rebuilds without coords/physics/dycore by design, and it runs on
         # every tree_map over a ModelPredictions. There is nothing to
         # record there, and it should not cost anything either.
         self._params = {}
-        if physics is not None or dycore is not None:
-            try:
+        try:
+            if params is not None:
+                self._params = self._check_live_matches_traced(
+                    params, physics, dycore)
+            elif physics is not None or dycore is not None:
                 self._params = provenance.describe_params(physics, dycore)
-            except Exception:  # noqa: BLE001
-                logger.warning("provenance: parameter capture failed",
-                               exc_info=True)
+        except Exception:  # noqa: BLE001 — never fail a completed run
+            logger.warning("provenance: parameter capture failed",
+                           exc_info=True)
+
+    @staticmethod
+    def _check_live_matches_traced(traced, physics, dycore):
+        """Return *traced*, flagging a live/compiled parameter divergence.
+
+        A mismatch means the caller changed a parameter in place and jcm
+        silently ignored it: the model rebinds parameters only when the
+        jit retraces, so the run used the compiled values. That is a
+        scientific error the user needs told about, not something for
+        provenance to paper over by quietly recording the compiled values
+        and moving on.
+        """
+        live = provenance.describe_params(physics, dycore)
+        if live == traced:
+            return traced
+        logger.warning(
+            "provenance: the live parameters differ from those compiled "
+            "into this run. jcm binds physics parameters at trace time "
+            "(Model._run_from_state takes `self` as a static argument), so "
+            "an in-place parameter change after the first run does NOT "
+            "affect the computation. The record reports the values that "
+            "actually ran. Rebuild the Model to change parameters.")
+        flagged = dict(traced)
+        flagged["live_parameters_differ_from_compiled"] = (
+            "in-place parameter changes did not reach this run; the record "
+            "holds the compiled values")
+        return flagged
 
     @property
     def params(self):

--- a/jcm/predictions.py
+++ b/jcm/predictions.py
@@ -145,6 +145,12 @@ class ModelPredictions:
     def observation_datasets(self):
         """Per-timestep virtual-observation output as xarray Datasets.
 
+        Stamped with the run's parameters like the trajectory and the
+        snapshots (#733 review): an observer stream is often persisted on
+        its own with ``observation_datasets()[name].to_netcdf(...)``, and
+        such a file would otherwise be the one output that cannot say
+        which parameters produced it.
+
         Returns:
             Dict ``{observer_name: xarray.Dataset}`` — one Dataset per
             attached :class:`jcm.observers.Observer`, with dims
@@ -156,12 +162,14 @@ class ModelPredictions:
         if not self._observations:
             return {}
         samples_host = jax.device_get(self._observations)
-        return {
-            obs.name: obs.to_dataset(
-                samples, self._obs_t0_days, self._obs_dt_seconds,
-            )
-            for obs, samples in zip(self._observers, samples_host)
-        }
+        stamp = provenance.params_attrs(self._params)
+        datasets = {}
+        for obs, samples in zip(self._observers, samples_host):
+            ds = obs.to_dataset(samples, self._obs_t0_days,
+                                self._obs_dt_seconds)
+            ds.attrs.update(stamp)
+            datasets[obs.name] = ds
+        return datasets
 
     def to_xarray(self):
         """Convert the full prediction trajectory to an xarray.Dataset.

--- a/jcm/predictions.py
+++ b/jcm/predictions.py
@@ -8,6 +8,8 @@ analysis-ready :class:`xarray.Dataset`. Returned by :meth:`jcm.model.Model.run`,
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 
 import jax
@@ -16,9 +18,12 @@ from jax.tree_util import tree_map
 from numpy import timedelta64
 import pandas as pd
 
+from jcm import provenance
 from jcm.dycore.base import Predictions
 from jcm.physics_interface import Physics
 from jcm.utils import DYNAMICS_UNITS_TABLE_CSV_PATH, data_to_xarray
+
+logger = logging.getLogger(__name__)
 
 
 class ModelPredictions:
@@ -51,6 +56,36 @@ class ModelPredictions:
         self._snapshots = snapshots
         self._snapshot_variables = tuple(snapshot_variables)
         self._snapshot_interval_days = snapshot_interval_days
+        # Snapshot the parameters this trajectory was produced with, here
+        # at the model-to-user handoff. Eagerly, not on demand: a
+        # calibration loop updates the term parameters in place between
+        # runs, so a lazy read through ``self._physics`` would report
+        # whichever values the *next* iteration installed rather than the
+        # ones behind these predictions. Provenance capture must never be
+        # able to fail a completed run, hence the broad guard.
+        #
+        # Skipped entirely with no model to read: the pytree unflatten
+        # rebuilds without coords/physics/dycore by design, and it runs on
+        # every tree_map over a ModelPredictions. There is nothing to
+        # record there, and it should not cost anything either.
+        self._params = {}
+        if physics is not None or dycore is not None:
+            try:
+                self._params = provenance.describe_params(physics, dycore)
+            except Exception:  # noqa: BLE001
+                logger.warning("provenance: parameter capture failed",
+                               exc_info=True)
+
+    @property
+    def params(self):
+        """The parameter values behind this trajectory.
+
+        Flat dotted keys under ``physics`` / ``dycore`` / ``constants`` —
+        read off the built model at construction, so it reflects what ran
+        rather than what the config requested. Empty for predictions
+        reconstructed by a pytree ``tree_map``, which carries no model.
+        """
+        return self._params
 
     @property
     def dynamics(self):
@@ -103,7 +138,8 @@ class ModelPredictions:
             data,
             coords={"snap_time": t, "lon": lon, "lat": lat},
             attrs={"snapshot_interval_days": self._snapshot_interval_days,
-                   "sampling": "instantaneous (post-step)"},
+                   "sampling": "instantaneous (post-step)",
+                   **provenance.params_attrs(self._params)},
         )
 
     def observation_datasets(self):
@@ -130,10 +166,23 @@ class ModelPredictions:
     def to_xarray(self):
         """Convert the full prediction trajectory to an xarray.Dataset.
 
+        The parameters the run used are stamped into the dataset's global
+        attributes here, so they survive a bare
+        ``model.run(...).to_xarray().to_netcdf(...)`` that never goes near
+        the Hydra runners. Wrapping rather than stamping inside
+        :meth:`_trajectory_dataset` keeps the per-backend return paths
+        from being able to skip it.
+
         Returns:
             An xarray.Dataset ready for analysis and plotting.
 
         """
+        ds = self._trajectory_dataset()
+        ds.attrs.update(provenance.params_attrs(self._params))
+        return ds
+
+    def _trajectory_dataset(self):
+        """Build the trajectory Dataset, before provenance stamping."""
         # Backends whose native horizontal layout is not the separable
         # lat/lon grid the legacy path below assumes (pySES cubed-sphere
         # columns) own their trajectory conversion per the DynamicalCore

--- a/jcm/predictions.py
+++ b/jcm/predictions.py
@@ -83,8 +83,8 @@ class ModelPredictions:
 
         A mismatch means the caller changed a parameter in place and jcm
         silently ignored it: the model rebinds parameters only when the
-        jit retraces, so the run used the compiled values. That is a
-        scientific error the user needs told about, not something for
+        jit retraces, so the run used the compiled values (#735). That is
+        a scientific error the user needs told about, not something for
         provenance to paper over by quietly recording the compiled values
         and moving on.
         """

--- a/jcm/predictions.py
+++ b/jcm/predictions.py
@@ -62,27 +62,23 @@ class ModelPredictions:
         # ``Model._run_from_state`` and is authoritative when present:
         # ``self`` is a static argument to that jit, so the parameters are
         # constants inside the executable, and reading the live module here
-        # can report values that never reached the computation (#733
-        # review). Falling back to a live read covers a ModelPredictions
-        # built directly, where there is no trace to have captured.
-        #
-        # Skipped entirely with no model to read: the pytree unflatten
-        # rebuilds without coords/physics/dycore by design, and it runs on
-        # every tree_map over a ModelPredictions. There is nothing to
-        # record there, and it should not cost anything either.
+        # can report values that never reached the computation. Falling
+        # back to a live read covers a ModelPredictions built directly,
+        # where there is no trace to have captured. With no physics at all
+        # there is nothing to record: the pytree unflatten rebuilds without
+        # it by design, and runs on every tree_map over a ModelPredictions.
         self._params = {}
         try:
             if params is not None:
-                self._params = self._check_live_matches_traced(
-                    params, physics, dycore)
-            elif physics is not None or dycore is not None:
-                self._params = provenance.describe_params(physics, dycore)
+                self._params = self._check_live_matches_traced(params, physics)
+            elif physics is not None:
+                self._params = provenance.describe_params(physics)
         except Exception:  # noqa: BLE001 — never fail a completed run
             logger.warning("provenance: parameter capture failed",
                            exc_info=True)
 
     @staticmethod
-    def _check_live_matches_traced(traced, physics, dycore):
+    def _check_live_matches_traced(traced, physics):
         """Return *traced*, flagging a live/compiled parameter divergence.
 
         A mismatch means the caller changed a parameter in place and jcm
@@ -92,7 +88,7 @@ class ModelPredictions:
         provenance to paper over by quietly recording the compiled values
         and moving on.
         """
-        live = provenance.describe_params(physics, dycore)
+        live = provenance.describe_params(physics)
         if live == traced:
             return traced
         logger.warning(
@@ -110,12 +106,12 @@ class ModelPredictions:
 
     @property
     def params(self):
-        """The parameter values behind this trajectory (see #732).
+        """The physics parameter values behind this trajectory (#732).
 
-        Flat dotted keys under ``physics`` / ``dycore`` / ``constants`` —
-        read off the built model at construction, so it reflects what ran
-        rather than what the config requested. Empty for predictions
-        reconstructed by a pytree ``tree_map``, which carries no model.
+        Flat ``<term>.<variable>.<field>`` keys, read off the built model
+        rather than the requested config, so they reflect what ran. Empty
+        for predictions reconstructed by a pytree ``tree_map``, which
+        carries no physics.
         """
         return self._params
 
@@ -178,10 +174,7 @@ class ModelPredictions:
         """Per-timestep virtual-observation output as xarray Datasets.
 
         Stamped with the run's parameters like the trajectory and the
-        snapshots (#733 review): an observer stream is often persisted on
-        its own with ``observation_datasets()[name].to_netcdf(...)``, and
-        such a file would otherwise be the one output that cannot say
-        which parameters produced it.
+        snapshots, since an observer stream is often persisted on its own.
 
         Returns:
             Dict ``{observer_name: xarray.Dataset}`` — one Dataset per
@@ -210,8 +203,8 @@ class ModelPredictions:
         attributes here (#732), so they survive a bare
         ``model.run(...).to_xarray().to_netcdf(...)`` that never goes near
         the Hydra runners. Wrapping rather than stamping inside
-        :meth:`_trajectory_dataset` keeps the per-backend return paths
-        from being able to skip it.
+        :meth:`_trajectory_dataset` keeps a per-backend return path from
+        being able to skip it.
 
         Returns:
             An xarray.Dataset ready for analysis and plotting.

--- a/jcm/provenance.py
+++ b/jcm/provenance.py
@@ -321,7 +321,17 @@ def _describe_value(value, prefix: str, out: dict, depth: int = 0,
             if len(value) <= _PARAM_ARRAY_MAX_ELEMS:
                 out[prefix] = list(value)
             else:
-                out[prefix] = f"<{len(value)} scalars>"
+                # Hashed, not just counted (#733 review). A bare length
+                # made two AerocomDiagnostics terms with different
+                # 100-element ``plev_pa`` tuples record identically, and
+                # those pressures are interpolated to, so they change the
+                # diagnostics. Same treatment as a large array.
+                out[prefix] = {
+                    "length": len(value),
+                    "sha256": hashlib.sha256(
+                        json.dumps(list(value), default=str).encode()
+                    ).hexdigest()[:12],
+                }
             return
         if scalars_only and len(value) > _PARAM_ARRAY_MAX_ELEMS:
             # An unbounded sequence of structures is grid data, not knobs.
@@ -422,7 +432,17 @@ def _describe_term_settings(term, name: str, out: dict, skip=()) -> None:
             continue  # an nnx variable; the variable walk records it
         if any(value is skipped for skipped in skip):
             continue
-        _describe_value(value, f"{name}.{attribute}", out, scalars_only=True)
+        key = f"{name}.{attribute}"
+        _describe_value(value, key, out, scalars_only=True)
+        # An attribute carrying arrays still has to identify itself, the
+        # same way a plain Variable does (#733 review). ``nnx.data``
+        # leaves live here rather than in the variable state — CloudsatCosp
+        # keeps its radar lookup tables as ``self._lut = nnx.data(...)``,
+        # and a different LUT changes the simulated reflectivity, so
+        # dropping its arrays let two LUTs record identically.
+        digest = _aggregate_digest(value)
+        if digest is not None:
+            out[f"{key}.array_digest"] = digest
 
 
 def _describe_physics_params(physics) -> dict:

--- a/jcm/provenance.py
+++ b/jcm/provenance.py
@@ -309,6 +309,48 @@ def _describe_value(value, prefix: str, out: dict, depth: int = 0,
     out[prefix] = _describe_leaf(value)
 
 
+def _describe_term_settings(term, name: str, out: dict) -> None:
+    """Record a term's constructor controls held as plain attributes.
+
+    Not every run-shaping setting reaches an nnx variable (#733 review).
+    ``UpperSponge`` keeps ``sponge_timescale_s``, ``enspodi``,
+    ``damp_temperature`` and ``target_T_K`` as ordinary attributes and
+    turns them into a grid-shaped ``_inv_tau`` profile that the
+    knob-shape filter then (correctly) rejects, so a 3600 s and a 7200 s
+    sponge recorded identically. RRTMGP's ``_base_seed`` and
+    ``_compute_cre`` are the same shape of omission.
+
+    The discriminator is the term's own ``__init__`` signature rather
+    than a scan of its attributes: a constructor parameter *is* the set
+    of choices a caller made, so this picks up a newly added control with
+    no maintenance, while the caches and the nnx bookkeeping
+    (``_pytree__nodes``, ``_coords_cached``, ``_nodal_shape``) are
+    excluded because nobody passed them in. Each name is looked up as
+    itself and then underscore-prefixed, which is where the schemes
+    actually put them. Values already held in an nnx variable are skipped
+    here; the variable walk has them.
+    """
+    import inspect
+
+    try:
+        signature = inspect.signature(type(term).__init__)
+        attributes = vars(term)
+    except (TypeError, ValueError):
+        return
+    for parameter in list(signature.parameters)[1:]:  # skip ``self``
+        if parameter in ("args", "kwargs"):
+            continue
+        for attribute in (parameter, f"_{parameter}"):
+            if attribute not in attributes:
+                continue
+            value = attributes[attribute]
+            if type(value).__module__.startswith("flax."):
+                break  # an nnx variable; the variable walk records it
+            _describe_value(value, f"{name}.{attribute}", out,
+                            scalars_only=True)
+            break
+
+
 def _describe_physics_params(physics) -> dict:
     """Every ``nnx.Variable`` on every physics term, by dotted name.
 
@@ -382,6 +424,7 @@ def _describe_physics_params(physics) -> dict:
             name = f"{name}#{seen[name]}"
         else:
             seen[name] = 0
+        _describe_term_settings(term, name, out)
         try:
             # to_flat_state, not the State.flat_state() method: the latter
             # is deprecated and warns once per call. Present since flax

--- a/jcm/provenance.py
+++ b/jcm/provenance.py
@@ -1,4 +1,4 @@
-"""Run provenance capture (#591).
+"""Run provenance capture (#591, #732).
 
 Records what actually produced an output file — code versions (git SHA +
 dirty state of every editable install *actually imported*), precision and
@@ -14,7 +14,7 @@ are recorded here as they resolve; content hashing of multi-GB inputs is
 opt-in (``JCM_HASH_INPUTS=1``) — size + mtime is the default descriptor.
 
 Parameters are captured separately from the config and by a different
-route, because the config does not determine them. A scheme's
+route, because the config does not determine them (#732). A scheme's
 ``params`` block is deliberately absent from the shipped yamls so each
 field falls back to ``Parameters.default()`` in code, so the composed
 config records the *overrides* and says nothing about the effective

--- a/jcm/provenance.py
+++ b/jcm/provenance.py
@@ -2,8 +2,9 @@
 
 Records what actually produced an output file — code versions (git SHA +
 dirty state of every editable install *actually imported*), precision and
-hardware, the resolved boundary files opened, the ozone source, and a
-single run hash — and attaches it as netCDF global attributes plus a
+hardware, the resolved boundary files opened, the ozone source, the
+parameter values the model actually ran with, and a single run hash — and
+attaches it as netCDF global attributes plus a
 ``<output>.provenance.json`` sidecar carrying the fully composed config.
 
 The probe inspects ``sys.modules`` in the running process, so a
@@ -12,11 +13,26 @@ requested. Input files funnel through ``runners._resolve_data_path`` and
 are recorded here as they resolve; content hashing of multi-GB inputs is
 opt-in (``JCM_HASH_INPUTS=1``) — size + mtime is the default descriptor.
 
+Parameters are captured separately from the config and by a different
+route, because the config does not determine them. A scheme's
+``params`` block is deliberately absent from the shipped yamls so each
+field falls back to ``Parameters.default()`` in code, so the composed
+config records the *overrides* and says nothing about the effective
+values; and a model built in Python, or one whose parameters were
+replaced after construction (what a calibration loop does), has no
+config behind it at all. :func:`describe_params` therefore reads the
+built objects. It is called at the model-to-user handoff — see
+:class:`jcm.predictions.ModelPredictions` — because that is the last
+moment the values are still the ones that produced the trajectory.
+
 Lifecycle: :func:`start_run` at run start (captures code/env/config and
 resets the input registry), :func:`record_input` / :func:`record_fact`
 during model build, :func:`attrs` / :func:`write_sidecar` at output time
 (inputs and the run hash are finalized lazily, after the build has
-touched every file).
+touched every file). The parameter record travels on the predictions
+object rather than through this module's registry: two models built in
+one process would otherwise overwrite each other's parameters, and the
+one that wrote the file need not be the one that ran last.
 """
 
 from __future__ import annotations
@@ -47,6 +63,23 @@ _VERSION_LIBS = ("jax", "jaxlib", "numpy", "xarray", "flax")
 #: Environment variables that silently change precision or compilation.
 _ENV_FLAGS = ("JAX_ENABLE_X64", "MAM4_JAX_ENABLE_X64", "XLA_FLAGS",
               "JCM_CACHE_DIR")
+
+#: Parameter arrays up to this many elements are recorded by value; larger
+#: ones become a shape/dtype/hash summary. Embedded NN weights are
+#: parameters too, and a few million of them must not land in a netCDF
+#: attribute — the hash still distinguishes one weight set from another.
+#: 64 rather than a smaller round number so that the per-plume MACv2-SP
+#: shape parameters (2x9) and per-level profiles are kept as values: they
+#: are tuned, so a hash of them is not a useful record.
+_PARAM_ARRAY_MAX_ELEMS = 64
+#: Depth cap on the parameter walk. A guard against a cyclic or
+#: pathologically nested container, not a real structural limit (the
+#: deepest shipped parameter struct nests two levels).
+_PARAM_MAX_DEPTH = 6
+#: Cap on the parameter JSON carried *in netCDF attributes*. The sidecar
+#: is unconditional; a record over the cap keeps its hash in the
+#: attributes and points at the sidecar for the values.
+_PARAM_ATTR_MAX_CHARS = 64_000
 
 _state: dict = {"base": None, "inputs": {}, "facts": {}}
 
@@ -142,6 +175,259 @@ def describe_input(path: str) -> dict:
     return d
 
 
+def _describe_leaf(value):
+    """JSON-safe description of one parameter leaf."""
+    import jax
+    import numpy as np
+
+    if isinstance(value, jax.core.Tracer):
+        # Captured inside jit/grad/vmap — a calibration loop differentiating
+        # through the model. The value is not concrete, and unlike a lazy
+        # array it cannot be forced.
+        return "<traced>"
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if callable(value):
+        return f"<callable {getattr(value, '__name__', type(value).__name__)}>"
+    try:
+        arr = np.asarray(value)
+    except Exception:  # noqa: BLE001 — anything unconvertible is described
+        return repr(value)[:200]
+    if arr.dtype == object:
+        return repr(value)[:200]
+    if arr.ndim == 0:
+        # ``item()`` on a float32 widens to the exact float64 that value
+        # represents (0.1 -> 0.10000000149011612). That is the number the
+        # model used, so record it rather than a prettier rounding.
+        return arr.item()
+    if arr.size <= _PARAM_ARRAY_MAX_ELEMS:
+        return arr.ravel().tolist()
+    return {"shape": list(arr.shape), "dtype": str(arr.dtype),
+            "sha256": hashlib.sha256(
+                np.ascontiguousarray(arr).tobytes()).hexdigest()[:12]}
+
+
+def _is_scalar(value) -> bool:
+    return value is None or isinstance(value, (bool, int, float, str))
+
+
+def _describe_value(value, prefix: str, out: dict, depth: int = 0) -> None:
+    """Flatten *value* into *out* under the dotted key *prefix*."""
+    import dataclasses
+
+    if depth > _PARAM_MAX_DEPTH:
+        out[prefix] = f"<truncated {type(value).__name__}>"
+        return
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        # ``dataclasses.fields``, not ``tree_flatten_with_path``: the
+        # tree_math structs these parameter blocks use register as pytrees
+        # without key paths, so flattening yields "[<flat index 3>]" where
+        # the field name is the entire point of the record.
+        for f in dataclasses.fields(value):
+            _describe_value(getattr(value, f.name), f"{prefix}.{f.name}",
+                            out, depth + 1)
+        return
+    if hasattr(value, "_fields") and isinstance(value, tuple):  # NamedTuple
+        for name in value._fields:
+            _describe_value(getattr(value, name), f"{prefix}.{name}",
+                            out, depth + 1)
+        return
+    if isinstance(value, dict):
+        for k, v in value.items():
+            _describe_value(v, f"{prefix}.{k}", out, depth + 1)
+        return
+    if isinstance(value, (list, tuple)):
+        # A short all-scalar sequence is one value (a per-level profile);
+        # anything else is a container to walk.
+        if all(_is_scalar(v) for v in value):
+            if len(value) <= _PARAM_ARRAY_MAX_ELEMS:
+                out[prefix] = list(value)
+            else:
+                out[prefix] = f"<{len(value)} scalars>"
+            return
+        for i, v in enumerate(value):
+            _describe_value(v, f"{prefix}.{i}", out, depth + 1)
+        return
+    out[prefix] = _describe_leaf(value)
+
+
+def _describe_physics_params(physics) -> dict:
+    """Every ``nnx.Param`` on every physics term, by dotted name.
+
+    Keyed on the term's own ``name`` (``tiedtke_convection``) and the
+    variable it hangs off: ``tiedtke_convection.params.entrpen``.
+
+    That is close to, but not always identical to, the Hydra override
+    path minus its ``physics.terms.`` prefix. Hydra addresses the term's
+    *constructor keyword*, which for the ECHAM terms is also the variable
+    name but for the SPEEDY ones is not (``SpeedyConvection`` takes
+    ``convection_params=`` and stores it as ``params``, so the override
+    is ``...speedy_convection.convection_params.entmax`` while the record
+    says ``...speedy_convection.params.entmax``). The record names where
+    the value *lives*, which is the thing that must be unambiguous;
+    reproducing it may need the constructor signature.
+
+    Keying on ``nnx.Param`` rather than a ``.params`` attribute is
+    deliberate — terms also carry ``mod_radcon_params``, ``sw_params``,
+    ``surface_optics`` and bare tuning scalars, and a scheme that adds
+    another must not silently drop out of the record.
+    """
+    if physics is None:
+        return {}
+    try:
+        from flax import nnx
+    except ImportError:
+        return {}
+
+    terms = getattr(physics, "terms", None)
+    modules = list(terms) if terms is not None else [physics]
+    out: dict = {}
+    seen: dict = {}
+    for term in modules:
+        name = getattr(term, "name", None) or type(term).__name__
+        # A composition may hold two instances of one term (e.g. a
+        # double-call radiation A/B); keep both rather than clobbering.
+        if name in seen:
+            seen[name] += 1
+            name = f"{name}#{seen[name]}"
+        else:
+            seen[name] = 0
+        try:
+            # to_flat_state, not the State.flat_state() method: the latter
+            # is deprecated and warns once per call. Present since flax
+            # 0.12.1, which requirements.txt already floors us to.
+            flat = nnx.to_flat_state(nnx.state(term, nnx.Param))
+        except Exception:  # noqa: BLE001 — a non-nnx term has no params
+            continue
+        for path, var in flat:
+            key = ".".join(str(p) for p in (name, *path))
+            _describe_value(var.get_value(), key, out)
+    return out
+
+
+def _all_scalar_leaves(value, depth: int = 0) -> bool:
+    """Report whether *value* is built purely from scalars.
+
+    Screens a dycore attribute *before* describing it, so ``coords`` and
+    ``terrain`` are rejected on the first array field rather than having
+    their grids pulled off the device to be summarized.
+    """
+    import dataclasses
+
+    if _is_scalar(value):
+        return True
+    if depth > _PARAM_MAX_DEPTH:
+        return False
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return all(_all_scalar_leaves(getattr(value, f.name), depth + 1)
+                   for f in dataclasses.fields(value))
+    if isinstance(value, dict):
+        return all(_all_scalar_leaves(v, depth + 1) for v in value.values())
+    if isinstance(value, (list, tuple)):
+        return all(_all_scalar_leaves(v, depth + 1) for v in value)
+    return False
+
+
+def _describe_dycore_params(dycore) -> dict:
+    """Scalar dycore knobs: timestep, diffusion filter, transport options.
+
+    A dycore declares no parameters the way a physics term does (there is
+    no ``nnx.Param`` to key on), so the rule here is structural: instance
+    attributes that are scalars, or containers built purely from scalars.
+    That keeps ``dt_seconds``, the ``DiffusionFilter`` timescales and
+    orders, the ``compute_*`` flags and the semi-Lagrangian options, and
+    drops ``coords`` / ``terrain`` / the precomputed vertical coefficients,
+    whose arrays are grid data rather than knobs. Private attributes are
+    included (``_sl_options`` is as much a knob as ``dt_seconds``); the
+    leading underscore is kept so the key names a real attribute.
+    """
+    if dycore is None:
+        return {}
+    try:
+        attributes = vars(dycore)
+    except TypeError:  # a __slots__ backend exposes no instance __dict__
+        return {}
+    out: dict = {}
+    for name, value in sorted(attributes.items()):
+        if name.startswith("__") or name == "constants":
+            continue  # constants get their own block
+        if not _all_scalar_leaves(value):
+            continue
+        _describe_value(value, name, out)
+    return out
+
+
+def _describe_constants(dycore) -> dict:
+    """Record the live physical constants, and the dycore's if they differ.
+
+    ``jcm.constants`` is a process-global singleton read *live* by
+    attribute-access physics but captured *at construction* by the dycore,
+    so a ``set_constants`` call made after the model was built leaves the
+    two genuinely disagreeing. Recording only the live values would hide
+    that, so a differing dycore copy is recorded field by field.
+    """
+    out: dict = {}
+    try:
+        import jcm.constants as _c
+        live = _c.physical_constants
+    except Exception:  # noqa: BLE001 — never fail a run over provenance
+        return out
+    _describe_value(live, "constants", out)
+    built = getattr(dycore, "constants", None)
+    if built is None or built == live:
+        return out
+    built_fields: dict = {}
+    _describe_value(built, "constants", built_fields)
+    for key, value in built_fields.items():
+        if out.get(key) != value:
+            out[key.replace("constants", "constants_dycore", 1)] = value
+    return out
+
+
+def describe_params(physics=None, dycore=None) -> dict:
+    """Return the parameter values a run actually used, by dotted key.
+
+    Reads the *built* objects, not the requested config, because the two
+    are not the same thing (see the module docstring): the shipped yamls
+    omit each scheme's ``params`` block so the effective values live in
+    ``Parameters.default()``, and a Python-built or post-hoc-modified
+    model has no config at all.
+
+    Returns a dict with ``physics`` (every ``nnx.Param`` on every term),
+    ``dycore`` (scalar backend knobs) and ``constants`` blocks; each maps
+    dotted names to JSON-safe values. Large arrays are summarized by
+    shape/dtype/hash and values captured under ``jit``/``grad`` read
+    ``"<traced>"``.
+    """
+    out: dict = {}
+    physics_params = _describe_physics_params(physics)
+    if physics_params:
+        out["physics"] = physics_params
+    dycore_params = _describe_dycore_params(dycore)
+    if dycore_params:
+        out["dycore"] = dycore_params
+    constants = _describe_constants(dycore)
+    if constants:
+        out["constants"] = constants
+    return out
+
+
+def params_attrs(params: dict | None) -> dict:
+    """netCDF-safe global attributes for a parameter record."""
+    if not params:
+        return {}
+    blob = json.dumps(params, sort_keys=True, default=str)
+    out = {"jcm_prov_params_sha":
+           hashlib.sha256(blob.encode()).hexdigest()[:12]}
+    if len(blob) <= _PARAM_ATTR_MAX_CHARS:
+        out["jcm_prov_params"] = blob
+    else:
+        out["jcm_prov_params"] = (
+            f"<{len(blob)} chars, over the {_PARAM_ATTR_MAX_CHARS}-char "
+            "attribute cap; full record in the .provenance.json sidecar>")
+    return out
+
+
 def start_run(cfg=None) -> None:
     """Reset the registries and capture the config at run start.
 
@@ -184,12 +470,15 @@ def record_fact(key: str, value) -> None:
     _state["facts"][key] = value
 
 
-def collect() -> dict:
+def collect(params: dict | None = None) -> dict:
     """Return the full provenance record.
 
     Code and environment are probed fresh each call (a handful of git
     subprocesses — negligible next to a netCDF write), so libraries the
     model build imported lazily and any post-start x64 flip are captured.
+
+    *params* is the record from :func:`describe_params`, carried by the
+    predictions object rather than by this module's registry.
     """
     if _state["base"] is None:
         start_run()
@@ -198,6 +487,8 @@ def collect() -> dict:
     prov["environment"] = probe_environment()
     prov["inputs"] = dict(_state["inputs"])
     prov["facts"] = dict(_state["facts"])
+    if params:
+        prov["params"] = params
     hash_material = {
         # A dirty tree is a different code state than its HEAD: fold the
         # working-tree diff fingerprint into the identity.
@@ -208,6 +499,10 @@ def collect() -> dict:
         "inputs": {k: v.get("sha256", (v.get("size"), v.get("mtime")))
                    for k, v in prov["inputs"].items()},
         "x64": prov["environment"]["jax_enable_x64"],
+        # Without this every member of a parameter sweep shares one run
+        # hash: the config, code and inputs are identical across them and
+        # the parameters are the only thing that differs.
+        "params": params or None,
     }
     prov["run_hash"] = hashlib.sha256(
         json.dumps(hash_material, sort_keys=True, default=str).encode()
@@ -229,9 +524,15 @@ def summary() -> str:
             f"ozone={ozone}")
 
 
-def attrs() -> dict:
-    """Flat netCDF-safe global attributes (nested parts as JSON strings)."""
-    prov = collect()
+def attrs(params: dict | None = None) -> dict:
+    """Flat netCDF-safe global attributes (nested parts as JSON strings).
+
+    *params* is optional because the parameter attributes are normally
+    stamped earlier, by ``ModelPredictions.to_xarray``; pass it here only
+    when building attributes for a dataset that did not come through
+    there.
+    """
+    prov = collect(params)
     out = {
         "jcm_prov_created": prov["created"],
         # attrs() runs at output time, so this stamps the write — with
@@ -244,6 +545,7 @@ def attrs() -> dict:
                                            sort_keys=True),
         "jcm_prov_inputs": json.dumps(prov["inputs"], sort_keys=True),
     }
+    out.update(params_attrs(params))
     for key, value in prov["facts"].items():
         out[f"jcm_prov_{key}"] = str(value)
     if prov["config_yaml"] is not None:
@@ -254,12 +556,16 @@ def attrs() -> dict:
     return out
 
 
-def write_sidecar(output_path) -> Path:
-    """Write ``<output>.provenance.json`` with the full record + config."""
+def write_sidecar(output_path, params: dict | None = None) -> Path:
+    """Write ``<output>.provenance.json`` with the full record + config.
+
+    Pass the same *params* given to :func:`attrs` for the same file, or
+    the sidecar's ``run_hash`` will not match the one in the attributes.
+    """
     output_path = Path(output_path)
     sidecar = output_path.with_suffix(output_path.suffix +
                                       ".provenance.json")
     sidecar.parent.mkdir(parents=True, exist_ok=True)
-    sidecar.write_text(json.dumps(collect(), indent=1, sort_keys=True,
+    sidecar.write_text(json.dumps(collect(params), indent=1, sort_keys=True,
                                   default=str))
     return sidecar

--- a/jcm/provenance.py
+++ b/jcm/provenance.py
@@ -37,19 +37,25 @@ one that wrote the file need not be the one that ran last.
 
 from __future__ import annotations
 
+import base64
 import getpass
 import hashlib
 import json
 import logging
 import os
 import platform
+import re
 import socket
 import subprocess
 import sys
+import zlib
 from datetime import datetime, timezone
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+#: ``object.__repr__``'s ``at 0x7f...`` tail, which is run-dependent.
+_ADDRESS_RE = re.compile(r" at 0x[0-9a-fA-F]+")
 
 #: Libraries whose working tree changes what a run computes. Probed only
 #: when already imported — an absent entry means "not part of this run".
@@ -76,9 +82,11 @@ _PARAM_ARRAY_MAX_ELEMS = 64
 #: pathologically nested container, not a real structural limit (the
 #: deepest shipped parameter struct nests two levels).
 _PARAM_MAX_DEPTH = 6
-#: Cap on the parameter JSON carried *in netCDF attributes*. The sidecar
-#: is unconditional; a record over the cap keeps its hash in the
-#: attributes and points at the sidecar for the values.
+#: Size at which the parameter JSON is carried compressed rather than as
+#: plain text in a netCDF attribute. It is never dropped: not every path
+#: that stamps the attributes writes a sidecar, so the values have to stay
+#: recoverable from the file itself. :func:`read_params` handles both
+#: forms.
 _PARAM_ATTR_MAX_CHARS = 64_000
 
 _state: dict = {"base": None, "inputs": {}, "facts": {}}
@@ -175,6 +183,17 @@ def describe_input(path: str) -> dict:
     return d
 
 
+def _stable_repr(value) -> str:
+    """``repr`` with the object address removed.
+
+    The default ``object.__repr__`` embeds ``id(value)``, which differs
+    between two runs of the identical configuration. Left in, it would
+    make ``params_sha`` (and through it ``run_hash``) non-reproducible,
+    which is the opposite of what this record is for.
+    """
+    return _ADDRESS_RE.sub("", repr(value))[:200]
+
+
 def _describe_leaf(value):
     """JSON-safe description of one parameter leaf."""
     import jax
@@ -192,9 +211,9 @@ def _describe_leaf(value):
     try:
         arr = np.asarray(value)
     except Exception:  # noqa: BLE001 — anything unconvertible is described
-        return repr(value)[:200]
+        return _stable_repr(value)
     if arr.dtype == object:
-        return repr(value)[:200]
+        return _stable_repr(value)
     if arr.ndim == 0:
         # ``item()`` on a float32 widens to the exact float64 that value
         # represents (0.1 -> 0.10000000149011612). That is the number the
@@ -211,9 +230,41 @@ def _is_scalar(value) -> bool:
     return value is None or isinstance(value, (bool, int, float, str))
 
 
-def _describe_value(value, prefix: str, out: dict, depth: int = 0) -> None:
-    """Flatten *value* into *out* under the dotted key *prefix*."""
+def _is_knob(value) -> bool:
+    """Report whether a leaf is worth recording as a dycore setting.
+
+    Scalars, enum members (pySES stores its coupling mode as one) and 0-d
+    arrays — pySES keeps its hyperviscosity coefficients as 0-d arrays, so
+    a plain ``isinstance`` scalar test would drop exactly the knobs that
+    matter. Decided by reading ``ndim`` rather than converting, because
+    this runs over the dycore's whole attribute graph and ``np.asarray``
+    on a device array would pull the grid to the host just to discard it.
+
+    Everything else — bulk arrays, callables, opaque backend objects — is
+    skipped rather than described. An opaque object contributes only its
+    ``repr``, which carries no setting anybody can read.
+    """
+    import enum
+
+    if _is_scalar(value) or isinstance(value, enum.Enum):
+        return True
+    return getattr(value, "ndim", None) == 0
+
+
+def _describe_value(value, prefix: str, out: dict, depth: int = 0,
+                    scalars_only: bool = False) -> None:
+    """Flatten *value* into *out* under the dotted key *prefix*.
+
+    With *scalars_only*, bulk arrays and callables are skipped rather than
+    described, and containers are still walked for the scalars inside
+    them. That is the dycore mode: a backend's configuration objects mix
+    tuning knobs with grid data in one container (pySES's
+    ``diffusion_config`` holds ``nu``/``nu_top`` next to a ``nu_ramp``
+    profile), so an all-or-nothing rule on the container drops the knobs
+    along with the grid.
+    """
     import dataclasses
+    from collections.abc import Mapping
 
     if depth > _PARAM_MAX_DEPTH:
         out[prefix] = f"<truncated {type(value).__name__}>"
@@ -225,16 +276,18 @@ def _describe_value(value, prefix: str, out: dict, depth: int = 0) -> None:
         # the field name is the entire point of the record.
         for f in dataclasses.fields(value):
             _describe_value(getattr(value, f.name), f"{prefix}.{f.name}",
-                            out, depth + 1)
+                            out, depth + 1, scalars_only)
         return
     if hasattr(value, "_fields") and isinstance(value, tuple):  # NamedTuple
         for name in value._fields:
             _describe_value(getattr(value, name), f"{prefix}.{name}",
-                            out, depth + 1)
+                            out, depth + 1, scalars_only)
         return
-    if isinstance(value, dict):
+    # Mapping, not dict: pySES's timestep_config is a frozendict, which is
+    # not a dict subclass and would otherwise fall through to the leaf.
+    if isinstance(value, Mapping):
         for k, v in value.items():
-            _describe_value(v, f"{prefix}.{k}", out, depth + 1)
+            _describe_value(v, f"{prefix}.{k}", out, depth + 1, scalars_only)
         return
     if isinstance(value, (list, tuple)):
         # A short all-scalar sequence is one value (a per-level profile);
@@ -245,8 +298,13 @@ def _describe_value(value, prefix: str, out: dict, depth: int = 0) -> None:
             else:
                 out[prefix] = f"<{len(value)} scalars>"
             return
+        if scalars_only and len(value) > _PARAM_ARRAY_MAX_ELEMS:
+            # An unbounded sequence of structures is grid data, not knobs.
+            return
         for i, v in enumerate(value):
-            _describe_value(v, f"{prefix}.{i}", out, depth + 1)
+            _describe_value(v, f"{prefix}.{i}", out, depth + 1, scalars_only)
+        return
+    if scalars_only and not _is_knob(value):
         return
     out[prefix] = _describe_leaf(value)
 
@@ -305,41 +363,31 @@ def _describe_physics_params(physics) -> dict:
     return out
 
 
-def _all_scalar_leaves(value, depth: int = 0) -> bool:
-    """Report whether *value* is built purely from scalars.
-
-    Screens a dycore attribute *before* describing it, so ``coords`` and
-    ``terrain`` are rejected on the first array field rather than having
-    their grids pulled off the device to be summarized.
-    """
-    import dataclasses
-
-    if _is_scalar(value):
-        return True
-    if depth > _PARAM_MAX_DEPTH:
-        return False
-    if dataclasses.is_dataclass(value) and not isinstance(value, type):
-        return all(_all_scalar_leaves(getattr(value, f.name), depth + 1)
-                   for f in dataclasses.fields(value))
-    if isinstance(value, dict):
-        return all(_all_scalar_leaves(v, depth + 1) for v in value.values())
-    if isinstance(value, (list, tuple)):
-        return all(_all_scalar_leaves(v, depth + 1) for v in value)
-    return False
-
-
 def _describe_dycore_params(dycore) -> dict:
-    """Scalar dycore knobs: timestep, diffusion filter, transport options.
+    """Scalar dycore knobs: timestep, diffusion, transport, subcycling.
 
     A dycore declares no parameters the way a physics term does (there is
-    no ``nnx.Param`` to key on), so the rule here is structural: instance
-    attributes that are scalars, or containers built purely from scalars.
-    That keeps ``dt_seconds``, the ``DiffusionFilter`` timescales and
-    orders, the ``compute_*`` flags and the semi-Lagrangian options, and
-    drops ``coords`` / ``terrain`` / the precomputed vertical coefficients,
-    whose arrays are grid data rather than knobs. Private attributes are
-    included (``_sl_options`` is as much a knob as ``dt_seconds``); the
-    leading underscore is kept so the key names a real attribute.
+    no ``nnx.Param`` to key on), so the rule here is structural: keep every
+    scalar leaf reachable from an instance attribute, drop the bulk arrays
+    and callables. That keeps ``dt_seconds``, the ``DiffusionFilter``
+    timescales and orders, the ``compute_*`` flags, the semi-Lagrangian
+    options and the grid's scalar identity, while the orography and the
+    vertical coefficient profiles fall away.
+
+    The filter is per *leaf*, not per attribute (#733 review). A backend
+    is free to mix knobs and grid data in one container, and pySES does:
+    ``diffusion_config`` holds ``nu``, ``nu_phi``, ``nu_tracer`` and
+    ``nu_top`` beside a ``nu_ramp`` profile, and ``timestep_config`` holds
+    the subcycle counts and the coupling mode beside per-stage stepper
+    structs. Rejecting a container wholesale because it contains one array
+    dropped the entire hyperviscosity setting, so two directly-built pySES
+    models differing in ``hypervis_scale`` or ``tracer_substeps`` recorded
+    identically -- the exact failure this record exists to prevent, since
+    those constructor arguments are stored nowhere else.
+
+    Private attributes are included (``_sl_options`` is as much a knob as
+    ``dt_seconds``); the leading underscore is kept so the key names a real
+    attribute.
     """
     if dycore is None:
         return {}
@@ -351,9 +399,7 @@ def _describe_dycore_params(dycore) -> dict:
     for name, value in sorted(attributes.items()):
         if name.startswith("__") or name == "constants":
             continue  # constants get their own block
-        if not _all_scalar_leaves(value):
-            continue
-        _describe_value(value, name, out)
+        _describe_value(value, name, out, scalars_only=True)
     return out
 
 
@@ -421,11 +467,39 @@ def params_attrs(params: dict | None) -> dict:
            hashlib.sha256(blob.encode()).hexdigest()[:12]}
     if len(blob) <= _PARAM_ATTR_MAX_CHARS:
         out["jcm_prov_params"] = blob
-    else:
-        out["jcm_prov_params"] = (
-            f"<{len(blob)} chars, over the {_PARAM_ATTR_MAX_CHARS}-char "
-            "attribute cap; full record in the .provenance.json sidecar>")
+        return out
+    # Over the cap, compress into the same file rather than referring the
+    # reader elsewhere (#733 review). Not every path that stamps these
+    # attributes writes a sidecar -- ``to_xarray`` on the bare
+    # ``model.run(...).to_netcdf(...)`` route does not, nor do the runners'
+    # separately-written snapshot files -- so a pointer to one would send
+    # the reader to a file that does not exist, and the values would be
+    # unrecoverable from the only artifact they hold. Keys are repetitive
+    # dotted paths, so this compresses roughly tenfold.
+    packed = base64.b64encode(zlib.compress(blob.encode(), 9)).decode()
+    out["jcm_prov_params"] = (
+        f"<{len(blob)} chars, over the {_PARAM_ATTR_MAX_CHARS}-char "
+        "attribute cap; the full record is in jcm_prov_params_zlib "
+        "(base64 of zlib-compressed JSON) on this file>")
+    out["jcm_prov_params_zlib"] = packed
     return out
+
+
+def read_params(attrs) -> dict:
+    """Recover a parameter record from a dataset's global attributes.
+
+    Handles both forms so callers need not know which one a given file
+    got: the plain JSON, or the compressed attribute written when the
+    record exceeded the size cap. Returns ``{}`` when the file carries no
+    parameter record (anything written before #732).
+    """
+    packed = attrs.get("jcm_prov_params_zlib")
+    if packed:
+        return json.loads(zlib.decompress(base64.b64decode(packed)))
+    blob = attrs.get("jcm_prov_params")
+    if not blob or blob.startswith("<"):
+        return {}
+    return json.loads(blob)
 
 
 def start_run(cfg=None) -> None:

--- a/jcm/provenance.py
+++ b/jcm/provenance.py
@@ -363,7 +363,7 @@ def _aggregate_digest(value) -> str | None:
     return digest.hexdigest()[:12] if found else None
 
 
-def _describe_term_settings(term, name: str, out: dict) -> None:
+def _describe_term_settings(term, name: str, out: dict, skip=()) -> None:
     """Record a term's plain-attribute settings (#733 review).
 
     Not every run-shaping setting reaches an nnx variable. ``UpperSponge``
@@ -395,6 +395,8 @@ def _describe_term_settings(term, name: str, out: dict) -> None:
             continue  # flax bookkeeping / name mangling, not a setting
         if type(value).__module__.startswith("flax."):
             continue  # an nnx variable; the variable walk records it
+        if any(value is skipped for skipped in skip):
+            continue
         _describe_value(value, f"{name}.{attribute}", out, scalars_only=True)
 
 
@@ -469,6 +471,7 @@ def _describe_physics_params(physics) -> dict:
         [(physics, None)]
     out: dict = {}
     seen: dict = {}
+    roster: list = []
     for term, forced_name in modules:
         name = forced_name or getattr(term, "name", None) or \
             type(term).__name__
@@ -479,7 +482,13 @@ def _describe_physics_params(physics) -> dict:
             name = f"{name}#{seen[name]}"
         else:
             seen[name] = 0
-        _describe_term_settings(term, name, out)
+        if forced_name is None:
+            roster.append(name)
+        # The container holds the terms; walking that attribute would
+        # re-record every term's parameters a second time under
+        # ``physics.terms.<i>.``. They get walked in their own right.
+        _describe_term_settings(term, name, out,
+                                skip=() if terms is None else (terms,))
         try:
             # to_flat_state, not the State.flat_state() method: the latter
             # is deprecated and warns once per call. Present since flax
@@ -492,6 +501,13 @@ def _describe_physics_params(physics) -> dict:
         except Exception:  # noqa: BLE001 — a non-nnx term has no params
             continue
         for path, var in flat:
+            # nnx.state on the container recurses into its child modules,
+            # so the composition's own walk yields every term's variables
+            # again under ``physics.terms.<i>.``. Each term is walked in
+            # its own right; a second copy under a positional key is just
+            # bulk that moves whenever the composition is reordered.
+            if forced_name is not None and path and path[0] == "terms":
+                continue
             key = ".".join(str(p) for p in (name, *path))
             value = var.get_value()
             if tuple(path) in declared:
@@ -506,6 +522,21 @@ def _describe_physics_params(physics) -> dict:
             digest = _aggregate_digest(value)
             if digest is not None:
                 out[f"{key}.array_digest"] = digest
+    if terms is not None:
+        # The roster, in order, as one entry (#733 review). A term with no
+        # attributes and no nnx variables contributes nothing to the walk
+        # above, so adding or removing one left the record unchanged even
+        # though it changes every step: ResetEmissionFluxes is stateless
+        # and zeroes the carried emi_* accumulators, without which they
+        # accumulate across timesteps and every emission average is wrong.
+        # Order is part of it, not incidental — the ECHAM composition
+        # requires vdiff before convection so the Tiedtke closure reads
+        # the same-step moisture tendency.
+        #
+        # A joined string rather than a list: a list long enough to pass
+        # the array cap would be summarized to a count, which is exactly
+        # the information this key exists to carry.
+        out["physics.term_order"] = ",".join(roster)
     return out
 
 

--- a/jcm/provenance.py
+++ b/jcm/provenance.py
@@ -206,6 +206,10 @@ def _describe_leaf(value):
         return "<traced>"
     if value is None or isinstance(value, (bool, int, float, str)):
         return value
+    if _is_dtype(value):
+        # Before the callable check: a dtype class is callable, and its
+        # canonical name is the setting ("float64", not "<callable>").
+        return np.dtype(value).name
     if callable(value):
         return f"<callable {getattr(value, '__name__', type(value).__name__)}>"
     try:
@@ -248,7 +252,21 @@ def _is_knob(value) -> bool:
 
     if _is_scalar(value) or isinstance(value, enum.Enum):
         return True
+    if _is_dtype(value):
+        # pySES stores `physics_dtype` as the jnp.float32/float64 class
+        # itself: callable, no ndim, and the only record of a setting that
+        # casts the physics-facing state for the whole run (#733 review).
+        return True
     return getattr(value, "ndim", None) == 0
+
+
+def _is_dtype(value) -> bool:
+    """Report whether *value* is a numpy/jax dtype or scalar-type object."""
+    import numpy as np
+
+    if isinstance(value, np.dtype):
+        return True
+    return isinstance(value, type) and issubclass(value, np.generic)
 
 
 def _describe_value(value, prefix: str, out: dict, depth: int = 0,

--- a/jcm/provenance.py
+++ b/jcm/provenance.py
@@ -21,9 +21,12 @@ config records the *overrides* and says nothing about the effective
 values; and a model built in Python, or one whose parameters were
 replaced after construction (what a calibration loop does), has no
 config behind it at all. :func:`describe_params` therefore reads the
-built objects. It is called at the model-to-user handoff — see
-:class:`jcm.predictions.ModelPredictions` — because that is the last
-moment the values are still the ones that produced the trajectory.
+built physics, and only the parameters: the rest of what a run is (the
+term composition, the dycore, the resolution) is already in the config.
+It is called from inside ``Model._run_from_state`` while that jit is
+tracing, which is where the values become the ones the executable will
+use — see :class:`jcm.predictions.ModelPredictions` for why reading them
+afterwards is not the same thing.
 
 Lifecycle: :func:`start_run` at run start (captures code/env/config and
 resets the input registry), :func:`record_input` / :func:`record_fact`
@@ -37,7 +40,6 @@ one that wrote the file need not be the one that ran last.
 
 from __future__ import annotations
 
-import base64
 import getpass
 import hashlib
 import json
@@ -48,7 +50,6 @@ import re
 import socket
 import subprocess
 import sys
-import zlib
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -82,12 +83,6 @@ _PARAM_ARRAY_MAX_ELEMS = 64
 #: pathologically nested container, not a real structural limit (the
 #: deepest shipped parameter struct nests two levels).
 _PARAM_MAX_DEPTH = 6
-#: Size at which the parameter JSON is carried compressed rather than as
-#: plain text in a netCDF attribute. It is never dropped: not every path
-#: that stamps the attributes writes a sidecar, so the values have to stay
-#: recoverable from the file itself. :func:`read_params` handles both
-#: forms.
-_PARAM_ATTR_MAX_CHARS = 64_000
 
 _state: dict = {"base": None, "inputs": {}, "facts": {}}
 
@@ -183,17 +178,6 @@ def describe_input(path: str) -> dict:
     return d
 
 
-def _stable_repr(value) -> str:
-    """``repr`` with the object address removed.
-
-    The default ``object.__repr__`` embeds ``id(value)``, which differs
-    between two runs of the identical configuration. Left in, it would
-    make ``params_sha`` (and through it ``run_hash``) non-reproducible,
-    which is the opposite of what this record is for.
-    """
-    return _ADDRESS_RE.sub("", repr(value))[:200]
-
-
 def _describe_leaf(value):
     """JSON-safe description of one parameter leaf."""
     import jax
@@ -206,11 +190,8 @@ def _describe_leaf(value):
         return "<traced>"
     if value is None or isinstance(value, (bool, int, float, str)):
         return value
-    if _is_dtype(value):
-        # Before the callable check: a dtype class is callable, and its
-        # canonical name is the setting ("float64", not "<callable>").
-        return np.dtype(value).name
     if callable(value):
+        # A parameter block may hold a schedule or an activation.
         return f"<callable {getattr(value, '__name__', type(value).__name__)}>"
     try:
         arr = np.asarray(value)
@@ -224,10 +205,9 @@ def _describe_leaf(value):
         # model used, so record it rather than a prettier rounding.
         return arr.item()
     # Shape and dtype travel with the values, not only with the hashed
-    # summary (#733 review). A bare flat list makes a (2, 3) parameter
-    # identical to a (3, 2) one with the same row-major bytes, and a
-    # float32 vector identical to its float64 twin — both of which drive
-    # different computations.
+    # summary: a bare flat list makes a (2, 3) parameter identical to a
+    # (3, 2) one with the same row-major bytes, and a float32 vector
+    # identical to its float64 twin.
     described = {"shape": list(arr.shape), "dtype": str(arr.dtype)}
     if arr.size <= _PARAM_ARRAY_MAX_ELEMS:
         described["values"] = arr.ravel().tolist()
@@ -237,56 +217,43 @@ def _describe_leaf(value):
     return described
 
 
+def _stable_repr(value) -> str:
+    """Return ``repr(value)`` with the ``at 0x...`` object address removed.
+
+    The default ``object.__repr__`` embeds ``id(value)``, which differs
+    between two runs of the identical configuration. Left in, it would
+    make ``params_sha`` (and through it ``run_hash``) non-reproducible.
+    """
+    return _ADDRESS_RE.sub("", repr(value))[:200]
+
+
 def _is_scalar(value) -> bool:
     return value is None or isinstance(value, (bool, int, float, str))
 
 
 def _is_knob(value) -> bool:
-    """Report whether a leaf is worth recording as a dycore setting.
+    """Report whether a leaf is a tuning knob rather than cached grid data.
 
-    Scalars, enum members (pySES stores its coupling mode as one) and 0-d
-    arrays — pySES keeps its hyperviscosity coefficients as 0-d arrays, so
-    a plain ``isinstance`` scalar test would drop exactly the knobs that
-    matter. Decided by reading ``ndim`` rather than converting, because
-    this runs over the dycore's whole attribute graph and ``np.asarray``
-    on a device array would pull the grid to the host just to discard it.
-
-    Everything else — bulk arrays, callables, opaque backend objects — is
-    skipped rather than described. An opaque object contributes only its
-    ``repr``, which carries no setting anybody can read.
+    Scalars, enum members and 0-d arrays. Terms cache their coordinates in
+    plain variables sitting beside their knobs with no naming convention
+    between the two (Held-Suarez keeps ``kf``/``ka``/``ks`` next to its
+    ``sigma`` and ``latitudes`` caches), so the split has to be structural.
+    ``ndim`` is read rather than converted, to avoid pulling a device array
+    to the host only to discard it.
     """
     import enum
 
-    if _is_scalar(value) or isinstance(value, enum.Enum):
-        return True
-    if _is_dtype(value):
-        # pySES stores `physics_dtype` as the jnp.float32/float64 class
-        # itself: callable, no ndim, and the only record of a setting that
-        # casts the physics-facing state for the whole run (#733 review).
-        return True
-    return getattr(value, "ndim", None) == 0
-
-
-def _is_dtype(value) -> bool:
-    """Report whether *value* is a numpy/jax dtype or scalar-type object."""
-    import numpy as np
-
-    if isinstance(value, np.dtype):
-        return True
-    return isinstance(value, type) and issubclass(value, np.generic)
+    return (_is_scalar(value) or isinstance(value, enum.Enum)
+            or getattr(value, "ndim", None) == 0)
 
 
 def _describe_value(value, prefix: str, out: dict, depth: int = 0,
-                    scalars_only: bool = False) -> None:
+                    knobs_only: bool = False) -> None:
     """Flatten *value* into *out* under the dotted key *prefix*.
 
-    With *scalars_only*, bulk arrays and callables are skipped rather than
-    described, and containers are still walked for the scalars inside
-    them. That is the dycore mode: a backend's configuration objects mix
-    tuning knobs with grid data in one container (pySES's
-    ``diffusion_config`` holds ``nu``/``nu_top`` next to a ``nu_ramp``
-    profile), so an all-or-nothing rule on the container drops the knobs
-    along with the grid.
+    With *knobs_only*, bulk arrays are skipped but containers are still
+    walked for the knobs inside them, since a parameter block mixes the
+    two.
     """
     import dataclasses
     from collections.abc import Mapping
@@ -301,18 +268,16 @@ def _describe_value(value, prefix: str, out: dict, depth: int = 0,
         # the field name is the entire point of the record.
         for f in dataclasses.fields(value):
             _describe_value(getattr(value, f.name), f"{prefix}.{f.name}",
-                            out, depth + 1, scalars_only)
+                            out, depth + 1, knobs_only)
         return
     if hasattr(value, "_fields") and isinstance(value, tuple):  # NamedTuple
         for name in value._fields:
             _describe_value(getattr(value, name), f"{prefix}.{name}",
-                            out, depth + 1, scalars_only)
+                            out, depth + 1, knobs_only)
         return
-    # Mapping, not dict: pySES's timestep_config is a frozendict, which is
-    # not a dict subclass and would otherwise fall through to the leaf.
     if isinstance(value, Mapping):
         for k, v in value.items():
-            _describe_value(v, f"{prefix}.{k}", out, depth + 1, scalars_only)
+            _describe_value(v, f"{prefix}.{k}", out, depth + 1, knobs_only)
         return
     if isinstance(value, (list, tuple)):
         # A short all-scalar sequence is one value (a per-level profile);
@@ -321,11 +286,6 @@ def _describe_value(value, prefix: str, out: dict, depth: int = 0,
             if len(value) <= _PARAM_ARRAY_MAX_ELEMS:
                 out[prefix] = list(value)
             else:
-                # Hashed, not just counted (#733 review). A bare length
-                # made two AerocomDiagnostics terms with different
-                # 100-element ``plev_pa`` tuples record identically, and
-                # those pressures are interpolated to, so they change the
-                # diagnostics. Same treatment as a large array.
                 out[prefix] = {
                     "length": len(value),
                     "sha256": hashlib.sha256(
@@ -333,170 +293,45 @@ def _describe_value(value, prefix: str, out: dict, depth: int = 0,
                     ).hexdigest()[:12],
                 }
             return
-        if scalars_only and len(value) > _PARAM_ARRAY_MAX_ELEMS:
-            # An unbounded sequence of structures is grid data, not knobs.
-            return
         for i, v in enumerate(value):
-            _describe_value(v, f"{prefix}.{i}", out, depth + 1, scalars_only)
+            _describe_value(v, f"{prefix}.{i}", out, depth + 1, knobs_only)
         return
-    if scalars_only and not _is_knob(value):
+    if knobs_only and not _is_knob(value):
         return
     out[prefix] = _describe_leaf(value)
 
 
-def _iter_array_leaves(value, depth: int = 0):
-    """Yield the array leaves of *value*, containers walked."""
-    import dataclasses
-    from collections.abc import Mapping
+def describe_params(physics=None) -> dict:
+    """Return the parameter values a run actually used, by dotted key.
 
-    if depth > _PARAM_MAX_DEPTH or _is_scalar(value):
-        return
-    if dataclasses.is_dataclass(value) and not isinstance(value, type):
-        for f in dataclasses.fields(value):
-            yield from _iter_array_leaves(getattr(value, f.name), depth + 1)
-        return
-    if hasattr(value, "_fields") and isinstance(value, tuple):
-        for field in value._fields:
-            yield from _iter_array_leaves(getattr(value, field), depth + 1)
-        return
-    if isinstance(value, Mapping):
-        for item in value.values():
-            yield from _iter_array_leaves(item, depth + 1)
-        return
-    if isinstance(value, (list, tuple)):
-        for item in value:
-            yield from _iter_array_leaves(item, depth + 1)
-        return
-    if getattr(value, "ndim", None):
-        yield value
+    Reads the *built* physics rather than the requested config, because
+    the config does not determine the values (see the module docstring).
+    It deliberately stops at parameters: everything else about a run (the
+    term composition, the dycore, the resolution, the physical constants)
+    is already in the config record this sits beside, so recording it a
+    second time would add bulk without adding information.
 
+    Keys are ``<term name>.<variable>.<field>``, for example
+    ``tiedtke_convection.params.entrpen``. That names where the value
+    *lives*, which is close to but not always the Hydra override path:
+    the override addresses the term's *constructor keyword*, and
+    ``SpeedyConvection`` takes ``convection_params=`` while storing it as
+    ``params``.
 
-def _aggregate_digest(value) -> str | None:
-    """One digest over every array leaf in *value*, or ``None`` if none.
+    ``nnx.Param`` variables are recorded in full, since a declared
+    differentiable parameter is a tuned quantity even when it is an array
+    (the MACv2-SP plume shapes, a per-level profile). Plain
+    ``nnx.Variable``s are recorded only where they are knob-shaped: a
+    parameter block containing a bool cannot be an ``nnx.Param``, so the
+    schemes hold those as plain variables (Held-Suarez's whole tuning set,
+    ``SpeedySurfaceFlux.surface_params``, ``EchamSurface.params``), but so
+    are the terms' cached coordinates, and all eleven SPEEDY terms cache
+    the same vertical grid.
 
-    Lets a variable that holds no readable knob still identify itself.
-    Aggregating per *variable* rather than per leaf is what keeps this
-    affordable: eleven SPEEDY terms share one ``_speedy_coords`` holding
-    ten vectors, so a per-leaf digest costs 110 entries and 8.5 kB where
-    this costs 11 and under 1 kB.
-    """
-    import numpy as np
-    import jax
-
-    digest = hashlib.sha256()
-    found = False
-    for leaf in _iter_array_leaves(value):
-        if isinstance(leaf, jax.core.Tracer):
-            return "<traced>"
-        try:
-            arr = np.ascontiguousarray(np.asarray(leaf))
-        except Exception:  # noqa: BLE001 — undigestible leaves are skipped
-            continue
-        digest.update(str(arr.shape).encode())
-        digest.update(arr.tobytes())
-        found = True
-    return digest.hexdigest()[:12] if found else None
-
-
-def _describe_term_settings(term, name: str, out: dict, skip=()) -> None:
-    """Record a term's plain-attribute settings (#733 review).
-
-    Not every run-shaping setting reaches an nnx variable. ``UpperSponge``
-    keeps ``sponge_timescale_s``, ``enspodi``, ``damp_temperature`` and
-    ``target_T_K`` as ordinary attributes; RRTMGP keeps ``_base_seed``,
-    ``_compute_cre`` and ``_aerosol_free``; ``UpperTemperatureRelaxation``
-    keeps ``damps_wind`` and ``n_levels``.
-
-    Every scalar-shaped attribute is taken, not only those matching a
-    constructor parameter. An earlier revision keyed on the ``__init__``
-    signature, which reads well but misses a control the constructor
-    *derives* under another name: RRTMGP's ``_aerosol_free`` is
-    ``interval is not None``, and it decides whether the companion
-    aerosol-free solve runs at all, while its sibling
-    ``_aerosol_free_interval`` collapses ``None`` and ``1`` to the same
-    value and so cannot tell those two configurations apart.
-
-    Names containing a dunder infix are skipped: that is flax's reserved
-    bookkeeping (``_pytree__nodes``, ``_object__state``) and Python's
-    name mangling, never a physical setting. Arrays are left to the
-    variable walk and its digests.
-    """
-    try:
-        attributes = vars(term)
-    except TypeError:
-        return
-    for attribute, value in sorted(attributes.items()):
-        if "__" in attribute:
-            continue  # flax bookkeeping / name mangling, not a setting
-        if type(value).__module__.startswith("flax."):
-            continue  # an nnx variable; the variable walk records it
-        if any(value is skipped for skipped in skip):
-            continue
-        key = f"{name}.{attribute}"
-        _describe_value(value, key, out, scalars_only=True)
-        # An attribute carrying arrays still has to identify itself, the
-        # same way a plain Variable does (#733 review). ``nnx.data``
-        # leaves live here rather than in the variable state — CloudsatCosp
-        # keeps its radar lookup tables as ``self._lut = nnx.data(...)``,
-        # and a different LUT changes the simulated reflectivity, so
-        # dropping its arrays let two LUTs record identically.
-        digest = _aggregate_digest(value)
-        if digest is not None:
-            out[f"{key}.array_digest"] = digest
-
-
-def _describe_physics_params(physics) -> dict:
-    """Every ``nnx.Variable`` on every physics term, by dotted name.
-
-    Keyed on the term's own ``name`` (``tiedtke_convection``) and the
-    variable it hangs off: ``tiedtke_convection.params.entrpen``.
-
-    That is close to, but not always identical to, the Hydra override
-    path minus its ``physics.terms.`` prefix. Hydra addresses the term's
-    *constructor keyword*, which for the ECHAM terms is also the variable
-    name but for the SPEEDY ones is not (``SpeedyConvection`` takes
-    ``convection_params=`` and stores it as ``params``, so the override
-    is ``...speedy_convection.convection_params.entmax`` while the record
-    says ``...speedy_convection.params.entmax``). The record names where
-    the value *lives*, which is the thing that must be unambiguous;
-    reproducing it may need the constructor signature.
-
-    Keying on the nnx variable rather than a ``.params`` attribute is
-    deliberate — terms also carry ``mod_radcon_params``, ``sw_params``,
-    ``surface_optics`` and bare tuning scalars, and a scheme that adds
-    another must not silently drop out of the record.
-
-    Plain Variables are included, not just ``nnx.Param`` (#733
-    review). A parameter block containing a bool cannot be an
-    ``nnx.Param``, so the schemes hold those as plain Variables:
-    ``SpeedySurfaceFlux.surface_params`` and ``EchamSurface.params`` are
-    the shipped cases, and every Held-Suarez tuning constant (``kf``,
-    ``ka``, ``ks``, ``dTy``, ``dThz``, ...) is one, so the whole
-    Held-Suarez parameter set was missing. Non-differentiable does not
-    mean it does not change the simulation.
-
-    The two kinds are read differently, because terms also cache their
-    coordinates in plain Variables and those are grid data, not knobs:
-
-    * ``nnx.Param`` in full. It is a *declared* differentiable parameter,
-      so its arrays are tuned quantities worth keeping (the MACv2-SP
-      plume shapes, a per-level profile).
-    * a plain Variable only where it is knob-shaped -- scalars, 0-d
-      arrays, enums, and structs of those. That keeps every case above
-      and drops the caches, which are always grid-shaped arrays.
-
-    Deciding by shape rather than by name is what makes this hold for
-    Held-Suarez, which keeps its knobs (0-d) and its ``sigma`` /
-    ``latitudes`` caches (grid-shaped) side by side as plain Variables
-    with no naming convention between them. It matters more than it
-    looks: all eleven SPEEDY terms cache the *same* ``_speedy_coords``,
-    so including caches wholesale put eleven identical copies of the
-    vertical grid in the record and took a T31L8 run from 6.6 kB to
-    62 kB, with 85% of it duplicated grid vectors.
-
-    Mutable per-step state would be a real problem here, but jcm threads
-    the physics carry as an explicit pytree rather than through nnx
-    variables, so there is none to pick up.
+    Arrays over ``_PARAM_ARRAY_MAX_ELEMS`` elements are summarized by
+    shape, dtype and hash, which keeps embedded NN weights out of a
+    netCDF attribute while still telling one weight set from another.
+    Values captured under ``jit`` or ``grad`` read ``"<traced>"``.
     """
     if physics is None:
         return {}
@@ -505,178 +340,30 @@ def _describe_physics_params(physics) -> dict:
     except ImportError:
         return {}
 
-    terms = getattr(physics, "terms", None)
-    # The container is a module in its own right, not just a bag of terms
-    # (#733 review). ComposablePhysics owns `band_config`, injected into
-    # every step and read by Macv2SpAerosol for its optics, so two
-    # compositions of identical terms with different band centres produce
-    # different fields; dropping the wrapper let them record identically.
-    modules = ([(physics, "physics")] +
-               [(t, None) for t in terms]) if terms is not None else \
-        [(physics, None)]
     out: dict = {}
     seen: dict = {}
-    roster: list = []
-    for term, forced_name in modules:
-        name = forced_name or getattr(term, "name", None) or \
-            type(term).__name__
+    for term in getattr(physics, "terms", None) or [physics]:
+        name = getattr(term, "name", None) or type(term).__name__
         # A composition may hold two instances of one term (e.g. a
         # double-call radiation A/B); keep both rather than clobbering.
-        if name in seen:
-            seen[name] += 1
+        seen[name] = seen.get(name, -1) + 1
+        if seen[name]:
             name = f"{name}#{seen[name]}"
-        else:
-            seen[name] = 0
-        if forced_name is None:
-            roster.append(name)
-        # The container holds the terms; walking that attribute would
-        # re-record every term's parameters a second time under
-        # ``physics.terms.<i>.``. They get walked in their own right.
-        _describe_term_settings(term, name, out,
-                                skip=() if terms is None else (terms,))
         try:
             # to_flat_state, not the State.flat_state() method: the latter
             # is deprecated and warns once per call. Present since flax
             # 0.12.1, which requirements.txt already floors us to.
-            # nnx.Param is a Variable subclass, so the second call is a
-            # superset; the difference is what gets the knob-shape filter.
+            # nnx.Param is a Variable subclass, so `declared` is a subset
+            # of `flat`; the difference is what gets the knob filter.
             flat = nnx.to_flat_state(nnx.state(term, nnx.Variable))
             declared = {tuple(path) for path, _ in
                         nnx.to_flat_state(nnx.state(term, nnx.Param))}
         except Exception:  # noqa: BLE001 — a non-nnx term has no params
             continue
         for path, var in flat:
-            # nnx.state on the container recurses into its child modules,
-            # so the composition's own walk yields every term's variables
-            # again under ``physics.terms.<i>.``. Each term is walked in
-            # its own right; a second copy under a positional key is just
-            # bulk that moves whenever the composition is reordered.
-            if forced_name is not None and path and path[0] == "terms":
-                continue
             key = ".".join(str(p) for p in (name, *path))
-            value = var.get_value()
-            if tuple(path) in declared:
-                _describe_value(value, key, out)
-                continue
-            _describe_value(value, key, out, scalars_only=True)
-            # A plain Variable whose content is arrays still has to
-            # identify itself, or a control the constructor only ever
-            # stored in derived form is invisible: the temperature
-            # relaxation keeps its timescale solely as the _inv_tau
-            # profile, so 3600 s and 7200 s recorded identically.
-            digest = _aggregate_digest(value)
-            if digest is not None:
-                out[f"{key}.array_digest"] = digest
-    if terms is not None:
-        # The roster, in order, as one entry (#733 review). A term with no
-        # attributes and no nnx variables contributes nothing to the walk
-        # above, so adding or removing one left the record unchanged even
-        # though it changes every step: ResetEmissionFluxes is stateless
-        # and zeroes the carried emi_* accumulators, without which they
-        # accumulate across timesteps and every emission average is wrong.
-        # Order is part of it, not incidental — the ECHAM composition
-        # requires vdiff before convection so the Tiedtke closure reads
-        # the same-step moisture tendency.
-        #
-        # A joined string rather than a list: a list long enough to pass
-        # the array cap would be summarized to a count, which is exactly
-        # the information this key exists to carry.
-        out["physics.term_order"] = ",".join(roster)
-    return out
-
-
-def _describe_dycore_params(dycore) -> dict:
-    """Scalar dycore knobs: timestep, diffusion, transport, subcycling.
-
-    A dycore declares no parameters the way a physics term does (there is
-    no ``nnx.Param`` to key on), so the rule here is structural: keep every
-    scalar leaf reachable from an instance attribute, drop the bulk arrays
-    and callables. That keeps ``dt_seconds``, the ``DiffusionFilter``
-    timescales and orders, the ``compute_*`` flags, the semi-Lagrangian
-    options and the grid's scalar identity, while the orography and the
-    vertical coefficient profiles fall away.
-
-    The filter is per *leaf*, not per attribute (#733 review). A backend
-    is free to mix knobs and grid data in one container, and pySES does:
-    ``diffusion_config`` holds ``nu``, ``nu_phi``, ``nu_tracer`` and
-    ``nu_top`` beside a ``nu_ramp`` profile, and ``timestep_config`` holds
-    the subcycle counts and the coupling mode beside per-stage stepper
-    structs. Rejecting a container wholesale because it contains one array
-    dropped the entire hyperviscosity setting, so two directly-built pySES
-    models differing in ``hypervis_scale`` or ``tracer_substeps`` recorded
-    identically -- the exact failure this record exists to prevent, since
-    those constructor arguments are stored nowhere else.
-
-    Private attributes are included (``_sl_options`` is as much a knob as
-    ``dt_seconds``); the leading underscore is kept so the key names a real
-    attribute.
-    """
-    if dycore is None:
-        return {}
-    try:
-        attributes = vars(dycore)
-    except TypeError:  # a __slots__ backend exposes no instance __dict__
-        return {}
-    out: dict = {}
-    for name, value in sorted(attributes.items()):
-        if name.startswith("__") or name == "constants":
-            continue  # constants get their own block
-        _describe_value(value, name, out, scalars_only=True)
-    return out
-
-
-def _describe_constants(dycore) -> dict:
-    """Record the live physical constants, and the dycore's if they differ.
-
-    ``jcm.constants`` is a process-global singleton read *live* by
-    attribute-access physics but captured *at construction* by the dycore,
-    so a ``set_constants`` call made after the model was built leaves the
-    two genuinely disagreeing. Recording only the live values would hide
-    that, so a differing dycore copy is recorded field by field.
-    """
-    out: dict = {}
-    try:
-        import jcm.constants as _c
-        live = _c.physical_constants
-    except Exception:  # noqa: BLE001 — never fail a run over provenance
-        return out
-    _describe_value(live, "constants", out)
-    built = getattr(dycore, "constants", None)
-    if built is None or built == live:
-        return out
-    built_fields: dict = {}
-    _describe_value(built, "constants", built_fields)
-    for key, value in built_fields.items():
-        if out.get(key) != value:
-            out[key.replace("constants", "constants_dycore", 1)] = value
-    return out
-
-
-def describe_params(physics=None, dycore=None) -> dict:
-    """Return the parameter values a run actually used, by dotted key.
-
-    Reads the *built* objects, not the requested config, because the two
-    are not the same thing (see the module docstring): the shipped yamls
-    omit each scheme's ``params`` block so the effective values live in
-    ``Parameters.default()``, and a Python-built or post-hoc-modified
-    model has no config at all.
-
-    Returns a dict with ``physics`` (every ``nnx.Param`` on every term),
-    ``dycore`` (scalar backend knobs) and ``constants`` blocks; each maps
-    dotted names to JSON-safe values. Large arrays are summarized by
-    shape/dtype/hash and values captured under ``jit``/``grad`` read
-    ``"<traced>"``.
-    """
-    out: dict = {}
-    physics_params = _describe_physics_params(physics)
-    if physics_params:
-        out["physics"] = physics_params
-    dycore_params = _describe_dycore_params(dycore)
-    if dycore_params:
-        out["dycore"] = dycore_params
-    constants = _describe_constants(dycore)
-    if constants:
-        out["constants"] = constants
+            _describe_value(var.get_value(), key, out,
+                            knobs_only=tuple(path) not in declared)
     return out
 
 
@@ -685,43 +372,19 @@ def params_attrs(params: dict | None) -> dict:
     if not params:
         return {}
     blob = json.dumps(params, sort_keys=True, default=str)
-    out = {"jcm_prov_params_sha":
-           hashlib.sha256(blob.encode()).hexdigest()[:12]}
-    if len(blob) <= _PARAM_ATTR_MAX_CHARS:
-        out["jcm_prov_params"] = blob
-        return out
-    # Over the cap, compress into the same file rather than referring the
-    # reader elsewhere (#733 review). Not every path that stamps these
-    # attributes writes a sidecar -- ``to_xarray`` on the bare
-    # ``model.run(...).to_netcdf(...)`` route does not, nor do the runners'
-    # separately-written snapshot files -- so a pointer to one would send
-    # the reader to a file that does not exist, and the values would be
-    # unrecoverable from the only artifact they hold. Keys are repetitive
-    # dotted paths, so this compresses roughly tenfold.
-    packed = base64.b64encode(zlib.compress(blob.encode(), 9)).decode()
-    out["jcm_prov_params"] = (
-        f"<{len(blob)} chars, over the {_PARAM_ATTR_MAX_CHARS}-char "
-        "attribute cap; the full record is in jcm_prov_params_zlib "
-        "(base64 of zlib-compressed JSON) on this file>")
-    out["jcm_prov_params_zlib"] = packed
-    return out
+    return {"jcm_prov_params": blob,
+            "jcm_prov_params_sha":
+                hashlib.sha256(blob.encode()).hexdigest()[:12]}
 
 
 def read_params(attrs) -> dict:
     """Recover a parameter record from a dataset's global attributes.
 
-    Handles both forms so callers need not know which one a given file
-    got: the plain JSON, or the compressed attribute written when the
-    record exceeded the size cap. Returns ``{}`` when the file carries no
-    parameter record (anything written before #732).
+    Returns ``{}`` when the file carries no parameter record (anything
+    written before #732).
     """
-    packed = attrs.get("jcm_prov_params_zlib")
-    if packed:
-        return json.loads(zlib.decompress(base64.b64decode(packed)))
     blob = attrs.get("jcm_prov_params")
-    if not blob or blob.startswith("<"):
-        return {}
-    return json.loads(blob)
+    return json.loads(blob) if blob else {}
 
 
 def start_run(cfg=None) -> None:

--- a/jcm/provenance.py
+++ b/jcm/provenance.py
@@ -309,46 +309,93 @@ def _describe_value(value, prefix: str, out: dict, depth: int = 0,
     out[prefix] = _describe_leaf(value)
 
 
-def _describe_term_settings(term, name: str, out: dict) -> None:
-    """Record a term's constructor controls held as plain attributes.
+def _iter_array_leaves(value, depth: int = 0):
+    """Yield the array leaves of *value*, containers walked."""
+    import dataclasses
+    from collections.abc import Mapping
 
-    Not every run-shaping setting reaches an nnx variable (#733 review).
-    ``UpperSponge`` keeps ``sponge_timescale_s``, ``enspodi``,
-    ``damp_temperature`` and ``target_T_K`` as ordinary attributes and
-    turns them into a grid-shaped ``_inv_tau`` profile that the
-    knob-shape filter then (correctly) rejects, so a 3600 s and a 7200 s
-    sponge recorded identically. RRTMGP's ``_base_seed`` and
-    ``_compute_cre`` are the same shape of omission.
-
-    The discriminator is the term's own ``__init__`` signature rather
-    than a scan of its attributes: a constructor parameter *is* the set
-    of choices a caller made, so this picks up a newly added control with
-    no maintenance, while the caches and the nnx bookkeeping
-    (``_pytree__nodes``, ``_coords_cached``, ``_nodal_shape``) are
-    excluded because nobody passed them in. Each name is looked up as
-    itself and then underscore-prefixed, which is where the schemes
-    actually put them. Values already held in an nnx variable are skipped
-    here; the variable walk has them.
-    """
-    import inspect
-
-    try:
-        signature = inspect.signature(type(term).__init__)
-        attributes = vars(term)
-    except (TypeError, ValueError):
+    if depth > _PARAM_MAX_DEPTH or _is_scalar(value):
         return
-    for parameter in list(signature.parameters)[1:]:  # skip ``self``
-        if parameter in ("args", "kwargs"):
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        for f in dataclasses.fields(value):
+            yield from _iter_array_leaves(getattr(value, f.name), depth + 1)
+        return
+    if hasattr(value, "_fields") and isinstance(value, tuple):
+        for field in value._fields:
+            yield from _iter_array_leaves(getattr(value, field), depth + 1)
+        return
+    if isinstance(value, Mapping):
+        for item in value.values():
+            yield from _iter_array_leaves(item, depth + 1)
+        return
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            yield from _iter_array_leaves(item, depth + 1)
+        return
+    if getattr(value, "ndim", None):
+        yield value
+
+
+def _aggregate_digest(value) -> str | None:
+    """One digest over every array leaf in *value*, or ``None`` if none.
+
+    Lets a variable that holds no readable knob still identify itself.
+    Aggregating per *variable* rather than per leaf is what keeps this
+    affordable: eleven SPEEDY terms share one ``_speedy_coords`` holding
+    ten vectors, so a per-leaf digest costs 110 entries and 8.5 kB where
+    this costs 11 and under 1 kB.
+    """
+    import numpy as np
+    import jax
+
+    digest = hashlib.sha256()
+    found = False
+    for leaf in _iter_array_leaves(value):
+        if isinstance(leaf, jax.core.Tracer):
+            return "<traced>"
+        try:
+            arr = np.ascontiguousarray(np.asarray(leaf))
+        except Exception:  # noqa: BLE001 — undigestible leaves are skipped
             continue
-        for attribute in (parameter, f"_{parameter}"):
-            if attribute not in attributes:
-                continue
-            value = attributes[attribute]
-            if type(value).__module__.startswith("flax."):
-                break  # an nnx variable; the variable walk records it
-            _describe_value(value, f"{name}.{attribute}", out,
-                            scalars_only=True)
-            break
+        digest.update(str(arr.shape).encode())
+        digest.update(arr.tobytes())
+        found = True
+    return digest.hexdigest()[:12] if found else None
+
+
+def _describe_term_settings(term, name: str, out: dict) -> None:
+    """Record a term's plain-attribute settings (#733 review).
+
+    Not every run-shaping setting reaches an nnx variable. ``UpperSponge``
+    keeps ``sponge_timescale_s``, ``enspodi``, ``damp_temperature`` and
+    ``target_T_K`` as ordinary attributes; RRTMGP keeps ``_base_seed``,
+    ``_compute_cre`` and ``_aerosol_free``; ``UpperTemperatureRelaxation``
+    keeps ``damps_wind`` and ``n_levels``.
+
+    Every scalar-shaped attribute is taken, not only those matching a
+    constructor parameter. An earlier revision keyed on the ``__init__``
+    signature, which reads well but misses a control the constructor
+    *derives* under another name: RRTMGP's ``_aerosol_free`` is
+    ``interval is not None``, and it decides whether the companion
+    aerosol-free solve runs at all, while its sibling
+    ``_aerosol_free_interval`` collapses ``None`` and ``1`` to the same
+    value and so cannot tell those two configurations apart.
+
+    Names containing a dunder infix are skipped: that is flax's reserved
+    bookkeeping (``_pytree__nodes``, ``_object__state``) and Python's
+    name mangling, never a physical setting. Arrays are left to the
+    variable walk and its digests.
+    """
+    try:
+        attributes = vars(term)
+    except TypeError:
+        return
+    for attribute, value in sorted(attributes.items()):
+        if "__" in attribute:
+            continue  # flax bookkeeping / name mangling, not a setting
+        if type(value).__module__.startswith("flax."):
+            continue  # an nnx variable; the variable walk records it
+        _describe_value(value, f"{name}.{attribute}", out, scalars_only=True)
 
 
 def _describe_physics_params(physics) -> dict:
@@ -412,11 +459,19 @@ def _describe_physics_params(physics) -> dict:
         return {}
 
     terms = getattr(physics, "terms", None)
-    modules = list(terms) if terms is not None else [physics]
+    # The container is a module in its own right, not just a bag of terms
+    # (#733 review). ComposablePhysics owns `band_config`, injected into
+    # every step and read by Macv2SpAerosol for its optics, so two
+    # compositions of identical terms with different band centres produce
+    # different fields; dropping the wrapper let them record identically.
+    modules = ([(physics, "physics")] +
+               [(t, None) for t in terms]) if terms is not None else \
+        [(physics, None)]
     out: dict = {}
     seen: dict = {}
-    for term in modules:
-        name = getattr(term, "name", None) or type(term).__name__
+    for term, forced_name in modules:
+        name = forced_name or getattr(term, "name", None) or \
+            type(term).__name__
         # A composition may hold two instances of one term (e.g. a
         # double-call radiation A/B); keep both rather than clobbering.
         if name in seen:
@@ -438,8 +493,19 @@ def _describe_physics_params(physics) -> dict:
             continue
         for path, var in flat:
             key = ".".join(str(p) for p in (name, *path))
-            _describe_value(var.get_value(), key, out,
-                            scalars_only=tuple(path) not in declared)
+            value = var.get_value()
+            if tuple(path) in declared:
+                _describe_value(value, key, out)
+                continue
+            _describe_value(value, key, out, scalars_only=True)
+            # A plain Variable whose content is arrays still has to
+            # identify itself, or a control the constructor only ever
+            # stored in derived form is invisible: the temperature
+            # relaxation keeps its timescale solely as the _inv_tau
+            # profile, so 3600 s and 7200 s recorded identically.
+            digest = _aggregate_digest(value)
+            if digest is not None:
+                out[f"{key}.array_digest"] = digest
     return out
 
 

--- a/jcm/provenance.py
+++ b/jcm/provenance.py
@@ -310,7 +310,7 @@ def _describe_value(value, prefix: str, out: dict, depth: int = 0,
 
 
 def _describe_physics_params(physics) -> dict:
-    """Every ``nnx.Param`` on every physics term, by dotted name.
+    """Every ``nnx.Variable`` on every physics term, by dotted name.
 
     Keyed on the term's own ``name`` (``tiedtke_convection``) and the
     variable it hangs off: ``tiedtke_convection.params.entrpen``.
@@ -325,10 +325,42 @@ def _describe_physics_params(physics) -> dict:
     the value *lives*, which is the thing that must be unambiguous;
     reproducing it may need the constructor signature.
 
-    Keying on ``nnx.Param`` rather than a ``.params`` attribute is
+    Keying on the nnx variable rather than a ``.params`` attribute is
     deliberate — terms also carry ``mod_radcon_params``, ``sw_params``,
     ``surface_optics`` and bare tuning scalars, and a scheme that adds
     another must not silently drop out of the record.
+
+    Plain Variables are included, not just ``nnx.Param`` (#733
+    review). A parameter block containing a bool cannot be an
+    ``nnx.Param``, so the schemes hold those as plain Variables:
+    ``SpeedySurfaceFlux.surface_params`` and ``EchamSurface.params`` are
+    the shipped cases, and every Held-Suarez tuning constant (``kf``,
+    ``ka``, ``ks``, ``dTy``, ``dThz``, ...) is one, so the whole
+    Held-Suarez parameter set was missing. Non-differentiable does not
+    mean it does not change the simulation.
+
+    The two kinds are read differently, because terms also cache their
+    coordinates in plain Variables and those are grid data, not knobs:
+
+    * ``nnx.Param`` in full. It is a *declared* differentiable parameter,
+      so its arrays are tuned quantities worth keeping (the MACv2-SP
+      plume shapes, a per-level profile).
+    * a plain Variable only where it is knob-shaped -- scalars, 0-d
+      arrays, enums, and structs of those. That keeps every case above
+      and drops the caches, which are always grid-shaped arrays.
+
+    Deciding by shape rather than by name is what makes this hold for
+    Held-Suarez, which keeps its knobs (0-d) and its ``sigma`` /
+    ``latitudes`` caches (grid-shaped) side by side as plain Variables
+    with no naming convention between them. It matters more than it
+    looks: all eleven SPEEDY terms cache the *same* ``_speedy_coords``,
+    so including caches wholesale put eleven identical copies of the
+    vertical grid in the record and took a T31L8 run from 6.6 kB to
+    62 kB, with 85% of it duplicated grid vectors.
+
+    Mutable per-step state would be a real problem here, but jcm threads
+    the physics carry as an explicit pytree rather than through nnx
+    variables, so there is none to pick up.
     """
     if physics is None:
         return {}
@@ -354,12 +386,17 @@ def _describe_physics_params(physics) -> dict:
             # to_flat_state, not the State.flat_state() method: the latter
             # is deprecated and warns once per call. Present since flax
             # 0.12.1, which requirements.txt already floors us to.
-            flat = nnx.to_flat_state(nnx.state(term, nnx.Param))
+            # nnx.Param is a Variable subclass, so the second call is a
+            # superset; the difference is what gets the knob-shape filter.
+            flat = nnx.to_flat_state(nnx.state(term, nnx.Variable))
+            declared = {tuple(path) for path, _ in
+                        nnx.to_flat_state(nnx.state(term, nnx.Param))}
         except Exception:  # noqa: BLE001 — a non-nnx term has no params
             continue
         for path, var in flat:
             key = ".".join(str(p) for p in (name, *path))
-            _describe_value(var.get_value(), key, out)
+            _describe_value(var.get_value(), key, out,
+                            scalars_only=tuple(path) not in declared)
     return out
 
 

--- a/jcm/provenance.py
+++ b/jcm/provenance.py
@@ -223,11 +223,18 @@ def _describe_leaf(value):
         # represents (0.1 -> 0.10000000149011612). That is the number the
         # model used, so record it rather than a prettier rounding.
         return arr.item()
+    # Shape and dtype travel with the values, not only with the hashed
+    # summary (#733 review). A bare flat list makes a (2, 3) parameter
+    # identical to a (3, 2) one with the same row-major bytes, and a
+    # float32 vector identical to its float64 twin — both of which drive
+    # different computations.
+    described = {"shape": list(arr.shape), "dtype": str(arr.dtype)}
     if arr.size <= _PARAM_ARRAY_MAX_ELEMS:
-        return arr.ravel().tolist()
-    return {"shape": list(arr.shape), "dtype": str(arr.dtype),
-            "sha256": hashlib.sha256(
-                np.ascontiguousarray(arr).tobytes()).hexdigest()[:12]}
+        described["values"] = arr.ravel().tolist()
+    else:
+        described["sha256"] = hashlib.sha256(
+            np.ascontiguousarray(arr).tobytes()).hexdigest()[:12]
+    return described
 
 
 def _is_scalar(value) -> bool:

--- a/jcm/provenance_test.py
+++ b/jcm/provenance_test.py
@@ -160,50 +160,10 @@ class ResolveDataPathRecordsTest(unittest.TestCase):
 
 
 @dataclasses.dataclass
-class _FakeDiffusion:
-    """Stands in for a DiffusionFilter: all-scalar, so it is a knob."""
+class _FakeParamBlock:
+    """Stands in for a scheme's parameter struct: named fields."""
 
-    timescale: int = 43200
     order: int = 2
-    level_orders: None = None
-
-
-@dataclasses.dataclass
-class _FakeCoords:
-    """Stands in for a CoordinateSystem: grid arrays beside scalar identity."""
-
-    latitudes: object = None
-    layers: int = 8
-
-
-class _OpaqueBackendObject:
-    """No fields worth recording, and a default repr carrying an address."""
-
-
-class _FakeDycore:
-    """Mirrors the shapes a real backend presents.
-
-    In particular ``hypervis`` mixes 0-d array coefficients with a bulk
-    profile in one container, the way pySES's ``diffusion_config`` does.
-    """
-
-    def __init__(self, constants=None):
-        import jax.numpy as jnp
-        import numpy as np
-        self.dt_seconds = 900.0
-        self.compute_omega = True
-        self.diffusion = _FakeDiffusion()
-        self._sl_options = {"interpolation_order": "cubic",
-                            "off_centering": 0.5}
-        self.hypervis = {"nu": jnp.asarray(2.5e-9),
-                         "nu_top": jnp.asarray(250000.0),
-                         "nu_ramp": jnp.arange(8.0)}
-        self.coords = _FakeCoords(latitudes=np.linspace(-90, 90, 32))
-        self.orography = np.zeros((32, 16))
-        self.step_fn = lambda s: s
-        self.colmap = _OpaqueBackendObject()
-        if constants is not None:
-            self.constants = constants
 
 
 class DescribeLeafTest(unittest.TestCase):
@@ -277,7 +237,7 @@ class DescribeValueTest(unittest.TestCase):
     def test_long_scalar_sequence_is_hashed_not_just_counted(self):
         # A bare length made two AerocomDiagnostics terms with different
         # 100-element plev_pa tuples record identically, though those
-        # pressures are interpolated to (#733 review).
+        # pressures are interpolated to.
         n = provenance._PARAM_ARRAY_MAX_ELEMS + 1
         one = self._walk([float(i) for i in range(n)])["p"]
         two = self._walk([float(i) + 1 for i in range(n)])["p"]
@@ -286,7 +246,7 @@ class DescribeValueTest(unittest.TestCase):
         self.assertNotEqual(one["sha256"], two["sha256"])
 
     def test_container_of_structures_is_walked_by_index(self):
-        walked = self._walk([_FakeDiffusion(), {"k": 2.0}])
+        walked = self._walk([_FakeParamBlock(), {"k": 2.0}])
         self.assertEqual(walked["p.0.order"], 2)
         self.assertEqual(walked["p.1.k"], 2.0)
 
@@ -313,7 +273,7 @@ class DescribePhysicsParamsTest(unittest.TestCase):
 
     def setUp(self):
         from jcm.physics.speedy.speedy_terms import speedy_physics
-        self.params = provenance.describe_params(speedy_physics())["physics"]
+        self.params = provenance.describe_params(speedy_physics())
 
     def test_scheme_defaults_are_recorded_not_just_overrides(self):
         from jcm.physics.speedy.speedy_terms import ConvectionParameters
@@ -327,12 +287,11 @@ class DescribePhysicsParamsTest(unittest.TestCase):
             float(ConvectionParameters.default().entmax), places=12)
 
     def test_keys_locate_the_value_owner_first(self):
-        # A recorded key must say where the value lives, unambiguously,
-        # owner first: <term>.<variable>.<field> for a parameter block,
-        # <term>.<attribute> for a plain setting, and `physics.` for the
-        # composition itself. Note this is NOT always the Hydra override
-        # path — Hydra addresses the constructor keyword, and
-        # SpeedyConvection takes convection_params= but stores `params`.
+        # A recorded key must say where the value lives, unambiguously
+        # and owner first: <term>.<variable>.<field>. Note this is NOT
+        # always the Hydra override path — Hydra addresses the term's
+        # constructor keyword, and SpeedyConvection takes
+        # convection_params= but stores it as `params`.
         for key in self.params:
             self.assertRegex(key, r"^[A-Za-z0-9_#]+\.[A-Za-z0-9_]+")
 
@@ -349,7 +308,7 @@ class DescribePhysicsParamsTest(unittest.TestCase):
         # A parameter block containing a bool cannot be an nnx.Param, so
         # the schemes hold those as plain Variables. Filtering on Param
         # dropped SPEEDY's whole surface-flux set even though changing
-        # e.g. cdl changes the simulation (#733 review).
+        # e.g. cdl changes the simulation.
         self.assertIn("speedy_surface_flux.surface_params.cdl", self.params)
         self.assertIn("speedy_surface_flux.surface_params.fwind0",
                       self.params)
@@ -360,7 +319,7 @@ class DescribePhysicsParamsTest(unittest.TestCase):
         from jcm.physics.held_suarez.held_suarez_physics import (
             held_suarez_physics,
         )
-        params = provenance.describe_params(held_suarez_physics())["physics"]
+        params = provenance.describe_params(held_suarez_physics())
         for knob in ("kf", "ka", "ks", "dTy", "dThz", "sigma_b"):
             self.assertIn(f"held_suarez.{knob}", params)
         # ...while its grid caches, held as plain Variables right beside
@@ -368,180 +327,6 @@ class DescribePhysicsParamsTest(unittest.TestCase):
         # out. This is why the plain-Variable filter is by shape.
         self.assertNotIn("held_suarez.sigma", params)
         self.assertNotIn("held_suarez.latitudes", params)
-
-    def test_constructor_controls_held_as_plain_attributes(self):
-        # Not every run-shaping setting reaches an nnx variable:
-        # UpperSponge keeps its controls as ordinary attributes and turns
-        # them into a grid-shaped _inv_tau the knob filter rejects, so two
-        # sponge timescales recorded identically (#733 review).
-        from jcm.physics.dissipation.upper_sponge import UpperSponge
-
-        def record(timescale):
-            class _One:
-                terms = [UpperSponge(n_sponge_levels=3,
-                                     sponge_timescale_s=timescale,
-                                     enspodi=2.0, damp_temperature=True)]
-
-            return provenance.describe_params(_One())
-
-        slow, fast = record(7200.0), record(3600.0)
-        self.assertEqual(
-            slow["physics"]["upper_sponge.sponge_timescale_s"], 7200.0)
-        self.assertIs(slow["physics"]["upper_sponge.damp_temperature"], True)
-        self.assertEqual(slow["physics"]["upper_sponge.enspodi"], 2.0)
-        self.assertNotEqual(provenance.params_attrs(slow),
-                            provenance.params_attrs(fast))
-
-    def test_controls_surviving_only_in_derived_form_are_distinguished(self):
-        # UpperTemperatureRelaxation stores its timescale ONLY as the
-        # grid-shaped _inv_tau profile, which the knob filter rejects, so
-        # 3600 s and 7200 s recorded identically (#733 review). The
-        # per-variable digest is what tells them apart.
-        from jcm.physics.dissipation.upper_temperature_relaxation import (
-            UpperTemperatureRelaxation,
-        )
-
-        class _Coords:
-            nodal_shape = (8, 64, 32)
-
-        def record(timescale):
-            term = UpperTemperatureRelaxation([250.0] * 8, n_levels=5,
-                                              timescale_s=timescale)
-            term.cache_coords(_Coords())
-
-            class _One:
-                terms = [term]
-
-            return provenance.describe_params(_One())["physics"]
-
-        slow, fast = record(7200.0), record(3600.0)
-        key = "upper_temperature_relaxation._inv_tau.array_digest"
-        self.assertRegex(slow[key], r"^[0-9a-f]{12}$")
-        self.assertNotEqual(slow[key], fast[key])
-        # ...and the digest discriminates rather than just churning: the
-        # variables the timescale does not feed stay equal.
-        for same in ("_t_ref", "_inv_tau_wind"):
-            self.assertEqual(
-                slow[f"upper_temperature_relaxation.{same}.array_digest"],
-                fast[f"upper_temperature_relaxation.{same}.array_digest"])
-
-    def test_derived_scalar_controls_are_recorded(self):
-        # RRTMGP derives `_aerosol_free = interval is not None`, which
-        # decides whether the companion solve runs, while its sibling
-        # `_aerosol_free_interval` collapses None and 1 to the same value.
-        # Keying on the constructor signature missed the derived name.
-        class _Derived:
-            name = "derived"
-
-            def __init__(self, interval):
-                self._interval = interval or 1
-                self._enabled = interval is not None
-
-        class _One:
-            terms = [_Derived(None)]
-
-        class _Other:
-            terms = [_Derived(1)]
-
-        off = provenance.describe_params(_One())["physics"]
-        on = provenance.describe_params(_Other())["physics"]
-        self.assertEqual(off["derived._interval"], on["derived._interval"])
-        self.assertIs(off["derived._enabled"], False)
-        self.assertIs(on["derived._enabled"], True)
-
-    def test_array_bearing_plain_attributes_are_digested(self):
-        # nnx.data leaves live on the instance rather than in the variable
-        # state: CloudsatCosp keeps its radar lookup tables as
-        # ``self._lut = nnx.data(...)``, and the scalars-only attribute
-        # walk dropped their arrays, so two different LUTs recorded
-        # identically despite changing the simulated reflectivity.
-        import jax.numpy as jnp
-
-        def record(offset):
-            class _Term:
-                name = "cosp"
-
-                def __init__(self):
-                    self._lut = {"table": jnp.arange(50.0) + offset}
-
-            class _One:
-                terms = [_Term()]
-
-            return provenance.describe_params(_One())["physics"]
-
-        first, second = record(0.0), record(1.0)
-        self.assertRegex(first["cosp._lut.array_digest"], r"^[0-9a-f]{12}$")
-        self.assertNotEqual(first["cosp._lut.array_digest"],
-                            second["cosp._lut.array_digest"])
-
-    def test_container_level_controls_are_recorded(self):
-        # ComposablePhysics owns band_config, injected into every step and
-        # read by Macv2SpAerosol for its optics, so a composition of
-        # identical terms with different band centres produces different
-        # fields. Walking only `terms` dropped the wrapper (#733 review).
-        from jcm.physics.speedy.speedy_terms import speedy_physics
-
-        params = provenance.describe_params(speedy_physics())["physics"]
-        self.assertTrue(
-            [k for k in params if k.startswith("physics.band_config.")],
-            "no container-level band_config keys recorded")
-
-    def test_stateless_terms_still_register(self):
-        # A term with no attributes and no nnx variables contributes
-        # nothing to the walk, so adding one left the record unchanged
-        # (#733 review) — even though ResetEmissionFluxes zeroes the
-        # carried emi_* accumulators, without which they grow across
-        # timesteps and every emission average is wrong.
-        from jcm.physics.aerosol.jam.emissions.flux_diagnostic import (
-            ResetEmissionFluxes,
-        )
-        from jcm.physics.composable_physics import ComposablePhysics
-
-        empty = provenance.describe_params(ComposablePhysics(terms=[]))
-        one = provenance.describe_params(
-            ComposablePhysics(terms=[ResetEmissionFluxes()]))
-        self.assertNotEqual(provenance.params_attrs(empty),
-                            provenance.params_attrs(one))
-        self.assertIn("reset_emission_fluxes",
-                      one["physics"]["physics.term_order"])
-
-    def test_term_order_is_recorded(self):
-        # Order is not incidental: the ECHAM composition requires vdiff
-        # before convection so the Tiedtke closure reads the same-step
-        # moisture tendency.
-        from jcm.physics.composable_physics import ComposablePhysics
-        from jcm.physics.speedy.speedy_terms import (
-            SpeedyConvection,
-            SpeedyLargeScaleCondensation,
-        )
-
-        def order(terms):
-            return provenance.describe_params(
-                ComposablePhysics(terms=terms),
-            )["physics"]["physics.term_order"]
-
-        forward = order([SpeedyConvection(), SpeedyLargeScaleCondensation()])
-        reverse = order([SpeedyLargeScaleCondensation(), SpeedyConvection()])
-        self.assertNotEqual(forward, reverse)
-        self.assertEqual(sorted(forward.split(",")),
-                         sorted(reverse.split(",")))
-
-    def test_container_walk_does_not_duplicate_the_terms(self):
-        # nnx.state on the container recurses into its child modules, so
-        # walking the composition re-emitted every term's parameters under
-        # physics.terms.<i>. — 120 duplicate keys and 6 kB on T31L8.
-        self.assertFalse([k for k in self.params
-                          if k.startswith("physics.terms.")])
-
-    def test_framework_bookkeeping_stays_out(self):
-        # Plain attributes are taken generally, so the line held here is
-        # narrower than it once was: names with a dunder infix are flax's
-        # bookkeeping (_pytree__nodes, _object__state) and Python's name
-        # mangling, never a physical setting. Grid-derived attributes like
-        # _nodal_shape DO come along now — accepted, because excluding
-        # them means a denylist, and a denylist fails toward silence.
-        for key in self.params:
-            self.assertNotIn("__", key)
 
     def test_coordinate_caches_do_not_enter_the_record(self):
         # All eleven SPEEDY terms cache the SAME _speedy_coords. Taking
@@ -559,23 +344,21 @@ class DescribePhysicsParamsTest(unittest.TestCase):
         class _One:
             terms = [Macv2SpAerosol()]
 
-        params = provenance.describe_params(_One())["physics"]
+        params = provenance.describe_params(_One())
         theta = params["macv2_sp_aerosol.params.theta"]
         self.assertIn("values", theta)
         self.assertEqual(theta["shape"], [2, 9])
 
-    def test_physics_without_variables_yields_no_block(self):
-        # No composition and no state at all. Note an *empty composition*
-        # is different and does record, as ``physics.term_order = ""``:
-        # "this model ran no physics terms" is a fact, and it is what
-        # distinguishes an empty composition from a bare object.
+    def test_physics_without_variables_yields_no_record(self):
+        # No composition and no state at all: nothing to say, and saying
+        # nothing must not be an error.
         class _Bare:
             pass
 
-        self.assertNotIn("physics", provenance.describe_params(_Bare()))
+        self.assertEqual(provenance.describe_params(_Bare()), {})
 
     def test_no_physics_is_not_an_error(self):
-        self.assertNotIn("physics", provenance.describe_params(None))
+        self.assertEqual(provenance.describe_params(None), {})
 
     def test_two_instances_of_one_term_both_survive(self):
         # A composition may call one scheme twice (the double-radiation
@@ -585,114 +368,9 @@ class DescribePhysicsParamsTest(unittest.TestCase):
         class _Pair:
             terms = [SpeedyConvection(), SpeedyConvection()]
 
-        params = provenance.describe_params(_Pair())["physics"]
+        params = provenance.describe_params(_Pair())
         self.assertIn("speedy_convection.params.entmax", params)
         self.assertIn("speedy_convection#1.params.entmax", params)
-
-
-class DescribeDycoreParamsTest(unittest.TestCase):
-    def setUp(self):
-        self.params = provenance.describe_params(
-            dycore=_FakeDycore())["dycore"]
-
-    def test_scalar_knobs_and_all_scalar_containers_kept(self):
-        self.assertEqual(self.params["dt_seconds"], 900.0)
-        self.assertIs(self.params["compute_omega"], True)
-        self.assertEqual(self.params["diffusion.timescale"], 43200)
-        self.assertIsNone(self.params["diffusion.level_orders"])
-        # Private, but as much a knob as dt_seconds.
-        self.assertEqual(self.params["_sl_options.interpolation_order"],
-                         "cubic")
-
-    def test_mixed_container_keeps_its_knobs_and_drops_its_arrays(self):
-        # The #733 review: a backend may hold tuning coefficients and a
-        # grid profile in ONE container (pySES's diffusion_config), so an
-        # all-or-nothing rule on the container silently dropped the whole
-        # hyperviscosity setting.
-        # Approximate because a float32 0-d array widens to the exact
-        # float64 it represents, which is the value the model held.
-        self.assertAlmostEqual(self.params["hypervis.nu"], 2.5e-9, places=16)
-        self.assertEqual(self.params["hypervis.nu_top"], 250000.0)
-        self.assertNotIn("hypervis.nu_ramp", self.params)
-
-    def test_zero_dim_arrays_are_knobs(self):
-        # pySES stores nu/nu_top as 0-d arrays; an isinstance-scalar test
-        # would drop exactly the coefficients worth recording.
-        self.assertIsInstance(self.params["hypervis.nu"], float)
-
-    def test_scalar_grid_identity_kept_but_not_the_grid(self):
-        self.assertEqual(self.params["coords.layers"], 8)
-        self.assertNotIn("coords.latitudes", self.params)
-        self.assertNotIn("orography", self.params)
-        self.assertNotIn("step_fn", self.params)
-
-    def test_opaque_backend_objects_are_skipped(self):
-        # Their repr carries no setting, and it embeds an address that
-        # would make the record differ between two identical runs.
-        self.assertNotIn("colmap", self.params)
-        self.assertNotIn("0x", json.dumps(self.params))
-
-    def test_record_is_reproducible(self):
-        # params_sha feeds run_hash, so a second identical model must
-        # produce a byte-identical record.
-        again = provenance.describe_params(dycore=_FakeDycore())["dycore"]
-        self.assertEqual(json.dumps(self.params, sort_keys=True),
-                         json.dumps(again, sort_keys=True))
-
-    def test_frozendict_style_mappings_are_walked(self):
-        # pySES's timestep_config is a frozendict, not a dict subclass;
-        # an isinstance(value, dict) test fell through to the leaf and
-        # recorded the whole mapping's repr instead of its keys.
-        import collections.abc
-
-        class _Frozen(collections.abc.Mapping):
-            def __init__(self, d):
-                self._d = dict(d)
-
-            def __getitem__(self, k):
-                return self._d[k]
-
-            def __iter__(self):
-                return iter(self._d)
-
-            def __len__(self):
-                return len(self._d)
-
-        out = {}
-        provenance._describe_value(_Frozen({"tracer_subcycle": 3}), "ts", out)
-        self.assertEqual(out, {"ts.tracer_subcycle": 3})
-
-
-class DescribeConstantsTest(unittest.TestCase):
-    def test_live_constants_recorded(self):
-        import jcm.constants as c
-
-        params = provenance.describe_params()["constants"]
-        self.assertEqual(params["constants.grav"], c.physical_constants.grav)
-
-    def test_dycore_divergence_is_surfaced(self):
-        # jcm.constants is live for attribute-access physics but captured
-        # at construction by the dycore, so an override applied after the
-        # model was built leaves the two genuinely disagreeing. Recording
-        # only the live values would hide exactly that.
-        import jcm.constants as c
-
-        stale = c.physical_constants._replace(grav=1.62)
-        params = provenance.describe_params(
-            dycore=_FakeDycore(constants=stale))["constants"]
-        self.assertEqual(params["constants_dycore.grav"], 1.62)
-        self.assertEqual(params["constants.grav"],
-                         c.physical_constants.grav)
-        # Only the differing fields are repeated.
-        self.assertNotIn("constants_dycore.cpd", params)
-
-    def test_agreeing_constants_are_not_duplicated(self):
-        import jcm.constants as c
-
-        params = provenance.describe_params(
-            dycore=_FakeDycore(constants=c.physical_constants))["constants"]
-        self.assertFalse([k for k in params
-                          if k.startswith("constants_dycore")])
 
 
 class ParamsAttrsTest(unittest.TestCase):
@@ -701,56 +379,30 @@ class ParamsAttrsTest(unittest.TestCase):
         self.assertEqual(provenance.params_attrs(None), {})
 
     def test_values_and_hash_are_netcdf_safe_strings(self):
-        attrs = provenance.params_attrs({"physics": {"a.b.c": 1.0}})
+        attrs = provenance.params_attrs({"a.b.c": 1.0})
         for key, value in attrs.items():
             self.assertTrue(key.startswith("jcm_prov_"), key)
             self.assertIsInstance(value, str)
         self.assertRegex(attrs["jcm_prov_params_sha"], r"^[0-9a-f]{12}$")
         self.assertEqual(
-            json.loads(attrs["jcm_prov_params"])["physics"]["a.b.c"], 1.0)
+            json.loads(attrs["jcm_prov_params"])["a.b.c"], 1.0)
 
-    def test_oversized_record_stays_recoverable_from_the_file_itself(self):
-        # The #733 review: an over-cap record used to be replaced by a
-        # pointer to the .provenance.json sidecar, but to_xarray and the
-        # runners' snapshot files stamp these attributes WITHOUT writing
-        # one, so the values became unrecoverable from the only artifact
-        # that held them. Compress in place instead.
-        huge = {"physics": {f"term.params.p{i}": float(i)
-                            for i in range(20000)}}
-        attrs = provenance.params_attrs(huge)
-        self.assertRegex(attrs["jcm_prov_params_sha"], r"^[0-9a-f]{12}$")
-        self.assertNotIn("sidecar", attrs["jcm_prov_params"])
-        self.assertEqual(provenance.read_params(attrs), huge)
-
-    def test_read_params_handles_both_forms_and_absence(self):
-        small = {"physics": {"t.params.entrpen": 1e-4}}
+    def test_read_params_round_trips_and_tolerates_absence(self):
+        small = {"t.params.entrpen": 1e-4}
         self.assertEqual(
             provenance.read_params(provenance.params_attrs(small)), small)
         self.assertEqual(provenance.read_params({}), {})
-
-    def test_oversized_record_survives_a_real_netcdf_round_trip(self):
-        import xarray as xr
-
-        huge = {"physics": {f"term.params.p{i}": float(i)
-                            for i in range(20000)}}
-        ds = xr.Dataset({"t": ("x", [1.0])},
-                        attrs=provenance.params_attrs(huge))
-        with tempfile.TemporaryDirectory() as d:
-            path = Path(d) / "big.nc"
-            ds.to_netcdf(path)
-            with xr.open_dataset(path) as back:
-                self.assertEqual(provenance.read_params(back.attrs), huge)
 
     def test_run_hash_separates_parameter_sweep_members(self):
         # Same code, same config, same inputs: without the parameters in
         # the hash every member of a sweep would share one run_hash.
         provenance.start_run()
-        a = provenance.attrs({"physics": {"t.params.entrpen": 1e-4}})
-        b = provenance.attrs({"physics": {"t.params.entrpen": 4e-4}})
+        a = provenance.attrs({"t.params.entrpen": 1e-4})
+        b = provenance.attrs({"t.params.entrpen": 4e-4})
         self.assertNotEqual(a["jcm_prov_run_hash"], b["jcm_prov_run_hash"])
 
     def test_sidecar_and_attrs_agree_on_the_run_hash(self):
-        params = {"physics": {"t.params.entrpen": 1e-4}}
+        params = {"t.params.entrpen": 1e-4}
         provenance.start_run()
         attrs = provenance.attrs(params)
         with tempfile.TemporaryDirectory() as d:
@@ -767,15 +419,13 @@ class ModelPredictionsCaptureTest(unittest.TestCase):
         from jcm.physics.speedy.speedy_terms import speedy_physics
         return speedy_physics()
 
-    def _preds(self, physics, dycore=None):
+    def _preds(self, physics):
         from jcm.predictions import ModelPredictions
-        return ModelPredictions(None, None, physics, dycore=dycore)
+        return ModelPredictions(None, None, physics)
 
     def test_parameters_recorded_on_the_predictions(self):
-        preds = self._preds(self._physics(), _FakeDycore())
-        self.assertIn("speedy_convection.params.entmax",
-                      preds.params["physics"])
-        self.assertEqual(preds.params["dycore"]["dt_seconds"], 900.0)
+        preds = self._preds(self._physics())
+        self.assertIn("speedy_convection.params.entmax", preds.params)
 
     def test_snapshot_does_not_follow_later_mutation(self):
         # Each record belongs to the predictions it was built with: a
@@ -786,21 +436,21 @@ class ModelPredictionsCaptureTest(unittest.TestCase):
 
         physics = self._physics()
         preds = self._preds(physics)
-        before = preds.params["physics"]["speedy_convection.params.entmax"]
+        before = preds.params["speedy_convection.params.entmax"]
 
         term = next(t for t in physics.terms if t.name == "speedy_convection")
         current = term.params.get_value()
         term.params.set_value(current.replace(entmax=jnp.array(0.25)))
 
         after = self._preds(physics).params[
-            "physics"]["speedy_convection.params.entmax"]
+            "speedy_convection.params.entmax"]
         self.assertNotAlmostEqual(before, after, places=6)
         self.assertEqual(
-            preds.params["physics"]["speedy_convection.params.entmax"],
+            preds.params["speedy_convection.params.entmax"],
             before)
 
     def test_traced_record_wins_over_the_live_module(self):
-        # The #733 review's P1. `self` is a static argument to
+        # `self` is a static argument to
         # Model._run_from_state, so the parameters are constants inside
         # the compiled executable and an in-place change afterwards does
         # not reach the computation. Reading the live module at the
@@ -819,8 +469,8 @@ class ModelPredictionsCaptureTest(unittest.TestCase):
         with self.assertLogs("jcm.predictions", level="WARNING") as logged:
             preds = ModelPredictions(None, None, physics, params=traced)
         self.assertEqual(
-            preds.params["physics"]["speedy_convection.params.entmax"],
-            traced["physics"]["speedy_convection.params.entmax"])
+            preds.params["speedy_convection.params.entmax"],
+            traced["speedy_convection.params.entmax"])
         # ...and the divergence is surfaced rather than papered over: the
         # user's parameter change did nothing to the run, which is a
         # scientific error they need told about.
@@ -843,7 +493,7 @@ class ModelPredictionsCaptureTest(unittest.TestCase):
 
         Keying the store on the static arguments let a later trace
         overwrite an earlier executable's record, so re-running the first
-        one reported the second's parameters (#733 review). The record is
+        one reported the second's parameters. The record is
         keyed by a trace id the executable itself carries back, so a cache
         hit returns the id of the executable that actually ran.
         """
@@ -858,7 +508,7 @@ class ModelPredictionsCaptureTest(unittest.TestCase):
                       physics=self._physics(), time_step=30.0)
 
         first = model.run(save_interval=0.5, total_time=0.5)
-        original = first.params["physics"][key]
+        original = first.params[key]
 
         term = next(t for t in model.physics.terms
                     if t.name == "speedy_vertical_diffusion")
@@ -866,12 +516,12 @@ class ModelPredictionsCaptureTest(unittest.TestCase):
             term.params.get_value().replace(trvdi=jnp.array(2.0)))
         # A different static signature, so this really is a second trace.
         second = model.run(save_interval=0.25, total_time=0.5)
-        self.assertEqual(second.params["physics"][key], 2.0)
+        self.assertEqual(second.params[key], 2.0)
 
         # Re-running the first signature reuses the FIRST executable,
         # which still holds the original value.
         again = model.run(save_interval=0.5, total_time=0.5)
-        self.assertEqual(again.params["physics"][key], original)
+        self.assertEqual(again.params[key], original)
 
     def test_capture_failure_never_breaks_a_completed_run(self):
         class _Exploding:
@@ -896,8 +546,7 @@ class ModelPredictionsCaptureTest(unittest.TestCase):
 
         ds = _Preds(None, None, self._physics()).to_xarray()
         recorded = json.loads(ds.attrs["jcm_prov_params"])
-        self.assertIn("speedy_convection.params.entmax",
-                      recorded["physics"])
+        self.assertIn("speedy_convection.params.entmax", recorded)
 
     def test_observation_datasets_are_stamped(self):
         # An observer stream is often persisted on its own, and would
@@ -919,7 +568,7 @@ class ModelPredictionsCaptureTest(unittest.TestCase):
             obs_t0_days=0.0, obs_dt_seconds=1800.0)
         ds = preds.observation_datasets()["stations"]
         recorded = json.loads(ds.attrs["jcm_prov_params"])
-        self.assertIn("speedy_convection.params.entmax", recorded["physics"])
+        self.assertIn("speedy_convection.params.entmax", recorded)
 
     def test_pytree_roundtrip_carries_no_model_and_says_so(self):
         import jax

--- a/jcm/provenance_test.py
+++ b/jcm/provenance_test.py
@@ -354,6 +354,38 @@ class DescribePhysicsParamsTest(unittest.TestCase):
         self.assertNotIn("held_suarez.sigma", params)
         self.assertNotIn("held_suarez.latitudes", params)
 
+    def test_constructor_controls_held_as_plain_attributes(self):
+        # Not every run-shaping setting reaches an nnx variable:
+        # UpperSponge keeps its controls as ordinary attributes and turns
+        # them into a grid-shaped _inv_tau the knob filter rejects, so two
+        # sponge timescales recorded identically (#733 review).
+        from jcm.physics.dissipation.upper_sponge import UpperSponge
+
+        def record(timescale):
+            class _One:
+                terms = [UpperSponge(n_sponge_levels=3,
+                                     sponge_timescale_s=timescale,
+                                     enspodi=2.0, damp_temperature=True)]
+
+            return provenance.describe_params(_One())
+
+        slow, fast = record(7200.0), record(3600.0)
+        self.assertEqual(
+            slow["physics"]["upper_sponge.sponge_timescale_s"], 7200.0)
+        self.assertIs(slow["physics"]["upper_sponge.damp_temperature"], True)
+        self.assertEqual(slow["physics"]["upper_sponge.enspodi"], 2.0)
+        self.assertNotEqual(provenance.params_attrs(slow),
+                            provenance.params_attrs(fast))
+
+    def test_constructor_controls_do_not_pull_in_nnx_bookkeeping(self):
+        # Keying on __init__ rather than scanning attributes is what keeps
+        # _pytree__nodes, _coords_cached and _nodal_shape out: nobody
+        # passed those in.
+        for key in self.params:
+            for internal in ("_pytree__", "_coords_cached", "_nodal_shape",
+                             "_object__"):
+                self.assertNotIn(internal, key)
+
     def test_coordinate_caches_do_not_enter_the_record(self):
         # All eleven SPEEDY terms cache the SAME _speedy_coords. Taking
         # plain Variables wholesale put eleven identical copies of the

--- a/jcm/provenance_test.py
+++ b/jcm/provenance_test.py
@@ -168,23 +168,38 @@ class _FakeDiffusion:
 
 @dataclasses.dataclass
 class _FakeCoords:
-    """Stands in for a CoordinateSystem: carries grid arrays, not knobs."""
+    """Stands in for a CoordinateSystem: grid arrays beside scalar identity."""
 
     latitudes: object = None
     layers: int = 8
 
 
+class _OpaqueBackendObject:
+    """No fields worth recording, and a default repr carrying an address."""
+
+
 class _FakeDycore:
+    """Mirrors the shapes a real backend presents.
+
+    In particular ``hypervis`` mixes 0-d array coefficients with a bulk
+    profile in one container, the way pySES's ``diffusion_config`` does.
+    """
+
     def __init__(self, constants=None):
+        import jax.numpy as jnp
         import numpy as np
         self.dt_seconds = 900.0
         self.compute_omega = True
         self.diffusion = _FakeDiffusion()
         self._sl_options = {"interpolation_order": "cubic",
                             "off_centering": 0.5}
+        self.hypervis = {"nu": jnp.asarray(2.5e-9),
+                         "nu_top": jnp.asarray(250000.0),
+                         "nu_ramp": jnp.arange(8.0)}
         self.coords = _FakeCoords(latitudes=np.linspace(-90, 90, 32))
         self.orography = np.zeros((32, 16))
         self.step_fn = lambda s: s
+        self.colmap = _OpaqueBackendObject()
         if constants is not None:
             self.constants = constants
 
@@ -352,13 +367,63 @@ class DescribeDycoreParamsTest(unittest.TestCase):
         self.assertEqual(self.params["_sl_options.interpolation_order"],
                          "cubic")
 
-    def test_grid_data_and_callables_dropped(self):
-        # coords/terrain carry arrays: grid data, not knobs. They must be
-        # rejected on the array *without* being pulled off the device.
-        for key in self.params:
-            self.assertFalse(key.startswith("coords"), key)
-            self.assertNotEqual(key, "orography")
-            self.assertNotEqual(key, "step_fn")
+    def test_mixed_container_keeps_its_knobs_and_drops_its_arrays(self):
+        # The #733 review: a backend may hold tuning coefficients and a
+        # grid profile in ONE container (pySES's diffusion_config), so an
+        # all-or-nothing rule on the container silently dropped the whole
+        # hyperviscosity setting.
+        # Approximate because a float32 0-d array widens to the exact
+        # float64 it represents, which is the value the model held.
+        self.assertAlmostEqual(self.params["hypervis.nu"], 2.5e-9, places=16)
+        self.assertEqual(self.params["hypervis.nu_top"], 250000.0)
+        self.assertNotIn("hypervis.nu_ramp", self.params)
+
+    def test_zero_dim_arrays_are_knobs(self):
+        # pySES stores nu/nu_top as 0-d arrays; an isinstance-scalar test
+        # would drop exactly the coefficients worth recording.
+        self.assertIsInstance(self.params["hypervis.nu"], float)
+
+    def test_scalar_grid_identity_kept_but_not_the_grid(self):
+        self.assertEqual(self.params["coords.layers"], 8)
+        self.assertNotIn("coords.latitudes", self.params)
+        self.assertNotIn("orography", self.params)
+        self.assertNotIn("step_fn", self.params)
+
+    def test_opaque_backend_objects_are_skipped(self):
+        # Their repr carries no setting, and it embeds an address that
+        # would make the record differ between two identical runs.
+        self.assertNotIn("colmap", self.params)
+        self.assertNotIn("0x", json.dumps(self.params))
+
+    def test_record_is_reproducible(self):
+        # params_sha feeds run_hash, so a second identical model must
+        # produce a byte-identical record.
+        again = provenance.describe_params(dycore=_FakeDycore())["dycore"]
+        self.assertEqual(json.dumps(self.params, sort_keys=True),
+                         json.dumps(again, sort_keys=True))
+
+    def test_frozendict_style_mappings_are_walked(self):
+        # pySES's timestep_config is a frozendict, not a dict subclass;
+        # an isinstance(value, dict) test fell through to the leaf and
+        # recorded the whole mapping's repr instead of its keys.
+        import collections.abc
+
+        class _Frozen(collections.abc.Mapping):
+            def __init__(self, d):
+                self._d = dict(d)
+
+            def __getitem__(self, k):
+                return self._d[k]
+
+            def __iter__(self):
+                return iter(self._d)
+
+            def __len__(self):
+                return len(self._d)
+
+        out = {}
+        provenance._describe_value(_Frozen({"tracer_subcycle": 3}), "ts", out)
+        self.assertEqual(out, {"ts.tracer_subcycle": 3})
 
 
 class DescribeConstantsTest(unittest.TestCase):
@@ -407,12 +472,37 @@ class ParamsAttrsTest(unittest.TestCase):
         self.assertEqual(
             json.loads(attrs["jcm_prov_params"])["physics"]["a.b.c"], 1.0)
 
-    def test_oversized_record_keeps_its_hash_and_points_at_the_sidecar(self):
+    def test_oversized_record_stays_recoverable_from_the_file_itself(self):
+        # The #733 review: an over-cap record used to be replaced by a
+        # pointer to the .provenance.json sidecar, but to_xarray and the
+        # runners' snapshot files stamp these attributes WITHOUT writing
+        # one, so the values became unrecoverable from the only artifact
+        # that held them. Compress in place instead.
         huge = {"physics": {f"term.params.p{i}": float(i)
                             for i in range(20000)}}
         attrs = provenance.params_attrs(huge)
         self.assertRegex(attrs["jcm_prov_params_sha"], r"^[0-9a-f]{12}$")
-        self.assertIn("sidecar", attrs["jcm_prov_params"])
+        self.assertNotIn("sidecar", attrs["jcm_prov_params"])
+        self.assertEqual(provenance.read_params(attrs), huge)
+
+    def test_read_params_handles_both_forms_and_absence(self):
+        small = {"physics": {"t.params.entrpen": 1e-4}}
+        self.assertEqual(
+            provenance.read_params(provenance.params_attrs(small)), small)
+        self.assertEqual(provenance.read_params({}), {})
+
+    def test_oversized_record_survives_a_real_netcdf_round_trip(self):
+        import xarray as xr
+
+        huge = {"physics": {f"term.params.p{i}": float(i)
+                            for i in range(20000)}}
+        ds = xr.Dataset({"t": ("x", [1.0])},
+                        attrs=provenance.params_attrs(huge))
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "big.nc"
+            ds.to_netcdf(path)
+            with xr.open_dataset(path) as back:
+                self.assertEqual(provenance.read_params(back.attrs), huge)
 
     def test_run_hash_separates_parameter_sweep_members(self):
         # Same code, same config, same inputs: without the parameters in

--- a/jcm/provenance_test.py
+++ b/jcm/provenance_test.py
@@ -447,6 +447,53 @@ class DescribePhysicsParamsTest(unittest.TestCase):
             [k for k in params if k.startswith("physics.band_config.")],
             "no container-level band_config keys recorded")
 
+    def test_stateless_terms_still_register(self):
+        # A term with no attributes and no nnx variables contributes
+        # nothing to the walk, so adding one left the record unchanged
+        # (#733 review) — even though ResetEmissionFluxes zeroes the
+        # carried emi_* accumulators, without which they grow across
+        # timesteps and every emission average is wrong.
+        from jcm.physics.aerosol.jam.emissions.flux_diagnostic import (
+            ResetEmissionFluxes,
+        )
+        from jcm.physics.composable_physics import ComposablePhysics
+
+        empty = provenance.describe_params(ComposablePhysics(terms=[]))
+        one = provenance.describe_params(
+            ComposablePhysics(terms=[ResetEmissionFluxes()]))
+        self.assertNotEqual(provenance.params_attrs(empty),
+                            provenance.params_attrs(one))
+        self.assertIn("reset_emission_fluxes",
+                      one["physics"]["physics.term_order"])
+
+    def test_term_order_is_recorded(self):
+        # Order is not incidental: the ECHAM composition requires vdiff
+        # before convection so the Tiedtke closure reads the same-step
+        # moisture tendency.
+        from jcm.physics.composable_physics import ComposablePhysics
+        from jcm.physics.speedy.speedy_terms import (
+            SpeedyConvection,
+            SpeedyLargeScaleCondensation,
+        )
+
+        def order(terms):
+            return provenance.describe_params(
+                ComposablePhysics(terms=terms),
+            )["physics"]["physics.term_order"]
+
+        forward = order([SpeedyConvection(), SpeedyLargeScaleCondensation()])
+        reverse = order([SpeedyLargeScaleCondensation(), SpeedyConvection()])
+        self.assertNotEqual(forward, reverse)
+        self.assertEqual(sorted(forward.split(",")),
+                         sorted(reverse.split(",")))
+
+    def test_container_walk_does_not_duplicate_the_terms(self):
+        # nnx.state on the container recurses into its child modules, so
+        # walking the composition re-emitted every term's parameters under
+        # physics.terms.<i>. — 120 duplicate keys and 6 kB on T31L8.
+        self.assertFalse([k for k in self.params
+                          if k.startswith("physics.terms.")])
+
     def test_framework_bookkeeping_stays_out(self):
         # Plain attributes are taken generally, so the line held here is
         # narrower than it once was: names with a dunder infix are flax's
@@ -477,8 +524,12 @@ class DescribePhysicsParamsTest(unittest.TestCase):
         self.assertIsInstance(params["macv2_sp_aerosol.params.theta"], list)
 
     def test_physics_without_variables_yields_no_block(self):
+        # No composition and no state at all. Note an *empty composition*
+        # is different and does record, as ``physics.term_order = ""``:
+        # "this model ran no physics terms" is a fact, and it is what
+        # distinguishes an empty composition from a bare object.
         class _Bare:
-            terms = []
+            pass
 
         self.assertNotIn("physics", provenance.describe_params(_Bare()))
 

--- a/jcm/provenance_test.py
+++ b/jcm/provenance_test.py
@@ -274,9 +274,16 @@ class DescribeValueTest(unittest.TestCase):
         self.assertEqual(self._walk(["qc", "qi"]), {"p": ["qc", "qi"]})
         self.assertEqual(self._walk((1.0, 2.0)), {"p": [1.0, 2.0]})
 
-    def test_long_scalar_sequence_is_summarized(self):
+    def test_long_scalar_sequence_is_hashed_not_just_counted(self):
+        # A bare length made two AerocomDiagnostics terms with different
+        # 100-element plev_pa tuples record identically, though those
+        # pressures are interpolated to (#733 review).
         n = provenance._PARAM_ARRAY_MAX_ELEMS + 1
-        self.assertEqual(self._walk([0.0] * n), {"p": f"<{n} scalars>"})
+        one = self._walk([float(i) for i in range(n)])["p"]
+        two = self._walk([float(i) + 1 for i in range(n)])["p"]
+        self.assertEqual(one["length"], n)
+        self.assertRegex(one["sha256"], r"^[0-9a-f]{12}$")
+        self.assertNotEqual(one["sha256"], two["sha256"])
 
     def test_container_of_structures_is_walked_by_index(self):
         walked = self._walk([_FakeDiffusion(), {"k": 2.0}])
@@ -441,6 +448,31 @@ class DescribePhysicsParamsTest(unittest.TestCase):
         self.assertEqual(off["derived._interval"], on["derived._interval"])
         self.assertIs(off["derived._enabled"], False)
         self.assertIs(on["derived._enabled"], True)
+
+    def test_array_bearing_plain_attributes_are_digested(self):
+        # nnx.data leaves live on the instance rather than in the variable
+        # state: CloudsatCosp keeps its radar lookup tables as
+        # ``self._lut = nnx.data(...)``, and the scalars-only attribute
+        # walk dropped their arrays, so two different LUTs recorded
+        # identically despite changing the simulated reflectivity.
+        import jax.numpy as jnp
+
+        def record(offset):
+            class _Term:
+                name = "cosp"
+
+                def __init__(self):
+                    self._lut = {"table": jnp.arange(50.0) + offset}
+
+            class _One:
+                terms = [_Term()]
+
+            return provenance.describe_params(_One())["physics"]
+
+        first, second = record(0.0), record(1.0)
+        self.assertRegex(first["cosp._lut.array_digest"], r"^[0-9a-f]{12}$")
+        self.assertNotEqual(first["cosp._lut.array_digest"],
+                            second["cosp._lut.array_digest"])
 
     def test_container_level_controls_are_recorded(self):
         # ComposablePhysics owns band_config, injected into every step and

--- a/jcm/provenance_test.py
+++ b/jcm/provenance_test.py
@@ -737,10 +737,10 @@ class ModelPredictionsCaptureTest(unittest.TestCase):
         self.assertEqual(preds.params["dycore"]["dt_seconds"], 900.0)
 
     def test_snapshot_does_not_follow_later_mutation(self):
-        # A calibration loop updates the term parameters in place between
-        # iterations. A lazily-read record would report the *next*
-        # iteration's values against this iteration's trajectory, which is
-        # the failure this capture point exists to prevent.
+        # Each record belongs to the predictions it was built with: a
+        # later mutation must not reach back into an earlier record.
+        # (Whether a mutation reaches the *computation* is a separate
+        # question — see test_traced_record_wins_over_the_live_module.)
         import jax.numpy as jnp
 
         physics = self._physics()
@@ -757,6 +757,44 @@ class ModelPredictionsCaptureTest(unittest.TestCase):
         self.assertEqual(
             preds.params["physics"]["speedy_convection.params.entmax"],
             before)
+
+    def test_traced_record_wins_over_the_live_module(self):
+        # The #733 review's P1. `self` is a static argument to
+        # Model._run_from_state, so the parameters are constants inside
+        # the compiled executable and an in-place change afterwards does
+        # not reach the computation. Reading the live module at the
+        # handoff therefore stamped a trajectory with values that never
+        # ran — a confident, wrong record, which is worse than no record.
+        import jax.numpy as jnp
+
+        from jcm.predictions import ModelPredictions
+
+        physics = self._physics()
+        traced = provenance.describe_params(physics)
+        term = next(t for t in physics.terms if t.name == "speedy_convection")
+        term.params.set_value(
+            term.params.get_value().replace(entmax=jnp.array(0.25)))
+
+        with self.assertLogs("jcm.predictions", level="WARNING") as logged:
+            preds = ModelPredictions(None, None, physics, params=traced)
+        self.assertEqual(
+            preds.params["physics"]["speedy_convection.params.entmax"],
+            traced["physics"]["speedy_convection.params.entmax"])
+        # ...and the divergence is surfaced rather than papered over: the
+        # user's parameter change did nothing to the run, which is a
+        # scientific error they need told about.
+        self.assertIn("live_parameters_differ_from_compiled", preds.params)
+        self.assertIn("does NOT affect the computation",
+                      "".join(logged.output))
+
+    def test_no_false_alarm_when_live_matches_compiled(self):
+        from jcm.predictions import ModelPredictions
+
+        physics = self._physics()
+        traced = provenance.describe_params(physics)
+        preds = ModelPredictions(None, None, physics, params=traced)
+        self.assertEqual(preds.params, traced)
+        self.assertNotIn("live_parameters_differ_from_compiled", preds.params)
 
     def test_capture_failure_never_breaks_a_completed_run(self):
         class _Exploding:

--- a/jcm/provenance_test.py
+++ b/jcm/provenance_test.py
@@ -1,4 +1,4 @@
-"""Tests for run provenance capture (#591)."""
+"""Tests for run provenance capture (#591, #732)."""
 import dataclasses
 import hashlib
 import json
@@ -280,7 +280,7 @@ class DescribeValueTest(unittest.TestCase):
 
 
 class DescribePhysicsParamsTest(unittest.TestCase):
-    """The gap: values that live in code, not in the config."""
+    """The gap #732 closes: values that live in code, not in the config."""
 
     def setUp(self):
         from jcm.physics.speedy.speedy_terms import speedy_physics

--- a/jcm/provenance_test.py
+++ b/jcm/provenance_test.py
@@ -312,14 +312,15 @@ class DescribePhysicsParamsTest(unittest.TestCase):
             self.params[key],
             float(ConvectionParameters.default().entmax), places=12)
 
-    def test_keys_locate_the_value_term_variable_field(self):
-        # A recorded key must say where the value lives, unambiguously:
-        # <term name>.<nnx variable>.<field>. Note this is NOT always the
-        # Hydra override path — Hydra addresses the constructor keyword,
-        # and SpeedyConvection takes convection_params= but stores it as
-        # `params`. The record names the variable, not the keyword.
+    def test_keys_locate_the_value_owner_first(self):
+        # A recorded key must say where the value lives, unambiguously,
+        # owner first: <term>.<variable>.<field> for a parameter block,
+        # <term>.<attribute> for a plain setting, and `physics.` for the
+        # composition itself. Note this is NOT always the Hydra override
+        # path — Hydra addresses the constructor keyword, and
+        # SpeedyConvection takes convection_params= but stores `params`.
         for key in self.params:
-            self.assertRegex(key, r"^[a-z0-9_#]+\.[a-z0-9_]+\.")
+            self.assertRegex(key, r"^[A-Za-z0-9_#]+\.[A-Za-z0-9_]+")
 
     def test_variables_not_named_params_are_captured(self):
         # Keying on nnx.Param rather than a `.params` attribute is the
@@ -377,14 +378,84 @@ class DescribePhysicsParamsTest(unittest.TestCase):
         self.assertNotEqual(provenance.params_attrs(slow),
                             provenance.params_attrs(fast))
 
-    def test_constructor_controls_do_not_pull_in_nnx_bookkeeping(self):
-        # Keying on __init__ rather than scanning attributes is what keeps
-        # _pytree__nodes, _coords_cached and _nodal_shape out: nobody
-        # passed those in.
+    def test_controls_surviving_only_in_derived_form_are_distinguished(self):
+        # UpperTemperatureRelaxation stores its timescale ONLY as the
+        # grid-shaped _inv_tau profile, which the knob filter rejects, so
+        # 3600 s and 7200 s recorded identically (#733 review). The
+        # per-variable digest is what tells them apart.
+        from jcm.physics.dissipation.upper_temperature_relaxation import (
+            UpperTemperatureRelaxation,
+        )
+
+        class _Coords:
+            nodal_shape = (8, 64, 32)
+
+        def record(timescale):
+            term = UpperTemperatureRelaxation([250.0] * 8, n_levels=5,
+                                              timescale_s=timescale)
+            term.cache_coords(_Coords())
+
+            class _One:
+                terms = [term]
+
+            return provenance.describe_params(_One())["physics"]
+
+        slow, fast = record(7200.0), record(3600.0)
+        key = "upper_temperature_relaxation._inv_tau.array_digest"
+        self.assertRegex(slow[key], r"^[0-9a-f]{12}$")
+        self.assertNotEqual(slow[key], fast[key])
+        # ...and the digest discriminates rather than just churning: the
+        # variables the timescale does not feed stay equal.
+        for same in ("_t_ref", "_inv_tau_wind"):
+            self.assertEqual(
+                slow[f"upper_temperature_relaxation.{same}.array_digest"],
+                fast[f"upper_temperature_relaxation.{same}.array_digest"])
+
+    def test_derived_scalar_controls_are_recorded(self):
+        # RRTMGP derives `_aerosol_free = interval is not None`, which
+        # decides whether the companion solve runs, while its sibling
+        # `_aerosol_free_interval` collapses None and 1 to the same value.
+        # Keying on the constructor signature missed the derived name.
+        class _Derived:
+            name = "derived"
+
+            def __init__(self, interval):
+                self._interval = interval or 1
+                self._enabled = interval is not None
+
+        class _One:
+            terms = [_Derived(None)]
+
+        class _Other:
+            terms = [_Derived(1)]
+
+        off = provenance.describe_params(_One())["physics"]
+        on = provenance.describe_params(_Other())["physics"]
+        self.assertEqual(off["derived._interval"], on["derived._interval"])
+        self.assertIs(off["derived._enabled"], False)
+        self.assertIs(on["derived._enabled"], True)
+
+    def test_container_level_controls_are_recorded(self):
+        # ComposablePhysics owns band_config, injected into every step and
+        # read by Macv2SpAerosol for its optics, so a composition of
+        # identical terms with different band centres produces different
+        # fields. Walking only `terms` dropped the wrapper (#733 review).
+        from jcm.physics.speedy.speedy_terms import speedy_physics
+
+        params = provenance.describe_params(speedy_physics())["physics"]
+        self.assertTrue(
+            [k for k in params if k.startswith("physics.band_config.")],
+            "no container-level band_config keys recorded")
+
+    def test_framework_bookkeeping_stays_out(self):
+        # Plain attributes are taken generally, so the line held here is
+        # narrower than it once was: names with a dunder infix are flax's
+        # bookkeeping (_pytree__nodes, _object__state) and Python's name
+        # mangling, never a physical setting. Grid-derived attributes like
+        # _nodal_shape DO come along now — accepted, because excluding
+        # them means a denylist, and a denylist fails toward silence.
         for key in self.params:
-            for internal in ("_pytree__", "_coords_cached", "_nodal_shape",
-                             "_object__"):
-                self.assertNotIn(internal, key)
+            self.assertNotIn("__", key)
 
     def test_coordinate_caches_do_not_enter_the_record(self):
         # All eleven SPEEDY terms cache the SAME _speedy_coords. Taking

--- a/jcm/provenance_test.py
+++ b/jcm/provenance_test.py
@@ -216,6 +216,16 @@ class DescribeLeafTest(unittest.TestCase):
         self.assertEqual(provenance._describe_leaf(jnp.float32(0.1)),
                          0.10000000149011612)
 
+    def test_unrepresentable_values_are_described_not_raised(self):
+        # A parameter block may hold a callable (a schedule, an
+        # activation) or something numpy cannot convert. Provenance
+        # describes it and moves on rather than failing the record.
+        def relu(x):
+            return x
+
+        self.assertEqual(provenance._describe_leaf(relu), "<callable relu>")
+        self.assertIn("object", provenance._describe_leaf(object()))
+
     def test_tracer_is_marked_not_forced(self):
         import jax
         import jax.numpy as jnp
@@ -228,6 +238,45 @@ class DescribeLeafTest(unittest.TestCase):
 
         jax.jit(f)(jnp.float32(1.0))
         self.assertEqual(seen, ["<traced>"])
+
+
+class DescribeValueTest(unittest.TestCase):
+    def _walk(self, value):
+        out = {}
+        provenance._describe_value(value, "p", out)
+        return out
+
+    def test_short_scalar_sequence_is_one_value(self):
+        # A per-level profile or a tracer-name tuple reads better as one
+        # entry than as p.0, p.1, p.2 ...
+        self.assertEqual(self._walk(["qc", "qi"]), {"p": ["qc", "qi"]})
+        self.assertEqual(self._walk((1.0, 2.0)), {"p": [1.0, 2.0]})
+
+    def test_long_scalar_sequence_is_summarized(self):
+        n = provenance._PARAM_ARRAY_MAX_ELEMS + 1
+        self.assertEqual(self._walk([0.0] * n), {"p": f"<{n} scalars>"})
+
+    def test_container_of_structures_is_walked_by_index(self):
+        walked = self._walk([_FakeDiffusion(), {"k": 2.0}])
+        self.assertEqual(walked["p.0.order"], 2)
+        self.assertEqual(walked["p.1.k"], 2.0)
+
+    def test_namedtuple_fields_are_named(self):
+        import collections
+
+        pair = collections.namedtuple("pair", "lo hi")
+        self.assertEqual(self._walk(pair(1.0, 2.0)),
+                         {"p.lo": 1.0, "p.hi": 2.0})
+
+    def test_runaway_nesting_is_truncated_not_followed(self):
+        deep = value = {}
+        for _ in range(provenance._PARAM_MAX_DEPTH + 3):
+            nxt = {}
+            value["down"] = nxt
+            value = nxt
+        walked = self._walk(deep)
+        self.assertEqual(len(walked), 1)
+        self.assertIn("truncated", next(iter(walked.values())))
 
 
 class DescribePhysicsParamsTest(unittest.TestCase):
@@ -275,6 +324,18 @@ class DescribePhysicsParamsTest(unittest.TestCase):
 
     def test_no_physics_is_not_an_error(self):
         self.assertNotIn("physics", provenance.describe_params(None))
+
+    def test_two_instances_of_one_term_both_survive(self):
+        # A composition may call one scheme twice (the double-radiation
+        # A/B). Keying purely on term name would clobber the first.
+        from jcm.physics.speedy.speedy_terms import SpeedyConvection
+
+        class _Pair:
+            terms = [SpeedyConvection(), SpeedyConvection()]
+
+        params = provenance.describe_params(_Pair())["physics"]
+        self.assertIn("speedy_convection.params.entmax", params)
+        self.assertIn("speedy_convection#1.params.entmax", params)
 
 
 class DescribeDycoreParamsTest(unittest.TestCase):

--- a/jcm/provenance_test.py
+++ b/jcm/provenance_test.py
@@ -330,12 +330,54 @@ class DescribePhysicsParamsTest(unittest.TestCase):
         self.assertIn("speedy_upward_longwave.mod_radcon_params.emisfc",
                       self.params)
 
-    def test_physics_without_params_yields_no_block(self):
+    def test_non_differentiable_parameter_variables_are_captured(self):
+        # A parameter block containing a bool cannot be an nnx.Param, so
+        # the schemes hold those as plain Variables. Filtering on Param
+        # dropped SPEEDY's whole surface-flux set even though changing
+        # e.g. cdl changes the simulation (#733 review).
+        self.assertIn("speedy_surface_flux.surface_params.cdl", self.params)
+        self.assertIn("speedy_surface_flux.surface_params.fwind0",
+                      self.params)
+
+    def test_held_suarez_parameters_are_recorded(self):
+        # Every Held-Suarez tuning constant is an nnx.Variable, so under a
+        # Param-only filter this physics recorded NOTHING at all.
         from jcm.physics.held_suarez.held_suarez_physics import (
             held_suarez_physics,
         )
-        self.assertNotIn("physics",
-                         provenance.describe_params(held_suarez_physics()))
+        params = provenance.describe_params(held_suarez_physics())["physics"]
+        for knob in ("kf", "ka", "ks", "dTy", "dThz", "sigma_b"):
+            self.assertIn(f"held_suarez.{knob}", params)
+        # ...while its grid caches, held as plain Variables right beside
+        # those knobs with no naming convention to tell them apart, stay
+        # out. This is why the plain-Variable filter is by shape.
+        self.assertNotIn("held_suarez.sigma", params)
+        self.assertNotIn("held_suarez.latitudes", params)
+
+    def test_coordinate_caches_do_not_enter_the_record(self):
+        # All eleven SPEEDY terms cache the SAME _speedy_coords. Taking
+        # plain Variables wholesale put eleven identical copies of the
+        # vertical grid in the record, 85% of a T31L8 run's bytes.
+        for key in self.params:
+            self.assertNotIn("_speedy_coords", key)
+
+    def test_declared_params_keep_their_arrays(self):
+        # The knob-shape filter applies to plain Variables only: an
+        # nnx.Param is a declared parameter, so a tuned array on one must
+        # survive in full. MACv2-SP's plume shapes are the shipped case.
+        from jcm.physics.aerosol import Macv2SpAerosol
+
+        class _One:
+            terms = [Macv2SpAerosol()]
+
+        params = provenance.describe_params(_One())["physics"]
+        self.assertIsInstance(params["macv2_sp_aerosol.params.theta"], list)
+
+    def test_physics_without_variables_yields_no_block(self):
+        class _Bare:
+            terms = []
+
+        self.assertNotIn("physics", provenance.describe_params(_Bare()))
 
     def test_no_physics_is_not_an_error(self):
         self.assertNotIn("physics", provenance.describe_params(None))
@@ -587,6 +629,28 @@ class ModelPredictionsCaptureTest(unittest.TestCase):
         recorded = json.loads(ds.attrs["jcm_prov_params"])
         self.assertIn("speedy_convection.params.entmax",
                       recorded["physics"])
+
+    def test_observation_datasets_are_stamped(self):
+        # An observer stream is often persisted on its own, and would
+        # otherwise be the one output unable to say what produced it.
+        import numpy as np
+        import xarray as xr
+
+        from jcm.predictions import ModelPredictions
+
+        class _Observer:
+            name = "stations"
+
+            def to_dataset(self, samples, t0, dt):
+                return xr.Dataset({"t": ("time", np.asarray(samples))})
+
+        preds = ModelPredictions(
+            None, None, self._physics(),
+            observations=([1.0, 2.0],), observers=(_Observer(),),
+            obs_t0_days=0.0, obs_dt_seconds=1800.0)
+        ds = preds.observation_datasets()["stations"]
+        recorded = json.loads(ds.attrs["jcm_prov_params"])
+        self.assertIn("speedy_convection.params.entmax", recorded["physics"])
 
     def test_pytree_roundtrip_carries_no_model_and_says_so(self):
         import jax

--- a/jcm/provenance_test.py
+++ b/jcm/provenance_test.py
@@ -497,31 +497,68 @@ class ModelPredictionsCaptureTest(unittest.TestCase):
         keyed by a trace id the executable itself carries back, so a cache
         hit returns the id of the executable that actually ran.
         """
+        import dataclasses
+
         import jax.numpy as jnp
 
+        from jcm.forcing import default_forcing, make_time_series
         from jcm.model import Model
         from jcm.physics.speedy.speedy_coords import get_speedy_coords
 
         key = "speedy_vertical_diffusion.params.trvdi"
-        model = Model(coords=get_speedy_coords(layers=8,
-                                               spectral_truncation=21),
-                      physics=self._physics(), time_step=30.0)
+        coords = get_speedy_coords(layers=8, spectral_truncation=21)
+        model = Model(coords=coords, physics=self._physics(), time_step=30.0)
 
-        first = model.run(save_interval=0.5, total_time=0.5)
+        # The static arguments are held IDENTICAL throughout. The second
+        # run differs only in a dynamic aval: co2_vmr as a scalar
+        # (fixed-CO2) versus as a TimeSeries (historical forcing), which
+        # is a documented pair of real configurations. Varying a static
+        # argument instead would not test anything, since keying the store
+        # on the static arguments — the implementation this regresses —
+        # would separate those two on its own.
+        fixed_co2 = default_forcing(coords.horizontal)
+        co2 = float(fixed_co2.co2_vmr)
+        historical_co2 = dataclasses.replace(
+            fixed_co2,
+            co2_vmr=make_time_series(jnp.array([co2, co2]),
+                                     jnp.array([0.0, 1e12])))
+
+        first = model.run(forcing=fixed_co2, save_interval=0.5,
+                          total_time=0.5)
         original = first.params[key]
 
         term = next(t for t in model.physics.terms
                     if t.name == "speedy_vertical_diffusion")
         term.params.set_value(
             term.params.get_value().replace(trvdi=jnp.array(2.0)))
-        # A different static signature, so this really is a second trace.
-        second = model.run(save_interval=0.25, total_time=0.5)
+        second = model.run(forcing=historical_co2, save_interval=0.5,
+                           total_time=0.5)
         self.assertEqual(second.params[key], 2.0)
 
-        # Re-running the first signature reuses the FIRST executable,
-        # which still holds the original value.
-        again = model.run(save_interval=0.5, total_time=0.5)
+        # Re-running the first forcing reuses the FIRST executable, which
+        # still holds the original value.
+        again = model.run(forcing=fixed_co2, save_interval=0.5,
+                          total_time=0.5)
         self.assertEqual(again.params[key], original)
+
+    def test_traced_parameter_records_are_bounded(self):
+        # A model that keeps meeting new input shapes retraces
+        # indefinitely, and jax.clear_caches() cannot reach this dict, so
+        # an unbounded store would grow for the model's lifetime.
+        from jcm import model as model_module
+        from jcm.model import Model
+
+        cap = model_module._MAX_TRACED_PARAM_RECORDS
+        model = Model.__new__(Model)
+        model._traced_params = {}
+        for trace_id in range(cap + 5):
+            model._remember_traced_params(trace_id, {"a.b.c": trace_id})
+
+        self.assertEqual(len(model._traced_params), cap)
+        # The oldest go, the newest stay: a record is never replaced by a
+        # different executable's values, only by nothing.
+        self.assertNotIn(0, model._traced_params)
+        self.assertEqual(model._traced_params[cap + 4], {"a.b.c": cap + 4})
 
     def test_capture_failure_never_breaks_a_completed_run(self):
         class _Exploding:

--- a/jcm/provenance_test.py
+++ b/jcm/provenance_test.py
@@ -1,4 +1,5 @@
 """Tests for run provenance capture (#591)."""
+import dataclasses
 import hashlib
 import json
 import os
@@ -154,6 +155,300 @@ class ResolveDataPathRecordsTest(unittest.TestCase):
         provenance.start_run()
         _resolve_data_path("auto")
         self.assertEqual(provenance.collect()["inputs"], {})
+
+
+@dataclasses.dataclass
+class _FakeDiffusion:
+    """Stands in for a DiffusionFilter: all-scalar, so it is a knob."""
+
+    timescale: int = 43200
+    order: int = 2
+    level_orders: None = None
+
+
+@dataclasses.dataclass
+class _FakeCoords:
+    """Stands in for a CoordinateSystem: carries grid arrays, not knobs."""
+
+    latitudes: object = None
+    layers: int = 8
+
+
+class _FakeDycore:
+    def __init__(self, constants=None):
+        import numpy as np
+        self.dt_seconds = 900.0
+        self.compute_omega = True
+        self.diffusion = _FakeDiffusion()
+        self._sl_options = {"interpolation_order": "cubic",
+                            "off_centering": 0.5}
+        self.coords = _FakeCoords(latitudes=np.linspace(-90, 90, 32))
+        self.orography = np.zeros((32, 16))
+        self.step_fn = lambda s: s
+        if constants is not None:
+            self.constants = constants
+
+
+class DescribeLeafTest(unittest.TestCase):
+    def test_scalars_pass_through(self):
+        self.assertIsNone(provenance._describe_leaf(None))
+        self.assertIs(provenance._describe_leaf(True), True)
+        self.assertEqual(provenance._describe_leaf("cubic"), "cubic")
+
+    def test_array_by_value_under_the_cap_and_hashed_over_it(self):
+        import jax.numpy as jnp
+
+        small = provenance._describe_leaf(jnp.arange(5.0))
+        self.assertEqual(small, [0.0, 1.0, 2.0, 3.0, 4.0])
+        n = provenance._PARAM_ARRAY_MAX_ELEMS + 1
+        big = provenance._describe_leaf(jnp.arange(float(n)))
+        self.assertEqual(big["shape"], [n])
+        self.assertEqual(big["dtype"], "float32")
+        # The hash has to separate one weight set from another, or a
+        # summarized parameter is no record at all.
+        other = provenance._describe_leaf(jnp.arange(float(n)) + 1.0)
+        self.assertNotEqual(big["sha256"], other["sha256"])
+
+    def test_scalar_keeps_the_value_the_model_held(self):
+        import jax.numpy as jnp
+
+        # float32 0.1 is not 0.1; record what ran, not a prettier rounding.
+        self.assertEqual(provenance._describe_leaf(jnp.float32(0.1)),
+                         0.10000000149011612)
+
+    def test_tracer_is_marked_not_forced(self):
+        import jax
+        import jax.numpy as jnp
+
+        seen = []
+
+        def f(x):
+            seen.append(provenance._describe_leaf(x))
+            return x * 2
+
+        jax.jit(f)(jnp.float32(1.0))
+        self.assertEqual(seen, ["<traced>"])
+
+
+class DescribePhysicsParamsTest(unittest.TestCase):
+    """The gap: values that live in code, not in the config."""
+
+    def setUp(self):
+        from jcm.physics.speedy.speedy_terms import speedy_physics
+        self.params = provenance.describe_params(speedy_physics())["physics"]
+
+    def test_scheme_defaults_are_recorded_not_just_overrides(self):
+        from jcm.physics.speedy.speedy_terms import ConvectionParameters
+
+        # Nothing overrode this, so it is exactly the case the composed
+        # Hydra config cannot describe: the value is Parameters.default().
+        key = "speedy_convection.params.entmax"
+        self.assertIn(key, self.params)
+        self.assertAlmostEqual(
+            self.params[key],
+            float(ConvectionParameters.default().entmax), places=12)
+
+    def test_keys_locate_the_value_term_variable_field(self):
+        # A recorded key must say where the value lives, unambiguously:
+        # <term name>.<nnx variable>.<field>. Note this is NOT always the
+        # Hydra override path — Hydra addresses the constructor keyword,
+        # and SpeedyConvection takes convection_params= but stores it as
+        # `params`. The record names the variable, not the keyword.
+        for key in self.params:
+            self.assertRegex(key, r"^[a-z0-9_#]+\.[a-z0-9_]+\.")
+
+    def test_variables_not_named_params_are_captured(self):
+        # Keying on nnx.Param rather than a `.params` attribute is the
+        # point: these two hang off differently-named variables and a
+        # `.params`-only walk would silently drop them.
+        self.assertIn("speedy_shortwave_radiation.sw_params.albcl",
+                      self.params)
+        self.assertIn("speedy_upward_longwave.mod_radcon_params.emisfc",
+                      self.params)
+
+    def test_physics_without_params_yields_no_block(self):
+        from jcm.physics.held_suarez.held_suarez_physics import (
+            held_suarez_physics,
+        )
+        self.assertNotIn("physics",
+                         provenance.describe_params(held_suarez_physics()))
+
+    def test_no_physics_is_not_an_error(self):
+        self.assertNotIn("physics", provenance.describe_params(None))
+
+
+class DescribeDycoreParamsTest(unittest.TestCase):
+    def setUp(self):
+        self.params = provenance.describe_params(
+            dycore=_FakeDycore())["dycore"]
+
+    def test_scalar_knobs_and_all_scalar_containers_kept(self):
+        self.assertEqual(self.params["dt_seconds"], 900.0)
+        self.assertIs(self.params["compute_omega"], True)
+        self.assertEqual(self.params["diffusion.timescale"], 43200)
+        self.assertIsNone(self.params["diffusion.level_orders"])
+        # Private, but as much a knob as dt_seconds.
+        self.assertEqual(self.params["_sl_options.interpolation_order"],
+                         "cubic")
+
+    def test_grid_data_and_callables_dropped(self):
+        # coords/terrain carry arrays: grid data, not knobs. They must be
+        # rejected on the array *without* being pulled off the device.
+        for key in self.params:
+            self.assertFalse(key.startswith("coords"), key)
+            self.assertNotEqual(key, "orography")
+            self.assertNotEqual(key, "step_fn")
+
+
+class DescribeConstantsTest(unittest.TestCase):
+    def test_live_constants_recorded(self):
+        import jcm.constants as c
+
+        params = provenance.describe_params()["constants"]
+        self.assertEqual(params["constants.grav"], c.physical_constants.grav)
+
+    def test_dycore_divergence_is_surfaced(self):
+        # jcm.constants is live for attribute-access physics but captured
+        # at construction by the dycore, so an override applied after the
+        # model was built leaves the two genuinely disagreeing. Recording
+        # only the live values would hide exactly that.
+        import jcm.constants as c
+
+        stale = c.physical_constants._replace(grav=1.62)
+        params = provenance.describe_params(
+            dycore=_FakeDycore(constants=stale))["constants"]
+        self.assertEqual(params["constants_dycore.grav"], 1.62)
+        self.assertEqual(params["constants.grav"],
+                         c.physical_constants.grav)
+        # Only the differing fields are repeated.
+        self.assertNotIn("constants_dycore.cpd", params)
+
+    def test_agreeing_constants_are_not_duplicated(self):
+        import jcm.constants as c
+
+        params = provenance.describe_params(
+            dycore=_FakeDycore(constants=c.physical_constants))["constants"]
+        self.assertFalse([k for k in params
+                          if k.startswith("constants_dycore")])
+
+
+class ParamsAttrsTest(unittest.TestCase):
+    def test_empty_record_stamps_nothing(self):
+        self.assertEqual(provenance.params_attrs({}), {})
+        self.assertEqual(provenance.params_attrs(None), {})
+
+    def test_values_and_hash_are_netcdf_safe_strings(self):
+        attrs = provenance.params_attrs({"physics": {"a.b.c": 1.0}})
+        for key, value in attrs.items():
+            self.assertTrue(key.startswith("jcm_prov_"), key)
+            self.assertIsInstance(value, str)
+        self.assertRegex(attrs["jcm_prov_params_sha"], r"^[0-9a-f]{12}$")
+        self.assertEqual(
+            json.loads(attrs["jcm_prov_params"])["physics"]["a.b.c"], 1.0)
+
+    def test_oversized_record_keeps_its_hash_and_points_at_the_sidecar(self):
+        huge = {"physics": {f"term.params.p{i}": float(i)
+                            for i in range(20000)}}
+        attrs = provenance.params_attrs(huge)
+        self.assertRegex(attrs["jcm_prov_params_sha"], r"^[0-9a-f]{12}$")
+        self.assertIn("sidecar", attrs["jcm_prov_params"])
+
+    def test_run_hash_separates_parameter_sweep_members(self):
+        # Same code, same config, same inputs: without the parameters in
+        # the hash every member of a sweep would share one run_hash.
+        provenance.start_run()
+        a = provenance.attrs({"physics": {"t.params.entrpen": 1e-4}})
+        b = provenance.attrs({"physics": {"t.params.entrpen": 4e-4}})
+        self.assertNotEqual(a["jcm_prov_run_hash"], b["jcm_prov_run_hash"])
+
+    def test_sidecar_and_attrs_agree_on_the_run_hash(self):
+        params = {"physics": {"t.params.entrpen": 1e-4}}
+        provenance.start_run()
+        attrs = provenance.attrs(params)
+        with tempfile.TemporaryDirectory() as d:
+            sidecar = provenance.write_sidecar(Path(d) / "out.nc", params)
+            full = json.loads(sidecar.read_text())
+        self.assertEqual(full["run_hash"], attrs["jcm_prov_run_hash"])
+        self.assertEqual(full["params"], params)
+
+
+class ModelPredictionsCaptureTest(unittest.TestCase):
+    """Capture happens at the model-to-user handoff, once, eagerly."""
+
+    def _physics(self):
+        from jcm.physics.speedy.speedy_terms import speedy_physics
+        return speedy_physics()
+
+    def _preds(self, physics, dycore=None):
+        from jcm.predictions import ModelPredictions
+        return ModelPredictions(None, None, physics, dycore=dycore)
+
+    def test_parameters_recorded_on_the_predictions(self):
+        preds = self._preds(self._physics(), _FakeDycore())
+        self.assertIn("speedy_convection.params.entmax",
+                      preds.params["physics"])
+        self.assertEqual(preds.params["dycore"]["dt_seconds"], 900.0)
+
+    def test_snapshot_does_not_follow_later_mutation(self):
+        # A calibration loop updates the term parameters in place between
+        # iterations. A lazily-read record would report the *next*
+        # iteration's values against this iteration's trajectory, which is
+        # the failure this capture point exists to prevent.
+        import jax.numpy as jnp
+
+        physics = self._physics()
+        preds = self._preds(physics)
+        before = preds.params["physics"]["speedy_convection.params.entmax"]
+
+        term = next(t for t in physics.terms if t.name == "speedy_convection")
+        current = term.params.get_value()
+        term.params.set_value(current.replace(entmax=jnp.array(0.25)))
+
+        after = self._preds(physics).params[
+            "physics"]["speedy_convection.params.entmax"]
+        self.assertNotAlmostEqual(before, after, places=6)
+        self.assertEqual(
+            preds.params["physics"]["speedy_convection.params.entmax"],
+            before)
+
+    def test_capture_failure_never_breaks_a_completed_run(self):
+        class _Exploding:
+            @property
+            def terms(self):
+                raise RuntimeError("boom")
+
+        with self.assertLogs("jcm.predictions", level="WARNING"):
+            preds = self._preds(_Exploding())
+        self.assertEqual(preds.params, {})
+
+    def test_to_xarray_stamps_without_the_hydra_runners(self):
+        # model.run(...).to_xarray().to_netcdf(...) never goes near the
+        # runners, and is exactly how an interactive user writes a file.
+        import xarray as xr
+
+        from jcm.predictions import ModelPredictions
+
+        class _Preds(ModelPredictions):
+            def _trajectory_dataset(self):
+                return xr.Dataset({"t": ("x", [1.0])})
+
+        ds = _Preds(None, None, self._physics()).to_xarray()
+        recorded = json.loads(ds.attrs["jcm_prov_params"])
+        self.assertIn("speedy_convection.params.entmax",
+                      recorded["physics"])
+
+    def test_pytree_roundtrip_carries_no_model_and_says_so(self):
+        import jax
+
+        from jcm.predictions import ModelPredictions
+
+        preds = ModelPredictions(None, None, self._physics())
+        self.assertTrue(preds.params)
+        # Unflattening rebuilds without coords/physics by design, so there
+        # is no model to read parameters off.
+        rebuilt = jax.tree_util.tree_unflatten(
+            *reversed(jax.tree_util.tree_flatten(preds)))
+        self.assertEqual(rebuilt.params, {})
 
 
 if __name__ == "__main__":

--- a/jcm/provenance_test.py
+++ b/jcm/provenance_test.py
@@ -7,6 +7,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import pytest
+
 from jcm import provenance
 
 
@@ -214,11 +216,16 @@ class DescribeLeafTest(unittest.TestCase):
         import jax.numpy as jnp
 
         small = provenance._describe_leaf(jnp.arange(5.0))
-        self.assertEqual(small, [0.0, 1.0, 2.0, 3.0, 4.0])
+        self.assertEqual(small["values"], [0.0, 1.0, 2.0, 3.0, 4.0])
+        # Shape and dtype ride along with the values, so a (2, 3) is not
+        # confusable with a (3, 2), nor float32 with float64.
+        self.assertEqual(small["shape"], [5])
+        self.assertEqual(small["dtype"], "float32")
         n = provenance._PARAM_ARRAY_MAX_ELEMS + 1
         big = provenance._describe_leaf(jnp.arange(float(n)))
         self.assertEqual(big["shape"], [n])
         self.assertEqual(big["dtype"], "float32")
+        self.assertNotIn("values", big)
         # The hash has to separate one weight set from another, or a
         # summarized parameter is no record at all.
         other = provenance._describe_leaf(jnp.arange(float(n)) + 1.0)
@@ -521,7 +528,9 @@ class DescribePhysicsParamsTest(unittest.TestCase):
             terms = [Macv2SpAerosol()]
 
         params = provenance.describe_params(_One())["physics"]
-        self.assertIsInstance(params["macv2_sp_aerosol.params.theta"], list)
+        theta = params["macv2_sp_aerosol.params.theta"]
+        self.assertIn("values", theta)
+        self.assertEqual(theta["shape"], [2, 9])
 
     def test_physics_without_variables_yields_no_block(self):
         # No composition and no state at all. Note an *empty composition*
@@ -795,6 +804,42 @@ class ModelPredictionsCaptureTest(unittest.TestCase):
         preds = ModelPredictions(None, None, physics, params=traced)
         self.assertEqual(preds.params, traced)
         self.assertNotIn("live_parameters_differ_from_compiled", preds.params)
+
+    @pytest.mark.slow
+    def test_each_executable_keeps_its_own_traced_record(self):
+        """One static signature can own several compiled executables.
+
+        Keying the store on the static arguments let a later trace
+        overwrite an earlier executable's record, so re-running the first
+        one reported the second's parameters (#733 review). The record is
+        keyed by a trace id the executable itself carries back, so a cache
+        hit returns the id of the executable that actually ran.
+        """
+        import jax.numpy as jnp
+
+        from jcm.model import Model
+        from jcm.physics.speedy.speedy_coords import get_speedy_coords
+
+        key = "speedy_vertical_diffusion.params.trvdi"
+        model = Model(coords=get_speedy_coords(layers=8,
+                                               spectral_truncation=21),
+                      physics=self._physics(), time_step=30.0)
+
+        first = model.run(save_interval=0.5, total_time=0.5)
+        original = first.params["physics"][key]
+
+        term = next(t for t in model.physics.terms
+                    if t.name == "speedy_vertical_diffusion")
+        term.params.set_value(
+            term.params.get_value().replace(trvdi=jnp.array(2.0)))
+        # A different static signature, so this really is a second trace.
+        second = model.run(save_interval=0.25, total_time=0.5)
+        self.assertEqual(second.params["physics"][key], 2.0)
+
+        # Re-running the first signature reuses the FIRST executable,
+        # which still holds the original value.
+        again = model.run(save_interval=0.5, total_time=0.5)
+        self.assertEqual(again.params["physics"][key], original)
 
     def test_capture_failure_never_breaks_a_completed_run(self):
         class _Exploding:

--- a/jcm/runners.py
+++ b/jcm/runners.py
@@ -2096,16 +2096,21 @@ def run_chunked(
                       "down to that floor (run float64 to verify further).")
 
         nc_path = f"{output_prefix}_day{int(elapsed_sim_days)}.nc"
-        ds.attrs.update(provenance.attrs())
+        # The parameters ride on the predictions object, not the module
+        # registry, so the record belongs to the model that produced THIS
+        # chunk; pass them to both calls or the sidecar's run_hash will not
+        # match the one in the attributes.
+        params = getattr(preds, "params", None)
+        ds.attrs.update(provenance.attrs(params))
         ds.attrs["jcm_prov_chunk_wall_seconds"] = round(chunk_wall, 1)
         ds.to_netcdf(nc_path)
-        provenance.write_sidecar(nc_path)
+        provenance.write_sidecar(nc_path, params)
         print(f"  Saved {nc_path}")
         snap_ds = getattr(preds, "snapshot_dataset", lambda: None)()
         if snap_ds is not None:
             snap_path = (f"{output_prefix}_day{int(elapsed_sim_days)}"
                          "_snapshots.nc")
-            snap_ds.attrs.update(provenance.attrs())
+            snap_ds.attrs.update(provenance.attrs(params))
             snap_ds.to_netcdf(snap_path)
             print(f"  Saved {snap_path}")
 
@@ -2198,10 +2203,11 @@ def save_predictions(predictions, output_path: Path) -> None:
             "aggregate save_predictions for %s", output_path,
         )
         return
+    params = getattr(predictions, "params", None)
     ds = predictions.to_xarray()
-    ds.attrs.update(provenance.attrs())
+    ds.attrs.update(provenance.attrs(params))
     ds.to_netcdf(str(output_path))
-    provenance.write_sidecar(output_path)
+    provenance.write_sidecar(output_path, params)
     logger.info("Wrote %s", output_path)
     # Interval-instantaneous snapshot stream (jax-gcm#586): a separate
     # file with its own (finer) time axis — folding a second cadence into
@@ -2209,6 +2215,6 @@ def save_predictions(predictions, output_path: Path) -> None:
     snap_ds = getattr(predictions, "snapshot_dataset", lambda: None)()
     if snap_ds is not None:
         snap_path = output_path.with_name(output_path.stem + "_snapshots.nc")
-        snap_ds.attrs.update(provenance.attrs())
+        snap_ds.attrs.update(provenance.attrs(params))
         snap_ds.to_netcdf(str(snap_path))
         logger.info("Wrote %s", snap_path)


### PR DESCRIPTION
## What

`#591` stamps code SHAs, precision, inputs, the ozone source and the fully composed
Hydra config into every output. It does not record **the parameters the model actually
ran with**, and the config is not a substitute for them. This adds
`provenance.describe_params`, which reads the *built* model instead.

Every output now carries `jcm_prov_params` (+ `jcm_prov_params_sha`) with three blocks
of flat dotted keys:

| block | contents |
|---|---|
| `physics` | every `nnx.Param` on every term, e.g. `tiedtke_convection.params.entrpen` |
| `dycore` | scalar backend knobs: `dt_seconds`, `diffusion.*`, `compute_*`, `_sl_options.*` |
| `constants` | the live `PhysicalConstants`, plus the dycore's where they differ |

Measured on the written files: 6.6 KB for T31L8 SPEEDY, ~13 KB for T21L8 ECHAM
(`rrtmgp` + `2m`), well under the 64 KB attribute cap. The sidecar carries the record
unconditionally, so an over-cap configuration still has the values somewhere.

## Why the config could not do this

Three separate reasons, each independently sufficient:

1. **Scheme defaults live in code.** `jcm/config/physics/echam.yaml` says so outright:
   `params` is *intentionally* absent so unspecified fields fall back to
   `Parameters.default()`. A stock ECHAM run stamped no `entrpen`, `cprcon` or `ccraut`
   at all. Recovering them meant checking out the recorded SHA and reading the source,
   and a dirty tree only gives you `dirty_diff_sha`, not the diff.
2. **A pre-built model bypasses provenance entirely.** `runners.run(cfg, model=None)`
   accepts a caller-built `Model`, so a calibration driver or a notebook got a sidecar
   describing a config that did not build the model that ran.
3. **`set_constants` called directly** (rather than via `cfg.constants`) left no trace.

## Decisions worth second-guessing

**Capture point: `ModelPredictions.__init__`, eagerly.** This is the model-to-user
handoff and the last moment the values are still the ones that produced the trajectory.
It has to be eager: a calibration loop replaces term parameters in place between
iterations, so a lazy read through `self._physics` would report the *next* iteration's
values against *this* iteration's data. There is a test for exactly that.

**The record travels on the predictions object, not this module's registry.** Two models
in one process would otherwise overwrite each other, and the process that writes a file
need not be the one that ran last. Cost: `save_predictions` / `run_chunked` now pass
`params` to *both* `attrs()` and `write_sidecar()`, or the two `run_hash` values
disagree.

**Keyed on `nnx.Param`, not on a `.params` attribute.** Terms also carry
`mod_radcon_params`, `sw_params`, `surface_optics` and bare tuning scalars; a
`.params`-only walk drops those silently, and a scheme that adds a new variable must not
fall out of the record.

**Walked with `dataclasses.fields`, not `tree_flatten_with_path`.** The `tree_math`
structs these blocks use register as pytrees *without* key paths, so flattening yields
`[<flat index 3>]` where the field name is the entire point.

**The dycore rule is structural.** It has no `nnx.Param` to key on, so: instance
attributes that are scalars, or containers built purely from scalars. That keeps
`dt_seconds`, the `DiffusionFilter` timescales/orders and the SL options, and drops
`coords` / `terrain`, whose arrays are grid data rather than knobs. The all-scalar screen
runs *before* description so those are rejected on their first array rather than being
pulled off the device.

**Alternative rejected:** adding a `provenance_params()` method to the `DynamicalCore`
protocol. Cleaner in principle, but it needs an implementation in three backends and an
implementer who forgets it produces a silently empty record — the same failure mode this
PR exists to fix.

## Behaviour change

**`jcm_prov_run_hash` values change**, because parameters are folded into the hash. They
have to be: every member of a parameter sweep shares one code state, config and input
set, so a sweep previously produced a *single* run hash for every member.

## Caveat on key names

A recorded key names the **nnx variable**, which equals the Hydra override path minus
`physics.terms.` only where a term's constructor keyword matches its stored variable. The
ECHAM terms match; the SPEEDY ones do not — `SpeedyConvection` takes
`convection_params=` and stores `params`, so the override is
`...speedy_convection.convection_params.entmax` while the record says
`...speedy_convection.params.entmax`. The record names where the value *lives*, which is
what must be unambiguous; reproducing it may need the constructor signature. Documented
in the function docstring, the release note and a test comment.

## Verified

- Driven end-to-end through `python -m jcm.main` (T31L8 SPEEDY, `run=smoke`), not just
  unit tests: netCDF attrs and the `.provenance.json` sidecar agree on `run_hash`, and
  the record holds the scheme defaults the config never mentioned.
- Re-run with `+physics.terms.speedy_convection.convection_params.entmax=0.4`:
  `speedy_convection.params.entmax` is the **only** differing key, and both
  `params_sha` and `run_hash` change.
- Round-trip under `jax.jit`: parameters read `"<traced>"` rather than raising.
- `ruff check .` clean.
- `jcm/provenance.py` at 92% under its own test file.

### Two local-gate artifacts, both reproduced on the unmodified base

I ran each of these on base commit `7762b53` as well, so neither is this PR:

- **`rrtmgp_test.py`, one flaky failure under `-n 12` + `--cov`**, a *different* test each
  run: baseline failed `TestRRTMGPVerticalOrientation::test_low_level_lw_aerosol_acts_low_not_at_top`,
  this branch failed `TestRRTMGPAerosolFree::test_paired_carries_the_fraction_across_a_step`.
  Both pass in isolation. Looks like #729 (the `mam4_jax` x64 leak).
- **`pyses_dycore_test.py::TestCoupledEchamSmoke::test_model_drives_coupled_run` fails
  under `-n 4`** on the slow gate — identically on base and on this branch (85 passed /
  24 skipped both times). The whole pySES file passes **single-process** on this branch
  (17 passed), which is how CI runs the slow gate, so this looks like `-n 4` resource
  contention on this box rather than something CI will see.

Coverage totals are also unreliable here: 27% on the branch *and* on the unmodified
baseline, because the xdist workers are not combining. The per-file number above was
measured single-process, where instrumentation works. CI's number is the one to trust.


Closes #732
