### PR TITLE
Test-suite hygiene: XLA cache growth, x64 isolation, un-skipped gradient checks, tooling gaps (#745 #704 #729 #262 #716 #701)

### DIFF
--- a/.claude/skills/derecho-jcm-runs/SKILL.md
+++ b/.claude/skills/derecho-jcm-runs/SKILL.md
@@ -41,7 +41,8 @@ Common flags (see `python scripts/mkjob.py --help` for all):
 | `--physics` | `echam-jam` | `echam-rrtmgp-2m` for no aerosol |
 | `--radiation` | (config default) | `grey` for a cheap-radiation A/B |
 | `--aquaplanet` | off | skips terrain/forcing files |
-| `--resume` | off | reuse the run dir's checkpoint |
+| `--resume` | off | reuse the run dir's checkpoint (without it the job deletes it) |
+| `--fresh` | off | refuse to generate if the run dir already has a checkpoint |
 | `--data` | `mirror` | HF bundles, prefetched at generation; `local` = legacy prepared files |
 | `--era` | `pd` | `pd` (2005–2014) or `pi` (1850s) mirror climatologies |
 | `--emissions` | (local mode) | legacy emissions file for `--data local` |

--- a/.claude/skills/derecho-jcm-runs/scripts/mkjob.py
+++ b/.claude/skills/derecho-jcm-runs/scripts/mkjob.py
@@ -159,7 +159,35 @@ def check_compose(a, overrides) -> None:
           f" spectral_truncation={trunc})\"", file=sys.stderr)
 
 
-def main() -> None:
+def check_rundir(rundir: str, resume: bool, fresh: bool) -> None:
+    """Say out loud what an existing checkpoint in ``rundir`` will cause.
+
+    A run dir is named only by ``--name``, so reusing a name silently picks up
+    the previous run: with --resume the job continues that integration, and
+    without it the script deletes the checkpoint and starts over. Both are
+    intended, neither is obvious at generation time (cf. #701).
+    """
+    ckpt = os.path.join(rundir, "checkpoint.msgpack")
+    if not os.path.exists(ckpt):
+        return
+    if fresh:
+        sys.exit(f"{ckpt} already exists and --fresh was passed: refusing to "
+                 "generate a job that would resume or delete it. Pick a new "
+                 "--name, or drop --fresh (with --resume to continue that "
+                 "run, without it to overwrite it).")
+    what = ("RESUME FROM it -- this job continues that integration, not a new "
+            "one" if resume else
+            "DELETE it at startup and integrate from scratch")
+    print("\n".join([
+        "!" * 72,
+        f"!! {ckpt}",
+        f"!! already exists. The generated job will {what}.",
+        "!! Pass a new --name for an independent run, or --fresh to refuse.",
+        "!" * 72,
+    ]), file=sys.stderr)
+
+
+def main(argv=None) -> None:
     p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("--name", required=True)
