### PR TITLE
aerosol: JAM runs drop MACv2-SP; explicit macsp.*/jam_optics.* output namespaces (#640, PR 3 of 4)

### DIFF
--- a/docs/design/jam.md
+++ b/docs/design/jam.md
@@ -92,16 +92,35 @@ physics = echam_physics(
 )
 ```
 
-For now the JAM path **augments** MACv2-SP rather than replacing it: MACv2-SP
-is kept for the aerosol radiative optics and Twomey factor that radiation and
-the cloud schemes currently read — a temporary fudge in lieu of proper JAM
-aerosol↔radiation and aerosol↔microphysics coupling (#495). Once JAM supplies
-those, MACv2-SP need not be included.
+The JAM path **replaces** MACv2-SP; the two are mutually exclusive aerosol
+sources (#640). MACv2-SP was a stopgap providing the shared `aerosol` optics /
+Twomey diagnostic before JAM had its own coupling — having both on was
+confusing and redundant. JAM now supplies both, so `echam_physics(
+aerosol_module="jam")` no longer composes `Macv2SpAerosol`:
 
-The 2M scheme uses ARG's `activated_cdnc` where it is non-empty and falls back
-to the MACv2-SP SPA floor wherever the online source is ≈0 (e.g. before the
-prognostic JAM tracers spin up from a zero-seeded initial state), so the
-default JAM+2M run always activates droplets.
+- **Optics.** A minimal `AerosolCarrySeeder` runs first and owns the shared
+  `aerosol` slot (which radiation hard-requires and the 2M microphysics reads),
+  resetting it to an all-zero base each step. `JamOpticsTerm` overwrites the
+  per-band SW/LW optics (consumed by RRTMGP) and — for the grey two-stream
+  scheme, which reads a single broadband 550 nm profile — the
+  `aod_profile`/`ssa_profile`/`asy_profile`/`angstrom` fields. With
+  `jam_optics=False` the zero base is left untouched, making the aerosol
+  **radiatively passive** — a clean A/B control for the direct effect.
+- **Activation.** The 2M scheme uses ARG's `activated_cdnc` where it is
+  non-empty and, in the JAM path, falls back where ARG is empty to its own
+  ECHAM-HAM minimum-CDNC (`cdnc_min_fixed`, 40 cm⁻³, or the dynamic max-radius
+  floor; #674) rather than the MACv2-SP SPA floor (which no longer exists in
+  this path — JAM carries no prescribed-plume `Nccn`). The SPA floor remains
+  the `macv2sp`+2M path's Twomey link.
+
+**Output namespaces (#640).** MACv2-SP's diagnostics publish under `macsp.*`
+(CF/AeroCom names where they exist, e.g. `macsp.od550aer`); JAM's column optics
+under `jam_optics.*` (`jam_optics.aod_550` is the band-centre-approx column
+AOD — distinct from the Mie-based `od550aer` of the `aerocom_optics` pass). The
+internal `aerosol` struct radiation/microphysics read by attribute is
+unchanged; only the output keys are namespaced. The old top-level
+`aerosol_optical_depth` key (which collided with a per-band `RadiationInput`
+field) is gone.
 
 ## Prescribed anthropogenic & biomass emissions (#498)
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -1,6 +1,35 @@
 Release Notes
 =============
 
+Unreleased — MACv2-SP removed from JAM; namespaced aerosol output
+-----------------------------------------------------------------
+
+- **MACv2-SP and JAM are now mutually exclusive aerosol sources** (#640).
+  ``echam_physics(aerosol_module="jam")`` no longer also composes MACv2-SP
+  (which was a stopgap for the shared ``aerosol`` optics/Twomey diagnostic
+  before JAM had its own coupling). JAM now owns the ``aerosol`` slot through a
+  minimal ``AerosolCarrySeeder`` and supplies the direct effect via
+  ``JamOpticsTerm`` — including the grey two-stream scheme's broadband 550 nm
+  profile fields, so grey+JAM keeps a direct effect. With ``jam_optics=False``
+  the aerosol is radiatively passive (all-zero optics), a clean A/B control.
+  MACv2-SP is unchanged for ``aerosol_module="macv2sp"``.
+- **Activation fallback.** In the JAM path the 2M scheme falls back, where
+  ARG's ``activated_cdnc`` is empty, to its own ECHAM-HAM minimum-CDNC floor
+  (``cdnc_min_fixed`` = 40 cm⁻³, or the dynamic max-radius floor; #674) rather
+  than the MACv2-SP SPA floor. The SPA floor remains the ``macv2sp``+2M path's
+  Twomey link.
+- **Breaking: aerosol output variables are renamed into explicit namespaces.**
+  MACv2-SP's ``aerosol.*`` output moves to ``macsp.*`` with CF/AeroCom names
+  where they exist (``aerosol.aod_total`` → ``macsp.od550aer``); JAM's column
+  optics publish under ``jam_optics.*`` (``jam_optics.aod_550`` is the
+  band-centre-approx column AOD, distinct from the Mie-based ``od550aer`` of the
+  ``aerocom_optics`` pass). The top-level ``aerosol_optical_depth`` key — which
+  collided with the unrelated per-band ``RadiationInput`` field — is **removed**;
+  its value lives on as ``jam_optics.aod_550``. The internal ``aerosol`` struct
+  that radiation and the microphysics read by attribute is unchanged; only the
+  output keys move. ``tools/aerocom_cmor.py`` and
+  ``tools/release_validation/health.py`` are updated for the new names.
+
 Unreleased — one vertical direction in the output, and CF metadata
 ------------------------------------------------------------------
 

--- a/jcm/physics/aerosol/carry_seeder.py
+++ b/jcm/physics/aerosol/carry_seeder.py
@@ -41,6 +41,25 @@ class AerosolCarrySeeder(PhysicsTerm):
     provides: ClassVar[tuple[str, ...]] = ("aerosol",)
     carry_slots: ClassVar[dict[str, type]] = {"aerosol": AerosolData}
 
+    # The shared ``aerosol`` struct is internal plumbing in the JAM path: it
+    # feeds radiation and the microphysics by attribute, but its fields are
+    # either duplicated in JAM's own ``jam_optics.*`` namespace (the profile /
+    # Angstrom fields ``JamOpticsTerm`` writes) or a meaningless zero default
+    # JAM never fills (``aod_total``/``Nccn``/``cdnc_factor``/anthropogenic /
+    # background — the MACv2-SP-specific outputs). Withhold the whole struct
+    # from output so none of those zero defaults can be read as data (#640;
+    # the per-band optics are already dropped by ``_EXCLUDED_OUTPUT_KEYS``).
+    _WITHHELD: ClassVar[tuple[str, ...]] = (
+        "aerosol.aod_profile", "aerosol.ssa_profile", "aerosol.asy_profile",
+        "aerosol.aod_total", "aerosol.aod_anthropogenic",
+        "aerosol.aod_background", "aerosol.cdnc_factor", "aerosol.Nccn",
+        "aerosol.angstrom",
+    )
+
+    def withheld_output_keys(self) -> tuple[str, ...]:
+        """Keep the internal ``aerosol`` plumbing struct out of the output."""
+        return self._WITHHELD
+
     def __init__(self):
         """Start at the standard RRTMGP band counts (see ``cache_band_config``)."""
         # SW/LW band counts — overridden by ``cache_band_config`` once

--- a/jcm/physics/aerosol/carry_seeder.py
+++ b/jcm/physics/aerosol/carry_seeder.py
@@ -1,0 +1,96 @@
+"""``AerosolCarrySeeder`` — owner of the shared ``aerosol`` diagnostic slot.
+
+Radiation reads its aerosol optics from the scheme-agnostic
+:class:`~jcm.physics.aerosol.aerosol_types.AerosolData` struct threaded under
+the ``"aerosol"`` diagnostics key (a hard ``requires`` on every radiation
+backend), and the 2M microphysics reads ``aerosol.Nccn``. Exactly one term
+must therefore *own* that carry slot — seed it at the right band shape on the
+first step and reset it to a well-defined zero base every step, so the optics
+terms that run afterwards only have to ``.copy(...)`` their fields in.
+
+In the MACv2-SP path :class:`~jcm.physics.aerosol.macv2_sp.Macv2SpAerosol` is
+that owner (it rebuilds the plume optics from scratch each step). In the JAM
+path (jax-gcm#640) MACv2-SP is gone, so this minimal seeder takes the role:
+it carries no physics, only the all-zero base. With ``jam_optics=True`` the
+:class:`~jcm.physics.aerosol.jam.optics.optics_term.JamOpticsTerm` overwrites
+the optics fields; with ``jam_optics=False`` the base is left untouched, which
+makes the aerosol **radiatively passive** (all-zero optics) — a clean A/B
+control for the aerosol direct effect rather than the old MACv2-SP leak-in.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from jcm.physics.aerosol.aerosol_types import AerosolData
+from jcm.physics.physics_term import PhysicsTendency, PhysicsTerm
+from jcm.terrain import TerrainData
+
+
+class AerosolCarrySeeder(PhysicsTerm):
+    """Seed and reset the shared ``aerosol`` slot with an all-zero base.
+
+    Sizes the per-band optics arrays to the active radiation backend via
+    :meth:`cache_band_config` (mirroring :class:`Macv2SpAerosol`) so the
+    cross-step carry agrees with what the optics terms write back.
+    """
+
+    name: ClassVar[str] = "aerosol_carry_seeder"
+    category: ClassVar[str] = "aerosol"
+    requires: ClassVar[tuple[str, ...]] = ()
+    provides: ClassVar[tuple[str, ...]] = ("aerosol",)
+    carry_slots: ClassVar[dict[str, type]] = {"aerosol": AerosolData}
+
+    def __init__(self):
+        """Start at the standard RRTMGP band counts (see ``cache_band_config``)."""
+        # SW/LW band counts — overridden by ``cache_band_config`` once
+        # ``ComposablePhysics`` knows the active radiation backend. Defaults
+        # cover the standard RRTMGP gas-optics files for standalone use.
+        self._n_bnd_sw: int = 14
+        self._n_bnd_lw: int = 16
+
+    def cache_band_config(self, band_config) -> None:
+        """Capture SW/LW band counts so the carry slot has the right shape."""
+        self._n_bnd_sw = len(band_config.sw_band_centers_nm)
+        self._n_bnd_lw = len(band_config.lw_band_centers_nm)
+
+    def initial_carry_state(self, coords):
+        """Zero-fill the aerosol carry slot at the active SW/LW band counts."""
+        ncols = (
+            coords.horizontal.nodal_shape[0]
+            * coords.horizontal.nodal_shape[1]
+        )
+        nlev = coords.nodal_shape[0]
+        return {
+            "aerosol": AerosolData.zeros(
+                (ncols,), nlev,
+                n_bnd_sw=self._n_bnd_sw, n_bnd_lw=self._n_bnd_lw,
+            )
+        }
+
+    def __call__(
+        self,
+        state,
+        diagnostics: dict,
+        forcing,
+        terrain: TerrainData,
+    ):
+        """Reset ``aerosol`` to an all-zero base for this step."""
+        nlev, ncols = state.temperature.shape
+
+        # Match the band shape of the active radiation backend, exactly as
+        # ``Macv2SpAerosol`` does, so the slot the optics terms overwrite has
+        # the shape they expect. Falls back to grey broadband defaults for a
+        # caller constructing the term outside ``ComposablePhysics``.
+        band_config = diagnostics.get("_band_config")
+        if band_config is None:
+            from jcm.physics.radiation.band_config import RadiationBandConfig
+            band_config = RadiationBandConfig.broadband()
+        n_bnd_sw = len(band_config.sw_band_centers_nm)
+        n_bnd_lw = len(band_config.lw_band_centers_nm)
+
+        base = AerosolData.zeros(
+            (ncols,), nlev, n_bnd_sw=n_bnd_sw, n_bnd_lw=n_bnd_lw,
+        )
+        zero_tendencies = PhysicsTendency.zeros(state.temperature.shape)
+        return zero_tendencies, {**diagnostics, "aerosol": base}

--- a/jcm/physics/aerosol/carry_seeder_test.py
+++ b/jcm/physics/aerosol/carry_seeder_test.py
@@ -1,0 +1,77 @@
+"""Tests for ``AerosolCarrySeeder`` (#640)."""
+
+import unittest
+
+import jax.numpy as jnp
+import numpy as np
+
+from jcm.physics.aerosol.carry_seeder import AerosolCarrySeeder
+from jcm.physics.radiation.band_config import RadiationBandConfig
+from jcm.physics_interface import PhysicsState
+
+
+class AerosolCarrySeederTest(unittest.TestCase):
+    def test_provides_and_withholds_the_aerosol_slot(self):
+        term = AerosolCarrySeeder()
+        self.assertEqual(term.provides, ("aerosol",))
+        self.assertIn("aerosol", term.carry_slots)
+        # The whole internal struct is withheld from output (plumbing).
+        withheld = term.withheld_output_keys()
+        self.assertIn("aerosol.aod_total", withheld)
+        self.assertIn("aerosol.Nccn", withheld)
+        self.assertIn("aerosol.aod_profile", withheld)
+
+    def test_call_resets_to_zero_base_at_band_shape(self):
+        term = AerosolCarrySeeder()
+        band = RadiationBandConfig(
+            sw_band_centers_nm=(400.0, 550.0, 900.0),
+            lw_band_centers_nm=(8000.0, 12000.0),
+        )
+        term.cache_band_config(band)
+        nlev, ncols = 4, 3
+        state = PhysicsState.zeros((nlev, ncols)).copy(
+            temperature=jnp.full((nlev, ncols), 285.0),
+        )
+        # A stale non-zero slot in the carry must be reset to zeros.
+        from jcm.physics.aerosol.aerosol_types import AerosolData
+        stale = AerosolData.zeros((ncols,), nlev, n_bnd_sw=3, n_bnd_lw=2).copy(
+            aod_total=jnp.ones(ncols),
+        )
+        tend, out = term(
+            state, {"aerosol": stale, "_band_config": band}, None, None,
+        )
+        a = out["aerosol"]
+        self.assertEqual(a.aod_sw_per_band.shape, (3, nlev, ncols))
+        self.assertEqual(a.aod_lw_per_band.shape, (2, nlev, ncols))
+        self.assertEqual(float(jnp.sum(a.aod_total)), 0.0)
+        self.assertEqual(float(jnp.max(jnp.abs(a.aod_sw_per_band))), 0.0)
+        # Zero atmospheric tendency.
+        self.assertEqual(float(jnp.max(jnp.abs(tend.temperature))), 0.0)
+
+    def test_call_falls_back_to_broadband_without_band_config(self):
+        term = AerosolCarrySeeder()
+        nlev, ncols = 2, 2
+        state = PhysicsState.zeros((nlev, ncols)).copy(
+            temperature=jnp.full((nlev, ncols), 285.0),
+        )
+        _, out = term(state, {}, None, None)
+        a = out["aerosol"]
+        bb = RadiationBandConfig.broadband()
+        self.assertEqual(a.aod_sw_per_band.shape[0],
+                         len(bb.sw_band_centers_nm))
+
+    def test_initial_carry_state_zero_filled(self):
+        from jcm.physics.echam.echam_levels import get_echam_levels
+        from jcm.utils import get_coords
+
+        term = AerosolCarrySeeder()
+        term.cache_band_config(RadiationBandConfig(
+            sw_band_centers_nm=(550.0,), lw_band_centers_nm=(10000.0,),
+        ))
+        coords = get_coords(get_echam_levels(47), spectral_truncation=21)
+        slot = term.initial_carry_state(coords)["aerosol"]
+        self.assertTrue(bool(np.all(np.asarray(slot.aod_sw_per_band) == 0.0)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jcm/physics/aerosol/jam/cloud_borne_store_test.py
+++ b/jcm/physics/aerosol/jam/cloud_borne_store_test.py
@@ -266,7 +266,10 @@ class CarryModeFactoryTest(unittest.TestCase):
         from jcm.physics.aerosol.jam import jam_aerosol_physics
 
         terms = jam_aerosol_physics()
-        self.assertEqual(terms[0].name, "jam_cloud_borne_store")
+        # The aerosol-carry seeder runs first (#640); the cloud-borne store is
+        # next, still ahead of the emitters/core that consume it.
+        self.assertEqual(terms[0].name, "aerosol_carry_seeder")
+        self.assertEqual(terms[1].name, "jam_cloud_borne_store")
         names = set()
         for t in terms:
             names |= {s.name for s in t.required_tracers()}
@@ -288,7 +291,14 @@ class CarryModeFactoryTest(unittest.TestCase):
         from jcm.physics.aerosol.jam import jam_aerosol_physics
 
         terms = jam_aerosol_physics()
-        self.assertEqual(terms[0].name, "jam_cloud_borne_store")
+        # Store is composed right after the aerosol-carry seeder (#640), before
+        # every term that consumes the cloud-borne carry.
+        self.assertEqual(terms[1].name, "jam_cloud_borne_store")
+        store_i = next(i for i, t in enumerate(terms)
+                       if t.name == "jam_cloud_borne_store")
+        core_i = next(i for i, t in enumerate(terms)
+                      if t.category == "aerosol_microphysics")
+        self.assertLess(store_i, core_i)
 
 
 if __name__ == "__main__":

--- a/jcm/physics/aerosol/jam/jam_integration_test.py
+++ b/jcm/physics/aerosol/jam/jam_integration_test.py
@@ -62,20 +62,24 @@ class JamIntegrationTest(unittest.TestCase):
 
         # The docstring's actual claim — activation feeds the 2M scheme —
         # must hold: the activated-CDNC diagnostic the 2M term consumes is
-        # present and positive somewhere (ARG or its SPA floor), and the
-        # 2M droplet-number tracer has been populated in response. A run
-        # where the coupling silently no-ops passes every finiteness check
-        # above but fails here (measured on a healthy cold-start run:
-        # activated_cdnc max ~66, qnc max ~3e-5 after 3 steps).
+        # present and positive somewhere (ARG, or the ECHAM-HAM cdnc_min floor
+        # the JAM path falls back to where ARG is empty, #640), and the 2M
+        # droplet-number tracer has been populated in response. A run where the
+        # coupling silently no-ops passes every finiteness check above but
+        # fails here (measured on a healthy cold-start run: activated_cdnc max
+        # ~66, qnc max ~3e-5 after 3 steps).
         physics = predictions.physics
         self.assertIn("activated_cdnc", physics)
         self.assertGreater(
             float(np.max(np.asarray(physics["activated_cdnc"]))), 0.0,
-            "activation never produced droplets (ARG + SPA floor both zero)",
+            "activation never produced droplets (ARG + cdnc_min floor zero)",
         )
-        self.assertGreater(
-            float(np.max(np.asarray(physics["aerosol"].Nccn))), 0.0,
-            "aerosol term produced no CCN",
+        # The shared aerosol slot is present and finite. MACv2-SP was removed
+        # from the JAM path (#640), so JAM carries no prescribed-plume Nccn —
+        # it stays zero (the cdnc_min fallback, not Nccn, drives activation).
+        self.assertIn("aerosol", physics)
+        self.assertTrue(
+            bool(np.all(np.isfinite(np.asarray(physics["aerosol"].Nccn))))
         )
         self.assertGreater(
             float(np.max(np.asarray(tracers["qnc"]))), 0.0,

--- a/jcm/physics/aerosol/jam/jam_terms.py
+++ b/jcm/physics/aerosol/jam/jam_terms.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import dataclasses
 
+from jcm.physics.aerosol.carry_seeder import AerosolCarrySeeder
 from jcm.physics.aerosol.jam.activation.arg_term import (
     ArgActivation,
     ArgParameters,
@@ -315,6 +316,13 @@ def jam_aerosol_physics(
         if carry_mode(spec) else []
     )
     pre_core = [
+        # Own the shared ``aerosol`` carry slot (#640). Radiation hard-requires
+        # it and the 2M microphysics reads ``aerosol.Nccn``; with MACv2-SP gone
+        # from the JAM path this seeder resets it to an all-zero base each step
+        # (JamOpticsTerm overwrites the optics when ``optics=True``; left zero =
+        # radiatively passive when ``optics=False``). Runs first so every
+        # downstream aerosol/radiation consumer sees a well-formed slot.
+        AerosolCarrySeeder(),
         *store_terms,
         *emissions,
         *transport_terms,

--- a/jcm/physics/aerosol/jam/jam_terms_test.py
+++ b/jcm/physics/aerosol/jam/jam_terms_test.py
@@ -10,15 +10,19 @@ class JamFactoryTest(unittest.TestCase):
         terms = jam_aerosol_physics()
         cats = [t.category for t in terms]
         names = [t.name for t in terms]
-        # Default storage is CARRY (#602 item 3 A/B): the store term owns
-        # the carry slot and runs first. Then the emi_* accumulator reset
-        # (which must precede every emitter — the diagnostics dict is
-        # threaded back from the previous step), the natural-emission
+        # The ``aerosol`` carry-slot seeder runs first (#640): radiation and
+        # the 2M microphysics read that slot, so it must be well-formed before
+        # any consumer. Default storage is CARRY (#602 item 3 A/B): the store
+        # term owns the cloud-borne carry and runs next. Then the emi_*
+        # accumulator reset (which must precede every emitter — the diagnostics
+        # dict is threaded back from the previous step), the natural-emission
         # schemes, then the core + processes.
-        self.assertEqual(names[0], "jam_cloud_borne_store")
-        self.assertEqual(names[1], "reset_emission_fluxes")
+        self.assertEqual(names[0], "aerosol_carry_seeder")
+        self.assertEqual(cats[0], "aerosol")
+        self.assertEqual(names[1], "jam_cloud_borne_store")
+        self.assertEqual(names[2], "reset_emission_fluxes")
         self.assertEqual(
-            names[2:5],
+            names[3:6],
             [
                 "jam_seasalt_emissions",
                 "jam_dms_emissions",
@@ -26,7 +30,7 @@ class JamFactoryTest(unittest.TestCase):
             ],
         )
         self.assertEqual(
-            cats[5:],
+            cats[6:],
             [
                 # Physics-side vertical transport (#602 item 2): turbulent
                 # mixing of every JAM tracer, then convective mass-flux
@@ -48,7 +52,7 @@ class JamFactoryTest(unittest.TestCase):
         )
         # The reset shares the emitters' category — it is part of that
         # block, not a separate stage.
-        self.assertTrue(all(c == "aerosol_emissions" for c in cats[1:5]))
+        self.assertTrue(all(c == "aerosol_emissions" for c in cats[2:6]))
 
     def test_activation_precedes_deposition(self):
         # wetdep requires activated_fraction, so ARG must come first.
@@ -94,12 +98,22 @@ class EchamPhysicsWiringTest(unittest.TestCase):
 
         phys = echam_physics(aerosol_module="jam", cloud_scheme="2m")
         cats = [t.category for t in phys.terms]
-        # MACv2-SP retained for optics, JAM aerosol terms appended.
-        self.assertIn("aerosol", cats)            # MACv2-SP provides "aerosol"
+        names = [t.name for t in phys.terms]
+        # No MACv2-SP in the JAM path (#640): the ``aerosol`` slot is owned by
+        # JAM's own ``AerosolCarrySeeder`` (category "aerosol"), not MACv2-SP.
+        self.assertNotIn("macv2_sp_aerosol", names)
+        self.assertIn("aerosol_carry_seeder", names)
+        self.assertIn("aerosol", cats)            # the seeder provides "aerosol"
         self.assertIn("aerosol_activation", cats)  # JAM ARG present
         # ARG activation must precede the 2M cloud term that reads it.
         self.assertLess(
             cats.index("aerosol_activation"), cats.index("clouds")
+        )
+        # The seeder must precede the radiation term that reads ``aerosol``.
+        self.assertLess(
+            names.index("aerosol_carry_seeder"),
+            next(i for i, t in enumerate(phys.terms)
+                 if t.category == "radiation"),
         )
 
     def test_jam_module_rejects_1m(self):

--- a/jcm/physics/aerosol/jam/optics/optics_integration_test.py
+++ b/jcm/physics/aerosol/jam/optics/optics_integration_test.py
@@ -61,7 +61,7 @@ class OpticsIntegrationTest(unittest.TestCase):
         # the old ``aod >= 0`` bound could not distinguish from healthy).
         # A stronger on/off flux-difference test needs a seeded aerosol
         # burden (cold-start AOD is radiatively invisible) — deferred.
-        aod = predictions.physics["aerosol_optical_depth"]
+        aod = predictions.physics["_jam_optics"]["aod_550"]
         aod = np.asarray(aod)
         self.assertTrue(np.all(np.isfinite(aod)))
         self.assertTrue(np.all(aod >= 0.0))

--- a/jcm/physics/aerosol/jam/optics/optics_term.py
+++ b/jcm/physics/aerosol/jam/optics/optics_term.py
@@ -9,10 +9,13 @@ the Mie efficiencies, and accumulate the extinction across modes;
 single-scattering albedo and asymmetry are extinction-/scattering-weighted.
 
 The expensive Mie evaluation is paid once at construction (``mie_lut``); the
-per-step path is a differentiable table interpolation. SW band optics overwrite
-MACv2-SP's fields (so the SW direct effect flows immediately); LW band optics
-populate the new ``aerosol`` LW fields consumed by RRTMGP. MACv2-SP is kept
-only for its indirect (Twomey/SPA) fields for now.
+per-step path is a differentiable table interpolation. The per-band SW/LW
+optics are written into the shared ``aerosol`` struct (seeded all-zero each
+step by ``AerosolCarrySeeder``) and consumed directly by RRTMGP. For the grey
+two-stream scheme, which reads a single broadband 550 nm profile rather than
+per-band optics, this term also writes ``aod_profile``/``ssa_profile``/
+``asy_profile`` (the SW band nearest 550 nm) and a band-ratio ``angstrom`` so
+grey+JAM keeps a direct effect (#640).
 """
 
 from __future__ import annotations
@@ -81,6 +84,8 @@ class _OpticsCache:
     ri_lw: dict
     aod_band_idx: int    # SW band index whose centre is closest to 550 nm
     aod_band_nm: float   # that band's actual centre wavelength [nm]
+    ang_band_idx: int    # SW band for the 550/865 Angstrom pair (grey #640)
+    ang_band_nm: float   # that band's actual centre wavelength [nm]
     ri_diag: dict | None = None   # RI at _DIAG_WAVELENGTHS_NM (#584), or None
 
 
@@ -169,6 +174,18 @@ class JamOpticsTerm(PhysicsTerm):
             aod_nm = float(sw_nm[aod_idx])
         else:
             aod_idx, aod_nm = 0, float("nan")
+        # Second SW band for the column Angstrom exponent fed to the grey
+        # two-stream scheme (#640): the band nearest 865 nm, giving the
+        # ECHAM-HAM 550/865 pair. With a single broadband SW band (grey's own
+        # default RadiationBandConfig) there is no ratio to form, so fall back
+        # to the 550 band index and flag it degenerate for the default below.
+        if sw_nm.size >= 2:
+            ang_idx = int(np.argmin(np.abs(sw_nm - 865.0)))
+            if ang_idx == aod_idx:
+                ang_idx = int(np.argmax(np.abs(sw_nm - aod_nm)))
+            ang_nm = float(sw_nm[ang_idx])
+        else:
+            ang_idx, ang_nm = aod_idx, aod_nm
         ri_diag = None
         if self._optics_diagnostics:
             diag_nm = jnp.asarray(_DIAG_WAVELENGTHS_NM)
@@ -177,7 +194,7 @@ class JamOpticsTerm(PhysicsTerm):
                 n_d, k_d = refractive_index_at(sp, diag_nm)
                 ri_diag[sp] = (np.asarray(n_d), np.asarray(k_d))
         self._cache = _OpticsCache(sw_nm, lw_nm, ri_sw, ri_lw, aod_idx, aod_nm,
-                                   ri_diag)
+                                   ang_idx, ang_nm, ri_diag)
 
     def _band_optics(self, state, aer, num_per_area, centers_nm, ri,
                      want_decomposition: bool = False):
@@ -497,11 +514,51 @@ class JamOpticsTerm(PhysicsTerm):
         else:
             aod_550 = jnp.zeros_like(state.temperature[0])
 
+        # Broadband 550 nm profile fields for hosts that read a single aerosol
+        # profile rather than per-band optics — specifically the grey
+        # two-stream scheme (grey_two_stream/radiation_scheme.py reads
+        # ``aerosol.aod_profile``/``ssa_profile``/``asy_profile``/``angstrom``
+        # and band-scales them itself). With MACv2-SP removed from the JAM path
+        # (#640) nothing else writes these, so grey+JAM would otherwise have a
+        # silent zero direct effect. Taken from the SW band whose centre is
+        # nearest 550 nm — a band-CENTRE approximation to the exact 550 nm
+        # optics (the per-species Mie pass at exactly 550 nm is the separate
+        # aerocom_optics diagnostic); it reuses the radiation bands already
+        # computed here and costs no extra Mie work. ``aod_profile`` inherits
+        # the same ``_AER_RAD_PMIN`` mask and ``_MAX_LAYER_TAU`` cap as the
+        # per-band SW AOD, so grey and RRTMGP see a consistent burden.
+        if aod_sw.shape[0]:
+            aod_profile = aod_sw[c.aod_band_idx]
+            ssa_profile = ssa_sw[c.aod_band_idx]
+            asy_profile = asy_sw[c.aod_band_idx]
+        else:
+            zeros3 = jnp.zeros_like(state.temperature)
+            aod_profile = ssa_profile = asy_profile = zeros3
+
+        # Column Angstrom exponent from the 550/865 nm band pair, which grey
+        # uses to scale ``aod_profile`` to its own SW/LW band wavelengths. This
+        # is the cheap band-RATIO Angstrom (two radiation-band column AODs) —
+        # NOT the Mie-based ``ang550865aer`` of the aerocom_optics pass — and
+        # is only well-defined with >=2 SW bands. Defaults to the fine-mode 1.5
+        # (the ``AerosolData`` zero default) with a single broadband SW band
+        # (grey's own config) or where a column has no aerosol at both bands.
+        if aod_sw.shape[0] and c.ang_band_idx != c.aod_band_idx:
+            od_a = jnp.maximum(jnp.sum(aod_sw[c.aod_band_idx], axis=0), 0.0)
+            od_b = jnp.maximum(jnp.sum(aod_sw[c.ang_band_idx], axis=0), 0.0)
+            both = (od_a > _TINY) & (od_b > _TINY)
+            ratio = jnp.maximum(od_a, _TINY) / jnp.maximum(od_b, _TINY)
+            lam_ratio = math.log(c.aod_band_nm / c.ang_band_nm)
+            angstrom = jnp.where(both, -jnp.log(ratio) / lam_ratio, 1.5)
+        else:
+            angstrom = jnp.full_like(state.temperature[0], 1.5)
+
         fields = {
             "aod_sw_per_band": aod_sw, "ssa_sw_per_band": ssa_sw,
             "asy_sw_per_band": asy_sw,
             "aod_lw_per_band": aod_lw, "ssa_lw_per_band": ssa_lw,
             "asy_lw_per_band": asy_lw,
+            "aod_profile": aod_profile, "ssa_profile": ssa_profile,
+            "asy_profile": asy_profile, "angstrom": angstrom,
             "aod_550": aod_550,
         }
         if self._optics_diagnostics:

--- a/jcm/physics/aerosol/jam/optics/optics_term.py
+++ b/jcm/physics/aerosol/jam/optics/optics_term.py
@@ -97,7 +97,40 @@ class JamOpticsTerm(PhysicsTerm):
     requires: ClassVar[tuple[str, ...]] = (
         "_jam_state", "aerosol", "air_density", "layer_thickness",
     )
-    provides: ClassVar[tuple[str, ...]] = ("aerosol", "aerosol_optical_depth")
+    provides: ClassVar[tuple[str, ...]] = ("aerosol", "_jam_optics")
+    # JAM's column optics diagnostics publish under the explicit ``jam_optics.*``
+    # namespace (#640): the ``_jam_optics`` carry dict flattens to
+    # ``jam_optics.<field>`` on output. CF/AeroCom metadata for the fields that
+    # survive (the per-band arrays are dropped by ``_EXCLUDED_OUTPUT_KEYS``).
+    output_attrs: ClassVar[dict[str, dict[str, str]]] = {
+        "jam_optics.aod_550": {
+            "units": "1",
+            "standard_name": (
+                "atmosphere_optical_thickness_due_to_ambient_aerosol_particles"
+            ),
+            "long_name": (
+                "JAM total-column aerosol optical depth at the SW band nearest "
+                "550 nm (band-centre approximation; the Mie-based od550aer is "
+                "the aerocom_optics diagnostic)"
+            ),
+        },
+        "jam_optics.aod_profile": {
+            "units": "1",
+            "long_name": "JAM 550 nm aerosol optical depth per layer",
+        },
+        "jam_optics.ssa_profile": {
+            "units": "1",
+            "long_name": "JAM 550 nm single-scattering albedo per layer",
+        },
+        "jam_optics.asy_profile": {
+            "units": "1",
+            "long_name": "JAM 550 nm asymmetry parameter per layer",
+        },
+        "jam_optics.angstrom": {
+            "units": "1",
+            "long_name": "JAM column Angstrom exponent (550/865 nm band ratio)",
+        },
+    }
 
     def __init__(self, *, spec: ModalAerosolSpec | None = None,
                  optics_diagnostics: bool = False):
@@ -144,7 +177,7 @@ class JamOpticsTerm(PhysicsTerm):
         30-band × 4-mode Mie evaluation on the intermediate steps is
         discarded work (~8× of the second-largest JAM cost). With the gate
         configured, those steps replay the previous compute's per-band
-        fields from the ``_jam_band_optics`` carry slot instead, using the
+        fields from the ``_jam_optics`` carry slot instead, using the
         *same* ``radiation.step`` counter the radiation gate reads (this
         term runs earlier in the chain, so both see the identical
         pre-increment value and agree within a step). ``interval_s <= 0``
@@ -570,7 +603,7 @@ class JamOpticsTerm(PhysicsTerm):
         return fields
 
     def __call__(self, state, diagnostics, forcing, terrain):
-        cached = diagnostics.get("_jam_band_optics")
+        cached = diagnostics.get("_jam_optics")
         if (self._radiation_interval_s is None or cached is None
                 or "radiation" not in diagnostics):
             # Ungated (every step): gate unconfigured, or no cached fields in
@@ -600,10 +633,15 @@ class JamOpticsTerm(PhysicsTerm):
                if k not in ("aod_550", "_optics_diag")}
         )
         tendency = PhysicsTendency.zeros(state.temperature.shape)
+        # The column AOD-550 no longer publishes a top-level
+        # ``aerosol_optical_depth`` key (#640): that name collided with the
+        # unrelated per-band ``RadiationInput`` field, and the value now lives
+        # under the JAM namespace as ``jam_optics.aod_550`` (from the
+        # ``_jam_optics`` carry dict, which also carries the per-band optics
+        # plumbing and the grey profile fields).
         return tendency, {
             **diagnostics,
             **fields.get("_optics_diag", {}),
             "aerosol": new_aerosol,
-            "aerosol_optical_depth": fields["aod_550"],
-            "_jam_band_optics": fields,
+            "_jam_optics": fields,
         }

--- a/jcm/physics/aerosol/jam/optics/optics_term_test.py
+++ b/jcm/physics/aerosol/jam/optics/optics_term_test.py
@@ -138,17 +138,17 @@ class JamOpticsTermTest(unittest.TestCase):
 
         base = {**diagnostics, "_dt_seconds": jnp.asarray(900.0)}
         # Step 0 (compute): no cache in the carry yet -> unconditional
-        # compute that seeds the ``_jam_band_optics`` slot.
+        # compute that seeds the ``_jam_optics`` slot.
         _, d0 = term(state, {**base, "radiation": _Rad(jnp.int32(0))},
                      None, None)
-        self.assertIn("_jam_band_optics", d0)
+        self.assertIn("_jam_optics", d0)
 
         # Step 1 (cached): perturb the aerosol state; output must equal the
         # step-0 fields, not fresh ones.
         aer2 = d0["_jam_state"].copy(number=d0["_jam_state"].number * 3.0)
         d1_in = {**base, "radiation": _Rad(jnp.int32(1)),
                  "_jam_state": aer2,
-                 "_jam_band_optics": d0["_jam_band_optics"]}
+                 "_jam_optics": d0["_jam_optics"]}
         _, d1 = term(state, d1_in, None, None)
         np.testing.assert_array_equal(
             np.asarray(d1["aerosol"].aod_sw_per_band),
@@ -214,7 +214,7 @@ class JamOpticsTermTest(unittest.TestCase):
             self.assertTrue(np.all(np.isfinite(np.asarray(arr))))
             # Asymmetry is physically [-1, 1] (negative g = back-scattering).
             self.assertTrue(bool(jnp.all((arr >= -1.0 - 1e-5) & (arr <= 1.0 + 1e-5))))
-        self.assertTrue(np.all(np.isfinite(np.asarray(diag["aerosol_optical_depth"]))))
+        self.assertTrue(np.all(np.isfinite(np.asarray(diag["_jam_optics"]["aod_550"]))))
 
     def test_empty_levels_carry_exactly_zero_tau(self):
         """POSITIVE-side ringing: tiny +ve number with a garbage wet radius
@@ -292,7 +292,7 @@ class JamOpticsTermTest(unittest.TestCase):
         }
         _, diag = term(state, diagnostics, None, None)
 
-        aod = diag["aerosol_optical_depth"]
+        aod = diag["_jam_optics"]["aod_550"]
         # Column field, one value per column; finite and physical.
         self.assertEqual(aod.shape, (ncols,))
         self.assertTrue(np.all(np.isfinite(np.asarray(aod))))
@@ -317,7 +317,7 @@ class JamOpticsTermTest(unittest.TestCase):
         state, diagnostics, band, *_ = _setup()
         term = self._term(band)
         _, diag = term(state, diagnostics, None, None)
-        aod_lognormal = float(jnp.max(diag["aerosol_optical_depth"]))
+        aod_lognormal = float(jnp.max(diag["_jam_optics"]["aod_550"]))
 
         # Monodisperse expectation: same LUT, same geometry, single radius.
         lut = default_mie_lut()
@@ -513,7 +513,7 @@ class OpticsDiagnosticsTest(unittest.TestCase):
         _, out0 = term(state, {**base, "radiation": _Rad(jnp.int32(0))}, None, None)
         # A replay step must go through lax.cond with the diagnostics present.
         _, out1 = term(state, {**base, "radiation": _Rad(jnp.int32(3)),
-                               "_jam_band_optics": out0["_jam_band_optics"]},
+                               "_jam_optics": out0["_jam_optics"]},
                        None, None)
         for k in term.optics_diagnostic_keys():
             np.testing.assert_allclose(np.asarray(out1[k]), np.asarray(out0[k]),

--- a/jcm/physics/aerosol/jam/optics/optics_term_test.py
+++ b/jcm/physics/aerosol/jam/optics/optics_term_test.py
@@ -120,6 +120,21 @@ class JamOpticsTermTest(unittest.TestCase):
         self.assertNotEqual(term._cache.ang_band_idx, term._cache.aod_band_idx)
         self.assertTrue(bool(np.all(np.isfinite(np.asarray(a.angstrom)))))
 
+    def test_single_broadband_sw_uses_default_angstrom(self):
+        """With a single broadband SW band (grey's own config) there is no
+        550/865 ratio, so Angstrom falls back to the fine-mode 1.5 default
+        while the profile still comes from the sole SW band (#640).
+        """
+        state, diagnostics, band, n_sw, n_lw = _setup(n_sw=1)
+        term = self._term(band)
+        self.assertEqual(term._cache.ang_band_idx, term._cache.aod_band_idx)
+        _, out = term(state, diagnostics, None, None)
+        a = out["aerosol"]
+        np.testing.assert_array_equal(
+            np.asarray(a.angstrom), np.full_like(np.asarray(a.angstrom), 1.5))
+        np.testing.assert_allclose(
+            np.asarray(a.aod_profile), np.asarray(a.aod_sw_per_band[0]))
+
     def test_radiation_gate_replays_cache_between_compute_steps(self):
         """With the gate configured, non-radiation steps must reuse the
         cached per-band fields (the radiation term can't see fresh optics

--- a/jcm/physics/aerosol/jam/optics/optics_term_test.py
+++ b/jcm/physics/aerosol/jam/optics/optics_term_test.py
@@ -90,6 +90,36 @@ class JamOpticsTermTest(unittest.TestCase):
         np.testing.assert_array_equal(np.asarray(a.aod_lw_per_band[:, 0]), 0.0)
         self.assertGreater(float(jnp.sum(a.aod_sw_per_band[:, 1:])), 0.0)
 
+    def test_writes_grey_profile_fields(self):
+        """The 550 nm profile fields grey radiation reads are populated (#640).
+
+        With MACv2-SP gone from the JAM path, ``JamOpticsTerm`` is the only
+        writer of ``aod_profile``/``ssa_profile``/``asy_profile``/``angstrom``
+        — the fields the grey two-stream scheme band-scales for its direct
+        effect. They must equal the SW band nearest 550 nm (band-centre
+        approximation) and carry a finite Angstrom exponent.
+        """
+        state, diagnostics, band, n_sw, n_lw = _setup()
+        term = self._term(band)
+        _, out = term(state, diagnostics, None, None)
+        a = out["aerosol"]
+        idx = term._cache.aod_band_idx
+        np.testing.assert_allclose(
+            np.asarray(a.aod_profile), np.asarray(a.aod_sw_per_band[idx]),
+            rtol=0, atol=0,
+        )
+        np.testing.assert_allclose(
+            np.asarray(a.ssa_profile), np.asarray(a.ssa_sw_per_band[idx]))
+        np.testing.assert_allclose(
+            np.asarray(a.asy_profile), np.asarray(a.asy_sw_per_band[idx]))
+        # A real burden was set up, so the profile carries optical depth.
+        self.assertGreater(float(jnp.sum(a.aod_profile)), 0.0)
+        # Angstrom is finite everywhere (band-ratio where AOD exists, the 1.5
+        # fine-mode default elsewhere); ang_band differs from the 550 band so
+        # the ratio path is exercised.
+        self.assertNotEqual(term._cache.ang_band_idx, term._cache.aod_band_idx)
+        self.assertTrue(bool(np.all(np.isfinite(np.asarray(a.angstrom)))))
+
     def test_radiation_gate_replays_cache_between_compute_steps(self):
         """With the gate configured, non-radiation steps must reuse the
         cached per-band fields (the radiation term can't see fresh optics

--- a/jcm/physics/aerosol/macv2_sp.py
+++ b/jcm/physics/aerosol/macv2_sp.py
@@ -421,6 +421,63 @@ class Macv2SpAerosol(PhysicsTerm):
     category: ClassVar[str] = "aerosol"
     requires: ClassVar[tuple[str, ...]] = ("height_full", "layer_thickness")
     provides: ClassVar[tuple[str, ...]] = ("aerosol",)
+    # Publish the MACv2-SP diagnostics under an explicit ``macsp.*`` namespace
+    # (#640) with the CF/AeroCom name where one exists (``od550aer`` for the
+    # total column AOD). The shared ``aerosol`` struct that radiation and the
+    # microphysics read by attribute is untouched — only the OUTPUT keys move.
+    # The per-SW/LW-band optics are dropped by ``_EXCLUDED_OUTPUT_KEYS``.
+    output_key_map: ClassVar[dict[str, str]] = {
+        "aerosol.aod_total": "macsp.od550aer",
+        "aerosol.aod_anthropogenic": "macsp.aod_anthropogenic",
+        "aerosol.aod_background": "macsp.aod_background",
+        "aerosol.aod_profile": "macsp.aod_profile",
+        "aerosol.ssa_profile": "macsp.ssa_profile",
+        "aerosol.asy_profile": "macsp.asy_profile",
+        "aerosol.cdnc_factor": "macsp.cdnc_factor",
+        "aerosol.Nccn": "macsp.nccn",
+        "aerosol.angstrom": "macsp.angstrom",
+    }
+    output_attrs: ClassVar[dict[str, dict[str, str]]] = {
+        "macsp.od550aer": {
+            "units": "1",
+            "standard_name": (
+                "atmosphere_optical_thickness_due_to_ambient_aerosol_particles"
+            ),
+            "long_name": "MACv2-SP total-column aerosol optical depth at 550 nm",
+        },
+        "macsp.aod_anthropogenic": {
+            "units": "1",
+            "long_name": "MACv2-SP anthropogenic-plume AOD at 550 nm",
+        },
+        "macsp.aod_background": {
+            "units": "1",
+            "long_name": "MACv2-SP natural-background AOD at 550 nm",
+        },
+        "macsp.aod_profile": {
+            "units": "1",
+            "long_name": "MACv2-SP 550 nm aerosol optical depth per layer",
+        },
+        "macsp.ssa_profile": {
+            "units": "1",
+            "long_name": "MACv2-SP 550 nm single-scattering albedo per layer",
+        },
+        "macsp.asy_profile": {
+            "units": "1",
+            "long_name": "MACv2-SP 550 nm asymmetry parameter per layer",
+        },
+        "macsp.cdnc_factor": {
+            "units": "1",
+            "long_name": "MACv2-SP Twomey CDNC enhancement factor",
+        },
+        "macsp.nccn": {
+            "units": "cm-3",
+            "long_name": "MACv2-SP cloud condensation nuclei concentration",
+        },
+        "macsp.angstrom": {
+            "units": "1",
+            "long_name": "MACv2-SP column Angstrom exponent",
+        },
+    }
     # Carry seeded as zeros; ``get_simple_aerosol`` rebuilds
     # AOD/SSA/asymmetry from the plume parameterisation every step
     # using the slot only as a shape source.

--- a/jcm/physics/clouds/lohmann_2m/scheme.py
+++ b/jcm/physics/clouds/lohmann_2m/scheme.py
@@ -1115,26 +1115,52 @@ class Lohmann2MMicrophysics(PhysicsTerm):
         else:
             tke = jnp.zeros_like(state.temperature)
 
-        # Activated CDNC source. The inline SPA floor (from the MACv2-SP Nccn)
-        # is always computed as a baseline. An upstream activation term (e.g.
-        # JAM's ARG, #461) may write an explicit ``activated_cdnc``; when it
-        # does we use it, but fall back to the SPA floor wherever that online
-        # source is empty (≈0) — e.g. before the prognostic JAM aerosol tracers
-        # spin up — so the default JAM+2M run still activates droplets. Both
-        # paths are differentiable and produce the same (nlev, ncols) field.
-        Nccn = diagnostics["aerosol"].Nccn
-        spa_floor = spa_activated_cdnc(
-            Nccn=Nccn[jnp.newaxis, :],
-            cloud_fraction=cloud_fraction,
-            prefactor=self._spa_prefactor.get_value(),
-            exponent=self._spa_exponent.get_value(),
-            cap_smoothing=self._spa_cap_smoothing.get_value(),
-        )
+        # Activated CDNC source. Which baseline fills the cells an online
+        # activation model leaves empty depends on the aerosol scheme, and the
+        # presence of the ``activated_cdnc`` diagnostic tells the two apart:
+        #
+        #  * MACv2-SP path (no online activation term, ``activated_cdnc``
+        #    absent): the SPA floor derived from the prescribed-plume
+        #    ``aerosol.Nccn`` IS the activation source — the scheme's only
+        #    Twomey link (Lin et al. 2025, ``jcm.physics.aerosol.spa``).
+        #
+        #  * JAM path (``ArgActivation`` writes ``activated_cdnc``, #461): JAM
+        #    carries no prescribed-plume ``Nccn`` (it was removed from the JAM
+        #    composition in #640), so the SPA floor would be identically zero
+        #    and leave ARG-empty cloudy cells with no droplets. Fall back
+        #    instead to the scheme's OWN minimum-CDNC — the ECHAM-HAM fixed
+        #    ``cdnc_min_fixed`` (40 cm⁻³) or the dynamic max-radius floor,
+        #    selected by ``ldyn_cdnc_min`` (#674). This is the same
+        #    ``minimum_CDNC`` the per-column warm microphysics enforces on the
+        #    droplet number (see ``minimum_CDNC`` below): feeding it as the
+        #    activation *target* here only sets the nucleation source in
+        #    ARG-empty cells; the per-column floor still owns the actual number
+        #    bound, so the droplet number is not doubly floored.
         arg_cdnc = diagnostics.get("activated_cdnc")
         if arg_cdnc is None:
-            activated_cdnc = spa_floor
+            Nccn = diagnostics["aerosol"].Nccn
+            activated_cdnc = spa_activated_cdnc(
+                Nccn=Nccn[jnp.newaxis, :],
+                cloud_fraction=cloud_fraction,
+                prefactor=self._spa_prefactor.get_value(),
+                exponent=self._spa_exponent.get_value(),
+                cap_smoothing=self._spa_cap_smoothing.get_value(),
+            )
         else:
-            activated_cdnc = jnp.where(arg_cdnc > 1.0, arg_cdnc, spa_floor)
+            # In-cloud liquid mass density (kg/m³) for the dynamic branch of
+            # ``minimum_CDNC``; the fixed branch ignores it. Masked to cloudy
+            # cells so the fallback (like the SPA floor it replaces) is zero in
+            # clear air — the activation gate is cloud-only anyway.
+            inv_cf_min = 1.0 / jnp.maximum(cloud_fraction, params_2m.epsec)
+            qc_in_cloud_kgm3 = jnp.where(
+                cloud_fraction > params_2m.epsec,
+                qc_interim * inv_cf_min * air_density, 0.0,
+            )
+            cdnc_min_floor = jnp.where(
+                cloud_fraction > params_2m.epsec,
+                minimum_CDNC(qc_in_cloud_kgm3, params_2m), 0.0,
+            )
+            activated_cdnc = jnp.where(arg_cdnc > 1.0, arg_cdnc, cdnc_min_floor)
 
         # Online heterogeneous ice nuclei (JAM #494); 0 where absent so the
         # core falls back to its DeMott floor. Immersion drives the mixed-phase

--- a/jcm/physics/composable_physics.py
+++ b/jcm/physics/composable_physics.py
@@ -20,6 +20,7 @@ See docs/design/composable_physics.md for the full design.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any, ClassVar
 
 import jax
@@ -94,6 +95,16 @@ class ComposablePhysics(nnx.Module, Physics):
         # as data (see _term_withheld_keys).
         self._term_withheld_keys = frozenset(
             key for t in terms for key in t.withheld_output_keys())
+        # Per-term output-key renames (e.g. the MACv2-SP ``aerosol.*`` struct
+        # fields → the ``macsp.*`` namespace, #640). Keyed by the INTERNAL
+        # dotted diagnostics name and applied in ``data_struct_to_dict`` after
+        # flattening; the FIRST term to claim a key wins (composition order),
+        # matching the units-table / output_attrs precedence rule.
+        output_key_map: dict[str, str] = {}
+        for t in terms:
+            for src, dst in getattr(t, "output_key_map", {}).items():
+                output_key_map.setdefault(src, dst)
+        self._output_key_map = output_key_map
         self.checkpoint_terms = checkpoint_terms
         self.vectorize_columns = vectorize_columns
         self.dt_seconds = float(dt_seconds)
@@ -567,6 +578,13 @@ class ComposablePhysics(nnx.Module, Physics):
     #: all-sky flux, ~240 W/m2 instead of ~-1 (jax-gcm#647).
     _term_withheld_keys: frozenset[str] = frozenset()
 
+    #: Internal-dotted-key → output-key renames aggregated from the terms'
+    #: :attr:`PhysicsTerm.output_key_map` (see ``__init__``). Applied to every
+    #: flattened output key so a scheme can publish its diagnostics under an
+    #: explicit namespace (e.g. MACv2-SP's ``aerosol.*`` → ``macsp.*``, #640)
+    #: without renaming the internal struct radiation/microphysics read.
+    _output_key_map: Mapping[str, str] = {}
+
     def units_table_paths(self) -> tuple:
         """Units/description CSVs of every term in this package, deduplicated.
 
@@ -625,6 +643,7 @@ class ComposablePhysics(nnx.Module, Physics):
             return super().data_struct_to_dict(struct, nodal_shape, sep)
 
         items: dict[str, Any] = {}
+        rename = self._output_key_map
         for k, v in struct.items():
             # The exclusion set holds dotted leaf names for sub-structs and
             # bare names for whole top-level entries (e.g. the ``_prev_step``
@@ -636,16 +655,18 @@ class ComposablePhysics(nnx.Module, Physics):
             if not out_key:
                 continue
             if isinstance(v, jax.Array):
-                items[out_key] = v
+                items[rename.get(out_key, out_key)] = v
             elif isinstance(v, dict) and k not in self._UNFLATTENED_DICTS:
                 # Plain dict-of-arrays diagnostic (e.g. the carry-stored
-                # cloud-borne fields ``_jam_cloud_borne``, #602 item 3):
-                # flatten one level with the same separator convention as
-                # typed sub-structs. Zero-size entries (empty band tables
-                # and the like) have no xarray shape and are skipped.
+                # cloud-borne fields ``_jam_cloud_borne``, #602 item 3, or the
+                # JAM optics ``_jam_optics`` carry, #640): flatten one level
+                # with the same separator convention as typed sub-structs.
+                # Zero-size entries (empty band tables and the like) have no
+                # xarray shape and are skipped.
                 for sk, sv in v.items():
                     if isinstance(sv, jax.Array) and sv.size:
-                        items[f"{out_key}{sep}{sk}"] = sv
+                        full_key = f"{out_key}{sep}{sk}"
+                        items[rename.get(full_key, full_key)] = sv
             elif hasattr(v, "__dict__") and v.__dict__:
                 # Typed sub-struct (e.g. PhysicsData.radiation). Flatten via
                 # the parent recursive helper; skip if it raises (sub-structs
@@ -659,7 +680,7 @@ class ComposablePhysics(nnx.Module, Physics):
                     if (full_key in self._EXCLUDED_OUTPUT_KEYS
                             or full_key in self._term_withheld_keys):
                         continue
-                    items[full_key] = sv
+                    items[rename.get(full_key, full_key)] = sv
 
         # Reshape column-vectorized diagnostics (a flattened ncols axis,
         # produced when ``vectorize_columns=True``) back to ``(lon, lat)``

--- a/jcm/physics/diagnostics/aerocom_test.py
+++ b/jcm/physics/diagnostics/aerocom_test.py
@@ -591,12 +591,51 @@ class PerBandOpticsSerializationTest(unittest.TestCase):
                                   radiation_scheme="rrtmgp"),
         )
         ds = model.run(total_time=0.02, save_interval=0.02).to_xarray()
-        sw = "jam_band_optics.aod_sw_per_band"
-        lw = "jam_band_optics.aod_lw_per_band"
+        sw = "jam_optics.aod_sw_per_band"
+        lw = "jam_optics.aod_lw_per_band"
         self.assertIn(sw, ds.data_vars)
         self.assertEqual(ds[sw].dims[1], "sw_band")
         self.assertIn(lw, ds.data_vars)
         self.assertEqual(ds[lw].dims[1], "lw_band")
+        # JAM optics publish under the explicit ``jam_optics.*`` namespace
+        # (#640); the column AOD is ``jam_optics.aod_550``.
+        self.assertIn("jam_optics.aod_550", ds.data_vars)
+        # The old top-level ``aerosol_optical_depth`` key is gone (it collided
+        # with the per-band RadiationInput field), and no MACv2-SP ``aerosol.*``
+        # /``macsp.*`` output appears in a JAM run (MACv2-SP is not composed).
+        self.assertNotIn("aerosol_optical_depth", ds.data_vars)
+        self.assertNotIn("aerosol.aod_total", ds.data_vars)
+        self.assertNotIn("aerosol.Nccn", ds.data_vars)
+        self.assertNotIn("macsp.od550aer", ds.data_vars)
+
+
+class Macv2NamespaceOutputTest(unittest.TestCase):
+    """MACv2-SP output moves to the explicit ``macsp.*`` namespace (#640)."""
+
+    @pytest.mark.slow
+    def test_macv2sp_publishes_macsp_namespace(self):
+        from jcm.model import Model
+        from jcm.physics.echam.echam_levels import get_echam_levels
+        from jcm.physics.echam.echam_terms import echam_physics
+        from jcm.terrain import TerrainData
+        from jcm.utils import get_coords
+
+        coords = get_coords(get_echam_levels(47), spectral_truncation=21)
+        model = Model(
+            coords=coords, terrain=TerrainData.aquaplanet(coords),
+            time_step=900.0,
+            physics=echam_physics(aerosol_module="macv2sp",
+                                  radiation_scheme="rrtmgp"),
+        )
+        ds = model.run(total_time=0.02, save_interval=0.02).to_xarray()
+        # Namespaced, CF-named MACv2-SP output present...
+        self.assertIn("macsp.od550aer", ds.data_vars)
+        self.assertIn("macsp.aod_anthropogenic", ds.data_vars)
+        # ...and the old ``aerosol.*`` struct keys and the top-level
+        # ``aerosol_optical_depth`` are gone.
+        self.assertNotIn("aerosol.aod_total", ds.data_vars)
+        self.assertNotIn("aerosol.angstrom", ds.data_vars)
+        self.assertNotIn("aerosol_optical_depth", ds.data_vars)
 
 
 class AerocomOpticsConfigTest(unittest.TestCase):

--- a/jcm/physics/echam/echam_terms.py
+++ b/jcm/physics/echam/echam_terms.py
@@ -395,11 +395,14 @@ def echam_physics(
             f"Unknown cloud_scheme={cloud_scheme!r}. Choose '1m' or '2m'."
         )
 
-    # For now MACv2-SP is kept alongside JAM to provide the ``aerosol``
-    # optics/Twomey diagnostic that radiation and the cloud schemes read — a
-    # temporary fudge in lieu of proper JAM aerosol↔radiation and
-    # aerosol↔microphysics coupling (#495). Once JAM supplies those, MACv2-SP
-    # need not be included in the JAM path.
+    # MACv2-SP and JAM are mutually exclusive aerosol sources (#640): running
+    # both was confusing and redundant, so the JAM composition no longer
+    # includes MACv2-SP. JAM owns the ``aerosol`` slot through its own
+    # ``AerosolCarrySeeder`` (radiatively passive when ``jam_optics=False``,
+    # overwritten by ``JamOpticsTerm`` when on) and supplies the cloud
+    # microphysics activation through ``ArgActivation``; the 2M scheme falls
+    # back to its ECHAM-HAM ``cdnc_min`` floor where ARG is empty rather than to
+    # the (now absent) MACv2-SP SPA floor.
     #
     # Wet deposition is split out and placed *after* the cloud microphysics
     # term so it scavenges against the current step's precip/condensate (the
@@ -470,7 +473,9 @@ def echam_physics(
         jam_pre_cloud_terms = [
             t for t in jam_terms if t.category not in _post_cloud
         ]
-        aerosol_terms = [Macv2SpAerosol(params=aerosol_p), *jam_pre_cloud_terms]
+        # No MACv2-SP in the JAM path (#640): ``jam_pre_cloud_terms`` already
+        # begins with the ``AerosolCarrySeeder`` that owns the ``aerosol`` slot.
+        aerosol_terms = [*jam_pre_cloud_terms]
     else:
         raise ValueError(
             f"Unknown aerosol_module={aerosol_module!r}. Choose 'macv2sp' "

--- a/jcm/physics/layout_audit_test.py
+++ b/jcm/physics/layout_audit_test.py
@@ -108,6 +108,10 @@ LAYOUT_AGNOSTIC = frozenset({
 #: environment's own nonzero seed fields instead of what the term changed.
 #: Move one here to LAYOUT_AGNOSTIC by giving it an ENV_HOOKS entry.
 INERT_IN_HARNESS = frozenset({
+    # Resets the shared ``aerosol`` slot to an all-zero base each step (#640);
+    # broadcasting-native but produces the same zeros in either host, so a
+    # host-vs-host comparison proves nothing — like ``ResetEmissionFluxes``.
+    "AerosolCarrySeeder",
     "BettsMillerConvection",
     "FrontalGravityWaveDrag",
     "IceNucleation",

--- a/jcm/physics/physics_term.py
+++ b/jcm/physics/physics_term.py
@@ -108,6 +108,15 @@ class PhysicsTerm(nnx.Module):
     # unit is worse than an absent one.
     output_attrs: ClassVar[Mapping[str, Mapping[str, str]]] = {}
 
+    # Output-key renames applied by ``ComposablePhysics.data_struct_to_dict``:
+    # ``{internal_dotted_key: output_key}``. Lets a scheme publish its
+    # diagnostics under an explicit namespace (e.g. MACv2-SP's ``aerosol.*``
+    # struct fields → ``macsp.*`` with CF-style names, #640) WITHOUT renaming
+    # the internal ``aerosol`` struct that radiation/microphysics read by
+    # attribute — those stay scheme-agnostic. The FIRST term to claim a key
+    # wins, matching the ``output_attrs`` / units-table precedence rule.
+    output_key_map: ClassVar[Mapping[str, str]] = {}
+
     def withheld_output_keys(self) -> tuple[str, ...]:
         """``<struct>.<field>`` keys this configuration never populates.
 

--- a/jcm/physics/radiation/grey_two_stream/radiation_scheme_test.py
+++ b/jcm/physics/radiation/grey_two_stream/radiation_scheme_test.py
@@ -6,6 +6,7 @@ gas and cloud optics integration, flux calculations, and output diagnostics.
 Date: 2025-01-10
 """
 
+import math
 import jax.numpy as jnp
 from jcm.physics.radiation.grey_two_stream.radiation_scheme import (
     prepare_radiation_state,
@@ -286,6 +287,74 @@ def test_radiation_scheme_basic():
     # Check that key diagnostic values exist and are scalars
     assert jnp.isscalar(diagnostics.toa_sw_down) or diagnostics.toa_sw_down.ndim == 0
     assert jnp.isscalar(diagnostics.toa_sw_up) or diagnostics.toa_sw_up.ndim == 0
+
+
+def test_aerosol_profile_has_direct_effect():
+    """A JAM-style 550 nm AOD profile must attenuate the surface SW (#640).
+
+    Grey radiation reads ``aod_profile``/``ssa_profile``/``asy_profile``/
+    ``angstrom`` from the shared ``AerosolData`` struct and band-scales them
+    itself; ``JamOpticsTerm`` now writes exactly those fields (the SW band
+    nearest 550 nm) so grey+JAM keeps a direct effect. This checks the grey
+    consumer end: the same struct with a non-zero vs zero column burden must
+    give a lower surface SW-down (aerosol extinction).
+    """
+    atm = create_test_atmosphere(nlev=8)
+    air_density = calculate_air_density(atm['pressure_levels'], atm['temperature'])
+    layer_thickness = calculate_layer_thickness(atm['pressure_levels'], atm['temperature'])
+    date = jdt.Datetime.from_pydatetime(datetime(2025, 6, 21, 12, 0, 0))
+    parameters = RadiationParameters.default()
+
+    def _run(aod_level):
+        nlev = 8
+        aod_profile = jnp.full((nlev, 1), aod_level)
+        aerosol = AerosolData(
+            aod_profile=aod_profile,
+            # Scattering aerosol (sulfate-like): SSA near 1, moderate asymmetry.
+            ssa_profile=jnp.full((nlev, 1), 0.95),
+            asy_profile=jnp.full((nlev, 1), 0.6),
+            aod_total=jnp.sum(aod_profile, axis=0),
+            aod_anthropogenic=jnp.sum(aod_profile, axis=0),
+            aod_background=jnp.zeros(1),
+            cdnc_factor=jnp.ones(1),
+            Nccn=jnp.zeros(1),
+            angstrom=jnp.full(1, 1.5),
+            aod_sw_per_band=jnp.zeros((1, nlev, 1)),
+            ssa_sw_per_band=jnp.zeros((1, nlev, 1)),
+            asy_sw_per_band=jnp.zeros((1, nlev, 1)),
+            aod_lw_per_band=jnp.zeros((1, nlev, 1)),
+            ssa_lw_per_band=jnp.zeros((1, nlev, 1)),
+            asy_lw_per_band=jnp.zeros((1, nlev, 1)),
+        )
+        _, diag = radiation_scheme(
+            temperature=atm['temperature'],
+            specific_humidity=atm['specific_humidity'],
+            pressure_levels=atm['pressure_levels'],
+            pressure_interfaces=atm['pressure_interfaces'],
+            layer_thickness=layer_thickness,
+            air_density=air_density,
+            cloud_water=atm['cloud_water'],
+            cloud_ice=atm['cloud_ice'],
+            cloud_fraction=atm['cloud_fraction'],
+            solar=_solar_from_dt(date),
+            latitude=0.0,
+            longitude=0.0,
+            parameters=parameters,
+            aerosol_data=aerosol,
+            surface_albedo_nir=jnp.array([0.2]),
+            surface_albedo_vis=jnp.array([0.2]),
+            surface_emissivity=jnp.array([0.95]),
+            surface_temperature=jnp.array([288.0]),
+        )
+        return float(diag.surface_sw_down)
+
+    clean = _run(0.0)
+    dusty = _run(0.1)   # column AOD ~0.8 across 8 levels
+    assert math.isfinite(clean) and math.isfinite(dusty)
+    assert dusty < clean, (
+        f"aerosol profile produced no surface-SW attenuation: "
+        f"clean={clean:.3f} vs dusty={dusty:.3f}"
+    )
 
 
 def test_radiation_scheme_nighttime():

--- a/notebooks/06_macv2_aerosols.py
+++ b/notebooks/06_macv2_aerosols.py
@@ -157,7 +157,7 @@ def main(macv2_path: Path) -> None:
 
         # Extract anthropogenic AOD from the diagnostic output.
         diag_ds = preds.to_xarray()
-        aod_anth = diag_ds["aerosol.aod_anthropogenic"].mean(dim="time")
+        aod_anth = diag_ds["macsp.aod_anthropogenic"].mean(dim="time")
         print(f"{label}: mean column AOD_anth = "
               f"{float(aod_anth.mean()):.4f}")
 

--- a/tools/aerocom_cmor.py
+++ b/tools/aerocom_cmor.py
@@ -88,7 +88,13 @@ NAME_MAP: dict[str, tuple[str, str, str, float, float]] = {
     "clouds.precip_snow": ("prls", "kg m-2 s-1", "Surface", 1.0, 0.0),
     "convection.precip_conv": ("prc", "kg m-2 s-1", "Surface", 1.0, 0.0),
     # --- aerosol optics ---
-    "aerosol.aod_total": ("od550aer", "1", "Column", 1.0, 0.0),
+    # Column AOD at ~550 nm: MACv2-SP publishes it as ``macsp.od550aer``; JAM
+    # (without the aerocom_optics Mie pass) as the band-centre-approx
+    # ``jam_optics.aod_550`` (#640). Either maps to od550aer; the exact-
+    # wavelength ``od550aer`` diagnostic below supersedes both when present
+    # (later entries win in ``convert``).
+    "macsp.od550aer": ("od550aer", "1", "Column", 1.0, 0.0),
+    "jam_optics.aod_550": ("od550aer", "1", "Column", 1.0, 0.0),
     # --- CFMIP satellite simulators (jax-gcm#581) ---
     # CALIPSO and MODIS cloud products. jcm already emits these under their
     # CMOR names, so the mapping is mostly identity — but without an entry
@@ -121,7 +127,7 @@ NAME_MAP: dict[str, tuple[str, str, str, float, float]] = {
     # --- spectral aerosol optics (jax-gcm#584) ---
     # These come from the diagnostic Mie pass at the OBSERVATION
     # wavelengths, so ``od550aer`` here is at exactly 550 nm. It is listed
-    # after ``aerosol.aod_total`` (the nearest radiation band centre)
+    # after ``macsp.od550aer`` / ``jam_optics.aod_550`` (band-centre AODs)
     # deliberately: later entries win, so the exact-wavelength field
     # supersedes the band-centre one when a run has both.
     "od550aer": ("od550aer", "1", "Column", 1.0, 0.0),
@@ -134,7 +140,11 @@ NAME_MAP: dict[str, tuple[str, str, str, float, float]] = {
     "ang4487aer": ("ang4487aer", "1", "Column", 1.0, 0.0),
     "aerindex": ("aerindex", "1", "Column", 1.0, 0.0),
     "ec355aer": ("ec355aer", "m-1", "ModelLevel", 1.0, 0.0),
-    "aerosol.angstrom": ("angstrm", "1", "Column", 1.0, 0.0),
+    # Column Angstrom exponent: MACv2-SP's plume value or JAM's 550/865 band
+    # ratio (#640). ``ang550865aer`` from the aerocom_optics Mie pass, when
+    # present, is the higher-fidelity field.
+    "macsp.angstrom": ("angstrm", "1", "Column", 1.0, 0.0),
+    "jam_optics.angstrom": ("angstrm", "1", "Column", 1.0, 0.0),
     # --- microphysical process rates (jax-gcm#585), column-integrated ---
     "autoconv": ("autoconv", "kg m-2 s-1", "Column", 1.0, 0.0),
     "accretn": ("accretn", "kg m-2 s-1", "Column", 1.0, 0.0),

--- a/tools/radiation_emulator/generate_training_data.py
+++ b/tools/radiation_emulator/generate_training_data.py
@@ -43,6 +43,7 @@ import pathlib
 import subprocess
 import sys
 import time
+import warnings
 
 import numpy as np
 
@@ -914,6 +915,58 @@ def _first_var(ds, names, default=None, shape=None):
     return np.full(shape, default, dtype=np.float64), f"<default {default}>"
 
 
+# Broadband 550 nm aerosol optics the per-band scaling (:func:`_per_band_optics`)
+# rebuilds from. Each run publishes these under exactly ONE scheme namespace
+# (#640): MACv2-SP under ``macsp.*``, the online JAM direct-effect optics under
+# ``jam_optics.*`` (a JAM run's optics term writes the 550 nm band-centre
+# profiles + a band-ratio Angstrom into those keys). The pre-#640 un-namespaced
+# ``aerosol.*`` names are kept LAST as a compatibility alias for old
+# trajectories. A single file only ever carries one namespace, so the order is a
+# documented preference, not a merge; ``macsp`` leads only because it is the
+# older/plainer diagnostic. Reading the removed ``aerosol.*`` names alone (the
+# pre-fix behaviour) silently substituted zeros on a post-rename file and trained
+# the emulator with the aerosol effect dropped -- hence the loud warning below
+# when NONE of the names are present.
+_AOD_PROFILE_NAMES = (
+    "macsp.aod_profile", "jam_optics.aod_profile", "aerosol.aod_profile")
+_SSA_PROFILE_NAMES = (
+    "macsp.ssa_profile", "jam_optics.ssa_profile", "aerosol.ssa_profile")
+_ASY_PROFILE_NAMES = (
+    "macsp.asy_profile", "jam_optics.asy_profile", "aerosol.asy_profile")
+_ANGSTROM_NAMES = (
+    "macsp.angstrom", "jam_optics.angstrom", "aerosol.angstrom")
+
+
+def _aerosol_optics_fields(ds, shape_3d, shape_2d):
+    """Resolve the broadband aerosol optics, warning loudly if none are present.
+
+    Returns the ``aod_profile``/``ssa_profile``/``asy_profile``/``angstrom``
+    arrays, taking each from the first present name in its preference list
+    (``macsp.*`` → ``jam_optics.*`` → legacy ``aerosol.*``). If the AOD profile
+    is absent under every name the whole quartet falls back to its documented
+    no-aerosol default and a warning fires: that is legitimate for a genuinely
+    aerosol-free run, but a silent zero on a run that DID carry aerosol would
+    train the emulator with the aerosol effect dropped, so it must be said.
+    """
+    aod, aod_src = _first_var(ds, list(_AOD_PROFILE_NAMES), 0.0, shape_3d)
+    fields = {
+        "aod_profile": aod,
+        "ssa_profile": _first_var(ds, list(_SSA_PROFILE_NAMES), 0.9, shape_3d)[0],
+        "asy_profile": _first_var(ds, list(_ASY_PROFILE_NAMES), 0.7, shape_3d)[0],
+        "angstrom": _first_var(ds, list(_ANGSTROM_NAMES), 1.5, shape_2d)[0],
+    }
+    if aod_src.startswith("<default"):
+        warnings.warn(
+            "no aerosol optics found: none of the aod_profile names "
+            f"{_AOD_PROFILE_NAMES!r} are present in the state file; training "
+            "columns will carry ZERO aerosol. This is correct only for a "
+            "genuinely aerosol-free run -- if the run had a MACv2-SP or JAM "
+            "aerosol scheme, its diagnostics were not written to output.",
+            stacklevel=2,
+        )
+    return fields
+
+
 @functools.lru_cache(maxsize=1)
 def _load_trajectory_fields(state_file):
     """Read every field the trajectory source needs from one JCM output file.
@@ -964,14 +1017,7 @@ def _load_trajectory_fields(state_file):
         ds, ["radiation.surface_albedo_nir"], 0.07, shape_2d)[0]
     out["surface_emissivity"] = _first_var(
         ds, ["radiation.surface_emissivity"], 0.98, shape_2d)[0]
-    out["aod_profile"] = _first_var(
-        ds, ["aerosol.aod_profile"], 0.0, shape_3d)[0]
-    out["ssa_profile"] = _first_var(
-        ds, ["aerosol.ssa_profile"], 0.9, shape_3d)[0]
-    out["asy_profile"] = _first_var(
-        ds, ["aerosol.asy_profile"], 0.7, shape_3d)[0]
-    out["angstrom"] = _first_var(
-        ds, ["aerosol.angstrom"], 1.5, shape_2d)[0]
+    out.update(_aerosol_optics_fields(ds, shape_3d, shape_2d))
     out["lat"] = np.asarray(ds["lat"].values)
     out["lon"] = np.asarray(ds["lon"].values)
     out["time"] = np.asarray(ds["time"].values)
@@ -986,8 +1032,9 @@ def trajectory_columns(n_columns, nlev, rng, n_bnd_sw, n_bnd_lw,
 
     Randomly subsamples over (time, lon, lat). Fields the run did not
     write fall back to documented constants; the per-band aerosol optics
-    are rebuilt from the broadband ``aerosol.*_profile`` diagnostics with
-    the MACv2-SP wavelength scaling, because JCM output never carries the
+    are rebuilt from the broadband 550 nm profile diagnostics (``macsp.*`` /
+    ``jam_optics.*`` / legacy ``aerosol.*``; see :func:`_aerosol_optics_fields`)
+    with the MACv2-SP wavelength scaling, because JCM output never carries the
     (n_bnd, nlev, ncols) per-band arrays.
 
     Point the source at SNAPSHOT output. Solar geometry is reconstructed

--- a/tools/radiation_emulator/generate_training_data_test.py
+++ b/tools/radiation_emulator/generate_training_data_test.py
@@ -15,6 +15,7 @@ import pathlib
 import sys
 import tempfile
 import unittest
+import warnings
 from unittest import mock
 
 import numpy as np
@@ -27,6 +28,7 @@ import generate_training_data  # noqa: E402
 from generate_training_data import (  # noqa: E402
     LABEL_FIELDS,
     PROFILE_FIELDS,
+    _aerosol_optics_fields,
     _clip_to_bounds,
     _finalize_batch,
     _latin_hypercube,
@@ -262,6 +264,84 @@ class EffectiveRadiusTest(unittest.TestCase):
         toa_large = np.asarray(labeller(large, 0)["sw_flux_up"])[:, 0]
         self.assertTrue(np.all(toa_small > toa_large + 1.0),
                         f"4 um {toa_small} vs 20 um {toa_large}")
+
+
+class AerosolNamespaceTest(unittest.TestCase):
+    """The trajectory loader must follow the #640 aerosol output rename.
+
+    Each run publishes the broadband 550 nm optics under exactly one scheme
+    namespace (``macsp.*`` or ``jam_optics.*``); pre-#640 files used the
+    un-namespaced ``aerosol.*``. Reading only the removed ``aerosol.*`` names
+    silently substituted zeros on a post-rename file, dropping the aerosol
+    effect from the training set. The loader must prefer the new names, fall
+    back to the legacy ones, and warn loudly when none are present.
+    """
+
+    SHAPE_3D = (2, 3)
+    SHAPE_2D = (3,)
+
+    def _ds(self, **vars_):
+        import xarray as xr
+
+        data = {}
+        for name, arr in vars_.items():
+            arr = np.asarray(arr, dtype=np.float64)
+            dims = ("level", "col") if arr.ndim == 2 else ("col",)
+            data[name] = xr.DataArray(arr, dims=dims)
+        return xr.Dataset(data)
+
+    def test_prefers_the_macsp_namespace(self):
+        aod = np.full(self.SHAPE_3D, 0.11)
+        ang = np.full(self.SHAPE_2D, 1.3)
+        ds = self._ds(**{
+            "macsp.aod_profile": aod,
+            "macsp.ssa_profile": np.full(self.SHAPE_3D, 0.95),
+            "macsp.asy_profile": np.full(self.SHAPE_3D, 0.65),
+            "macsp.angstrom": ang,
+        })
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            out = _aerosol_optics_fields(ds, self.SHAPE_3D, self.SHAPE_2D)
+        np.testing.assert_array_equal(out["aod_profile"], aod)
+        np.testing.assert_array_equal(out["angstrom"], ang)
+
+    def test_prefers_jam_optics_namespace(self):
+        aod = np.full(self.SHAPE_3D, 0.07)
+        ds = self._ds(**{
+            "jam_optics.aod_profile": aod,
+            "jam_optics.ssa_profile": np.full(self.SHAPE_3D, 0.9),
+            "jam_optics.asy_profile": np.full(self.SHAPE_3D, 0.7),
+            "jam_optics.angstrom": np.full(self.SHAPE_2D, 1.1),
+        })
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            out = _aerosol_optics_fields(ds, self.SHAPE_3D, self.SHAPE_2D)
+        np.testing.assert_array_equal(out["aod_profile"], aod)
+
+    def test_falls_back_to_legacy_aerosol_names(self):
+        aod = np.full(self.SHAPE_3D, 0.05)
+        ds = self._ds(**{
+            "aerosol.aod_profile": aod,
+            "aerosol.ssa_profile": np.full(self.SHAPE_3D, 0.9),
+            "aerosol.asy_profile": np.full(self.SHAPE_3D, 0.7),
+            "aerosol.angstrom": np.full(self.SHAPE_2D, 1.5),
+        })
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            out = _aerosol_optics_fields(ds, self.SHAPE_3D, self.SHAPE_2D)
+        np.testing.assert_array_equal(out["aod_profile"], aod)
+
+    def test_warns_and_defaults_when_no_aerosol_names_present(self):
+        ds = self._ds()  # a genuinely aerosol-free (or misconfigured) file
+        with self.assertWarnsRegex(UserWarning, "no aerosol optics"):
+            out = _aerosol_optics_fields(ds, self.SHAPE_3D, self.SHAPE_2D)
+        # The quartet falls back to the documented no-aerosol defaults.
+        np.testing.assert_array_equal(
+            out["aod_profile"], np.zeros(self.SHAPE_3D))
+        np.testing.assert_array_equal(
+            out["ssa_profile"], np.full(self.SHAPE_3D, 0.9))
+        np.testing.assert_array_equal(
+            out["angstrom"], np.full(self.SHAPE_2D, 1.5))
 
 
 class SweepCoverageTest(unittest.TestCase):

--- a/tools/release_validation/health.py
+++ b/tools/release_validation/health.py
@@ -154,7 +154,8 @@ def main():
     if aod is not None:
         check("aod_550", wmean(aod, weights), *RANGES["aod_550"])
     else:
-        print("NOTE  no AOD field found (aod_550/aod_total); skipping")
+        print("NOTE  no AOD field found "
+              "(jam_optics.aod_550/macsp.od550aer); skipping")
 
     # Per-species global burdens (JAM runs): the shared ``burden`` sums
     # interstitial + cloud-borne mass over the species' modes and

--- a/tools/release_validation/health.py
+++ b/tools/release_validation/health.py
@@ -53,8 +53,8 @@ RANGES = {
     "precip_mm_day": (2.0, 4.0),
     "cloud_cover": (0.4, 0.8),
     "near_surface_T": (278.0, 295.0),
-    # Global-mean 550 nm AOD: JAM's jam_band_optics.aod_550 or MACv2-SP's
-    # aerosol.aod_total. Wide gate — a from-zero JAM spin-up year sits low,
+    # Global-mean 550 nm AOD: JAM's jam_optics.aod_550 or MACv2-SP's
+    # macsp.od550aer. Wide gate — a from-zero JAM spin-up year sits low,
     # so use --last-n to score the settled months.
     "aod_550": (0.02, 0.35),
 }
@@ -144,10 +144,10 @@ def main():
     t_low = ds["temperature"].isel(level=0)
     check("near_surface_T", wmean(t_low, weights), *RANGES["near_surface_T"])
 
-    # 550 nm AOD — JAM publishes jam_band_optics.aod_550, MACv2-SP runs
-    # publish aerosol.aod_total; whichever is present is the scheme's AOD.
+    # 550 nm AOD — JAM publishes jam_optics.aod_550, MACv2-SP runs
+    # publish macsp.od550aer; whichever is present is the scheme's AOD.
     aod = None
-    for key in ("jam_band_optics.aod_550", "aerosol.aod_total"):
+    for key in ("jam_optics.aod_550", "macsp.od550aer"):
         if key in ds:
             aod = ds[key]
             break


### PR DESCRIPTION
Refs #640 (maintainer decision from its review discussion: "we should not have MACv2-SP on at all when JAM is active — it's confusing and redundant"); advances #495 (JAM now fully owns its optics/activation coupling; MACv2-SP is no longer composed as a stand-in).

## What

**MACv2-SP is gone from JAM compositions.** `echam_physics(aerosol_module="jam")` no longer includes `Macv2SpAerosol`; the "temporary fudge" arrangement and its comment are deleted. MACv2-SP is unchanged as the default (`aerosol_module="macv2sp"`).

Two structural prerequisites made that possible:
- **`AerosolCarrySeeder`** (new, always present on the JAM path) owns the `aerosol` carry slot MACv2-SP used to seed. With `jam_optics=false` the slot stays all-zero — a genuinely radiatively-passive aerosol, which is a *cleaner* A/B control than the previous MACv2-optics leak-in (RRTMGP provably tolerates zero optics: the `*noa` companion solve is exactly that).
- **The 2M activation floor is re-sourced.** Where JAM's ARG activation is empty (spin-up, aerosol-free cells), the scheme now falls back to its own ECHAM-HAM minimum-CDNC pathway (`cdnc_min_fixed` = 40 cm⁻³ / the dynamic branch) instead of the MACv2-derived SPA floor. The MACv2+2M path keeps the SPA floor — it is that path's Twomey link. The asymmetry and the no-double-flooring argument are commented at the dispatch.

**Grey+JAM keeps an aerosol direct effect**: `JamOpticsTerm` now also writes the 550 nm profile fields (`aod/ssa/asy_profile` from the SW band nearest 550 nm, band-centre approximation, commented) and a band-ratio `angstrom`, which is what the grey two-stream reads. Verified by a column test with/without a synthetic burden.

**Output names say what they are.** Via a new `PhysicsTerm.output_key_map` mechanism: MACv2-SP's fields publish under `macsp.*` with CF/AeroCom names where they exist (`macsp.od550aer`, not `aerosol.aod_total`); JAM's band optics publish under `jam_optics.*`; the top-level `aerosol_optical_depth` key is removed (it name-collided with an unrelated per-band `RadiationInput` field) — JAM's band-approximate column AOD is `jam_optics.aod_550`, kept distinct from the Mie-based `od550aer` of `aerocom_optics`. **This is a breaking output-format change**; release notes carry the rename table, and `tools/aerocom_cmor.py`, release-validation health, and the MACv2 notebook are updated.

## Decisions a reviewer should second-guess

- **The cdnc_min fallback feeds `minimum_CDNC` as the ARG-empty activation *target*** (masked to cloudy cells, idempotent with the scheme's own per-column floor — the only added effect is a truthful nonzero activation diagnostic in ARG-empty cloudy cells, matching HAM's background activation). If you'd rather it be a bare `cdnc_min_fixed` constant independent of `ldyn_cdnc_min`, that's a one-line change — flagged deliberately.
- Grey's profile fields use the band-centre approximation (not a second Mie pass) — consistent with not forcing `aerocom_optics` on.
- The JAM per-band arrays remain in output under their new names (the `aerocom` band-dimension wiring depends on them); they were renamed, not dropped.

## Verification

- `ruff` clean; fast suite **2346 passed, coverage 95.79%**; CI-parity slow gate (no extras) **92 passed, 83.37%** — both on this exact tip after rebase onto the #750 squash.
- Tests added: no `Macv2SpAerosol` in JAM compositions; seeder presence/ordering + zero-optics base; grey+JAM attenuation; cdnc_min fallback when ARG is empty; model-level output assertions (`macsp.*` present in a MACv2 run, `jam_optics.*` in a JAM run, old keys absent).

Stacked note: PR 4 of the campaign (#674 parameter pass) is already open on top of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFu9rxRPLQ7qj3hwZf6zRE