### PR TITLE
feat(nudging): optional specific-humidity relaxation, and a public vertical_interp_log_p

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -697,6 +697,11 @@ through the standard physics-coupling path. The same setup works under
 SPEEDY, ECHAM, or any other physics package, on any
 :class:`DynamicalCore` backend.
 
+.. note::
+   ``NudgingTarget`` fields use the model-state units: winds in m/s,
+   temperature in K, and specific humidity in **g/kg**. ERA5 stores
+   humidity in kg/kg, so multiply by 1000 before building the target.
+
 Composing extra terms: the upper sponge
 ----------------------------------------
 

--- a/jcm/data/bc/interpolate_ozone.py
+++ b/jcm/data/bc/interpolate_ozone.py
@@ -36,10 +36,14 @@ from jcm.physics.echam.echam_levels import get_echam_levels
 REFERENCE_SURFACE_PRESSURE_PA = 101325.0
 
 
-def _vertical_interp_log_p(
+def vertical_interp_log_p(
     o3_source: np.ndarray, plev_source: np.ndarray, plev_target: np.ndarray,
 ) -> np.ndarray:
     """Vertical-interp ``o3_source`` from ``plev_source`` to ``plev_target``.
+
+    Public because nothing here is ozone-specific beyond the argument names:
+    the same log-pressure interpolation applies to any field given on pressure
+    levels, temperature, humidity and winds included.
 
     Args:
         o3_source: ``(..., nplev_source, ..., ...)`` ozone field; the
@@ -113,7 +117,7 @@ def interpolate_ozone(
     b = np.asarray(vertical.b_centers)
     plev_target = a + b * reference_ps_pa
 
-    o3_out = _vertical_interp_log_p(o3_in, plev_source, plev_target)
+    o3_out = vertical_interp_log_p(o3_in, plev_source, plev_target)
 
     # Build output dataset preserving lat/lon/time, replacing plev with level.
     ds_out = xr.Dataset(

--- a/jcm/data/era5.py
+++ b/jcm/data/era5.py
@@ -256,10 +256,21 @@ def dataset_on_model_grid(coords, start: str, end: str, *,
 
 
 def nudging_target(coords, start: str, end: str, *, freq: str = "6h",
-                   cache: bool = True):
-    """Build a time-varying :class:`~jcm.nudging.NudgingTarget` for the window."""
+                   humidity: bool = True, cache: bool = True):
+    """Build a time-varying :class:`~jcm.nudging.NudgingTarget` for the window.
+
+    ``humidity`` controls whether ``q`` is fetched alongside the winds and
+    temperature. It defaults to True because a target built without ``q``
+    carries no humidity reference at all, and pairing one with a non-zero
+    ``inv_tau_humidity`` (:meth:`~jcm.nudging.NudgingConfig.temp_humidity`
+    sets one on every level) is a configuration error rather than a
+    humidity-free run. Pass ``humidity=False`` for a winds-only target to
+    skip downloading and caching the extra variable.
+    """
     from jcm.nudging import NudgingTarget
-    ds = dataset_on_model_grid(coords, start, end, freq=freq, cache=cache)
+    variables = ("u", "v", "T", "q") if humidity else ("u", "v", "T")
+    ds = dataset_on_model_grid(coords, start, end, freq=freq,
+                               variables=variables, cache=cache)
     return NudgingTarget.from_dataset(ds)
 
 

--- a/jcm/data/era5.py
+++ b/jcm/data/era5.py
@@ -256,21 +256,10 @@ def dataset_on_model_grid(coords, start: str, end: str, *,
 
 
 def nudging_target(coords, start: str, end: str, *, freq: str = "6h",
-                   humidity: bool = True, cache: bool = True):
-    """Build a time-varying :class:`~jcm.nudging.NudgingTarget` for the window.
-
-    ``humidity`` controls whether ``q`` is fetched alongside the winds and
-    temperature. It defaults to True because a target built without ``q``
-    carries no humidity reference at all, and pairing one with a non-zero
-    ``inv_tau_humidity`` (:meth:`~jcm.nudging.NudgingConfig.temp_humidity`
-    sets one on every level) is a configuration error rather than a
-    humidity-free run. Pass ``humidity=False`` for a winds-only target to
-    skip downloading and caching the extra variable.
-    """
+                   cache: bool = True):
+    """Build a time-varying :class:`~jcm.nudging.NudgingTarget` for the window."""
     from jcm.nudging import NudgingTarget
-    variables = ("u", "v", "T", "q") if humidity else ("u", "v", "T")
-    ds = dataset_on_model_grid(coords, start, end, freq=freq,
-                               variables=variables, cache=cache)
+    ds = dataset_on_model_grid(coords, start, end, freq=freq, cache=cache)
     return NudgingTarget.from_dataset(ds)
 
 

--- a/jcm/nudging.py
+++ b/jcm/nudging.py
@@ -51,8 +51,12 @@ class NudgingTarget:
     """Gridpoint reference fields the relaxation drives the state toward.
 
     All fields are dimensional in the model's native conventions: ``u_wind``
-    and ``v_wind`` in m/s, ``temperature`` in K, on the
-    ``(nlev, *horizontal_shape)`` layout the dycore exposes via
+    and ``v_wind`` in m/s, ``temperature`` in K, ``specific_humidity`` in
+    g/kg, the :class:`PhysicsState` convention (the state bridge
+    dimensionalizes humidity as gram/kilogram). A kg/kg reference such as raw
+    ERA5 must be multiplied by 1000 before it lands here, otherwise the
+    relaxation silently drives the model toward ~1/1000 of the intended
+    humidity. Fields are on the ``(nlev, *horizontal_shape)`` layout via
     ``coords.horizontal.nodal_shape``. Each leaf can be a bare
     ``jnp.ndarray`` (static target) or a :class:`jcm.forcing.TimeSeries`
     leaf with a leading time axis that ``select(date, calendar)`` slices
@@ -65,21 +69,30 @@ class NudgingTarget:
     u_wind: jnp.ndarray
     v_wind: jnp.ndarray
     temperature: jnp.ndarray
+    # Optional, and last so a three-argument construction still works. None
+    # means "no humidity reference", which is the pre-existing behaviour: the
+    # relaxation leaves specific humidity alone. Bias-correction training is
+    # what needs it, and it pairs with a non-zero `inv_tau_humidity`.
+    specific_humidity: jnp.ndarray = None
 
     @classmethod
     def from_dataset(cls, ds, *,
                      u_var: str = "u", v_var: str = "v",
-                     T_var: str = "T",
+                     T_var: str = "T", q_var: str = "q",
                      time_var: Optional[str] = "time") -> "NudgingTarget":
         """Build a :class:`NudgingTarget` from an xarray Dataset.
 
         Args:
-            ds: ``xarray.Dataset`` carrying ``u``, ``v``, ``T`` (or names
-                overridden by the ``*_var`` kwargs). Each is expected with
-                axes ``(time, lev, lat, lon)`` — time is optional, see
-                ``time_var``. Loaded verbatim onto the model grid;
+            ds: ``xarray.Dataset`` carrying ``u``, ``v``, ``T`` and
+                optionally ``q`` (or names overridden by the ``*_var``
+                kwargs). Each is expected with axes
+                ``(time, lev, lat, lon)``; time is optional (see
+                ``time_var``). Loaded verbatim onto the model grid;
                 regridding is the user's responsibility before loading.
-            u_var, v_var, T_var: netCDF variable names.
+            u_var, v_var, T_var, q_var: netCDF variable names. ``q_var``
+                may be absent, in which case ``specific_humidity`` is
+                filled with zeros and only matters when paired with a
+                non-zero ``inv_tau_humidity``.
             time_var: Time coord name. ``None`` for static (climatology)
                 reference data.
 
@@ -99,15 +112,19 @@ class NudgingTarget:
         u = to_jax(u_var)
         v = to_jax(v_var)
         T = to_jax(T_var)
+        # Humidity is optional: a wind/temperature-only target (the original
+        # use case) carries no q field, so fall back to zeros.
+        q = to_jax(q_var) if q_var in ds else jnp.zeros_like(T)
 
         if is_time_varying:
             time_seconds = _time_axis_seconds_from_ds(ds.rename({time_var: "time"}))
-            return cls(
-                u_wind=make_time_series(u, time_seconds, align_mode=BY_DATE),
-                v_wind=make_time_series(v, time_seconds, align_mode=BY_DATE),
-                temperature=make_time_series(T, time_seconds, align_mode=BY_DATE),
-            )
-        return cls(u_wind=u, v_wind=v, temperature=T)
+
+            def ts(a):
+                return make_time_series(a, time_seconds, align_mode=BY_DATE)
+
+            return cls(u_wind=ts(u), v_wind=ts(v),
+                       temperature=ts(T), specific_humidity=ts(q))
+        return cls(u_wind=u, v_wind=v, temperature=T, specific_humidity=q)
 
 
 # ---------------------------------------------------------------------------
@@ -120,21 +137,26 @@ class NudgingConfig:
     """Per-variable, per-level inverse relaxation timescales (1 / s).
 
     All values are dimensional (per second). Zero entries mean "no nudging"
-    for that variable / level — that's how the common "winds above the PBL
+    for that variable / level, which is how the common "winds above the PBL
     only" pattern is expressed: ``inv_tau_wind`` non-zero from the free
-    troposphere upwards, zero below; ``inv_tau_temperature`` zero everywhere.
+    troposphere upwards, zero below, with ``inv_tau_temperature`` and
+    ``inv_tau_humidity`` zero everywhere.
 
     Wind nudging applies symmetrically to ``u_wind`` and ``v_wind`` (one
     inverse-timescale profile covers both). Surface-pressure nudging is
-    deliberately not supported through the physics path — the dycore
+    deliberately not supported through the physics path: the dycore
     advances surface pressure via the continuity equation, and a ps
     nudging tendency would require extending :class:`PhysicsTendency` with
     a ``normalized_surface_pressure`` field. Add it only when a concrete
     use case lands.
     """
 
-    inv_tau_wind: jnp.ndarray         # (nlev,) — applied to both u and v
+    inv_tau_wind: jnp.ndarray         # (nlev,) applied to both u and v
     inv_tau_temperature: jnp.ndarray  # (nlev,)
+    # Optional, and last, so a wind/temperature config still takes two
+    # arguments. None means humidity is not relaxed, which is what this module
+    # did before humidity became configurable.
+    inv_tau_humidity: jnp.ndarray = None  # (nlev,) applied to specific humidity
 
     @classmethod
     def winds_only(cls, nlev: int, *, tau_seconds: float = 21600.0,
@@ -155,6 +177,30 @@ class NudgingConfig:
         return cls(
             inv_tau_wind=inv_tau * mask,
             inv_tau_temperature=jnp.zeros(nlev),
+            inv_tau_humidity=jnp.zeros(nlev),
+        )
+
+    @classmethod
+    def temp_humidity(cls, nlev: int, *, tau_seconds: float = 21600.0) -> "NudgingConfig":
+        """Nudge temperature and specific humidity on every level, winds free.
+
+        The complement of :meth:`winds_only`: it constrains the
+        thermodynamic state and leaves the circulation free to respond. The
+        tendencies such a run records are the supervised target a learned
+        correction term can be fitted to.
+
+        Args:
+            nlev: Number of vertical levels.
+            tau_seconds: Relaxation timescale in seconds (default 6 h),
+                shared by temperature and humidity.
+
+        """
+        inv_tau = 1.0 / float(tau_seconds)
+        ones = jnp.ones(nlev)
+        return cls(
+            inv_tau_wind=jnp.zeros(nlev),
+            inv_tau_temperature=inv_tau * ones,
+            inv_tau_humidity=inv_tau * ones,
         )
 
 
@@ -200,10 +246,12 @@ def nudging_tendency(state: PhysicsState, target: NudgingTarget,
                      nodal_shape: tuple | None = None) -> PhysicsTendency:
     """Newtonian relaxation tendency in gridpoint space.
 
-    ``dX/dt = inv_tau · (X_ref − X)`` per relaxed variable. Variables with
-    zero ``inv_tau`` get zero tendency. Tracers and specific humidity are
-    not nudged — the tendency carries zeros for them so the
-    :class:`PhysicsTendency` pytree shape matches the state's tracer dict.
+    ``dX/dt = inv_tau * (X_ref - X)`` per relaxed variable. Variables with
+    zero ``inv_tau`` get zero tendency, so temperature, winds, and specific
+    humidity are each nudged only where their ``inv_tau`` profile is
+    non-zero. Tracers are never nudged; the tendency carries zeros for them
+    so the :class:`PhysicsTendency` pytree shape matches the state's tracer
+    dict.
 
     Args:
         state: Current gridpoint state.
@@ -227,6 +275,8 @@ def nudging_tendency(state: PhysicsState, target: NudgingTarget,
 
     inv_tau_wind = _profile(config.inv_tau_wind)
     inv_tau_temp = _profile(config.inv_tau_temperature)
+    inv_tau_q = (None if config.inv_tau_humidity is None
+                 else _profile(config.inv_tau_humidity))
 
     # The target is assembled on the dycore's nodal (nlev, nlon, nlat) grid,
     # but under column vectorisation the state arriving here has already been
@@ -276,12 +326,22 @@ def nudging_tendency(state: PhysicsState, target: NudgingTarget,
     v_t = inv_tau_wind * (_match(target.v_wind, state.v_wind) - state.v_wind)
     T_t = inv_tau_temp * (
         _match(target.temperature, state.temperature) - state.temperature)
-    q_zeros = jnp.zeros_like(state.specific_humidity)
+    # No humidity reference, or no humidity timescale, relaxes nothing. That
+    # matches the wind/temperature-only behaviour this module had before
+    # humidity became configurable. Both are checked on the Python object
+    # rather than traced: each is either present for the whole run or absent
+    # for the whole run.
+    if target.specific_humidity is None or config.inv_tau_humidity is None:
+        q_t = jnp.zeros_like(state.specific_humidity)
+    else:
+        q_t = inv_tau_q * (
+            _match(target.specific_humidity, state.specific_humidity)
+            - state.specific_humidity)
     tracer_zeros = {name: jnp.zeros_like(t) for name, t in state.tracers.items()}
 
     return PhysicsTendency(
         u_wind=u_t, v_wind=v_t, temperature=T_t,
-        specific_humidity=q_zeros, tracers=tracer_zeros,
+        specific_humidity=q_t, tracers=tracer_zeros,
     )
 
 

--- a/jcm/nudging.py
+++ b/jcm/nudging.py
@@ -90,9 +90,9 @@ class NudgingTarget:
                 ``time_var``). Loaded verbatim onto the model grid;
                 regridding is the user's responsibility before loading.
             u_var, v_var, T_var, q_var: netCDF variable names. ``q_var``
-                may be absent, in which case ``specific_humidity`` is
-                filled with zeros and only matters when paired with a
-                non-zero ``inv_tau_humidity``.
+                may be absent, in which case ``specific_humidity`` stays
+                ``None``, the "no humidity reference" sentinel, and the
+                relaxation leaves humidity alone.
             time_var: Time coord name. ``None`` for static (climatology)
                 reference data.
 
@@ -112,9 +112,13 @@ class NudgingTarget:
         u = to_jax(u_var)
         v = to_jax(v_var)
         T = to_jax(T_var)
-        # Humidity is optional: a wind/temperature-only target (the original
-        # use case) carries no q field, so fall back to zeros.
-        q = to_jax(q_var) if q_var in ds else jnp.zeros_like(T)
+        # Humidity is optional, and its absence has to survive as ``None``:
+        # that is the sentinel the tendency reads as "no humidity reference".
+        # Substituting zeros turns "leave humidity alone" into "relax toward a
+        # bone-dry atmosphere" the moment the target meets a non-zero
+        # ``inv_tau_humidity``, which is exactly what
+        # ``NudgingConfig.temp_humidity`` sets on every level.
+        q = to_jax(q_var) if q_var in ds else None
 
         if is_time_varying:
             time_seconds = _time_axis_seconds_from_ds(ds.rename({time_var: "time"}))
@@ -122,8 +126,8 @@ class NudgingTarget:
             def ts(a):
                 return make_time_series(a, time_seconds, align_mode=BY_DATE)
 
-            return cls(u_wind=ts(u), v_wind=ts(v),
-                       temperature=ts(T), specific_humidity=ts(q))
+            return cls(u_wind=ts(u), v_wind=ts(v), temperature=ts(T),
+                       specific_humidity=None if q is None else ts(q))
         return cls(u_wind=u, v_wind=v, temperature=T, specific_humidity=q)
 
 

--- a/jcm/nudging_test.py
+++ b/jcm/nudging_test.py
@@ -124,6 +124,10 @@ class TestNudgingTendencyDirection(unittest.TestCase):
         shape = (nlev, nlon, nlat)
 
         ds = _zero_winds_target_dataset(nlev, nlon, nlat, T_K=250.0)
+        # A real humidity reference below the state's 0.01: this case is about
+        # the direction of the tendency, not about a missing ``q``.
+        ds["q"] = (("lev", "lon", "lat"),
+                   np.full((nlev, nlon, nlat), 5e-3, dtype=np.float32))
         target = NudgingTarget.from_dataset(ds, time_var=None)
         config = NudgingConfig(
             inv_tau_wind=jnp.ones(nlev),
@@ -143,7 +147,7 @@ class TestNudgingTendencyDirection(unittest.TestCase):
         self.assertTrue(jnp.all(tend.u_wind <= 0.0))
         self.assertTrue(jnp.all(tend.v_wind >= 0.0))         # state v < target v
         self.assertTrue(jnp.all(tend.temperature <= 0.0))    # state T > target T
-        self.assertTrue(jnp.all(tend.specific_humidity <= 0.0))  # state q > target q (0)
+        self.assertTrue(jnp.all(tend.specific_humidity <= 0.0))  # state q > target q
 
 
 class TestNudgingTendencyBroadcasting(unittest.TestCase):
@@ -194,14 +198,54 @@ class TestNudgingTendencyBroadcasting(unittest.TestCase):
 
 
 class TestNudgingTargetHumidity(unittest.TestCase):
-    """``from_dataset`` carries specific humidity when present, zeros when not."""
+    """``from_dataset`` carries specific humidity when present, ``None`` when not."""
 
-    def test_humidity_absent_is_zero(self):
+    def test_humidity_absent_stays_none(self):
+        """A missing ``q`` must not become a zero-humidity reference.
+
+        ``None`` is the documented "no humidity reference" sentinel, and the
+        tendency reads it as "leave humidity alone". Filling zeros instead
+        turns a wind/temperature target into a reference for a bone-dry
+        atmosphere.
+        """
         nlev, nlon, nlat = 4, 8, 6
         ds = _zero_winds_target_dataset(nlev, nlon, nlat)
         target = NudgingTarget.from_dataset(ds, time_var=None)
-        self.assertEqual(target.specific_humidity.shape, (nlev, nlon, nlat))
-        self.assertTrue(jnp.all(target.specific_humidity == 0.0))
+        self.assertIsNone(target.specific_humidity)
+
+    def test_humidity_absent_does_not_dry_the_atmosphere(self):
+        """A q-less target under ``temp_humidity`` leaves humidity untouched."""
+        nlev, nlon, nlat = 4, 8, 6
+        shape = (nlev, nlon, nlat)
+        ds = _zero_winds_target_dataset(nlev, nlon, nlat, T_K=250.0)
+        target = NudgingTarget.from_dataset(ds, time_var=None)
+        state = PhysicsState(
+            u_wind=jnp.zeros(shape), v_wind=jnp.zeros(shape),
+            temperature=jnp.full(shape, 280.0),
+            specific_humidity=jnp.full(shape, 8.0),  # g/kg, a moist column
+            geopotential=jnp.zeros(shape),
+            normalized_surface_pressure=jnp.ones((nlon, nlat)),
+            tracers={},
+        )
+        tend = nudging_tendency(
+            state, target, NudgingConfig.temp_humidity(nlev=nlev))
+        # Temperature is still relaxed; humidity is left entirely alone.
+        self.assertTrue(jnp.all(tend.temperature < 0.0))
+        self.assertTrue(jnp.all(tend.specific_humidity == 0.0))
+
+    def test_humidity_absent_time_varying_stays_none(self):
+        """The ``TimeSeries`` path preserves the sentinel too."""
+        nlev, nlon, nlat, nt = 4, 8, 6, 2
+        zeros = np.zeros((nt, nlev, nlon, nlat), dtype=np.float32)
+        dims = ("time", "lev", "lon", "lat")
+        ds = xr.Dataset(
+            {"u": (dims, zeros), "v": (dims, zeros.copy()),
+             "T": (dims, np.full_like(zeros, 250.0))},
+            coords={"time": np.array(["2000-01-01", "2000-01-02"],
+                                     dtype="datetime64[ns]")},
+        )
+        target = NudgingTarget.from_dataset(ds)
+        self.assertIsNone(target.specific_humidity)
 
     def test_humidity_present_is_loaded(self):
         nlev, nlon, nlat = 4, 8, 6

--- a/jcm/nudging_test.py
+++ b/jcm/nudging_test.py
@@ -8,6 +8,7 @@ plumbing.
 
 import unittest
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 import xarray as xr
@@ -52,6 +53,17 @@ class TestNudgingConfig(unittest.TestCase):
         cfg = NudgingConfig.winds_only(self.nlev, pbl_levels=2)
         self.assertTrue(jnp.all(cfg.inv_tau_wind[:-2] > 0.0))
         self.assertTrue(jnp.all(cfg.inv_tau_wind[-2:] == 0.0))
+
+    def test_winds_only_zeros_humidity(self):
+        cfg = NudgingConfig.winds_only(self.nlev)
+        self.assertTrue(jnp.all(cfg.inv_tau_humidity == 0.0))
+
+    def test_temp_humidity_zeros_winds(self):
+        # The offline-warmup config nudges T and q, leaves winds free.
+        cfg = NudgingConfig.temp_humidity(self.nlev, tau_seconds=86400.0)
+        self.assertTrue(jnp.all(cfg.inv_tau_wind == 0.0))
+        self.assertTrue(jnp.all(cfg.inv_tau_temperature > 0.0))
+        self.assertTrue(jnp.all(cfg.inv_tau_humidity > 0.0))
 
 
 class TestInvTauProfile(unittest.TestCase):
@@ -116,12 +128,13 @@ class TestNudgingTendencyDirection(unittest.TestCase):
         config = NudgingConfig(
             inv_tau_wind=jnp.ones(nlev),
             inv_tau_temperature=jnp.ones(nlev),
+            inv_tau_humidity=jnp.ones(nlev),
         )
         state = PhysicsState(
             u_wind=jnp.full(shape, 5.0),
             v_wind=jnp.full(shape, -3.0),
             temperature=jnp.full(shape, 280.0),
-            specific_humidity=jnp.zeros(shape),
+            specific_humidity=jnp.full(shape, 0.01),
             geopotential=jnp.zeros(shape),
             normalized_surface_pressure=jnp.ones((nlon, nlat)),
             tracers={},
@@ -130,6 +143,73 @@ class TestNudgingTendencyDirection(unittest.TestCase):
         self.assertTrue(jnp.all(tend.u_wind <= 0.0))
         self.assertTrue(jnp.all(tend.v_wind >= 0.0))         # state v < target v
         self.assertTrue(jnp.all(tend.temperature <= 0.0))    # state T > target T
+        self.assertTrue(jnp.all(tend.specific_humidity <= 0.0))  # state q > target q (0)
+
+
+class TestNudgingTendencyBroadcasting(unittest.TestCase):
+    """The tendency is broadcasting-native: column block agrees with the grid."""
+
+    def test_column_block_matches_grid(self):
+        nlev, nlon, nlat = 4, 6, 3
+        ncols = nlon * nlat
+        key = jax.random.split(jax.random.key(0), 4)
+        config = NudgingConfig(
+            inv_tau_wind=jnp.linspace(0.5, 1.5, nlev),
+            inv_tau_temperature=jnp.linspace(1.0, 2.0, nlev),
+            inv_tau_humidity=jnp.linspace(0.1, 0.4, nlev),
+        )
+
+        def make(shape, horiz):
+            return PhysicsState(
+                u_wind=jax.random.normal(key[0], shape),
+                v_wind=jax.random.normal(key[1], shape),
+                temperature=250.0 + jax.random.normal(key[2], shape),
+                specific_humidity=1.0 + jax.random.uniform(key[3], shape),
+                geopotential=jnp.zeros(shape),
+                normalized_surface_pressure=jnp.ones(horiz),
+                tracers={},
+            )
+
+        grid = make((nlev, nlon, nlat), (nlon, nlat))
+        block = jax.tree_util.tree_map(
+            lambda a: a.reshape((nlev, ncols) if a.ndim == 3 else (ncols,)),
+            grid)
+        target_grid = jax.tree_util.tree_map(jnp.zeros_like, grid)
+        target_block = jax.tree_util.tree_map(jnp.zeros_like, block)
+        t_grid = nudging_tendency(
+            grid, NudgingTarget(target_grid.u_wind, target_grid.v_wind,
+                                target_grid.temperature,
+                                target_grid.specific_humidity), config)
+        t_block = nudging_tendency(
+            block, NudgingTarget(target_block.u_wind, target_block.v_wind,
+                                 target_block.temperature,
+                                 target_block.specific_humidity), config)
+        self.assertEqual(t_block.temperature.shape, (nlev, ncols))
+        np.testing.assert_allclose(
+            np.asarray(t_grid.temperature).reshape(nlev, ncols),
+            np.asarray(t_block.temperature), rtol=1e-6)
+        np.testing.assert_allclose(
+            np.asarray(t_grid.specific_humidity).reshape(nlev, ncols),
+            np.asarray(t_block.specific_humidity), rtol=1e-6)
+
+
+class TestNudgingTargetHumidity(unittest.TestCase):
+    """``from_dataset`` carries specific humidity when present, zeros when not."""
+
+    def test_humidity_absent_is_zero(self):
+        nlev, nlon, nlat = 4, 8, 6
+        ds = _zero_winds_target_dataset(nlev, nlon, nlat)
+        target = NudgingTarget.from_dataset(ds, time_var=None)
+        self.assertEqual(target.specific_humidity.shape, (nlev, nlon, nlat))
+        self.assertTrue(jnp.all(target.specific_humidity == 0.0))
+
+    def test_humidity_present_is_loaded(self):
+        nlev, nlon, nlat = 4, 8, 6
+        q = np.full((nlev, nlon, nlat), 5e-3, dtype=np.float32)
+        ds = _zero_winds_target_dataset(nlev, nlon, nlat)
+        ds["q"] = (("lev", "lon", "lat"), q)
+        target = NudgingTarget.from_dataset(ds, time_var=None)
+        np.testing.assert_allclose(np.asarray(target.specific_humidity), q)
 
 
 class TestNudgingTermInPhysicsStack(unittest.TestCase):


### PR DESCRIPTION
## Describe your changes

The API slice of #764. That PR was closed — the NN bias correction itself now lives in [`jcm-experiments/nn-bias-correction`](https://github.com/climate-analytics-lab/jcm-experiments/tree/main/nn-bias-correction) — but two of the changes in it are in the main API and are worth having on their own. This is those two and nothing else: 4 files, +224/−27.

**Optional specific-humidity relaxation.** Nudging could relax winds and temperature but not humidity. `NudgingTarget` gains `specific_humidity` and `NudgingConfig` gains `inv_tau_humidity`. Both default to `None`, meaning not relaxed, and both are positioned last, so every existing target and config keeps working with the argument count it has today. `nudging_tendency` returns a zero humidity tendency unless both are supplied, and it decides that with a Python-level `is None` rather than a traced `jnp.where`, so jit resolves it at trace time and the wind-and-temperature path costs exactly what it did before. `from_dataset` gains `q_var` and leaves `specific_humidity` as `None` when the variable is absent, so a dataset without humidity never reads as a dry atmosphere, and `NudgingConfig.temp_humidity` builds the T/q profile — the complement of the `winds_only` that was already there.

The humidity in a `NudgingTarget` is in g/kg, the `PhysicsState` convention, and the docstring says so. Raw ERA5 is kg/kg, so getting this wrong nudges the model toward one thousandth of the intended value and nothing anywhere raises. That is the whole reason for the docs hunk below.

**`vertical_interp_log_p` made public.** Nothing in the ozone climatology's log-pressure interpolation is ozone-specific beyond the argument names, and an ERA5 loader outside this repository reuses it for temperature, humidity and winds. Importing an underscore name across packages couples to a private detail. There are exactly two references to it in the whole repository, both inside `interpolate_ozone.py`; the internal call site follows the rename.

**A units note in `getting_started.rst`,** five lines next to the nudging example, saying what units the target fields are in.

## Testing

Branched off current `dev` (`f96575c1`). Neither `nudging.py` nor `interpolate_ozone.py` has been touched on `dev` since I first wrote these, so they apply cleanly.

`pytest jcm/nudging_test.py` gives 21 passed, 3 subtests passed. Eight of those cases are new or changed: `winds_only` zeroing humidity, `temp_humidity` zeroing winds, the sign of the humidity tendency, humidity absent (static and time-varying, both staying `None`) and present in `from_dataset`, the humidity tendency staying exactly zero when a target without `q` meets `temp_humidity`, and a grid-versus-flattened-column agreement test that pins the broadcasting down rather than leaving it asserted in a docstring. `pytest jcm/data/bc/` gives 9 passed. `ruff check` with the pinned 0.15.17 is clean. All of that in a fresh CPU environment built from `requirements.txt` plus the forked dinosaur.

The `claude-review` check fails with an empty `ANTHROPIC_API_KEY` in its log — fork PRs do not get repository secrets, so I do not think that one is about this branch.

## Issue ticket number and link

#356, and the closed #764.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