@@ -192,7 +220,11 @@ def main() -> None:
     p.add_argument("--emissions", default=EMISSIONS,
                    help="anthropogenic emissions netCDF")
     p.add_argument("--resume", action="store_true",
-                   help="keep an existing checkpoint in the run dir")
+                   help="keep an existing checkpoint in the run dir, so the "
+                        "job continues that integration")
+    p.add_argument("--fresh", action="store_true",
+                   help="refuse to generate a job when the run dir already "
+                        "holds a checkpoint (nothing resumed, nothing deleted)")
     p.add_argument("--bench", action="store_true",
                    help="variant matrix (reference + grey) with settled rates")
     p.add_argument("--bench-variant", action="append", default=[],
@@ -203,11 +235,12 @@ def main() -> None:
     p.add_argument("--dinosaur", default=DEFAULT_DINOSAUR)
     p.add_argument("--check", action="store_true",
                    help="compose the config before emitting the script")
-    a = p.parse_args()
+    a = p.parse_args(argv)
 
     a.mem = a.mem or ("200GB" if a.gpus > 1 else "160GB")
     frac = 0.85 if a.gpus > 1 else 0.93
     rundir = f"{SCRATCH}/jam_runs/{a.name}"
+    check_rundir(rundir, a.resume, a.fresh)
     if not a.aquaplanet and a.data == "mirror":
         a.bundle_paths = fetch_bundles(a)
     elif a.physics.endswith("jam") and not a.no_emissions:

--- a/.claude/skills/derecho-jcm-runs/scripts/mkjob_test.py
+++ b/.claude/skills/derecho-jcm-runs/scripts/mkjob_test.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+"""Checks for mkjob.py's existing-checkpoint handling.
+
+    python mkjob_test.py
+
+Dependency-free and standalone: pytest does not collect ``.claude`` (its
+default norecursedirs skips dotted directories), so this runs itself.
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+
+def _run(tmp, name, *flags):
+    """Generate a job under SCRATCH=tmp; return (stdout, stderr, exit code)."""
+    os.environ["SCRATCH"] = tmp
+    import importlib
+
+    import mkjob
+    importlib.reload(mkjob)          # SCRATCH is read at import time
+    out, err, code = io.StringIO(), io.StringIO(), 0
+    # --aquaplanet/--no-emissions keep generation offline: no bundle fetch,
+    # no JAM aux-input check, so the test needs nothing but a tmp dir.
+    argv = ["--name", name, "--days", "1", "--aquaplanet", "--no-emissions",
+            *flags]
+    try:
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            mkjob.main(argv)
+    except SystemExit as e:
+        code = e.code
+    return out.getvalue(), err.getvalue(), code
+
+
+def _seed(tmp, name):
+    d = os.path.join(tmp, "jam_runs", name)
+    os.makedirs(d, exist_ok=True)
+    ckpt = os.path.join(d, "checkpoint.msgpack")
+    open(ckpt, "wb").write(b"stale")
+    return ckpt
+
+
+def test_quiet_for_a_new_rundir(tmp):
+    _, err, code = _run(tmp, "new_run")
+    assert code == 0, code
+    assert "checkpoint.msgpack" not in err, err
+
+
+def test_warns_that_the_job_will_resume(tmp):
+    ckpt = _seed(tmp, "old_run")
+    out, err, code = _run(tmp, "old_run", "--resume")
+    assert code == 0, code
+    assert ckpt in err and "RESUME FROM it" in err, err
+    # --resume means the script keeps the checkpoint rather than deleting it.
+    assert "rm -f" not in out
+
+
+def test_warns_that_the_job_will_delete_the_checkpoint(tmp):
+    ckpt = _seed(tmp, "old_run")
+    out, err, code = _run(tmp, "old_run")
+    assert code == 0, code
+    assert ckpt in err and "DELETE it at startup" in err, err
+    assert 'rm -f "$RUNDIR"/checkpoint.msgpack' in out
+
+
+def test_fresh_refuses_and_emits_no_script(tmp):
+    ckpt = _seed(tmp, "old_run")
+    out, err, code = _run(tmp, "old_run", "--fresh")
+    assert isinstance(code, str) and ckpt in code, code
+    assert "--fresh" in code and "--resume" in code
+    assert out == "", out
+    assert err == "", err
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(list(globals().items())):
+        if not name.startswith("test_"):
+            continue
+        with tempfile.TemporaryDirectory() as tmp:
+            try:
+                fn(tmp)
+                print(f"PASS {name}")
+            except AssertionError as e:
+                failures += 1
+                print(f"FAIL {name}: {e}")
+    print(f"{failures} failure(s)")
+    sys.exit(1 if failures else 0)

--- a/.claude/skills/jcm-local-ci/SKILL.md
+++ b/.claude/skills/jcm-local-ci/SKILL.md
@@ -17,7 +17,9 @@ scripts/local_ci.sh --local-fast /path/to/worktree     # ...and a fast gate on t
 
 Lint runs on the current node; both test gates run in a single
 `develop`-queue PBS job (`select=1:ncpus=16:mem=200GB`), fast then slow,
-sequentially. Watch the job log for `FAST_EXIT=0` and `SLOW_EXIT=0`.
+sequentially. Watch the job log for `FAST_EXIT=0`, `SLOW_EXIT=0` and the
+closing `GATES PASSED`: the job exits non-zero if either gate failed, so a
+job that ends green means both passed.
 
 The gates go to a compute node because a login node caps you at 10 GiB
 (see `docs/source/design/test_suite_memory.md`) — well under what an

--- a/.claude/skills/jcm-local-ci/SKILL.md
+++ b/.claude/skills/jcm-local-ci/SKILL.md
@@ -11,12 +11,21 @@ Reproduces the three CI gates from `.github/workflows/run_test.yaml` +
 ## One command
 
 ```bash
-scripts/local_ci.sh /path/to/worktree     # lint + fast gate locally, slow gate via qsub
+scripts/local_ci.sh /path/to/worktree                  # lint here, both gates via qsub
+scripts/local_ci.sh --local-fast /path/to/worktree     # ...and a fast gate on this node
 ```
 
-It runs lint and the fast gate on the current node (~3–5 min with
-`-n 12`) and submits the slow gate as a `develop`-queue PBS job
-(~30–45 min). Watch the job log for `SLOW_EXIT=0`.
+Lint runs on the current node; both test gates run in a single
+`develop`-queue PBS job (`select=1:ncpus=16:mem=200GB`), fast then slow,
+sequentially. Watch the job log for `FAST_EXIT=0` and `SLOW_EXIT=0`.
+
+The gates go to a compute node because a login node caps you at 10 GiB
+(see `docs/source/design/test_suite_memory.md`) — well under what an
+`-n 12` fast suite needs, so a local run there reports OOM-killed workers
+as unrelated test failures. `--local-fast` opts into an `-n 2` fast run on
+the current node anyway, for a quick read before the job lands; it runs
+*before* the submission, never alongside it, because both would fight over
+the same worktree's `.coverage.*`.
 
 ## The gates, individually
 
@@ -32,14 +41,16 @@ JAX_PLATFORMS=cpu pytest -n 4 -m "slow" --cov=jcm \
     --cov-config=.coveragerc-pr --cov-fail-under=80
 ```
 
-Gate 3 is real compute — run it on a `develop`-queue node
-(8 cpus / 220 GB, ~13 min with `-n 4`), not a login node. The `-n 4` is
+Gates 2 and 3 are real compute — run them on a `develop`-queue node, not
+a login node; `local_ci.sh` does. The `-n 4` on gate 3 is
 **mandatory on Derecho**, not an optimization: a single serial process
 accumulates thousands of mmap'd XLA JIT code sections and dies mid-suite
 with `LLVM ERROR: Unable to allocate section memory!` (SIGSEGV/SIGABRT —
 three attempts at 120–220 GB all failed identically; RAM is not the
 issue, per-process map count is). Splitting across workers resets the
 budget. GitHub's runners tolerate the serial run; Derecho's do not.
+(`docs/source/design/test_suite_memory.md` covers the related growth in
+retained XLA executables that the root `conftest.py` bounds.)
 
 ## Local Claude review
 
@@ -71,9 +82,8 @@ replying — Codex has been right (forcing unit conventions) and wrong
 - **Login-node load produces phantom failures.** A `-n 12` fast-suite
   run on a busy login node has produced 50+ failures across unrelated
   subsystems that all pass serially (twice now: 55 in July, 53 in
-  August). Before believing a red local run, rerun a sample of the
-  failures serially; better, don't share the node with heavy I/O jobs
-  during the run.
+  August). That is why the fast gate is a PBS job too. Before believing a
+  red `--local-fast` run, rerun a sample of the failures serially.
 - **Never run two coverage suites concurrently in one worktree.**
   pytest-cov erases `.coverage.*` at startup and combines at exit, so a
   fast-gate run (or a stray `rm .coverage*`) deletes an overlapping
@@ -97,6 +107,8 @@ replying — Codex has been right (forcing unit conventions) and wrong
   repo's documented mechanism, see the header comment there.
 - `JAX_PLATFORMS=cpu` is mandatory on GPU nodes (xdist workers
   otherwise fight over the GPU).
+- The gate job asks for 16 cpus so `-n 12` (fast) and `-n 4` (slow) both
+  fit, and 200 GB because the suite is memory-bound, not CPU-bound.
 - `local_ci.sh` exports `JAX_COMPILATION_CACHE_DIR` (default
   `$SCRATCH/jcm-jax-cache`) so xdist workers and successive gate runs
   share XLA compiles of identical jitted modules instead of each

--- a/.claude/skills/jcm-local-ci/scripts/local_ci.sh
+++ b/.claude/skills/jcm-local-ci/scripts/local_ci.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
-# Local jax-gcm CI: lint + fast gate here, slow gate via PBS develop queue.
-#   local_ci.sh [worktree]   (default: current directory)
+# Local jax-gcm CI: lint on this node, both test gates in one PBS job.
+#   local_ci.sh [worktree]                 lint here, gates via qsub
+#   local_ci.sh --local-fast [worktree]    also run the fast gate on this node
 set -uo pipefail
+LOCAL_FAST=0
+if [ "${1:-}" = "--local-fast" ]; then LOCAL_FAST=1; shift; fi
 REPO=$(cd "${1:-.}" && pwd)
 VENV=${JCM_VENV:-$HOME/.venvs/jaxgcm}
 ACCOUNT=${PBS_ACCOUNT:-UCSD0085}
@@ -15,34 +18,48 @@ cd "$REPO"
 # location as jcm.runners.maybe_enable_compilation_cache uses for runs.
 export JAX_COMPILATION_CACHE_DIR=${JAX_COMPILATION_CACHE_DIR:-${SCRATCH:-$HOME/.cache/jcm}/jcm-jax-cache}
 
-echo "=== lint ==="
+echo "=== lint (here) ==="
 ruff check . || { echo "LINT FAILED"; exit 1; }
 
-echo "=== fast gate (not slow, cov>=90) ==="
-JAX_PLATFORMS=cpu pytest -n 12 -m "not slow" --cov=jcm --cov-fail-under=90 -q
-FAST=$?
-echo "FAST_EXIT=$FAST"
+# Runs before the qsub, never alongside it: pytest-cov erases and recombines
+# .coverage.* per worktree, so two concurrent suites destroy each other's data.
+if [ "$LOCAL_FAST" = 1 ]; then
+    echo "=== fast gate (this node, -n 2) ==="
+    echo "WARNING: interactive work on a login node lives in a 10 GiB per-user"
+    echo "         memory cgroup. -n 2 is the ceiling there, heavy packages"
+    echo "         (jcm/physics/radiation/, the JAM tests) may still be"
+    echo "         OOM-killed, and a killed worker looks like unrelated test"
+    echo "         failures. The PBS gate below is the authoritative run."
+    JAX_PLATFORMS=cpu pytest -n 2 -m "not slow" --cov=jcm --cov-fail-under=90 -q
+    echo "LOCAL_FAST_EXIT=$?"
+fi
 
-echo "=== slow gate: submitting to develop queue ==="
+echo "=== submitting both gates to the develop queue ==="
 JOB=$(mktemp --suffix=.pbs)
 cat > "$JOB" <<EOF
 #!/bin/bash
-#PBS -N jcm_slow_ci
+#PBS -N jcm_ci
 #PBS -A $ACCOUNT
 #PBS -q develop
-#PBS -l select=1:ncpus=8:mem=120GB
-#PBS -l walltime=02:00:00
+#PBS -l select=1:ncpus=16:mem=200GB
+#PBS -l walltime=03:00:00
 #PBS -m abe
 #PBS -j oe
-#PBS -o $REPO/jcm_slow_ci.log
+#PBS -o $REPO/jcm_ci.log
 set -uo pipefail
 source $VENV/bin/activate
 cd $REPO
 export JAX_PLATFORMS=cpu
 export JAX_COMPILATION_CACHE_DIR=$JAX_COMPILATION_CACHE_DIR
-pytest -v -s -m "slow" --cov=jcm --cov-config=.coveragerc-pr --cov-fail-under=80 2>&1 | tail -40
-echo SLOW_EXIT=\${PIPESTATUS[0]}
+
+# Sequential, not concurrent: the two gates share this worktree's .coverage.*.
+echo "=== fast gate (not slow, cov>=90) ==="
+pytest -n 12 -m "not slow" --cov=jcm --cov-fail-under=90 -q
+echo "FAST_EXIT=\$?"
+
+echo "=== slow gate (slow only, cov>=80 vs .coveragerc-pr) ==="
+pytest -n 4 -m "slow" --cov=jcm --cov-config=.coveragerc-pr --cov-fail-under=80
+echo "SLOW_EXIT=\$?"
 EOF
 qsub "$JOB"
-echo "watch: grep SLOW_EXIT $REPO/jcm_slow_ci.log"
-exit $FAST
+echo "watch: grep -E 'FAST_EXIT|SLOW_EXIT' $REPO/jcm_ci.log"

--- a/.claude/skills/jcm-local-ci/scripts/local_ci.sh
+++ b/.claude/skills/jcm-local-ci/scripts/local_ci.sh
@@ -23,6 +23,7 @@ ruff check . || { echo "LINT FAILED"; exit 1; }
 
 # Runs before the qsub, never alongside it: pytest-cov erases and recombines
 # .coverage.* per worktree, so two concurrent suites destroy each other's data.
+LOCAL_FAST_STATUS=0
 if [ "$LOCAL_FAST" = 1 ]; then
     echo "=== fast gate (this node, -n 2) ==="
     echo "WARNING: interactive work on a login node lives in a 10 GiB per-user"
@@ -30,8 +31,9 @@ if [ "$LOCAL_FAST" = 1 ]; then
     echo "         (jcm/physics/radiation/, the JAM tests) may still be"
     echo "         OOM-killed, and a killed worker looks like unrelated test"
     echo "         failures. The PBS gate below is the authoritative run."
-    JAX_PLATFORMS=cpu pytest -n 2 -m "not slow" --cov=jcm --cov-fail-under=90 -q
-    echo "LOCAL_FAST_EXIT=$?"
+    JAX_PLATFORMS=cpu pytest -n 2 -m "not slow" --cov=jcm --cov-fail-under=90 -q \
+        || LOCAL_FAST_STATUS=$?
+    echo "LOCAL_FAST_EXIT=$LOCAL_FAST_STATUS"
 fi
 
 echo "=== submitting both gates to the develop queue ==="
@@ -53,13 +55,33 @@ export JAX_PLATFORMS=cpu
 export JAX_COMPILATION_CACHE_DIR=$JAX_COMPILATION_CACHE_DIR
 
 # Sequential, not concurrent: the two gates share this worktree's .coverage.*.
+# Each status is kept rather than left in \$? (the next echo would replace it),
+# so the slow gate still runs after a fast-gate failure and the job's own exit
+# code still reports it -- a green job must mean both gates passed.
+FAST_STATUS=0
+SLOW_STATUS=0
+
 echo "=== fast gate (not slow, cov>=90) ==="
-pytest -n 12 -m "not slow" --cov=jcm --cov-fail-under=90 -q
-echo "FAST_EXIT=\$?"
+pytest -n 12 -m "not slow" --cov=jcm --cov-fail-under=90 -q || FAST_STATUS=\$?
+echo "FAST_EXIT=\$FAST_STATUS"
 
 echo "=== slow gate (slow only, cov>=80 vs .coveragerc-pr) ==="
-pytest -n 4 -m "slow" --cov=jcm --cov-config=.coveragerc-pr --cov-fail-under=80
-echo "SLOW_EXIT=\$?"
+pytest -n 4 -m "slow" --cov=jcm --cov-config=.coveragerc-pr --cov-fail-under=80 \
+    || SLOW_STATUS=\$?
+echo "SLOW_EXIT=\$SLOW_STATUS"
+
+if [ "\$FAST_STATUS" -ne 0 ] || [ "\$SLOW_STATUS" -ne 0 ]; then
+    echo "GATES FAILED (fast=\$FAST_STATUS slow=\$SLOW_STATUS)"
+    exit 1
+fi
+echo "GATES PASSED"
 EOF
 qsub "$JOB"
-echo "watch: grep -E 'FAST_EXIT|SLOW_EXIT' $REPO/jcm_ci.log"
+echo "watch: grep -E 'FAST_EXIT|SLOW_EXIT|GATES' $REPO/jcm_ci.log"
+
+# A failed local fast gate must not look like a clean wrapper run; the job is
+# still submitted, since it is the authoritative gate.
+if [ "$LOCAL_FAST_STATUS" -ne 0 ]; then
+    echo "LOCAL FAST GATE FAILED (exit $LOCAL_FAST_STATUS) — job submitted anyway"
+    exit "$LOCAL_FAST_STATUS"
+fi

--- a/.github/workflows/run_test.yaml
+++ b/.github/workflows/run_test.yaml
@@ -51,6 +51,10 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # ~2x the slowest recent green run (52 min). The default is 6 h, so a
+    # hung compile or a deadlocked test would otherwise burn a whole runner
+    # day before anyone noticed.
+    timeout-minutes: 110
     strategy:
       matrix:
         python-version: ["3.11"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,10 @@ coverage this way). Every Codex/bot inline comment gets an explicit
 threaded reply ("Confirmed and fixed in <sha>" / "Refuted: <evidence>")
 before handing back — see `jcm-local-ci` for the `gh api` one-liner.
 
+Run these on a compute node, not a Derecho login node: the suite is
+memory-bound and a 10 GiB cgroup turns `-n 12` into an OOM that reads as
+random failures (`docs/source/design/test_suite_memory.md`).
+
 Ruff is the only linter (config in `pyproject.toml`); no formatter, no type
 checker, no pre-commit hooks. Tests are `*_test.py` co-located with their
 module. CI: push runs fast tests at 90% coverage, PRs also run slow tests at

--- a/conftest.py
+++ b/conftest.py
@@ -1,43 +1,81 @@
 """Session-wide pytest hooks.
 
-Slow-suite memory ceiling (issue #745)
---------------------------------------
-The CI slow job runs the WHOLE suite in a single process
-(``pytest -v -s -m slow ...`` — no xdist), so JAX's compilation cache and the
-device arrays it retains accumulate ~unboundedly from module to module. On the
-hosted runner's hard memory ceiling that reproducibly OOM-kills the
-memory-heaviest test (the RRTMGP RCE integration,
-``rce_test.py::TestRceIntegrationRrtmgp``) after ~70 slow tests have run — the
-process is killed (exit 137/143), not a test assertion. Clearing JAX's caches
-and forcing a GC at each module's teardown releases the retained compiled
-executables between modules, capping peak RSS at roughly one module's working
-set instead of the whole suite's cumulative footprint.
-
-Scoped to modules that actually contain a slow-marked test: the fast (xdist)
-suite deselects slow tests, so this never fires there — each short-lived xdist
-worker frees its own memory on exit anyway, and a per-module cache clear would
-only force needless recompilation.
+Rationale, and how to run the gates on a memory-capped host such as a
+Derecho login node: ``docs/source/design/test_suite_memory.md``.
 """
 
 import gc
+import os
+import sys
 
 import pytest
 
 
-@pytest.fixture(scope="module", autouse=True)
-def _bound_slow_suite_memory(request):
-    """Clear JAX caches + GC at each slow module's teardown (issue #745)."""
-    yield
-    module = request.module
-    if not any(
-        item.get_closest_marker("slow")
-        for item in request.session.items
-        if getattr(item, "module", None) is module
-    ):
+def _memory_group(item):
+    """Nodeid of the class (or module) the item belongs to."""
+    cls = item.getparent(pytest.Class)
+    if cls is not None:
+        return cls.nodeid
+    module = item.getparent(pytest.Module)
+    return module.nodeid if module is not None else item.nodeid
+
+
+def _rss_bytes():
+    """Resident set size of this pytest process in bytes, or None.
+
+    ``/proc`` is Linux-only, so fall back to ``ru_maxrss`` — a high-water
+    mark, reported in KiB on Linux but in bytes on macOS. None means the
+    process size cannot be measured here at all.
+    """
+    try:
+        with open("/proc/self/statm") as f:
+            return int(f.read().split()[1]) * os.sysconf("SC_PAGE_SIZE")
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import resource
+        maxrss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    except (ImportError, OSError):
+        return None
+    return maxrss if sys.platform == "darwin" else maxrss * 1024
+
+
+# How far the process may grow between cache clears. Clearing is not free —
+# it forces later tests to recompile — so it is worth doing only once the
+# retained executables are actually costing memory. Zero disables the gate
+# and clears at every boundary, as does an unmeasurable process size.
+_MAX_GROWTH_BYTES = int(os.environ.get("JCM_TEST_CACHE_GROWTH_MB", "1024")) * 2**20
+_rss_at_last_clear = None
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_runtest_teardown(item, nextitem):
+    """Release JAX's compiled executables as the process grows (#745, #704).
+
+    A pytest process retains every executable it compiles, so a long session
+    accumulates them until it is OOM-killed — which surfaces as a crashed
+    xdist worker or a SIGTERM'd CI job, never as a test failure. Tests within
+    a class share their compilations, so the caches are dropped only at a
+    class/module boundary, and only once the process has grown by
+    ``JCM_TEST_CACHE_GROWTH_MB`` since the last drop. A zero budget, or a
+    platform whose RSS we cannot read, drops at every boundary instead.
+
+    Runs ``trylast`` so pytest's own teardown has already dropped the
+    class-scoped fixtures' references by the time the GC runs.
+    """
+    global _rss_at_last_clear
+    if nextitem is not None and _memory_group(item) == _memory_group(nextitem):
         return
+    rss = _rss_bytes()
+    if _MAX_GROWTH_BYTES > 0 and rss is not None:
+        if _rss_at_last_clear is None:
+            # First boundary: everything collected is imported, so this is the
+            # floor the compilation caches grow from.
+            _rss_at_last_clear = rss
+            return
+        if rss - _rss_at_last_clear < _MAX_GROWTH_BYTES:
+            return
     import jax
-    # Release the compiled executables + retained arrays this module's slow
-    # tests accumulated before the next module adds its own, so a single-process
-    # slow run's peak RSS does not grow with the whole suite (#745).
     jax.clear_caches()
     gc.collect()
+    _rss_at_last_clear = _rss_bytes()

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,4 @@
-"""Session-wide pytest hooks.
+"""Session-wide pytest hooks: memory ceiling and global-config isolation.
 
 Rationale, and how to run the gates on a memory-capped host such as a
 Derecho login node: ``docs/source/design/test_suite_memory.md``.
@@ -9,6 +9,49 @@ import os
 import sys
 
 import pytest
+
+# The pySES backend needs float64 for the whole life of the objects its
+# ``setUpClass`` fixtures build, so its tests are exempt from the x64 pinning
+# below; ``jcm/dycore/pyses/conftest.py`` schedules them last instead.
+_PYSES_TESTS = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                            "jcm", "dycore", "pyses") + os.sep
+
+_X64_BASELINE = False
+
+
+def pytest_configure(config):
+    """Record the session's starting ``jax_enable_x64`` (issue #729).
+
+    Imported here rather than lazily at the first test because the baseline
+    has to predate every test-module import: a module that flips the flag at
+    collection time would otherwise define the baseline meant to detect it.
+    """
+    global _X64_BASELINE
+    import jax
+    _X64_BASELINE = bool(jax.config.read("jax_enable_x64"))
+
+
+@pytest.fixture(autouse=True)
+def _pin_jax_x64(request):
+    """Hold ``jax_enable_x64`` at the session default around each test (#729).
+
+    Constructing the MAM4-JAX adapter (and importing some optional
+    dependencies) flips the flag process-wide, which silently runs every later
+    test in that process/xdist worker in float64 and fails dtype assertions
+    that have nothing to do with aerosols.
+    """
+    import jax
+    if str(getattr(request.node, "path", "")).startswith(_PYSES_TESTS):
+        yield
+        return
+
+    def _restore():
+        if bool(jax.config.read("jax_enable_x64")) != _X64_BASELINE:
+            jax.config.update("jax_enable_x64", _X64_BASELINE)
+
+    _restore()
+    yield
+    _restore()
 
 
 def _memory_group(item):

--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -23,6 +23,7 @@ JAX-GCM is designed to be a fully differentiable climate model that balances eas
    design/aerocom_erfari_sampling
    design/data_mirror
    design/packaged_config_tree
+   design/test_suite_memory
 
 Core Architecture
 -----------------

--- a/docs/source/design/test_suite_memory.md
+++ b/docs/source/design/test_suite_memory.md
@@ -1,9 +1,10 @@
-# Running the test suite: memory
+# Running the test suite: memory, and process-global state
 
-The jcm test suite is memory-bound, not CPU-bound, which changes how you have
+The jcm test suite is memory-bound, not CPU-bound, and it runs a lot of code
+that mutates process-global JAX configuration. Both facts change how you have
 to run it — especially on a Derecho login node. This page explains what the
-root `conftest.py` does about it and how to run the CI gates without fighting
-the machine.
+root `conftest.py` does about them and how to run the CI gates without
+fighting the machine.
 
 ## Why a pytest process grows without bound
 
@@ -97,3 +98,36 @@ Two related login-node observations that are *not* the problem:
 * Never run `pytest -n 12` on a login node: 12 workers × a few GB against a
   10 GiB cap is a guaranteed OOM, and the resulting red run carries no
   information.
+
+## Process-global JAX config: `jax_enable_x64`
+
+Two dependencies turn float64 on for the whole process:
+
+* `import mam4_jax` does it at import time, and `Mam4JaxMicrophysics.__init__`
+  does it again explicitly (default-on via `MAM4_JAX_ENABLE_X64`, so the
+  dycore state built afterwards inherits the precision the MAM4 core needs);
+* the pySES CAM-SE backend does it when its first grid/dycore is built.
+
+A test that leaves the flag on runs every later test in the same process (or
+xdist worker) in float64, which fails dtype assertions in unrelated packages
+and looks exactly like a numerical regression. The root `conftest.py` pins
+the flag: an autouse function-scoped fixture restores it to the session's
+starting value before *and* after every test, so neither a leak from an
+earlier test nor a leak from this one can propagate.
+
+Two deliberate exceptions:
+
+* Tests under `jcm/dycore/pyses/` are exempt. Their `setUpClass` fixtures
+  build float64 backends that later tests in the same class reuse, so the
+  flag must stay on for the life of the class; `jcm/dycore/pyses/conftest.py`
+  schedules the whole package last instead. That reordering is defeated by
+  `pytest-randomly`, so pass `-p no:randomly` if you have it installed.
+* `jcm/physics/aerosol/jam/microphysics/mam4_jax.py` restores the flag
+  around its own `import mam4_jax`, so importing the adapter — including at
+  collection time, via `pytest.importorskip` — cannot change anyone's dtype.
+  Constructing the adapter still sets the precision it needs; set
+  `MAM4_JAX_ENABLE_X64=0` to force a float32 core.
+
+CI never sees the mam4 side of this: it installs `pip install -e .` with no
+extras, so those tests skip there. The pin is what makes a local run with the
+`jcm[mam4]` extra installed agree with CI.

--- a/docs/source/design/test_suite_memory.md
+++ b/docs/source/design/test_suite_memory.md
@@ -1,0 +1,99 @@
+# Running the test suite: memory
+
+The jcm test suite is memory-bound, not CPU-bound, which changes how you have
+to run it — especially on a Derecho login node. This page explains what the
+root `conftest.py` does about it and how to run the CI gates without fighting
+the machine.
+
+## Why a pytest process grows without bound
+
+Every `jit`/`pmap` trace in a session leaves a compiled XLA executable in
+JAX's caches, and the executable keeps its donated buffers and constants
+alive. Nothing evicts them: a pytest process that has run 500 physics tests
+is holding 500 executables, even though only the current test needs one. The
+arrays involved are tiny — `rrtmgp_test.py` works on a handful of 10-level
+columns — so the footprint is almost entirely compiled code and its
+constants.
+
+When the process hits a hard memory ceiling it is *killed*, and that never
+looks like a test failure:
+
+* under `pytest -n`, the symptom is `worker gwN crashed` and an arbitrary,
+  run-dependent subset of "failures" (issue #704);
+* in the single-process CI slow job, it is exit 143/137 with every completed
+  test passing (issue #745);
+* in a long single-process run on Derecho, it is a segfault inside
+  `backend_compile_and_load` (issue #729).
+
+Tests within one class share their compilations (same fixtures, same shapes),
+so the cache is worth keeping *within* a class and worth much less across
+classes. The root `conftest.py` therefore calls `jax.clear_caches()` +
+`gc.collect()` from a `pytest_runtest_teardown` hook at each class/module
+boundary — but only once the process has grown by more than
+`JCM_TEST_CACHE_GROWTH_MB` (default 1024) since the last clear. The gate
+matters: clearing costs recompilation, and on light modules that cost is real
+while the memory saved is not. It reads RSS from `/proc/self/statm`, falling
+back to `getrusage`; where neither is available the gate cannot be evaluated
+and the caches are dropped at every boundary.
+
+Measured on this login node, `JAX_PLATFORMS=cpu pytest -q -m "not slow"`:
+
+| | peak RSS | wall time |
+| --- | --- | --- |
+| **`jcm/physics/radiation/rrtmgp_test.py`** (41 tests) | | |
+| no clearing | 7.66 GB | died at test 32/41 |
+| clear at every boundary | 3.41 GB | 442 s |
+| clear when 1 GB has accumulated | 4.85 GB | 439 s |
+| **`clouds/sundqvist_test.py` + `convection/betts_miller`** (33 tests) | | |
+| no clearing | 2.86 GB | 32.2 s |
+| clear at every boundary | 2.08 GB | 47.3 s |
+| clear when 1 GB has accumulated | 2.38 GB | 33.1 s |
+
+The "no clearing" rrtmgp run is the bug itself: it was OOM-killed nine tests
+short of the end, as a segfault inside `backend_compile_and_load`. Clearing at
+*every* boundary caps memory hardest but costs 47% on the light modules, where
+consecutive classes reuse the same executables; the growth gate buys almost
+all of the memory back for no measurable time anywhere.
+
+The clear applies to every suite, not just the `slow` one: the fast xdist
+suite hits the same ceiling, and a worker that dies takes its tests with it.
+
+## Derecho login nodes: a 10 GiB cgroup, not a slow CPU
+
+Interactive work on a Derecho login node runs inside a per-user memory
+cgroup:
+
+```bash
+cat /sys/fs/cgroup/memory/user.slice/user-$(id -u).slice/memory.limit_in_bytes
+# 10737418240   (10 GiB, shared by every process you have running there)
+```
+
+That is the real cause of the "nondeterministic radiation failures" and the
+"single-process run segfaults" reports: with several xdist workers each
+holding a few GB of executables, the cgroup OOM killer takes whichever worker
+asks for memory next, which is why the failing set changes run to run and why
+every one of those tests passes in isolation.
+
+Two related login-node observations that are *not* the problem:
+
+* `nproc` reports **1** on a login node. That is `OMP_NUM_THREADS=1` set by
+  `ncarenv` — `nproc --all` and `len(os.sched_getaffinity(0))` both report
+  128. Oversubscription is not what makes `-n 8` fail there.
+* `place=scatter:exclhost` PBS jobs with 200 GB have also segfaulted; they
+  inherit the same `OMP_NUM_THREADS=1`, but their failures were likewise
+  memory-shaped, not CPU-shaped.
+
+### How to run the gates
+
+* **Preferred:** on a compute node, via the `jcm-local-ci` skill's PBS flow.
+  A `-q develop` node gives you the whole node's memory and `-n 12` behaves.
+* **On a login node:** `-n 2` at most, and expect to run heavy packages
+  (`jcm/physics/radiation/`, the JAM tests) separately. Watch the cgroup with
+  `cat /sys/fs/cgroup/memory/user.slice/user-$(id -u).slice/memory.usage_in_bytes`
+  while it runs.
+* `JCM_TEST_CACHE_GROWTH_MB=0` makes the conftest clear at every class/module
+  boundary — the tightest memory setting, at the recompilation cost in the
+  table above. Use it if a run is still being killed.
+* Never run `pytest -n 12` on a login node: 12 workers × a few GB against a
+  10 GiB cap is a guaranteed OOM, and the resulting red run carries no
+  information.

--- a/docs/source/developer.rst
+++ b/docs/source/developer.rst
@@ -95,7 +95,8 @@ The suite is memory-bound, and a process killed by a memory ceiling shows up
 as an arbitrary set of "failures" rather than an error. Before running it in
 parallel — in particular on a Derecho login node, where a 10 GiB per-user
 cgroup makes ``-n 12`` an OOM rather than a test result — see
-:doc:`design/test_suite_memory`.
+:doc:`design/test_suite_memory`, which also covers the ``jax_enable_x64``
+isolation the root ``conftest.py`` provides.
 
 Code Quality
 ^^^^^^^^^^^^

--- a/docs/source/developer.rst
+++ b/docs/source/developer.rst
@@ -91,6 +91,12 @@ Run the test suite to ensure your changes don't break existing functionality:
 
 Write tests for your changes in the appropriate test file (e.g., ``jcm/module_name_test.py``). We aim for high unit test coverage to support the increasing complexity of physics going forward.
 
+The suite is memory-bound, and a process killed by a memory ceiling shows up
+as an arbitrary set of "failures" rather than an error. Before running it in
+parallel — in particular on a Derecho login node, where a 10 GiB per-user
+cgroup makes ``-n 12`` an OOM rather than a test result — see
+:doc:`design/test_suite_memory`.
+
 Code Quality
 ^^^^^^^^^^^^
 

--- a/docs/source/developer.rst
+++ b/docs/source/developer.rst
@@ -171,6 +171,14 @@ stage that deserves its own line in the report needs a scope adding there;
 individual physics terms need no changes, since the term loop already labels
 them by ``PhysicsTerm.name``.
 
+Before writing a report the tool checks that the trace is complete: the
+``dynamics``, ``bridge_to_physics`` and ``bridge_to_dynamics`` scopes sit
+outside every loop and branch in the step, so each must show up in the
+attribution exactly once per step. It fails — naming the labels — if any of the
+three is missing (the HLO-metadata join broke, so every number would be
+misattributed) or if any is short of the step count (the event buffer
+overflowed, so every number would be an undercount).
+
 Note that ``profile_terms.py`` disables CUDA graph capture — otherwise every
 kernel reports the same synthetic instruction and nothing is attributable — so
 its *total* step time reads high. For throughput use ``tools/benchmark.py`` and

--- a/jcm/dycore/dinosaur/dycore_test.py
+++ b/jcm/dycore/dinosaur/dycore_test.py
@@ -164,6 +164,16 @@ class TracerMassFixerTest(unittest.TestCase):
     step.
     """
 
+    def setUp(self):
+        # The fixer closes integral(q dp) to roundoff, so the closure
+        # assertions below only hold in float64: in float32 the residual is
+        # ~1e-6, the precision of the sum itself rather than a transport leak.
+        import jax
+
+        prior = jax.config.read("jax_enable_x64")
+        jax.config.update("jax_enable_x64", True)
+        self.addCleanup(jax.config.update, "jax_enable_x64", prior)
+
     def _dycore_with_tracer(self):
         from jcm.physics.physics_term import TracerSpec
 

--- a/jcm/dycore/pyses/hydra_config_test.py
+++ b/jcm/dycore/pyses/hydra_config_test.py
@@ -84,7 +84,9 @@ class PysesHydraConfigTest(unittest.TestCase):
         canonical files document ne30.
         """
         pytest.importorskip("pyses")
-        pytest.importorskip("mam4_jax")  # echam-jam's default JAM core
+        # The submodule, not the package: a stale flat-layout mam4-jax wheel
+        # satisfies a bare "mam4_jax" import and then fails inside build_model.
+        pytest.importorskip("mam4_jax.core")  # echam-jam's default JAM core
         from jcm.runners import build_model
 
         for name in ("ma-ne30-l47", "ma-ne30-l95"):

--- a/jcm/model_test.py
+++ b/jcm/model_test.py
@@ -388,7 +388,8 @@ class TestModelUnit(unittest.TestCase):
             "unit parameter tangent produced an all-zero trajectory tangent",
         )
 
-    @pytest.mark.skip(reason="finite differencing produces nans")
+    # ~70 s: eight one-step T30 SPEEDY integrations (AD + central differences).
+    @pytest.mark.slow
     def test_speedy_model_state_gradient_check(self):
         from jcm.model import Model
         from jcm.physics.speedy.speedy_coords import get_speedy_coords
@@ -396,20 +397,42 @@ class TestModelUnit(unittest.TestCase):
         # Create model that goes through one timestep
         model = Model(coords=get_speedy_coords())
         state = model._prepare_initial_dycore_state()
+        _ = model.run(total_time=0)  # to set up model fields
 
-        def f(state_f):
-            _ = model.run(total_time=0) # to set up model fields
-            predictions = model.run(initial_state=state_f, save_interval=(1/48.), total_time=(1/48.))
-            return model._final_dycore_state, predictions
-        
+        # check_vjp/check_jvp probe with unit-normal tangents, but the initial
+        # condition's spectral coefficients are O(1e-5): a unit perturbation
+        # drives the model into its humidity/temperature limiters, where the
+        # central difference is identically zero for any eps. Differentiating
+        # w.r.t. a small-amplitude perturbation is the same Jacobian at the
+        # same point, probed inside the model's linear regime.
+        perturbation_scale = 1e-5
+        zero_perturbation = jax.tree.map(jnp.zeros_like, state)
+
+        def f(delta):
+            perturbed = jax.tree.map(lambda x, d: x + perturbation_scale * d, state, delta)
+            predictions = model.run(initial_state=perturbed, save_interval=(1/48.), total_time=(1/48.))
+            # ModelPredictions also carries integer diagnostics (cloud-top
+            # level, step counters) and a bool flag, and finite differencing
+            # those is undefined ("numpy boolean subtract"), so the check
+            # covers the differentiable float leaves.
+            return [leaf for leaf in jax.tree.leaves(predictions)
+                    if jnp.issubdtype(jnp.asarray(leaf).dtype, jnp.floating)]
+
         # Calculate gradient
         f_jvp = functools.partial(jax.jvp, f)
         f_vjp = functools.partial(jax.vjp, f) 
 
-        check_vjp(f, f_vjp, args = (state,), 
-                                atol=None, rtol=1, eps=0.00001)
-        check_jvp(f, f_jvp, args = (state,), 
-                                atol=None, rtol=1, eps=0.001)    
+        # One eps for both checks: f perturbs the state by
+        # perturbation_scale * eps, so anything below ~1e-4 lands under a
+        # float32 ulp of the state and the difference is rounding noise.
+        # At 1e-3 the AD/FD gap is ~0.14 (vjp) / ~0.16 (jvp) and systematic,
+        # not noisy — a physics step's humidity and temperature limiters are
+        # where-branches the central difference straddles — so rtol keeps ~3x
+        # margin for branch flips that move with the platform.
+        check_vjp(f, f_vjp, args = (zero_perturbation,), 
+                                atol=None, rtol=5e-1, eps=0.001)
+        check_jvp(f, f_jvp, args = (zero_perturbation,), 
+                                atol=None, rtol=5e-1, eps=0.001)    
     
     @pytest.mark.slow
     def test_speedy_model_default_statistics(self):

--- a/jcm/physics/aerosol/jam/microphysics/mam4_jax.py
+++ b/jcm/physics/aerosol/jam/microphysics/mam4_jax.py
@@ -97,18 +97,33 @@ from jcm.physics.aerosol.jam.tracer_layout import (
 from jcm.physics.convection.saturation import saturation_specific_humidity
 from jcm.physics_interface import PhysicsTendency
 
+@contextlib.contextmanager
+def _preserved_x64():
+    """Undo any process-wide ``jax_enable_x64`` flip made inside the block."""
+    prior = jax.config.read("jax_enable_x64")
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prior)
+
+
 # MAM4-JAX (GPL-3.0) core. Imported at module level — this whole adapter module
 # is itself only imported when JAM selects the mam4_jax core (lazily, via
-# ``jam_terms``), so a plain jcm import never reaches this GPL dependency. The
-# import enables ``jax_enable_x64`` by default; ``__init__`` sets the final
-# precision per-instance (see ``enable_x64``). If the ``jcm[mam4]`` extra isn't
-# installed this raises ``ImportError`` here, which is the right signal.
-import mam4_jax  # noqa: F401
-from mam4_jax.core import data
-from mam4_jax.coupling import amicphys as _amicphys
-from mam4_jax.coupling.amicphys import amicphys
-from mam4_jax.physics.calcsize import calcsize
-from mam4_jax.physics.wateruptake import wateruptake
+# ``jam_terms``), so a plain jcm import never reaches this GPL dependency. If
+# the ``jcm[mam4]`` extra isn't installed this raises ``ImportError`` here,
+# which is the right signal.
+#
+# The import turns ``jax_enable_x64`` on process-wide; it is restored here so
+# merely importing the adapter cannot change the dtype of unrelated code
+# (issue #729). ``__init__`` sets the precision each instance needs, so the
+# import-time flip is redundant.
+with _preserved_x64():
+    import mam4_jax  # noqa: F401
+    from mam4_jax.core import data
+    from mam4_jax.coupling import amicphys as _amicphys
+    from mam4_jax.coupling.amicphys import amicphys
+    from mam4_jax.physics.calcsize import calcsize
+    from mam4_jax.physics.wateruptake import wateruptake
 
 # amicphys ``name_gas`` order (igas): 0 = SOA gas, 1 = H₂SO₄. ``data.LMAP_GAS``
 # maps each to its pcnst slot, so jcm's gas tokens resolve to q indices.

--- a/jcm/physics/aerosol/jam/microphysics/mam4_jax_test.py
+++ b/jcm/physics/aerosol/jam/microphysics/mam4_jax_test.py
@@ -13,14 +13,16 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-# Importing mam4_jax flips jax_enable_x64 on globally (it needs float64).
-# Capture and restore the flag around the import so *collection* of this module
-# doesn't leave x64 on and corrupt sibling tests' float32 dtype assertions when
-# the optional dependency is installed. Each test below re-enables x64 (via the
-# term's lazy import) and restores it in tearDown.
+# Importing mam4_jax flips jax_enable_x64 on globally (it needs float64), so
+# restore the flag around the import to keep *collection* of this module from
+# corrupting sibling tests' float32 dtype assertions. The ``finally`` matters:
+# a missing/too-old mam4-jax leaves x64 on via the partial import before
+# ``importorskip`` raises ``Skipped`` (issue #729).
 _x64_at_import = jax.config.read("jax_enable_x64")
-pytest.importorskip("mam4_jax.coupling")
-jax.config.update("jax_enable_x64", _x64_at_import)
+try:
+    pytest.importorskip("mam4_jax.coupling")
+finally:
+    jax.config.update("jax_enable_x64", _x64_at_import)
 
 
 def _column_state(nlev=4, ncols=2):

--- a/jcm/physics/convection/speedy_convection_test.py
+++ b/jcm/physics/convection/speedy_convection_test.py
@@ -3,7 +3,6 @@ import numpy as np
 import jax.numpy as jnp
 import jax
 import functools
-import pytest
 from jax.test_util import check_vjp, check_jvp
 
 class TestConvectionUnit(unittest.TestCase):
@@ -280,7 +279,6 @@ class TestConvectionUnit(unittest.TestCase):
                                 atol=None, rtol=1, eps=0.00001)
 
 
-    @pytest.mark.skip(reason="finite differencing produces nans - pre-existing issue unrelated to exchange coefficients")
     def test_get_convection_tendencies_varying_gradient_check(self):
         from jcm.utils import convert_back, convert_to_float
         ps = jnp.ones((ix, il))

--- a/jcm/physics/radiation/speedy_longwave_test.py
+++ b/jcm/physics/radiation/speedy_longwave_test.py
@@ -3,7 +3,6 @@ import jax.numpy as jnp
 import numpy as np
 import jax
 import functools
-import pytest
 from jax.test_util import check_vjp, check_jvp
 
 def initialize_arrays(ix, il, kx):
@@ -199,12 +198,13 @@ class TestLongwave(unittest.TestCase):
         f_jvp = functools.partial(jax.jvp, f)
         f_vjp = functools.partial(jax.vjp, f)  
 
+        # radset is smooth in temperature, so float32 central differences track
+        # AD to ~2e-3 (vjp) and to the noise floor (jvp).
         check_vjp(f, f_vjp, args = (temp, epslw), 
-                                atol=None, rtol=1, eps=0.00001)
+                                atol=None, rtol=1e-2, eps=0.00001)
         check_jvp(f, f_jvp, args = (temp, epslw), 
-                                atol=None, rtol=1, eps=0.000001)
+                                atol=None, rtol=1e-2, eps=0.000001)
         
