### PR TITLE
Prescribed/SCM state loading: the tracers the physics declares, and an orientation that is checked

### DIFF
--- a/docs/source/design/output_vertical_conventions.md
+++ b/docs/source/design/output_vertical_conventions.md
@@ -102,6 +102,41 @@ vertical-coordinate neighbourhood carry their own units and standard names via
 `PhysicsTerm.output_attrs`, declared next to the code that computes them
 ([#740]).
 
+### Detection is inferred, so it is also checked
+
+The `level` coordinate is *evidence* of orientation, not proof: a file whose
+`level` is a bare integer index (a pre-#710 product, or a Dataset assembled by
+hand) carries no orientation at all, and the loader then has to assume
+top-first. So the inference is checked against the file's own pressures
+([#718]): after conversion, `pressure_full` must increase with index, and its
+surface entry must be within a factor of two of the surface pressure the state
+itself carries. Either check failing raises rather than handing physics a
+column whose temperature belongs to one level and whose pressure belongs to
+another. Files with no `pressure_full` — a trimmed restart such as
+`spinup_state.nc` — fall back to the `level` inference alone.
+
+The factor of two is deliberately loose: the lowest full level sits within a
+percent or so of the surface, while an inverted column misses by the ratio of
+surface to model-top pressure, four or five orders of magnitude. This is a
+wrong-orientation detector, not a check on the vertical grid.
+
+### Tracers come from the physics, not from the file
+
+The loader cannot tell a prognostic tracer from a diagnostic — both are
+ordinary level-dimensioned variables — so it does not guess. With
+`run.tracer_vars` unset, the names come from the configured physics'
+`required_tracers()`, and every declared tracer the file actually carries is
+loaded; anything declared but absent is warned about. Reading the declarations
+rather than matching a hardcoded `qc`/`qi` list is what makes this work for
+the two-moment scheme (`qnc`/`qni`) and for JAM's per-species tracers.
+
+This was the second half of [#718]: `run.mode=prescribed` dropped a saved
+state's condensate unless every variable was named by hand, so radiation ran
+against a clear sky and returned plausible, wrong fluxes — a global-mean
+surface downward longwave of 95.6 W/m² against an expected ~340, with no error
+and no NaN. An explicit `tracer_vars` mapping still wins outright, and `{}`
+loads nothing.
+
 ## Reading pre-#710 files
 
 Output written before this change has `level_i` as a bare integer index with
@@ -110,6 +145,7 @@ no attributes, and interface variables stored TOA-first. The presence of
 interface variables reversed before being paired with anything on `level`.
 
 [#710]: https://github.com/climate-analytics-lab/jax-gcm/issues/710
+[#718]: https://github.com/climate-analytics-lab/jax-gcm/issues/718
 [#739]: https://github.com/climate-analytics-lab/jax-gcm/issues/739
 [#740]: https://github.com/climate-analytics-lab/jax-gcm/issues/740
 [#741]: https://github.com/climate-analytics-lab/jax-gcm/issues/741

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -49,6 +49,15 @@ module or directly::
    python -m jcm.main run.mode=scm run.state_file=path/to/state.nc \
        run.column.lat_deg=0 run.column.lon_deg=180
 
+The state-file modes (``run.mode=scm`` and ``run.mode=prescribed``) read a
+netCDF written by an earlier run. Both the vertical orientation and the tracer
+list are handled for you: output files are surface-first and are flipped into
+the top-first physics frame on load, and with ``run.tracer_vars`` unset (the
+default) every tracer the configured physics declares — ``qc``/``qi`` for the
+one-moment cloud scheme, plus ``qnc``/``qni`` for the two-moment one — is
+loaded from the file when it carries it. Pass an explicit mapping to rename
+variables, or ``run.tracer_vars={}`` to load none.
+
 Inspect the available config groups and the fully-composed config::
 
    python -m jcm.main --help                                   # config-group choices

--- a/jcm/cf_metadata.py
+++ b/jcm/cf_metadata.py
@@ -61,6 +61,11 @@ HYBRID_B_FULL = "hybrid_b_full"
 HYBRID_A_HALF = "hybrid_a_half"
 HYBRID_B_HALF = "hybrid_b_half"
 
+#: Name of the full-level pressure diagnostic. Named here because readers use
+#: it to *verify* a file's vertical orientation independently of the ``level``
+#: coordinate — see :func:`jcm.utils.load_states_from_xarray` (#718).
+PRESSURE_FULL = "pressure_full"
+
 _SIGMA_COMMON_ATTRS = {
     "units": "1",
     "positive": "down",
@@ -86,7 +91,7 @@ _PARAMETRIC_SIGMA_STANDARD_NAME = "atmosphere_hybrid_sigma_pressure_coordinate"
 #: :attr:`jcm.physics.physics_term.PhysicsTerm.output_attrs` (#740); a variable
 #: absent from every source simply carries whatever attrs it already had.
 _VARIABLE_ATTRS: dict[str, dict[str, str]] = {
-    "pressure_full": {
+    PRESSURE_FULL: {
         "standard_name": "air_pressure",
         "units": "Pa",
         "long_name": "air pressure at layer mid-level",

--- a/jcm/config/run/default.yaml
+++ b/jcm/config/run/default.yaml
@@ -56,8 +56,16 @@ mode: full
 state_file: null
 
 # Tracer variables to load from the state file (mapping tracer name →
-# variable name). Defaults to none; set e.g. ``{qc: qc, qi: qi}`` for the
-# ICON 1-moment scheme.
+# variable name), for ``mode`` ``prescribed`` / ``scm``.
+#
+# ``null`` (the default) means AUTO: every tracer the configured physics
+# declares via ``required_tracers()`` is loaded from the identically-named
+# variable when the file has one. That is what keeps a saved state's cloud
+# condensate from being silently dropped — radiation driven on a state whose
+# ``qc``/``qi`` went missing returns a plausible-looking clear sky (#718).
+#
+# Set an explicit mapping (e.g. ``{qc: qc, qi: qi}``) to override the names,
+# or ``{}`` to deliberately load no tracers at all.
 tracer_vars: null
 
 # Column location for ``mode: scm`` (degrees).

--- a/jcm/data/test/echam_t63l47/generate_default_stats.py
+++ b/jcm/data/test/echam_t63l47/generate_default_stats.py
@@ -92,11 +92,17 @@ def _block_until_ready(predictions):
     return predictions
 
 
-def _load_spinup_state():
+def _load_spinup_state(physics):
     """Load the saved spun-up nodal PhysicsState as the initial condition.
 
     Returns the state in the top-first physics frame the model expects;
     ``load_states_from_xarray`` handles the file's on-disk orientation.
+
+    ``physics`` supplies the tracer list: the loader picks up whatever
+    ``required_tracers()`` declares and the file carries, so the spun-up
+    ``qc``/``qi`` arrive rather than starting the run from a clear sky
+    (#718). This used to be a local ``qc``/``qi`` scan here, which left every
+    other caller — and every other tracer — unprotected.
     """
     import xarray as xr
     from jcm.utils import load_states_from_xarray
@@ -109,12 +115,8 @@ def _load_spinup_state():
             "on a GPU to create it."
         )
     ds = xr.open_dataset(spinup_path)
-    tracer_vars = {}
-    for tname in ("qc", "qi"):
-        if tname in ds.data_vars:
-            tracer_vars[tname] = tname
     return load_states_from_xarray(
-        ds, tracer_vars=tracer_vars or None,
+        ds, required_tracers=physics.required_tracers(),
     )
 
 
@@ -152,7 +154,7 @@ def run_default_echam_t63l47_model(save_interval=1.0, total_time=5.0):
     model = Model(
         coords=coords, terrain=terrain, physics=physics, time_step=12,
     )
-    initial_state = _load_spinup_state()
+    initial_state = _load_spinup_state(physics)
 
     predictions = model.run(
         initial_state=initial_state,

--- a/jcm/runners.py
+++ b/jcm/runners.py
@@ -1766,13 +1766,22 @@ def _run_full(cfg: DictConfig, model: Model | None = None) -> ModelPredictions:
     raise ValueError(f"Unknown init.kind={cfg.init.kind!r}")
 
 
-def _load_states_from_cfg(cfg: DictConfig):
+def _load_states_from_cfg(cfg: DictConfig, physics):
     """Open ``cfg.run.state_file`` and return a stacked ``PhysicsState``.
 
     ``state_file`` is a netCDF from a previous JCM run, i.e. surface-first;
     ``load_states_from_xarray`` detects that and returns a top-first
     physics-frame state (#741), which is what the SCM / prescribed-state
-    runners expect.
+    runners expect, and rejects a file whose orientation disagrees with its
+    own pressures rather than handing physics an inverted column (#718).
+
+    ``physics`` is the configured package (``None`` for a caller that has
+    none). Which tracers to load comes from it: with ``run.tracer_vars``
+    unset, every tracer the physics declares via ``required_tracers()`` and
+    that the file actually carries is loaded. Without that the condensate a
+    saved state holds was silently dropped, so cloud-aware physics ran
+    against a clear sky — the second half of #718. ``run.tracer_vars: {}``
+    opts out explicitly; an explicit mapping still wins outright.
     """
     state_file = _resolve_data_path(cfg.run.get("state_file", None))
     if not state_file:
@@ -1786,9 +1795,16 @@ def _load_states_from_cfg(cfg: DictConfig):
 
     tracer_vars = cfg.run.get("tracer_vars", None)
     if tracer_vars is not None:
+        # Keep an explicit empty mapping distinct from ``null``: the former
+        # means "no tracers", the latter "take them from the physics".
         tracer_vars = OmegaConf.to_container(tracer_vars, resolve=True)
     ds = xr.open_dataset(state_file)
-    return ds, load_states_from_xarray(ds, tracer_vars=tracer_vars or None)
+    return ds, load_states_from_xarray(
+        ds,
+        tracer_vars=tracer_vars,
+        required_tracers=(
+            physics.required_tracers() if physics is not None else None),
+    )
 
 
 def _run_prescribed(cfg: DictConfig):
@@ -1799,7 +1815,7 @@ def _run_prescribed(cfg: DictConfig):
     physics = build_physics(cfg)
     terrain = build_terrain(cfg, coords)
     forcing = build_forcing(cfg, coords)
-    _, states = _load_states_from_cfg(cfg)
+    _, states = _load_states_from_cfg(cfg, physics)
 
     model = PrescribedStateModel(
         physics=physics,
@@ -1852,7 +1868,7 @@ def _run_scm(cfg: DictConfig):
     physics = build_physics(cfg)
     # Build coords just to grab the vertical coord; horizontal grid is unused.
     coords = build_coords(cfg)
-    ds, states = _load_states_from_cfg(cfg)
+    ds, states = _load_states_from_cfg(cfg, physics)
     column_states, (i_lon, i_lat, actual_lat, actual_lon) = _select_column(
         states, ds, lat_deg=lat_deg, lon_deg=lon_deg,
     )

--- a/jcm/runners_test.py
+++ b/jcm/runners_test.py
@@ -1108,7 +1108,7 @@ class TestRunDispatchErrorPaths(unittest.TestCase):
         cfg = _compose(["physics=held_suarez", "grid=held_suarez_t31_l8"])
         cfg.run.mode = "prescribed"
         with self.assertRaisesRegex(ValueError, "state_file"):
-            _load_states_from_cfg(cfg)
+            _load_states_from_cfg(cfg, None)
 
     def test_scm_mode_requires_column(self):
         from jcm.runners import _run_scm
@@ -1119,6 +1119,112 @@ class TestRunDispatchErrorPaths(unittest.TestCase):
         cfg.run.column = None
         with self.assertRaisesRegex(ValueError, "run.column"):
             _run_scm(cfg)
+
+
+class TestPrescribedStateTracerLoading(unittest.TestCase):
+    """``prescribed`` / ``scm`` load the tracers the physics declares (#718).
+
+    With ``run.tracer_vars`` unset the condensate a saved state carries used
+    to be dropped, so cloud-aware physics ran against a clear sky and
+    returned plausible, wrong fluxes. The tracer list now comes from the
+    configured physics rather than from the user remembering to write it out.
+    """
+
+    NLEV = 4
+
+    class _StubPhysics:
+        """Stands in for a physics package that declares condensate tracers.
+
+        ``_load_states_from_cfg`` only ever calls ``required_tracers()``, so
+        building a real ECHAM package here would cost seconds to test one
+        line of plumbing.
+        """
+
+        def required_tracers(self):
+            from jcm.physics.physics_term import TracerSpec
+            return (TracerSpec(name="qc"), TracerSpec(name="qi"))
+
+    def _write_state_file(self, path):
+        """Write a minimal JCM-convention state file: surface-first, with qc/qi."""
+        import xarray as xr
+
+        nlev, nlon, nlat = self.NLEV, 3, 2
+        shape = (nlev, nlon, nlat)
+        dims = ("level", "lon", "lat")
+
+        def column(profile):
+            return np.broadcast_to(
+                np.asarray(profile, dtype=float)[:, None, None], shape).copy()
+
+        # Surface-first, as every JCM output file is written: level index 0 is
+        # the surface (sigma ~1, ~1e5 Pa).
+        ds = xr.Dataset(
+            data_vars={
+                "u_wind": (dims, np.zeros(shape)),
+                "v_wind": (dims, np.zeros(shape)),
+                "temperature": (dims, column([288.0, 260.0, 230.0, 200.0])),
+                "specific_humidity": (dims, column([1e-2, 5e-3, 1e-3, 1e-6])),
+                "geopotential": (dims, np.zeros(shape)),
+                "pressure_full": (dims, column([9.9e4, 7e4, 4e4, 1e4])),
+                "qc": (dims, column([2e-4, 1e-4, 0.0, 0.0])),
+                "qi": (dims, column([0.0, 0.0, 3e-5, 1e-5])),
+                "normalized_surface_pressure": (
+                    ("lon", "lat"), np.ones((nlon, nlat))),
+            },
+            coords={"level": np.linspace(0.99, 0.01, nlev)},
+        )
+        ds.to_netcdf(path)
+
+    def _cfg_with_state_file(self, tmpdir):
+        state_file = Path(tmpdir) / "state.nc"
+        self._write_state_file(str(state_file))
+        cfg = _compose(["physics=held_suarez", "grid=held_suarez_t31_l8"])
+        cfg.run.mode = "prescribed"
+        cfg.run.state_file = str(state_file)
+        return cfg
+
+    def test_declared_tracers_are_loaded_when_tracer_vars_is_unset(self):
+        import tempfile
+        from jcm.runners import _load_states_from_cfg
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg = self._cfg_with_state_file(tmpdir)
+            self.assertIsNone(cfg.run.get("tracer_vars", None))
+            _, states = _load_states_from_cfg(cfg, self._StubPhysics())
+
+        self.assertEqual(set(states.tracers), {"qc", "qi"})
+        # Loaded in the top-first physics frame like the rest of the state:
+        # the file's surface value (index 0) ends up last.
+        self.assertAlmostEqual(
+            float(np.asarray(states.tracers["qc"])[-1, 0, 0]), 2e-4)
+
+    def test_explicit_empty_mapping_still_loads_nothing(self):
+        """``tracer_vars: {}`` is the documented opt-out.
+
+        It must stay distinct from ``null`` -- otherwise, now that ``null``
+        means "infer", there is no way to ask for no tracers at all.
+        """
+        import tempfile
+        from jcm.runners import _load_states_from_cfg
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg = self._cfg_with_state_file(tmpdir)
+            cfg.run.tracer_vars = {}
+            _, states = _load_states_from_cfg(cfg, self._StubPhysics())
+
+        self.assertEqual(dict(states.tracers), {})
+
+    def test_physics_without_tracers_loads_none(self):
+        import tempfile
+        from jcm.runners import _load_states_from_cfg
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg = self._cfg_with_state_file(tmpdir)
+            _, states = _load_states_from_cfg(cfg, build_physics(cfg))
+
+        # held_suarez declares no tracers, so nothing is picked up even
+        # though the file carries qc/qi.
+        self.assertEqual(dict(states.tracers), {})
 
 
 class TestOutputPathAndSave(unittest.TestCase):

--- a/jcm/utils.py
+++ b/jcm/utils.py
@@ -464,6 +464,144 @@ def data_to_xarray(
 # Helpers for ``SingleColumnModel`` / ``PrescribedStateModel``
 # ---------------------------------------------------------------------------
 
+def _tracer_names(required_tracers) -> tuple[str, ...]:
+    """Names from ``required_tracers``, which may be specs or bare strings.
+
+    ``ComposablePhysics.required_tracers()`` returns ``TracerSpec`` objects;
+    callers that only know names (a notebook, a test) may pass strings.
+    """
+    return tuple(t if isinstance(t, str) else t.name for t in required_tracers)
+
+
+def _resolve_tracer_vars(ds, tracer_vars, required_tracers) -> dict[str, str]:
+    """Decide which file variables become ``PhysicsState.tracers`` (#718).
+
+    An explicit ``tracer_vars`` mapping always wins — the empty mapping
+    included, which is how a caller says "load no tracers". ``None`` means
+    *infer*, and inference is only possible when the caller declares what it
+    needs: the file alone cannot tell a prognostic tracer from a diagnostic,
+    since both are written as ordinary level-dimensioned variables. So the
+    names come from the configured physics' ``required_tracers()``, and the
+    identically-named variables the file actually carries are picked up.
+
+    Inferring from the physics rather than matching a hardcoded ``qc``/``qi``
+    list is what makes this work for every scheme: the two-moment cloud
+    scheme also needs ``qnc``/``qni``, and JAM declares a tracer per aerosol
+    species. Those declarations already exist; this just reads them.
+
+    Loading nothing when nothing is declared is correct. Loading nothing when
+    the physics *does* declare ``qc``/``qi`` and the file has them is the #718
+    failure — radiation then sees a cloud-free sky and returns plausible,
+    wrong fluxes with no error — so both the pick-up and every drop are
+    logged.
+    """
+    names = _tracer_names(required_tracers or ())
+
+    if tracer_vars is None:
+        resolved = {name: name for name in names if name in ds}
+        if resolved:
+            logging.info(
+                "load_states_from_xarray: loading tracer(s) %s, declared by "
+                "the physics and present in the state file.",
+                ", ".join(resolved),
+            )
+        missing = [name for name in names if name not in resolved]
+        if missing:
+            logging.warning(
+                "load_states_from_xarray: the physics declares tracer(s) %s "
+                "but the state file carries no such variable(s); physics will "
+                "see them as absent (zero).",
+                ", ".join(missing),
+            )
+        return resolved
+
+    dropped = [name for name in names if name not in tracer_vars and name in ds]
+    if dropped:
+        logging.warning(
+            "load_states_from_xarray: tracer(s) %s are declared by the physics "
+            "and present in the state file, but the explicit tracer_vars "
+            "mapping omits them; physics will see them as zero.",
+            ", ".join(dropped),
+        )
+    return dict(tracer_vars)
+
+
+def _check_top_first_pressures(ds, surface_pressure_var: str) -> None:
+    """Verify the converted Dataset really is in the top-first physics frame.
+
+    Orientation is *inferred* from the ``level`` coordinate, and a file whose
+    ``level`` is a bare index carries no orientation at all — so the
+    inference needs an independent check (#718). In the top-first frame
+    ``pressure_full`` must increase with index, and its last (surface) entry
+    must be within a factor of two of the surface pressure the state itself
+    carries. Both hold to within a percent or so for any real hybrid or sigma
+    column — the lowest full level sits just above the surface — while an
+    inverted column misses by the ratio of surface to model-top pressure,
+    four or five orders of magnitude. The factor of two is deliberately far
+    looser than any physical column needs: this is a wrong-orientation
+    detector, not a precision check on the vertical grid.
+
+    Skipped when the file has no ``pressure_full`` (a trimmed restart file
+    holding only the prognostic fields, e.g. ``spinup_state.nc``) or when the
+    sampled column is not finite; those fall back to the ``level``-coordinate
+    inference alone.
+
+    Args:
+      ds: Dataset already converted to the top-first frame.
+      surface_pressure_var: name of the variable holding
+        ``normalized_surface_pressure`` — p_s / p0 by definition of the
+        ``PhysicsState`` field, whatever the file calls it.
+
+    Raises:
+      ValueError: the state is not top-first, so physics would pair each
+        level's fields with another level's pressure.
+
+    """
+    if cf_metadata.PRESSURE_FULL not in ds:
+        return
+
+    from jcm import constants as c
+
+    def _first_column(da):
+        """One column: every non-level dimension reduced to its first index."""
+        return da.isel({
+            dim: 0 for dim in da.dims if dim != cf_metadata.LEVEL_DIM
+        })
+
+    pressure = np.asarray(
+        _first_column(ds[cf_metadata.PRESSURE_FULL]).values, dtype=float)
+    if (pressure.ndim != 1 or pressure.size < 2
+            or not np.all(np.isfinite(pressure))):
+        return
+
+    if not np.all(np.diff(pressure) > 0):
+        raise ValueError(
+            f"{cf_metadata.PRESSURE_FULL!r} does not increase with level index "
+            f"after conversion to the top-first physics frame "
+            f"({pressure[0]:.4g} Pa at index 0, {pressure[-1]:.4g} Pa at the "
+            f"last index). The file's vertical orientation could not be read "
+            f"from its {cf_metadata.LEVEL_DIM!r} coordinate, so physics would "
+            f"be handed each level's fields paired with another level's "
+            f"pressure (#718). Reverse the level axis before loading, or write "
+            f"the file through jcm.cf_metadata.finalize_output."
+        )
+
+    if surface_pressure_var not in ds:
+        return
+    surface_pressure = c.p0 * float(np.asarray(
+        _first_column(ds[surface_pressure_var]).values, dtype=float).ravel()[0])
+    if not np.isfinite(surface_pressure) or surface_pressure <= 0.0:
+        return
+    if not 0.5 < pressure[-1] / surface_pressure < 2.0:
+        raise ValueError(
+            f"the loaded state's surface {cf_metadata.PRESSURE_FULL} "
+            f"({pressure[-1]:.4g} Pa) disagrees with the surface pressure it "
+            f"carries ({surface_pressure:.4g} Pa) by more than a factor of "
+            f"two. The vertical axis is inconsistent with the state's own "
+            f"surface pressure — most likely an inverted column (#718)."
+        )
+
+
 def load_states_from_xarray(
     ds,
     u_wind_var: str = 'u_wind',
@@ -473,6 +611,7 @@ def load_states_from_xarray(
     geopotential_var: str = 'geopotential',
     surface_pressure_var: str = 'normalized_surface_pressure',
     tracer_vars: Mapping[str, str] | None = None,
+    required_tracers=None,
 ):
     """Load a ``PhysicsState`` time series from an xarray ``Dataset``.
 
@@ -491,17 +630,34 @@ def load_states_from_xarray(
     top-first and passes through. If the ``level`` coordinate is absent or
     non-numeric (a bare integer index), orientation cannot be determined; the
     data passes through unflipped, top-first is assumed, and a warning is
-    logged.
+    logged. That inference is then *checked* against the file's own
+    ``pressure_full`` where it has one, and a state that is not top-first is
+    rejected rather than handed to physics (#718).
+
+    Tracers beyond ``specific_humidity`` are resolved from ``tracer_vars`` when
+    given and otherwise inferred from ``required_tracers`` — see
+    :func:`_resolve_tracer_vars`. Passing neither loads no tracers, which for
+    cloud-aware physics means a cloud-free sky, so callers that have a physics
+    object should pass its ``required_tracers()``.
 
     Args:
       ds: Dataset containing the required variables.
       *_var: Variable names in ``ds`` for each ``PhysicsState`` field.
-      tracer_vars: Mapping ``tracer_name → ds_variable_name`` for additional
-        tracers beyond ``specific_humidity``.
+      tracer_vars: Explicit mapping ``tracer_name → ds_variable_name`` for
+        tracers beyond ``specific_humidity``. ``None`` (the default) infers
+        from ``required_tracers``; an empty mapping loads no tracers.
+      required_tracers: What the consuming physics needs — an iterable of
+        ``TracerSpec`` (as ``ComposablePhysics.required_tracers()`` returns)
+        or of bare names. Used only to infer ``tracer_vars`` and to warn about
+        declared tracers the file has but the caller drops.
 
     Returns:
       ``PhysicsState`` whose leading axis is time, in the top-first physics
       frame.
+
+    Raises:
+      ValueError: the Dataset's vertical orientation is inconsistent with its
+        own pressures, so no faithful top-first state can be built.
 
     """
     from jcm.physics_interface import PhysicsState
@@ -532,10 +688,14 @@ def load_states_from_xarray(
             cf_metadata.LEVEL_DIM,
         )
 
-    tracers = {}
-    if tracer_vars:
-        for tracer_name, var_name in tracer_vars.items():
-            tracers[tracer_name] = jnp.asarray(ds[var_name].values)
+    # The orientation above is inferred; this is the independent check on it.
+    _check_top_first_pressures(ds, surface_pressure_var)
+
+    tracers = {
+        tracer_name: jnp.asarray(ds[var_name].values)
+        for tracer_name, var_name
+        in _resolve_tracer_vars(ds, tracer_vars, required_tracers).items()
+    }
 
     return PhysicsState(
         u_wind=jnp.asarray(ds[u_wind_var].values),

--- a/jcm/utils_test.py
+++ b/jcm/utils_test.py
@@ -715,13 +715,21 @@ class TestLoadStatesFromXarray(unittest.TestCase):
     """
 
     @staticmethod
-    def _make_dataset(level_coord, nlev=4, nlon=3, nlat=2):
+    def _make_dataset(level_coord, nlev=4, nlon=3, nlat=2,
+                      tracers=(), pressure_full=None):
         """Build a minimal state Dataset with a distinct value per level.
 
         ``temperature[k] == 200 + 10*k`` so the vertical profile is
         unambiguous and a flip is detectable. ``level_coord`` sets (or omits)
         the ``level`` coordinate; the *data* is written in whatever order
         matches ``level_coord``.
+
+        ``tracers`` names extra level-dimensioned variables to add (each with
+        its own distinct profile, so a mis-mapped tracer is detectable).
+        ``pressure_full``, when given, is the per-level pressure in the same
+        file order as the rest of the data — the loader cross-checks it
+        against the state's own surface pressure (#718). Omitting it models a
+        trimmed restart file, where that check cannot run.
         """
         prof = 200.0 + 10.0 * np.arange(nlev)  # increases with array index
         col = np.broadcast_to(prof[:, None, None], (nlev, nlon, nlat))
@@ -736,8 +744,27 @@ class TestLoadStatesFromXarray(unittest.TestCase):
                 ("level", "lon", "lat"), np.zeros((nlev, nlon, nlat))),
             "normalized_surface_pressure": (("lon", "lat"), surf),
         }
+        for i, name in enumerate(tracers):
+            tracer_prof = (i + 1) * 1e-4 * (1.0 + np.arange(nlev))
+            data_vars[name] = (
+                ("level", "lon", "lat"),
+                np.broadcast_to(
+                    tracer_prof[:, None, None], (nlev, nlon, nlat)).copy(),
+            )
+        if pressure_full is not None:
+            data_vars["pressure_full"] = (
+                ("level", "lon", "lat"),
+                np.broadcast_to(
+                    np.asarray(pressure_full, dtype=float)[:, None, None],
+                    (nlev, nlon, nlat)).copy(),
+            )
         coords = {} if level_coord is None else {"level": level_coord}
         return xr.Dataset(data_vars=data_vars, coords=coords)
+
+    @staticmethod
+    def _surface_first_level(nlev=4):
+        """Descending sigma: the on-disk convention every JCM file uses."""
+        return np.linspace(0.99, 0.01, nlev)
 
     def test_surface_first_file_is_flipped_to_top_first(self):
         # Descending sigma coordinate (index 0 ≈ surface) marks a
@@ -780,6 +807,143 @@ class TestLoadStatesFromXarray(unittest.TestCase):
         np.testing.assert_allclose(loaded_profile, file_profile)
         self.assertTrue(
             any("orientation" in msg.lower() for msg in cm.output))
+
+
+class TestLoadStatesTracerResolution(unittest.TestCase):
+    """Which file variables become ``state.tracers`` (#718).
+
+    A saved state carries its cloud condensate, but the loader used to drop
+    it unless the caller named every variable by hand — so radiation driven
+    on a saved state saw a clear sky and returned plausible, wrong fluxes.
+    The names now come from what the configured physics declares.
+    """
+
+    _make_dataset = staticmethod(TestLoadStatesFromXarray._make_dataset)
+    _surface_first_level = staticmethod(
+        TestLoadStatesFromXarray._surface_first_level)
+
+    def _dataset(self, nlev=4, tracers=("qc", "qi")):
+        return self._make_dataset(
+            self._surface_first_level(nlev), nlev=nlev, tracers=tracers)
+
+    def test_declared_tracers_are_loaded_and_logged(self):
+        # The default path: physics declares qc/qi, the file has them, so
+        # they are loaded without the caller naming a single variable.
+        from jcm.physics.physics_term import TracerSpec
+
+        ds = self._dataset()
+        with self.assertLogs(level="INFO") as cm:
+            state = load_states_from_xarray(
+                ds, required_tracers=(TracerSpec(name="qc"),
+                                      TracerSpec(name="qi")),
+            )
+
+        self.assertEqual(set(state.tracers), {"qc", "qi"})
+        # Tracers must be flipped with the rest of the state, not left in
+        # file order — a tracer paired with the wrong level is the same bug
+        # in a different variable.
+        np.testing.assert_allclose(
+            np.asarray(state.tracers["qc"])[:, 0, 0],
+            ds["qc"].values[::-1, 0, 0])
+        self.assertTrue(any("qc" in msg and "qi" in msg for msg in cm.output))
+
+    def test_bare_tracer_names_are_accepted(self):
+        # Callers without a physics object (a notebook, a test) may pass
+        # names instead of TracerSpecs.
+        state = load_states_from_xarray(
+            self._dataset(), required_tracers=["qc", "qi"])
+        self.assertEqual(set(state.tracers), {"qc", "qi"})
+
+    def test_declared_tracer_absent_from_file_warns(self):
+        # A dynamics-only state file is a legitimate starting point, so this
+        # is a warning rather than an error -- but it must not be silent:
+        # physics will run with that tracer at zero.
+        ds = self._dataset(tracers=("qc",))
+        with self.assertLogs(level="WARNING") as cm:
+            state = load_states_from_xarray(
+                ds, required_tracers=["qc", "qi"])
+
+        self.assertEqual(set(state.tracers), {"qc"})
+        self.assertTrue(any("qi" in msg for msg in cm.output))
+
+    def test_explicit_mapping_wins_and_warns_about_drops(self):
+        # An explicit mapping is honoured verbatim (it may rename), but
+        # dropping a declared tracer the file actually carries is exactly the
+        # silent failure #718 was about, so it is reported.
+        ds = self._dataset()
+        with self.assertLogs(level="WARNING") as cm:
+            state = load_states_from_xarray(
+                ds, tracer_vars={"qc": "qc"}, required_tracers=["qc", "qi"])
+
+        self.assertEqual(set(state.tracers), {"qc"})
+        self.assertTrue(any("qi" in msg for msg in cm.output))
+
+    def test_empty_mapping_opts_out_of_inference(self):
+        # ``{}`` is how a caller says "no tracers" and must not be treated as
+        # "unset"; only the explicit-drop warning fires.
+        with self.assertLogs(level="WARNING"):
+            state = load_states_from_xarray(
+                self._dataset(), tracer_vars={}, required_tracers=["qc", "qi"])
+        self.assertEqual(state.tracers, {})
+
+    def test_no_declaration_loads_no_tracers(self):
+        # The file cannot say which of its variables are prognostic tracers,
+        # so a caller that declares nothing gets nothing.
+        state = load_states_from_xarray(self._dataset())
+        self.assertEqual(state.tracers, {})
+
+
+class TestLoadStatesPressureGuard(unittest.TestCase):
+    """The loaded state must be top-first by its own pressures too (#718).
+
+    Orientation is inferred from the ``level`` coordinate, which a file may
+    not have; ``pressure_full`` is the independent check on that inference.
+    """
+
+    _make_dataset = staticmethod(TestLoadStatesFromXarray._make_dataset)
+    _surface_first_level = staticmethod(
+        TestLoadStatesFromXarray._surface_first_level)
+
+    # Surface-first pressures for a 4-level column, ~1e5 Pa at the surface,
+    # matching the factory's normalized_surface_pressure of 1.0 (p0 = 1e5).
+    _SURFACE_FIRST_PRESSURE = np.array([9.9e4, 7.0e4, 4.0e4, 1.0e4])
+
+    def test_consistent_surface_first_file_loads(self):
+        ds = self._make_dataset(
+            self._surface_first_level(), pressure_full=self._SURFACE_FIRST_PRESSURE)
+        state = load_states_from_xarray(ds)
+        # Flipped to top-first, so index 0 holds what the file's last index did.
+        self.assertEqual(
+            np.asarray(state.temperature)[0, 0, 0],
+            ds["temperature"].values[-1, 0, 0])
+
+    def test_inverted_column_is_rejected(self):
+        # No usable ``level`` coordinate, so the loader assumes top-first and
+        # does not flip -- but the pressures say the file is surface-first.
+        # This is the #718 failure, and it must now be loud.
+        ds = self._make_dataset(
+            level_coord=None, pressure_full=self._SURFACE_FIRST_PRESSURE)
+        with self.assertRaisesRegex(ValueError, "does not increase"):
+            load_states_from_xarray(ds)
+
+    def test_pressures_inconsistent_with_surface_pressure_are_rejected(self):
+        # Monotonic the right way, but on a scale that cannot belong to this
+        # state: the surface level is 1e-3 of the surface pressure carried in
+        # the file.
+        ds = self._make_dataset(
+            self._surface_first_level(),
+            pressure_full=np.array([100.0, 40.0, 10.0, 1.0]))
+        with self.assertRaisesRegex(ValueError, "factor of two"):
+            load_states_from_xarray(ds)
+
+    def test_file_without_pressures_falls_back_to_the_level_coordinate(self):
+        # A trimmed restart file (only the prognostic fields) has no
+        # ``pressure_full``; the level-coordinate inference still applies.
+        ds = self._make_dataset(self._surface_first_level())
+        state = load_states_from_xarray(ds)
+        np.testing.assert_allclose(
+            np.asarray(state.temperature)[:, 0, 0],
+            ds["temperature"].values[::-1, 0, 0])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Describe your changes

#742 closed half of #718 without saying so — it folded in #741, which is the same
orientation defect seen from the writer's side, so `load_states_from_xarray` has
returned a top-first state since then. The other half was never touched: no tracers
are loaded unless `run.tracer_vars` is set, so a state file's `qc`/`qi` are dropped
and radiation runs against a clear sky. Both halves together produced the issue's
95.6 W/m² surface downward longwave against an expected ~340, with clear-sky fluxes
identical to all-sky. With only the flip fixed, that run still returns
plausible-looking, wrong numbers.

**Tracers come from the physics, not from a hardcoded list.** `tracer_vars=None` now
means *infer*, and the names come from the consuming physics' `required_tracers()` —
the `TracerSpec` registry that already exists. The issue suggested defaulting to "the
condensate variables present in the file"; matching a hardcoded `qc`/`qi` list would
have fixed the reported instance and left the two-moment scheme's `qnc`/`qni` and
JAM's per-species tracers just as exposed. The declarations are already there, so
this just reads them. The file alone cannot tell a prognostic tracer from a
diagnostic — both are ordinary level-dimensioned variables — so a caller that
declares nothing still gets nothing, and inference never guesses from the file.
Every pick-up and every drop is logged: silence is what turned this into a debugging
campaign instead of a glance at the log.

**The orientation inference is now checked.** #741 reads the direction from the
`level` coordinate *values*, but a file whose `level` is a bare index carries no
orientation at all and is assumed top-first. After conversion, `pressure_full` must
increase with index and its surface entry must sit within a factor of two of the
surface pressure the state itself carries; either failing raises. This is the
cross-check the issue asked for, and it upgrades the bare-index case from "log a
warning and hand physics garbage" to a hard failure.

**The T63L47 stats generator stops doing it locally.** `_load_spinup_state` had
solved this for itself by scanning the file for `qc`/`qi` — the same fix applied to
one caller and one pair of names. It now asks the physics like everything else.

### Decisions worth second-guessing

- **`run.tracer_vars: null` changes meaning: AUTO, not NONE.** That is the point of
  the fix, but it does change what an existing prescribed/SCM config does — a run
  that silently had no condensate will now have it. `tracer_vars: {}` is the
  documented opt-out, which is why `tracer_vars or None` had to go: it collapsed
  `{}` into `null` and left no way to ask for no tracers once `null` meant
  something else.
- **A declared tracer missing from the file warns rather than raises.** A
  dynamics-only state file is a legitimate starting point. A tracer the file *has*
  and the caller drops is the #718 failure, so that warns too — an explicit mapping
  still wins outright rather than being overridden.
- **The pressure check's factor of two is deliberately loose.** The lowest full
  level sits within a percent or so of the surface; an inverted column misses by
  four or five orders of magnitude. It is a wrong-orientation detector, not a check
  on the vertical grid, and it cannot fire on a real hybrid or sigma column.
- **The check is skipped, not failed, when the file has no `pressure_full`.** A
  trimmed restart such as `spinup_state.nc` holds only the prognostic fields; those
  keep the `level`-coordinate inference alone.
- **`_load_states_from_cfg` takes `physics` as a required argument.** Both
  dispatchers already build it before loading the state. Required rather than
  defaulted so a future call site cannot quietly reintroduce the clear-sky bug.

## Issue ticket number and link

Closes #718. The orientation half was already fixed by #742 (via the folded-in
#741); this PR adds the cross-check on that inference and fixes the tracer half,
which nothing had touched.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Verified

- `ruff check .` clean locally; CI `lint` green.
- Locally, every module this diff touches at `-m "not slow"`: `utils_test`,
  `cf_metadata_test`, `prescribed_state_model_test`, `single_column_model_test`,
  `observers_test` (120 passed) and `runners_test` (99 passed, 7 subtests). The
  `prescribed`/`scm` dispatch tests drive real Held-Suarez output through the new
  guard, so it is exercised against a genuine output file, not only synthetic ones.
- Whole-repo gates: green in CI — fast **1982 passed, 45 skipped, 61 subtests**,
  coverage **90.99%** (≥90); the PR slow-test job green at its 80% threshold.
  `jcm/utils.py` is at 97%. (The full local suite was started but this sandbox has
  4 throttled cores and it had not finished after ~3h, so the whole-repo numbers
  quoted here are CI's, not a local run's.)
- 17 new tests: tracer resolution (declared/specs/bare names/missing/explicit
  override/explicit empty/undeclared), the pressure guard (consistent file loads,
  inverted column rejected, scale mismatch rejected, no-`pressure_full` fallback),
  and the runner wiring (auto-load, `{}` opt-out, tracerless physics).

## Documentation

`docs/source/design/output_vertical_conventions.md` gains the reader-side contract
next to the writer-side rules it mirrors: that orientation detection is an inference
with a fallback, how it is checked, and why the tracer list comes from the physics.
`docs/source/getting_started.rst` gains the paragraph a CLI user needs, since
`run.mode=scm`/`prescribed` are user-facing.