-    @pytest.mark.skip(reason="finite differencing produces nans - pre-existing issue unrelated to exchange coefficients")
     def test_downward_longwave_rad_fluxes_gradient_check(self):
         from jcm.utils import convert_back, convert_to_float
         # FIXME: This array doesn't need to be this big once we fix the interfaces
@@ -237,13 +237,17 @@ class TestLongwave(unittest.TestCase):
         f_jvp = functools.partial(jax.jvp, f)
         f_vjp = functools.partial(jax.vjp, f)  
 
+        # eps is wedged: below ~1e-5 it is under an ulp of the O(400) st4a/dfabs
+        # fields, and at 1e-4 it steps across a where-branch in them. The
+        # quantisation that leaves puts the inner product ~7e-2 from AD.
         check_vjp(f, f_vjp, args = (physics_data_floats, state_floats, parameters_floats, forcing_floats, terrain_floats), 
-                                atol=None, rtol=1, eps=0.00001)
+                                atol=None, rtol=1e-1, eps=0.00001)
+        # eps=1e-4 leaves the O(1e3) scalar leaves (dt_seconds) bit-unchanged in
+        # float32 and reports a zero reference slope; 1e-3 moves them by ulps.
         check_jvp(f, f_jvp, args = (physics_data_floats, state_floats, parameters_floats, forcing_floats, terrain_floats), 
-                                atol=None, rtol=1, eps=0.0001)
+                                atol=None, rtol=2e-2, eps=0.001)
 
 
-    @pytest.mark.skip(reason="finite differencing produces nans - pre-existing issue unrelated to exchange coefficients")
     def test_upward_longwave_rad_fluxes_gradient_check(self):
         from jcm.utils import convert_back, convert_to_float
         ta = jnp.ones((kx, ix, il)) * 300
@@ -284,10 +288,14 @@ class TestLongwave(unittest.TestCase):
         f_jvp = functools.partial(jax.jvp, f)
         f_vjp = functools.partial(jax.vjp, f)  
 
+        # Same float32 wedge as the downward check, but on a smaller output
+        # tree: the inner product lands ~3e-2 from AD.
         check_vjp(f, f_vjp, args = (physics_data_floats, state_floats, parameters_floats, forcing_floats, terrain_floats), 
-                                atol=None, rtol=1, eps=0.00001)
+                                atol=None, rtol=5e-2, eps=0.00001)
+        # eps=1e-4 leaves the O(1e3) scalar leaves (dt_seconds) bit-unchanged in
+        # float32 and reports a zero reference slope; 1e-3 moves them by ulps.
         check_jvp(f, f_jvp, args = (physics_data_floats, state_floats, parameters_floats, forcing_floats, terrain_floats), 
-                                atol=None, rtol=1, eps=0.0001)
+                                atol=None, rtol=2e-2, eps=0.001)
 
 
 

--- a/jcm/physics/radiation/speedy_shortwave.py
+++ b/jcm/physics/radiation/speedy_shortwave.py
@@ -587,9 +587,15 @@ def solar(tyear, speedy_coords: SpeedyCoords, csol=4.*solc):
     # Compute daily-average insolation at the top of the atmosphere
     csolp = csol / pigr
 
-    # Calculate the solar radiation at the top of the atmosphere for each latitude
-    ch0 = jnp.clip(-tdecl * speedy_coords.sia / speedy_coords.coa, -1+epsilon, 1-epsilon) # Clip to prevent blowup of gradients
-    h0 = jnp.arccos(ch0)
+    # Half-day angle. A clip alone cannot hold arccos off its +/-1 singularity:
+    # float32 rounds 1-epsilon (1e-9) back to 1.0, so d(arccos)/dx = -1/sqrt(1-x^2)
+    # is -inf and the clip's zero tangent multiplies it to NaN. The where puts
+    # polar day/night on a branch AD never differentiates, and the 1e-6 margin
+    # keeps the interior arccos slope finite in float32.
+    ch0 = -tdecl * speedy_coords.sia / speedy_coords.coa
+    h0 = jnp.where(ch0 >= 1.0, 0.0,
+                   jnp.where(ch0 <= -1.0, pigr,
+                             jnp.arccos(jnp.clip(ch0, -1.0 + 1e-6, 1.0 - 1e-6))))
     sh0 = jnp.sin(h0)
 
     topsr = csolp * fdis * (h0 * speedy_coords.sia * sdecl + sh0 * speedy_coords.coa * cdecl)

--- a/jcm/physics/radiation/speedy_shortwave_test.py
+++ b/jcm/physics/radiation/speedy_shortwave_test.py
@@ -5,7 +5,6 @@ import jax
 import jax_datetime as jdt
 import functools
 from jax.test_util import check_vjp, check_jvp
-import pytest
 # truth for test cases are generated from https://github.com/duncanwp/speedy_test
 
 class TestSolar(unittest.TestCase):
@@ -110,7 +109,30 @@ class TestSolar(unittest.TestCase):
         df_dtyear, df_dcoords, df_dcsol = f_vjp(input)
 
         self.assertFalse(jnp.any(jnp.isnan(df_dtyear)))
-        
+
+    def test_solar_gradients_finite_under_polar_day_and_night(self):
+        """Gradients must stay finite where the polar cap saturates the half-day
+        angle. ``arccos`` sits on its +/-1 singularity there and a float32 clip
+        cannot hold it off, so this guards the ``where`` in ``solar`` (#262).
+        tyear = 0.2 (the other gradient tests) has no polar cap and misses it.
+        """
+        from jcm.physics.speedy.physical_constants import solc
+        csol = 4. * solc
+        for tyear in (0.0, 0.4, 0.6, 0.8):
+            with self.subTest(tyear=tyear):
+                topsr = solar(tyear, speedy_coords, csol)
+                # Guard the guard: these dates must actually have a polar night.
+                self.assertTrue(bool(jnp.any(topsr == 0.0)))
+
+                _, tangent = jax.jvp(lambda t: solar(t, speedy_coords, csol),
+                                     (tyear,), (1.0,))
+                self.assertFalse(bool(jnp.any(jnp.isnan(tangent))))
+
+                _, f_vjp = jax.vjp(solar, tyear, speedy_coords, csol)
+                cotangents = f_vjp(jnp.ones_like(topsr))
+                for leaf in jax.tree.leaves(cotangents):
+                    self.assertFalse(bool(jnp.any(jnp.isnan(leaf))))
+
     def test_solar_gradient_check(self): 
         from jcm.physics.speedy.physical_constants import solc
         tyear = 0.2
@@ -449,13 +471,6 @@ class TestShortWaveRadiation(unittest.TestCase):
         self.assertFalse(df_dparams.isnan().any_true())
         self.assertFalse(df_dforcing.isnan().any_true())
 
-    # solar() clips the hour angle with epsilon = 1e-9, which is a no-op in
-    # float32 (1-1e-9 rounds to 1.0), so arccos meets |x| = 1 and its -inf
-    # derivative times the clip's zero tangent is NaN. Needs a double-where in
-    # solar() itself; the fixture below is otherwise repaired and ready.
-    @pytest.mark.skip(reason="solar() NaNs its own gradient at polar day/night: "
-                             "clip(ch0, -1+1e-9, 1-1e-9) is a no-op in float32, so "
-                             "arccos hits |x|=1 where d/dx = -inf (issue #262)")
     def test_get_zonal_average_fields_gradient_check(self):
         from jcm.utils import convert_back, convert_to_float
         """Test whether gradients are close for shortwave radiation"""

--- a/jcm/physics/radiation/speedy_shortwave_test.py
+++ b/jcm/physics/radiation/speedy_shortwave_test.py
@@ -123,10 +123,12 @@ class TestSolar(unittest.TestCase):
         f_jvp = functools.partial(jax.jvp, f)
         f_vjp = functools.partial(jax.vjp, f)  
 
+        # solar() is smooth away from the polar cap, so the float32 central
+        # difference matches AD to ~7e-4 (vjp) and ~6e-3 (jvp) here.
         check_vjp(f, f_vjp, args = (tyear, speedy_coords, csol), 
-                                atol=None, rtol=1, eps=0.0001)
+                                atol=None, rtol=1e-2, eps=0.0001)
         check_jvp(f, f_jvp, args = (tyear, speedy_coords, csol), 
-                                atol=None, rtol=1, eps=0.000001)
+                                atol=None, rtol=2e-2, eps=0.000001)
         
 class TestShortWaveRadiation(unittest.TestCase):
 
@@ -447,13 +449,23 @@ class TestShortWaveRadiation(unittest.TestCase):
         self.assertFalse(df_dparams.isnan().any_true())
         self.assertFalse(df_dforcing.isnan().any_true())
 
-    @pytest.mark.skip(reason="JAX gradients are producing nans")
+    # solar() clips the hour angle with epsilon = 1e-9, which is a no-op in
+    # float32 (1-1e-9 rounds to 1.0), so arccos meets |x| = 1 and its -inf
+    # derivative times the clip's zero tangent is NaN. Needs a double-where in
+    # solar() itself; the fixture below is otherwise repaired and ready.
+    @pytest.mark.skip(reason="solar() NaNs its own gradient at polar day/night: "
+                             "clip(ch0, -1+1e-9, 1-1e-9) is a no-op in float32, so "
+                             "arccos hits |x|=1 where d/dx = -inf (issue #262)")
     def test_get_zonal_average_fields_gradient_check(self):
         from jcm.utils import convert_back, convert_to_float
         """Test whether gradients are close for shortwave radiation"""
         qa = 0.5 * 1000. * jnp.array([0., 0.00035438, 0.00347954, 0.00472337, 0.00700214,0.01416442,0.01782708, 0.0216505])
         qsat = 1000. * jnp.array([0., 0.00037303, 0.00366268, 0.00787228, 0.01167024, 0.01490992, 0.01876534, 0.02279])
-        rh = qa/qsat
+        # qsat's top entry is a placeholder zero, so a bare qa/qsat leaves a NaN
+        # in rh that get_clouds passes straight through to its output and that
+        # finite differencing then turns into a NaN reference gradient. q = 0
+        # there, so the dry value 0 is the physical answer.
+        rh = jnp.where(qsat > 0, qa / jnp.where(qsat > 0, qsat, 1.0), 0.0)
         geopotential = jnp.arange(7, -1, -1, dtype = float)
         se = .1*geopotential
         xy = (ix, il)
@@ -473,7 +485,7 @@ class TestShortWaveRadiation(unittest.TestCase):
         date_data = DateData.set_date(
             jdt.Datetime.from_pydatetime(jdt.to_datetime('2001-08-08'))
         )
-        physics_data = PhysicsData.zeros(xy,kx,surface_flux=surface_flux, humidity=humidity, convection=convection, condensation=condensation, shortwave_rad=sw_data, dt_seconds=date_data.dt_seconds)
+        physics_data = PhysicsData.zeros(xy,kx,surface_flux=surface_flux, humidity=humidity, convection=convection, condensation=condensation, shortwave_rad=sw_data, dt_seconds=date_data.dt_seconds, speedy_coords=speedy_coords)
         state = PhysicsState.zeros(zxy, specific_humidity=qa, geopotential=geopotential, normalized_surface_pressure=psa)
         _, physics_data = get_clouds(state, physics_data, parameters, forcing, terrain)
 
@@ -496,11 +508,13 @@ class TestShortWaveRadiation(unittest.TestCase):
         f_vjp = functools.partial(jax.vjp, f)  
 
         check_vjp(f, f_vjp, args = (physics_data_floats, state_floats, forcing_floats, terrain_floats), 
-                                atol=None, rtol=1, eps=0.00001)
+                                atol=None, rtol=2e-2, eps=0.00001)
+        # float32 resolves ~1e-7 relative, so eps must move the O(1e3) scalar
+        # leaves (dt_seconds, fsol) by several ulps: 1e-4 leaves them unchanged
+        # and reports a zero reference slope, 1e-3 does not.
         check_jvp(f, f_jvp, args = (physics_data_floats, state_floats, forcing_floats, terrain_floats), 
-                                atol=None, rtol=1, eps=0.0001)
+                                atol=None, rtol=2e-2, eps=0.001)
 
-    @pytest.mark.skip(reason="finite differencing produces nans - pre-existing issue unrelated to exchange coefficients")
     def test_get_shortwave_rad_fluxes_gradient_check(self):
         from jcm.utils import convert_back, convert_to_float
         """Test whether gradients are close for shortwave radiation"""
@@ -531,18 +545,28 @@ class TestShortWaveRadiation(unittest.TestCase):
         f_jvp = functools.partial(jax.jvp, f)
         f_vjp = functools.partial(jax.vjp, f)  
 
+        # PhysicsData.ones() is an unphysical state that puts mod_radcon.tau2 and
+        # stratc on the transmissivity where-branches, so their central
+        # difference is a step of size 1/eps that AD (correctly) reports as
+        # smooth; it dominates the inner product, which needs rtol=1 as a
+        # result. The jvp below compares leaf-by-leaf and is unaffected.
         check_vjp(f, f_vjp, args = (physics_data_floats, state_floats, parameters_floats, forcing_floats, terrain_floats), 
                                 atol=None, rtol=1, eps=0.00001)
+        # eps=1e-4 leaves the O(1e3) scalar leaves (dt_seconds, fsol) bit-unchanged
+        # in float32 and reports a zero reference slope; 1e-3 moves them by ulps.
         check_jvp(f, f_jvp, args = (physics_data_floats, state_floats, parameters_floats, forcing_floats, terrain_floats), 
-                                atol=None, rtol=1, eps=0.0001)
+                                atol=None, rtol=2e-2, eps=0.001)
 
-    @pytest.mark.skip(reason="finite differencing produces nans")
     def test_clouds_gradient_check_realistic_values(self):
         from jcm.utils import convert_back, convert_to_float
 
         qa = 0.5 * 1000. * jnp.array([0., 0.00035438, 0.00347954, 0.00472337, 0.00700214,0.01416442,0.01782708, 0.0216505])
         qsat = 1000. * jnp.array([0., 0.00037303, 0.00366268, 0.00787228, 0.01167024, 0.01490992, 0.01876534, 0.02279])
-        rh = qa/qsat
+        # qsat's top entry is a placeholder zero, so a bare qa/qsat leaves a NaN
+        # in rh that get_clouds passes straight through to its output and that
+        # finite differencing then turns into a NaN reference gradient. q = 0
+        # there, so the dry value 0 is the physical answer.
+        rh = jnp.where(qsat > 0, qa / jnp.where(qsat > 0, qsat, 1.0), 0.0)
         geopotential = jnp.arange(7, -1, -1, dtype = float)
         se = .1*geopotential
 
@@ -567,34 +591,49 @@ class TestShortWaveRadiation(unittest.TestCase):
             jdt.Datetime.from_pydatetime(jdt.to_datetime('2001-08-08'))
         )
 
-        physics_data = PhysicsData.zeros(xy,kx,surface_flux=surface_flux, humidity=humidity, convection=convection, condensation=condensation, shortwave_rad=sw_data, dt_seconds=date_data.dt_seconds)
+        physics_data = PhysicsData.zeros(xy,kx,surface_flux=surface_flux, humidity=humidity, convection=convection, condensation=condensation, shortwave_rad=sw_data, dt_seconds=date_data.dt_seconds, speedy_coords=speedy_coords)
         state = PhysicsState.zeros(zxy, specific_humidity=qa, geopotential=geopotential, normalized_surface_pressure=psa)
-        forcing = ForcingData.zeros(xy, fmask=fmask)
+        forcing = ForcingData.zeros(xy)
+        # The land-sea mask lives on TerrainData; get_clouds blends the stratiform
+        # cloud fraction towards its land value with it, so exercise a partly-land column.
+        terrain_land = terrain.copy(fmask=fmask)
 
         # Set float inputs
         physics_data_floats = convert_to_float(physics_data)
         state_floats = convert_to_float(state)
         parameters_floats = convert_to_float(parameters)
         forcing_floats = convert_to_float(forcing)
-        terrain_floats = convert_to_float(terrain)
+        terrain_floats = convert_to_float(terrain_land)
 
         def f(physics_data_f, state_f, parameters_f, forcing_f,terrain_f):
             tend_out, data_out = get_clouds(physics_data=convert_back(physics_data_f, physics_data), 
                                        state=convert_back(state_f, state), 
                                        parameters=convert_back(parameters_f, parameters), 
                                        forcing=convert_back(forcing_f, forcing), 
-                                       terrain=convert_back(terrain_f, terrain)
+                                       terrain=convert_back(terrain_f, terrain_land)
                                        )
+            # icltop is an integer cloud-top level index that convert_to_float
+            # promotes to a float leaf; its true slope is zero but a central
+            # difference across a level change is a 1/eps spike, which swamps
+            # the vjp inner product. Hold it fixed and check the rest.
+            data_out = data_out.copy(shortwave_rad=data_out.shortwave_rad.copy(
+                icltop=jnp.zeros_like(data_out.shortwave_rad.icltop)))
             return convert_to_float(data_out)
         
         # Calculate gradient
         f_jvp = functools.partial(jax.jvp, f)
         f_vjp = functools.partial(jax.vjp, f)  
 
+        # With icltop held fixed the inner product agrees to ~2.5e-2; the
+        # residual is float32 finite differencing of cloudc, which get_clouds
+        # clips at 1.
         check_vjp(f, f_vjp, args = (physics_data_floats, state_floats, parameters_floats, forcing_floats, terrain_floats), 
-                                atol=None, rtol=1, eps=0.00001)
+                                atol=None, rtol=5e-2, eps=0.00001)
+        # float32 carries ~1e-7 relative resolution, so a central difference with
+        # eps=1e-6 leaves the O(1e3) scalar leaves (dt_seconds, fsol) bit-unchanged
+        # and reports a zero reference derivative; 1e-3 moves them by many ulps.
         check_jvp(f, f_jvp, args = (physics_data_floats, state_floats, parameters_floats, forcing_floats, terrain_floats), 
-                                atol=None, rtol=1, eps=0.000001)
+                                atol=None, rtol=2e-2, eps=0.001)
 
 class TestCloudDiagnosticsResolutionInvariance(unittest.TestCase):
     """The cloud diagnostics feeding the SW scheme are evaluated at fixed sigma

--- a/jcm/physics/surface/speedy_surface_flux_test.py
+++ b/jcm/physics/surface/speedy_surface_flux_test.py
@@ -214,9 +214,6 @@ class TestSurfaceFluxesUnit(unittest.TestCase):
         for name, value in vars(physics_data.surface_flux).items():
             self.assertEqual(value.shape, XY, f"{name} is not a 2D map")
 
-    @unittest.skipUnless(jax.config.read("jax_enable_x64"),
-                         "needs x64 to build a forcing that differs in precision "
-                         "from the state")
     def test_land_branch_tolerates_higher_precision_forcing(self):
         """Forcing may arrive at a different precision from the state.
 
@@ -224,22 +221,27 @@ class TestSurfaceFluxesUnit(unittest.TestCase):
         back, while the model state stays float32. The land fluxes inherit
         the forcing dtype, so the zero arm of the land branch has to inherit
         it too or ``lax.cond`` rejects the pair outright.
-        """
-        args = build_inputs()
-        to_f32 = lambda tree: jax.tree.map(
-            lambda leaf: jnp.asarray(leaf, jnp.float32)
-            if jnp.issubdtype(jnp.asarray(leaf).dtype, jnp.floating) else leaf, tree)
-        for key in ("state", "physics_data", "terrain"):
-            args[key] = to_f32(args[key])
-        args["forcing"] = jax.tree.map(
-            lambda leaf: jnp.asarray(leaf, jnp.float64)
-            if jnp.issubdtype(jnp.asarray(leaf).dtype, jnp.floating) else leaf,
-            args["forcing"])
-        self.assertEqual(args["forcing"].stl_am.dtype, jnp.float64)
-        self.assertEqual(args["state"].temperature.dtype, jnp.float32)
 
-        _, physics_data = get_surface_fluxes(**args)
-        self.assertTrue(jnp.all(jnp.isfinite(physics_data.surface_flux.hfluxn)))
+        Enables x64 for the duration rather than skipping without it: the
+        session pins the flag off, so a skip condition read at import time
+        could never be true.
+        """
+        with jax.enable_x64():
+            args = build_inputs()
+            to_f32 = lambda tree: jax.tree.map(
+                lambda leaf: jnp.asarray(leaf, jnp.float32)
+                if jnp.issubdtype(jnp.asarray(leaf).dtype, jnp.floating) else leaf, tree)
+            for key in ("state", "physics_data", "terrain"):
+                args[key] = to_f32(args[key])
+            args["forcing"] = jax.tree.map(
+                lambda leaf: jnp.asarray(leaf, jnp.float64)
+                if jnp.issubdtype(jnp.asarray(leaf).dtype, jnp.floating) else leaf,
+                args["forcing"])
+            self.assertEqual(args["forcing"].stl_am.dtype, jnp.float64)
+            self.assertEqual(args["state"].temperature.dtype, jnp.float32)
+
+            _, physics_data = get_surface_fluxes(**args)
+            self.assertTrue(jnp.all(jnp.isfinite(physics_data.surface_flux.hfluxn)))
 
     def test_fluxes_are_linear_in_the_land_fraction(self):
         """Each published flux is the fmask weighting of its two components.

--- a/tools/profile_terms.py
+++ b/tools/profile_terms.py
@@ -692,6 +692,78 @@ def subcycle_steps(model, time_step_min: float) -> tuple[int, frozenset[str]]:
     return per_cycle, frozenset(gated)
 
 
+def probe_labels() -> set[str]:
+    """Return the scopes whose execution count must equal the step count.
+
+    The dynamics and bridge scopes sit directly in ``Model``'s step function,
+    outside every loop and conditional, so each of their instructions runs
+    exactly once per step BY CONSTRUCTION. (A physics term is no good for
+    this: internal scans and vmaps put its per-instruction counts all over
+    the place.)
+    """
+    from jcm import profiling
+
+    return {profiling.DYNAMICS, profiling.BRIDGE_TO_PHYSICS,
+            profiling.BRIDGE_TO_DYNAMICS}
+
+
+def check_trace_completeness(steps_seen: dict[str, int], steps: int,
+                             n_kernels: int, cycle: int = 1) -> None:
+    """Raise unless every probe scope was captured for all ``steps`` steps.
+
+    The profiler's event buffer holds ~1e6 events and a JAM step emits ~19,000
+    kernels, so a long enough window silently stops recording partway instead
+    of erroring -- a 120-step window captured only 20 steps and reported a 4x
+    undercount that looked entirely plausible.
+
+    Two ways the trace can be untrustworthy, each its own hard error:
+
+    * a probe label is missing entirely, which means the HLO-metadata join
+      failed rather than that the scope was cheap -- every number in the
+      report would then be misattributed;
+    * every probe is present but one is short, so the buffer overflowed.
+      EVERY probe must be complete, not just the best of them: the probes are
+      ordered within a step (bridge_to_physics runs before dynamics), so a
+      buffer that fills partway through the final step leaves the earlier
+      probe at the full count while a later one is short.
+
+    Parameters
+    ----------
+    steps_seen
+        :attr:`Attribution.steps_seen` -- minimum per-instruction execution
+        count per component.
+    steps
+        Number of steps the profiled window actually ran.
+    n_kernels
+        Kernels recovered from the trace, reported to size the overflow.
+    cycle
+        Radiation sub-cycle length, used to suggest a shorter window that
+        still contains a whole number of cycles.
+
+    """
+    probes = probe_labels()
+    seen = {label: n for label, n in steps_seen.items() if label in probes}
+    missing = sorted(probes - seen.keys())
+    if missing:
+        raise SystemExit(
+            f"attribution recovered no {', '.join(missing)} probe(s) from the "
+            f"trace ({n_kernels} kernels captured; recovered probes {seen}) -- "
+            "the HLO metadata join is broken, so every number in the report "
+            "would be misattributed. Check that the XLA dump and the trace "
+            "come from the same run and that the op_name metadata still "
+            "carries the jcm: scopes."
+        )
+    worst = min(seen.values())
+    if worst < steps:
+        fits = max(cycle, worst // cycle * cycle)
+        raise SystemExit(
+            f"the trace covers only {worst} of the {steps} steps run "
+            f"({n_kernels} kernels captured; per-probe {seen}), so the "
+            "profiler's event buffer overflowed and every number would be an "
+            f"undercount. Profile a shorter window: --steps {fits} or fewer."
+        )
+
+
 def _config_summary(cfg, overrides: list[str]) -> str:
     """One-line description of what was profiled, for the report header."""
     groups = [o for o in overrides
@@ -785,37 +857,10 @@ def main(argv=None) -> int:
 
     kernels = load_trace_kernels(trace_dir)
     att = attribute(kernels, hlo_index, members)
-
-    # The profiler's event buffer holds ~1e6 events and a JAM step emits
-    # ~19,000 kernels, so a long enough window silently stops recording partway
-    # instead of erroring -- a 120-step window captured only 20 steps and
-    # reported a 4x undercount that looked entirely plausible.
-    #
-    # The dynamics and bridge scopes sit directly in Model's step function,
-    # outside every loop and conditional, so each of their instructions runs
-    # exactly once per step BY CONSTRUCTION. That makes them the trace's
-    # completeness check. (A physics term is no good for this: internal scans
-    # and vmaps put its per-instruction counts all over the place.)
-    from jcm import profiling
-
-    probes = {profiling.DYNAMICS, profiling.BRIDGE_TO_PHYSICS,
-              profiling.BRIDGE_TO_DYNAMICS}
-    # EVERY probe must be complete, not just the best of them. The probes are
-    # ordered within a step (bridge_to_physics runs before dynamics), so a
-    # buffer that fills partway through the final step leaves the earlier probe
-    # at the full count while a later one is short; taking the max would accept
-    # that trace and then divide short totals by the full step count.
-    cycle = result.get("radiation_subcycle_steps", 1)
-    seen = {label: n for label, n in att.steps_seen.items() if label in probes}
-    if seen and min(seen.values()) < result["steps"]:
-        worst = min(seen.values())
-        fits = max(cycle, worst // cycle * cycle)
-        raise SystemExit(
-            f"the trace covers only {worst} of the {result['steps']} steps run "
-            f"({len(kernels)} kernels captured; per-probe {seen}), so the "
-            "profiler's event buffer overflowed and every number would be an "
-            f"undercount. Profile a shorter window: --steps {fits} or fewer."
-        )
+    check_trace_completeness(
+        att.steps_seen, result["steps"], len(kernels),
+        cycle=result.get("radiation_subcycle_steps", 1),
+    )
 
     result.update({
         "preset": args.preset,

--- a/tools/profile_terms_test.py
+++ b/tools/profile_terms_test.py
@@ -414,3 +414,56 @@ def test_report_scales_every_gated_term(parsed):
     report = pt.render_report(result)
     assert "| tiedtke_convection | 0.02 | 80.0 | 0.20 |" in report
     assert "| dynamics | 0.01 | 20.0 | 0.05 |" in report
+
+
+# --------------------------------------------------------------------------
+# Trace completeness (#716): a report is only written if all three
+# by-construction-once-per-step probes are recovered for every step.
+# --------------------------------------------------------------------------
+
+def _full(steps: int) -> dict[str, int]:
+    """steps_seen with every probe complete, plus a noisy physics term."""
+    return {label: steps for label in pt.probe_labels()} | {
+        "tiedtke_convection": 3 * steps}
+
+
+def test_completeness_rejects_a_trace_with_no_probes_recovered():
+    """An empty probe set means the metadata join broke, not a cheap step."""
+    with pytest.raises(SystemExit) as e:
+        pt.check_trace_completeness({"tiedtke_convection": 40}, 20, 12345)
+    msg = str(e.value)
+    assert "recovered no" in msg
+    for label in pt.probe_labels():
+        assert label in msg
+
+
+def test_completeness_rejects_a_partially_recovered_probe_set():
+    """A subset is as broken as none, and the error names what is missing."""
+    from jcm import profiling
+
+    seen = _full(20)
+    del seen[profiling.BRIDGE_TO_PHYSICS]
+    with pytest.raises(SystemExit) as e:
+        pt.check_trace_completeness(seen, 20, 12345)
+    # Only the absent probe is named as missing; the recovered ones are not.
+    missing = str(e.value).split("recovered no ", 1)[1].split(" probe(s)", 1)[0]
+    assert missing == profiling.BRIDGE_TO_PHYSICS
+
+
+def test_completeness_rejects_a_short_trace_when_all_probes_are_present():
+    """All three probes recovered but short: the event buffer overflowed."""
+    from jcm import profiling
+
+    seen = _full(20)
+    seen[profiling.DYNAMICS] = 7
+    with pytest.raises(SystemExit) as e:
+        pt.check_trace_completeness(seen, 20, 12345, cycle=3)
+    msg = str(e.value)
+    assert "covers only 7 of the 20 steps" in msg
+    # The suggested retry keeps a whole number of radiation sub-cycles.
+    assert "--steps 6" in msg
+
+
+def test_completeness_accepts_a_full_trace():
+    """Every probe present at the full step count passes silently."""
+    assert pt.check_trace_completeness(_full(20), 20, 12345, cycle=10) is None

--- a/tools/release_validation/README.md
+++ b/tools/release_validation/README.md
@@ -24,9 +24,19 @@ python tools/release_validation/launch.py --repo . --submit
 python tools/release_validation/scm_check.py 10
 
 # 3. Health-check each finished run (exit 0 = all gates pass)
-python tools/release_validation/health.py $SCRATCH/jam_runs/mx_<member> \
-    --last-n 40 --log runs/mx_<member>.log
+python tools/release_validation/health.py $SCRATCH/jam_runs/mx_<member>_<tag> \
+    --last-n 40 --log runs/mx_<member>_<tag>.log
 ```
+
+Every artefact of a launch — rundir, PBS job name, outputs, log — is
+namespaced by a run tag, which defaults to the launched repo's HEAD short
+SHA (`--tag` overrides it; outside a git checkout it falls back to the UTC
+date). A member is a *fresh* year, so `launch.py` refuses to write a job
+whose rundir already holds a `checkpoint.msgpack`: continue that
+integration with `--resume`, or launch under a new `--tag`. The tag is what
+keeps two branches' validation runs of the same member apart: sharing a
+rundir lets `run_chunked` silently resume the other branch's checkpoint
+(#701).
 
 A FAIL is a recorded verdict, not necessarily a blocker: members with
 known characteristics (the 1m bright-cloud TOA, SPEEDY's wet bias, the

--- a/tools/release_validation/launch.py
+++ b/tools/release_validation/launch.py
@@ -1,6 +1,7 @@
 """Generate (and optionally submit) the release-validation matrix runs.
 
-    python tools/release_validation/launch.py --repo . [--members a,b] [--submit]
+    python tools/release_validation/launch.py --repo . [--members a,b] \
+        [--tag SHA] [--resume] [--submit]
 
 Each member of ``matrix.yaml`` references a validated preset in
 ``tools/benchmark.py``'s ``PRESETS`` (the single home of known-good
@@ -10,11 +11,16 @@ A100. Per-grid inputs resolve automatically inside jcm (``terrain=auto``,
 inputs staged per
 ``jcm/data/mirror/SOURCES.md`` (dms/dust/oxidants + emissions on the
 model grid) via the ``JAM_INPUTS``/``JCM_EMISSIONS`` environment.
-Health-check finished runs with ``health.py``; run ``scm_check.py`` for
-the SCM member (CPU, no PBS needed).
+Each run directory is namespaced by ``--tag`` (default: the launched
+repo's HEAD short SHA), because a release-validation member is a *fresh*
+year: a fixed rundir let a second matrix run silently resume the first
+one's checkpoint. Health-check finished runs with ``health.py``; run
+``scm_check.py`` for the SCM member (CPU, no PBS needed).
 """
 import argparse
+import datetime
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -81,6 +87,44 @@ def _preset_grid(preset_name: str) -> str | None:
     return cfg.hydra.runtime.choices.get("grid")
 
 
+def repo_tag(repo: str | Path) -> str:
+    """Return the run tag for ``repo``: its HEAD short SHA where there is one.
+
+    Naming the rundir after the commit makes the provenance already recorded
+    in each output (``jcm=<sha>``) match the integration that produced it.
+    Outside a git checkout (a tarball, an exported tree) fall back to the UTC
+    date, which still separates one day's launch from the next.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "--short", "HEAD"],
+            capture_output=True, text=True, check=True).stdout.strip()
+    except (subprocess.CalledProcessError, OSError):
+        out = ""
+    tag = out or "nogit_" + datetime.datetime.now(
+        datetime.timezone.utc).strftime("%Y%m%d")
+    # The tag lands in a PBS job name and a path, so keep it to safe characters.
+    return re.sub(r"[^A-Za-z0-9_]", "_", tag)
+
+
+def check_fresh(rundir: str, resume: bool) -> None:
+    """Refuse to (re)launch into a rundir that already holds a checkpoint.
+
+    ``run_chunked`` resumes from ``checkpoint_path`` when it exists, so a
+    second launch into a populated directory continues someone else's
+    integration and reports a healthy year for a run that never happened
+    (#701). Crashing on a mismatched physics composition is the lucky case.
+    """
+    ckpt = Path(rundir) / "checkpoint.msgpack"
+    if ckpt.exists() and not resume:
+        raise SystemExit(
+            f"{ckpt} already exists — this member has been launched under "
+            "this tag before, and starting here would resume that run "
+            "instead of integrating a fresh year. Either pass --resume to "
+            "continue it deliberately, or launch under a new --tag (the "
+            "default is the repo HEAD short SHA).")
+
+
 def overrides(name: str, m: dict, d: dict, rundir: str) -> list[str]:
     # Presets may carry their own output plumbing (the pyses ones set
     # run.checkpoint_path); ours must win, so strip conflicting keys
@@ -132,15 +176,21 @@ echo {marker}
 """
 
 
-def main():
+def main(argv=None):
+    """Write (and optionally submit) one PBS job per matrix member."""
     ap = argparse.ArgumentParser()
     ap.add_argument("--repo", default=".")
     ap.add_argument("--members", default=None,
                     help="comma-separated subset (default: all)")
+    ap.add_argument("--tag", default=None,
+                    help="rundir/job namespace (default: repo HEAD short SHA)")
+    ap.add_argument("--resume", action="store_true",
+                    help="continue an existing run rather than refusing to "
+                         "start on top of its checkpoint")
     ap.add_argument("--submit", action="store_true")
     ap.add_argument("--account",
                     default=os.environ.get("PBS_ACCOUNT", "UCSD0085"))
-    a = ap.parse_args()
+    a = ap.parse_args(argv)
 
     cfg = yaml.safe_load(open(HERE / "matrix.yaml"))
     d = cfg["defaults"]
@@ -151,10 +201,20 @@ def main():
     outdir = Path(repo) / "runs"
     outdir.mkdir(exist_ok=True)
 
+    run_tag = a.tag or repo_tag(repo)
+    print(f"run tag: {run_tag}")
+
     wanted = a.members.split(",") if a.members else list(cfg["members"])
-    for name in wanted:
+    # The tag namespaces the rundir, the job name, the outputs and the log
+    # together, so one launch's artefacts never mix with another's. Vet every
+    # member before writing anything: a matrix launch that would resume a
+    # previous one should fail whole, not half-submitted.
+    plan = [(name, f"mx_{name.replace('-', '_')}_{run_tag}") for name in wanted]
+    for _, tag in plan:
+        check_fresh(f"{scratch}/jam_runs/{tag}", a.resume)
+
+    for name, tag in plan:
         m = cfg["members"][name]
-        tag = "mx_" + name.replace("-", "_")
         rundir = f"{scratch}/jam_runs/{tag}"
         ovs = " \\\n    ".join(
             overrides(tag, m, d, rundir) + [f"hydra.run.dir={rundir}"])

--- a/tools/release_validation/launch.py
+++ b/tools/release_validation/launch.py
@@ -87,6 +87,28 @@ def _preset_grid(preset_name: str) -> str | None:
     return cfg.hydra.runtime.choices.get("grid")
 
 
+TAG_UNSAFE = re.compile(r"[^A-Za-z0-9_]")
+
+
+def check_tag(tag: str) -> str:
+    """Return an explicit ``--tag``, refusing anything unsafe to embed.
+
+    The tag becomes a path segment, a PBS job name and the completion
+    marker, so a branch-style ``feature/foo`` writes the job into a
+    directory that does not exist and a tag carrying spaces or shell
+    metacharacters produces malformed PBS directives. Reject rather than
+    rewrite: folding ``a/b`` and ``a_b`` onto one tag would put two
+    launches in one rundir, the checkpoint collision this tool exists to
+    prevent (#701).
+    """
+    if not tag or TAG_UNSAFE.search(tag):
+        raise SystemExit(
+            f"--tag {tag!r} is not a usable run tag: it names a run "
+            "directory, a PBS job and the completion marker, so it must be "
+            "non-empty and made only of letters, digits and underscores.")
+    return tag
+
+
 def repo_tag(repo: str | Path) -> str:
     """Return the run tag for ``repo``: its HEAD short SHA where there is one.
 
@@ -103,8 +125,9 @@ def repo_tag(repo: str | Path) -> str:
         out = ""
     tag = out or "nogit_" + datetime.datetime.now(
         datetime.timezone.utc).strftime("%Y%m%d")
-    # The tag lands in a PBS job name and a path, so keep it to safe characters.
-    return re.sub(r"[^A-Za-z0-9_]", "_", tag)
+    # Same safe character set check_tag demands of an explicit --tag, but
+    # derived rather than typed, so rewrite quietly instead of failing.
+    return TAG_UNSAFE.sub("_", tag)
 
 
 def check_fresh(rundir: str, resume: bool) -> None:
@@ -183,7 +206,8 @@ def main(argv=None):
     ap.add_argument("--members", default=None,
                     help="comma-separated subset (default: all)")
     ap.add_argument("--tag", default=None,
-                    help="rundir/job namespace (default: repo HEAD short SHA)")
+                    help="rundir/job namespace, letters/digits/underscore "
+                         "only (default: repo HEAD short SHA)")
     ap.add_argument("--resume", action="store_true",
                     help="continue an existing run rather than refusing to "
                          "start on top of its checkpoint")
@@ -201,7 +225,7 @@ def main(argv=None):
     outdir = Path(repo) / "runs"
     outdir.mkdir(exist_ok=True)
 
-    run_tag = a.tag or repo_tag(repo)
+    run_tag = check_tag(a.tag) if a.tag is not None else repo_tag(repo)
     print(f"run tag: {run_tag}")
 
     wanted = a.members.split(",") if a.members else list(cfg["members"])

--- a/tools/release_validation/launch_test.py
+++ b/tools/release_validation/launch_test.py
@@ -1,0 +1,134 @@
+"""Tests for the release-validation launcher.
+
+The guarded property is provenance: every member of a matrix launch must
+integrate a *fresh* year in a directory named after the commit under test. A
+fixed rundir let a second launch silently resume the first one's checkpoint
+and report a healthy year for an integration that never ran (#701).
+
+Nothing here submits anything -- ``qsub`` is monkeypatched out.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import launch  # noqa: E402
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+MEMBER = "speedy-t31"          # the cheapest member: no JAM aux-input lookup
+
+
+@pytest.fixture
+def scratch(tmp_path, monkeypatch):
+    """Return a throwaway SCRATCH, so rundirs never touch the real one."""
+    monkeypatch.setenv("SCRATCH", str(tmp_path / "scratch"))
+    return tmp_path / "scratch"
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """Return a stand-in repo to write ``runs/*.pbs`` into."""
+    (tmp_path / "repo").mkdir()
+    return tmp_path / "repo"
+
+
+def _launch(repo, *args):
+    return launch.main(["--repo", str(repo), "--members", MEMBER, *args])
+
+
+def test_repo_tag_is_the_head_short_sha():
+    """The default tag names the commit the outputs will claim provenance for."""
+    sha = subprocess.run(["git", "-C", str(REPO), "rev-parse", "--short", "HEAD"],
+                         capture_output=True, text=True, check=True).stdout.strip()
+    assert launch.repo_tag(REPO) == sha
+
+
+def test_repo_tag_falls_back_outside_a_checkout(tmp_path):
+    """A non-git tree still gets a tag that separates one day's launch."""
+    tag = launch.repo_tag(tmp_path)
+    assert tag.startswith("nogit_")
+    assert tag.replace("_", "").isalnum()
+
+
+def test_default_tag_namespaces_the_rundir(scratch, repo):
+    """With no --tag, the rundir carries the launched repo's own HEAD SHA."""
+    git = ["git", "-C", str(repo), "-c", "user.email=t@t", "-c", "user.name=t"]
+    subprocess.run([*git[:3], "init", "-q"], check=True)
+    (repo / "f").write_text("x")
+    subprocess.run([*git, "add", "f"], check=True)
+    subprocess.run([*git, "commit", "-qm", "c"], check=True)
+    sha = subprocess.run([*git[:3], "rev-parse", "--short", "HEAD"],
+                         capture_output=True, text=True,
+                         check=True).stdout.strip()
+
+    _launch(repo)
+    job = (repo / "runs" / f"mx_speedy_t31_{sha}.pbs").read_text()
+    assert f"{scratch}/jam_runs/mx_speedy_t31_{sha}" in job
+
+
+def test_explicit_tag_gives_each_launch_its_own_rundir(scratch, repo):
+    """Two tags of the same member write two jobs and two checkpoint paths."""
+    _launch(repo, "--tag", "aaa1111")
+    _launch(repo, "--tag", "bbb2222")
+    ckpts = set()
+    for tag in ("aaa1111", "bbb2222"):
+        job = (repo / "runs" / f"mx_speedy_t31_{tag}.pbs").read_text()
+        rundir = f"{scratch}/jam_runs/mx_speedy_t31_{tag}"
+        assert f"run.checkpoint_path={rundir}/checkpoint.msgpack" in job
+        assert f"run.output_prefix={rundir}/mx_speedy_t31_{tag}" in job
+        assert f"hydra.run.dir={rundir}" in job
+        ckpts.add(rundir)
+    assert len(ckpts) == 2
+
+
+def _seed_checkpoint(scratch, tag):
+    rundir = scratch / "jam_runs" / f"mx_speedy_t31_{tag}"
+    rundir.mkdir(parents=True)
+    (rundir / "checkpoint.msgpack").write_bytes(b"stale")
+    return rundir
+
+
+def test_existing_checkpoint_is_refused(scratch, repo):
+    """Relaunching into a populated rundir would resume the previous run."""
+    rundir = _seed_checkpoint(scratch, "aaa1111")
+    with pytest.raises(SystemExit) as e:
+        _launch(repo, "--tag", "aaa1111")
+    msg = str(e.value)
+    assert str(rundir / "checkpoint.msgpack") in msg
+    assert "--resume" in msg and "--tag" in msg
+    # Refused before writing anything, so nothing can be submitted by hand.
+    assert not (repo / "runs" / "mx_speedy_t31_aaa1111.pbs").exists()
+
+
+def test_resume_bypasses_the_refusal(scratch, repo):
+    """--resume is the explicit way to continue an interrupted member."""
+    _seed_checkpoint(scratch, "aaa1111")
+    _launch(repo, "--tag", "aaa1111", "--resume")
+    assert (repo / "runs" / "mx_speedy_t31_aaa1111.pbs").exists()
+
+
+def test_a_dirty_member_blocks_the_whole_matrix(scratch, repo, monkeypatch):
+    """One populated rundir fails the launch whole, not half-submitted."""
+    _seed_checkpoint(scratch, "aaa1111")
+    calls = []
+    monkeypatch.setattr(launch.subprocess, "run",
+                        lambda cmd, **kw: calls.append(cmd))
+    with pytest.raises(SystemExit):
+        launch.main(["--repo", str(repo), "--tag", "aaa1111", "--submit"])
+    assert calls == []
+    assert not list((repo / "runs").glob("*.pbs"))
+
+
+def test_submit_qsubs_the_written_job(scratch, repo, monkeypatch):
+    """--submit hands the generated script to qsub, unchanged."""
+    calls = []
+    monkeypatch.setattr(launch.subprocess, "run",
+                        lambda cmd, **kw: calls.append(cmd))
+    _launch(repo, "--tag", "aaa1111", "--submit")
+    path = repo / "runs" / "mx_speedy_t31_aaa1111.pbs"
+    assert calls == [["qsub", str(path)]]

--- a/tools/release_validation/launch_test.py
+++ b/tools/release_validation/launch_test.py
@@ -86,6 +86,19 @@ def test_explicit_tag_gives_each_launch_its_own_rundir(scratch, repo):
     assert len(ckpts) == 2
 
 
+@pytest.mark.parametrize("tag", ["feature/foo", "x y", "a;echo hi", ""])
+def test_unsafe_explicit_tag_is_refused(scratch, repo, tag):
+    """A tag that is not both a path segment and a job name is refused.
+
+    Unchecked, ``feature/foo`` wrote into a directory that does not exist and
+    ``x y`` produced a malformed ``#PBS -N`` directive.
+    """
+    with pytest.raises(SystemExit) as e:
+        _launch(repo, "--tag", tag)
+    assert "--tag" in str(e.value)
+    assert not list((repo / "runs").glob("*.pbs"))
+
+
 def _seed_checkpoint(scratch, tag):
     rundir = scratch / "jam_runs" / f"mx_speedy_t31_{tag}"
     rundir.mkdir(parents=True)


### PR DESCRIPTION
Closes #745, closes #704, closes #729, closes #262, closes #716, closes #701.

One PR for the test-suite and test-tooling issues that had accumulated. Each issue is one commit (two for #262 and #701).

## What the investigation found first

Three of these issues turned out to share one cause that none of them named. Derecho login nodes have a **hard 10 GiB per-user memory cgroup**, and each pytest process retains XLA executables across tests (`rrtmgp_test.py` alone peaks at 7.7 GB single-process with tiny arrays). Under `pytest -n 4` the workers are OOM-killed and pytest reports `worker gwN crashed while running <test>` for whichever test was unlucky. That is the whole "nondeterministic radiation failures" signature of #704, the "single-process run segfaults" half of #729, and the mechanism behind the CI runner ceiling in #745. The earlier x64-leak hypothesis for the phantom failures was disproven (zero flips recorded per test), although the x64 leak itself is real and is fixed here too. Details in the new `docs/source/design/test_suite_memory.md`.

## Changes

**#745 / #704 — retained XLA executables** (`conftest.py`, `.github/workflows/run_test.yaml`)
- A `pytest_runtest_teardown` hook (portable: `/proc/self/statm`, then `getrusage`, else clear at every boundary) clears JAX caches and GCs at each class/module boundary, gated on the process having grown by `JCM_TEST_CACHE_GROWTH_MB` (default 1024) since the last clear. Unconditional clearing at every boundary cost +47% wall time on light modules for little memory gain, so the gate is the shipped default and `=0` restores every-boundary clearing.
- Measured on `rrtmgp_test.py`: 7.66 GB peak and a crash at test 32/41 on dev, 4.85 GB and 41 passed with the gate (3.41 GB ungated). No runtime cost.
- `timeout-minutes: 110` on the test job (about 2x the slowest recent green run) so a hang cannot burn the 6 h default.

**#729 — `jax_enable_x64` leak** (`conftest.py`, `mam4_jax.py`, `mam4_jax_test.py`)
- An autouse fixture restores the session's `jax_enable_x64` before and after every test. `jcm/dycore/pyses/` is exempt because its class-scoped fixtures build f64 backends that later tests in the class reuse; that package's own conftest already schedules it last.
- `import mam4_jax` is wrapped in a context manager that preserves the flag, since the deliberate flip lives in `Mam4JaxAdapter.__init__` and the import-time side effect was never needed.
- `mam4_jax_test.py` had a live bug: `pytest.importorskip("mam4_jax.coupling")` partially imports `mam4_jax` (flipping x64) and then raises `Skipped`, so the module-level restore never ran. Now `try/finally`.
- The pin exposed two tests that had only ever passed by riding that contamination: the dinosaur `TracerMassFixerTest` mass-closure tests build float64 fields, and in isolation fail at 3e-7 and 6e-7. They now enable x64 themselves, with the tolerance untouched. CI never saw them because they need `dinosaur-sl`. A `speedy_surface_flux_test` case gated on `skipUnless(x64)` at import time would have become permanently dead; it now runs under `jax.enable_x64()`.
- The `importorskip("mam4_jax")` guard in the pySES Hydra config test is satisfied by a stale flat-layout mam4-jax wheel and then fails on `mam4_jax.core`; tightened to the submodule.

**#262 — skipped gradient checks** (`speedy_shortwave.py` and four test modules)
- Four checks pass as-is and are un-skipped. Two shortwave fixtures had rotted with API drift (`fmask` moved to `TerrainData`, `PhysicsData.zeros` needs coords, an `rh = 0/0` NaN at the model top) and are repaired. The model-state check was handing `check_vjp` a pytree with int and bool leaves and an impure return; it now differentiates the float leaves of `ModelPredictions` with respect to a small-amplitude state perturbation, because a unit-normal tangent on O(1e-5) spectral coefficients drives the model into its limiters where the central difference is identically zero. It runs 68 s and is marked slow.
- The un-skipped checks all carried `rtol=1` (100% relative tolerance), which is a NaN check, not a gradient check. Each is now tightened to the tightest value that holds over three runs, with a one-line justification: 1e-2 to 1e-1 for the radiation checks, with the jvp step raised to 1e-3 because `dt_seconds` does not move by a float32 ulp at 1e-4. Two stay loose with the reason in the comment: the shortwave-flux vjp sits on `where` branches of the radiation constants at the all-ones fixture, and the model check has a systematic limiter-branch offset of about 0.15 at rtol 0.5. Tightening the clouds check also exposed that `convert_to_float` promotes the integer cloud-top level index into the differentiated tree; it is now held fixed.
- **Production fix:** `solar()` clipped `ch0` to `1 - 1e-9` before `arccos`, which is a no-op in float32 (rounds to 1.0), so the polar day/night columns sat exactly on the `arccos` singularity and every reverse-mode gradient through SPEEDY shortwave was NaN. Replaced with a double-`where` that keeps the zero tangent from multiplying an infinite slope. Forward change is at most 1.2e-4 W/m² of TOA insolation over a full year on both the 8-level and 47-level grids (one float32 ulp). A new test asserts finite jvp and vjp at four dates that each contain a polar night. This is one of the float32 clip-at-singularity NaN sites of the kind #663 catalogues.

**#716 — profile_terms completeness gate** (`tools/profile_terms.py`, `profile_terms_test.py`)
- The gate is hoisted to a module-level helper and now requires every expected probe label to be recovered from the trace; a missing probe raises its own error naming the absent labels. Four regression tests cover empty, partial, short-count and complete traces.

**#701 — release_validation fixed rundir** (`tools/release_validation/launch.py`, new `launch_test.py`, README)
- Every launch is namespaced `mx_<member>_<tag>` with `--tag` defaulting to the repo HEAD short SHA. A rundir that already contains `checkpoint.msgpack` is refused unless `--resume` is passed, and the whole matrix is vetted before any job is written. Eight tests with monkeypatched `qsub`.
- Related, rolled in: `jcm-local-ci/scripts/local_ci.sh` ran the fast gate with 12 workers on the current node, which the new design doc says cannot work on a login node. Both gates now run in one PBS develop-queue job, lint stays local, and `--local-fast` opts into a 2-worker local run with a warning.
- Related, rolled in: `derecho-jcm-runs/scripts/mkjob.py` had the same fixed-rundir pattern with a two-sided hazard (silent resume with `--resume`, silent deletion of the old checkpoint without it). It now prints an unmissable warning saying which will happen, and gains `--fresh` to refuse instead.

## Out of scope, deliberately
- **#663's "repo-wide d/dparam test"**: the right test exists in outline but will fail on merge until the three confirmed NaN sites in tte_tke, ARG activation and ice nucleation are fixed. That is a physics change with its own validation; it stays with #663.
- **#692** (pySES float32 smoke segfault): seen on a 200 GB develop node with no cgroup cap and needs the `pyses` extra that CI never installs, so the OOM explanation above does not cover it. Needs a PBS reproduction with `faulthandler`. A note is left on the issue.

## Docs
`docs/source/design/test_suite_memory.md` (in the design toctree), `docs/source/developer.rst`, a three-line pointer in `CLAUDE.md`, and the release-validation and derecho-jcm-runs READMEs.

## Verification
All three gates run on a Derecho develop node (16 cpus, 200 GB) against the final commits, with `dinosaur-sl` and the `pyses` extra installed so the SL and pySES tests were exercised too:

| gate | result |
|---|---|
| `ruff check .` | clean |
| fast, `-n 12 -m "not slow"` | 2400 passed, 31 skipped, 0 failed; coverage 94.45% (gate 90%) |
| slow, `-n 4 -m slow` | 101 passed, 19 skipped, 0 failed; coverage 82.17% (gate 80%) |

The first full run, before the review fix-ups, had three fast failures: two `TracerMassFixerTest` cases and the pySES ma-ne30 construction test. All three were pre-existing on `dev` in this environment (see the #729 bullets above) and are fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4x2keECpxEf5JvJ5rM3ty
