### PR TITLE
docs: README shop front, Python-only quick start, one CLI & batch-jobs page (#639)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,51 +10,35 @@
 <img src="logo.png" alt="JAX-GCM logo" width="180">
 
 JAX-GCM is a differentiable atmospheric general circulation model written
-in JAX. Its pluggable dynamical-core interface currently ships with the
-[Dinosaur](https://github.com/neuralgcm/dinosaur) spectral backend and
-couples it to modular SPEEDY, Held-Suarez, and ECHAM-style physics packages,
-with support for gradient-based calibration, ML-physics experiments, and
-accelerated CPU/GPU/TPU runs.
+entirely in JAX. A pluggable dynamical-core interface couples the
+[Dinosaur](https://github.com/neuralgcm/dinosaur) spectral backend to modular
+SPEEDY, Held-Suarez, and ECHAM-style physics packages.
 
-The v2.0 release focus is the ECHAM T63L47 hybrid-coordinate stack with
-RRTMGP radiation:
+## Why JCM
 
-```bash
-python -m jcm.main physics=echam grid=echam_t63_l47_hybrid run=longrun
-```
-
-## Highlights
-
-- Fully differentiable JAX implementation compatible with `jit`, `grad`, and `vmap`
-- Pluggable dynamical-core protocol with a shipped Dinosaur spectral backend
-- Dycore-agnostic, operator-split gridpoint physics coupling
-- SPEEDY, Held-Suarez, and composable ECHAM physics configurations
-- ECHAM T63L47 hybrid-coordinate target setup with grey, RRTMGP, or neural-emulated radiation
-- xarray/netCDF output, chunked long-run health checks, and resumable checkpoints
-- Docker and Kubernetes deployment examples for GPU batch runs
+- **Flexible.** Switch from lightweight SPEEDY physics to full-fat ECHAM with
+  online aerosol by changing one flag — and compose anything in between, term
+  by term, through one composable-physics API.
+- **Differentiable.** Any output is differentiable with respect to the physics
+  parameters, the initial conditions, and the boundary conditions, so gradient
+  calibration, data assimilation, and hybrid physics-ML experiments come for
+  free from JAX's `jit`, `grad`, and `vmap`.
+- **Fast, on whatever you have.** The same configuration runs on CPU, GPU, or
+  TPU. ECHAM T63L47 climate with RRTMGP radiation costs roughly 22.7 s per
+  simulated day on a single GPU — about 4x faster again with the
+  neural-emulated radiation backend — and SPEEDY is cheaper still.
 
 ## Installation
-
-Install the latest release:
 
 ```bash
 pip install jcm
 ```
 
-For the development branch:
+JCM requires Python 3.11 or newer. See
+[the getting-started guide](https://jax-gcm.readthedocs.io/en/latest/getting_started.html)
+for the development install and the full dependency set.
 
-```bash
-git clone https://github.com/climate-analytics-lab/jax-gcm.git
-cd jax-gcm
-git switch dev
-pip install -e .
-```
-
-JCM requires Python 3.11 or newer. The full dependency set is listed in
-[`requirements.txt`](requirements.txt), including JAX, Flax, Dinosaur,
-Hydra, xarray, and optional RRTMGP support.
-
-## Quick Start
+## Quick start
 
 Run a short SPEEDY aquaplanet integration from Python:
 
@@ -62,163 +46,27 @@ Run a short SPEEDY aquaplanet integration from Python:
 from jcm.model import Model
 from jcm.physics.speedy.speedy_coords import get_speedy_coords
 
-# Build coords (pass spmd_mesh=(x, y, z) here to enable multi-device sharding)
+# T31 spectral resolution, 8 vertical levels. Omitting time_step lets the
+# Model resolve a numerically stable default from the physics and grid
+# (SPEEDY picks 30 min here; the no-limit default for ECHAM/Held-Suarez is
+# 12 min).
 coords = get_speedy_coords(layers=8, spectral_truncation=31)
+model = Model(coords=coords)
 
-# Create a model with default configuration. time_step (minutes) is
-# optional: when omitted, the Model resolves a numerically stable default
-# from the active physics and resolution (30 min for the standard
-# configurations; see "Choosing the time step" in the getting-started docs).
-model = Model(
-    coords=coords,
-    time_step=30.0,  # minutes
-)
-
-predictions = model.run(save_interval=10.0, total_time=120.0)
+predictions = model.run(save_interval=10.0, total_time=120.0)  # days
 ds = predictions.to_xarray()
 print(ds)
 ```
 
-Most production runs use the Hydra CLI:
-
-```bash
-# Default 10-day SPEEDY aquaplanet
-python -m jcm.main
-
-# ECHAM T63L47 with the production RRTMGP radiation
-python -m jcm.main physics=echam grid=echam_t63_l47_hybrid
-
-# One validated configuration, one command (the configuration group)
-python -m jcm.main +configuration=t63-echam-jam
-
-# Chunked, resumable long run. Every run group shares one complete key
-# schema now, so run.checkpoint_path sets cleanly without a +/++ prefix.
-python -m jcm.main physics=echam grid=echam_t63_l47_hybrid run=longrun \
-    run.checkpoint_path=/scratch/$JOB_ID.ckpt
-
-# Inspect available config groups and the composed config
-python -m jcm.main --help
-python -m jcm.main --cfg job grid=echam_t63_l47_hybrid
-```
-
-Config groups live under [`jcm/config/`](jcm/config/) (`physics`, `grid`,
-`run`, `init`, `terrain`, `forcing`, `diffusion`, and `configuration` — the
-last promotes each validated physics×grid×init×forcing combination to a
-single `+configuration=<name>` composition).
-
-Boundary-condition and emissions files can be pulled straight from the
-project data mirror on Hugging Face by prefixing any file path with
-`hf://` (fetch once on a node with internet — afterwards the local cache serves compute nodes offline):
-
-```bash
-python -m jcm.main physics=echam-jam grid=echam_t63_l47_hybrid \
-    terrain=from_file terrain.file=hf://bundles/t63/terrain.nc \
-    forcing=from_file forcing.file=hf://bundles/t63/forcing_pd.nc
-```
-
-See `docs/source/design/data_mirror.md` for the full bundle catalogue.
-
-### Emulated radiation
-
-``physics=echam-emulated-2m`` swaps RRTMGP for a GRU emulator trained to
-reproduce it — a settled 4.4x end-to-end at T63L47 (22.7 -> 5.1 s per sim day; see `docs/source/design/radiation_nn_emulator.md`). Trained weights ship with the package (``weights_file: auto``
-resolves ``jcm/data/emulator_weights_per_band_u64.nc``), so it runs out of
-the box:
-
-```bash
-python -m jcm.main physics=echam-emulated-2m grid=echam_t63_l47_hybrid
-```
-
-Point ``physics.terms.nn_emulator_radiation.weights_file`` at another
-checkpoint to swap networks. The emulator sees ozone and CO2 but **not
-CH4 or N2O**, so runs varying those gases are refused with a pointer to
-``physics=echam-rrtmgp-2m`` (jax-gcm#738). Generate labels and train with
-``tools/radiation_emulator/`` — see
-`docs/source/design/radiation_nn_emulator.md`. ``weights_file: null``
-initialises randomly, which is only useful for cost benchmarking and must
-be paired with ``zero_tendency: true``.
-
-## Physics Packages
-
-**SPEEDY** provides a compact climate-physics package for development,
-testing, and optimization examples: simplified convection, large-scale
-condensation, radiation, surface fluxes, vertical diffusion, and
-orographic drag.
-
-**ECHAM** is the v2.0 release target for climate-quality integrations. It
-includes Tiedtke-Nordeng convection, Sundqvist cloud cover, 1M/2M cloud
-microphysics, TTE-TKE vertical diffusion, multi-tile surface physics,
-gravity-wave drag, MACv2-SP aerosols, simple chemistry, and selectable
-radiation backends (`grey`, `rrtmgp`, `emulated`). See
-[`docs/source/echam_physics.rst`](docs/source/echam_physics.rst) for
-scheme notes, references, and current performance guidance.
-
-Individual parameterizations are `PhysicsTerm` modules and can be
-combined with the composable physics API:
-
-```python
-from jcm.physics.echam.echam_terms import echam_physics
-
-physics = echam_physics(radiation_scheme="rrtmgp")
-physics = echam_physics().remove("hines")
-```
-
-## Notebooks
-
-Examples live in [`notebooks/`](notebooks/):
-
-- `01_jcm_demo.ipynb`: SPEEDY aquaplanet and basic xarray analysis
-- `02_optimization_example.ipynb`: differentiable parameter optimization
-- `03_generate_speedy_default_stats.ipynb`: bundled SPEEDY reference statistics
-- `04_jcm_era5_example.ipynb`: ERA5-style initial state workflow
-- `04_jcm_slides.ipynb`: presentation overview
-- `05_jcm_echam_demo.ipynb`: ECHAM and composable physics demo
-- `06_macv2_aerosols.py`: MACv2-SP aerosol parameter workflow
-
-## Docker And Deployment
-
-Build the CUDA-enabled image locally:
-
-```bash
-docker build -t jcm .
-docker run --rm --gpus all jcm physics=echam grid=echam_t63_l47_hybrid
-```
-
-Mount `/app/outputs` to persist Hydra output directories:
-
-```bash
-docker run --rm --gpus all -v "$(pwd)/outputs:/app/outputs" jcm \
-    physics=echam grid=echam_t63_l47_hybrid run.total_time=30
-```
-
-Kubernetes examples for the NRP Nautilus cluster are in
-[`deploy/k8s/`](deploy/k8s/).
-
 ## Documentation
 
-Read the hosted documentation at
-[jax-gcm.readthedocs.io](https://jax-gcm.readthedocs.io/en/latest/) or
-build it locally:
+- [Getting started](https://jax-gcm.readthedocs.io/en/latest/getting_started.html) — the Python quick start: coords, terrain, physics, running, and analysing output.
+- [Running at scale](https://jax-gcm.readthedocs.io/en/latest/running_at_scale.html) — the `python -m jcm.main` Hydra CLI, validated configurations, chunked/resumable runs, Docker, and GPU/batch patterns.
+- [ECHAM physics](https://jax-gcm.readthedocs.io/en/latest/echam_physics.html) and [SPEEDY physics](https://jax-gcm.readthedocs.io/en/latest/speedy_physics.html) — scheme notes and references.
+- Example notebooks live in [`notebooks/`](notebooks/).
 
-```bash
-cd docs
-make html
-```
-
-Then open `docs/build/html/index.html`.
-
-## Testing And Development
-
-Run the fast suite locally:
-
-```bash
-pytest -m "not slow"
-ruff check .
-```
-
-The GitHub test workflow enforces coverage on push and pull requests. New
-work should target the `dev` branch; clean release points are merged to
-`main` and tagged.
+Full documentation is hosted at
+[jax-gcm.readthedocs.io](https://jax-gcm.readthedocs.io/en/latest/).
 
 ## Citation
 

--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -24,6 +24,9 @@ JAX-GCM is designed to be a fully differentiable climate model that balances eas
    design/data_mirror
    design/packaged_config_tree
    design/test_suite_memory
+   design/observers
+   design/pyses_followups
+   design/pyses_performance_review
 
 Core Architecture
 -----------------

--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -25,7 +25,6 @@ JAX-GCM is designed to be a fully differentiable climate model that balances eas
    design/packaged_config_tree
    design/test_suite_memory
    design/observers
-   design/pyses_followups
    design/pyses_performance_review
 
 Core Architecture

--- a/docs/source/design/pyses_followups.md
+++ b/docs/source/design/pyses_followups.md
@@ -1,1 +1,0 @@
-- [ ] JAM term: .at[].set with float64 value on float32 operand under x64 (FutureWarning in ne30 2m-jam run; find via JAX_DEBUG... or grep scatter sites in jam/) — pin like PR #564 conds

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -31,108 +31,12 @@ Requirements
 
 See ``requirements.txt`` for the complete list of dependencies.
 
-Command-line interface
-----------------------
+.. note::
 
-Most simulations can be launched without writing any Python via the bundled
-Hydra CLI. ``jcm/main.py`` is executable so it can be invoked either as a
-module or directly::
-
-   ./jcm/main.py                                               # direct invocation
-   python -m jcm.main                                          # equivalent module form
-   python -m jcm.main physics=echam-rrtmgp grid=echam_t63_l47_hybrid
-   python -m jcm.main physics=echam grid=echam_t63_l47_hybrid
-   python -m jcm.main physics=held_suarez grid=held_suarez_t31_l8 \
-       run.total_time=30 run.save_interval=1
-   python -m jcm.main physics=echam +physics.terms.tiedtke_convection.params.entrpen=4e-4
-   python -m jcm.main physics=echam-rrtmgp grid=echam_t63_l47_hybrid run=longrun
-   python -m jcm.main physics=echam-emulated-2m grid=echam_t63_l47_hybrid
-   python -m jcm.main run.mode=scm run.state_file=path/to/state.nc \
-       run.column.lat_deg=0 run.column.lon_deg=180
-
-The state-file modes (``run.mode=scm`` and ``run.mode=prescribed``) read a
-netCDF written by an earlier run. Both the vertical orientation and the tracer
-list are handled for you: output files are surface-first and are flipped into
-the top-first physics frame on load, and with ``run.tracer_vars`` unset (the
-default) every tracer the configured physics declares — ``qc``/``qi`` for the
-one-moment cloud scheme, plus ``qnc``/``qni`` for the two-moment one — is
-loaded from the file when it carries it. Pass an explicit mapping to rename
-variables, or ``run.tracer_vars={}`` to load none.
-
-Inspect the available config groups and the fully-composed config::
-
-   python -m jcm.main --help                                   # config-group choices
-   python -m jcm.main --cfg job                                # composed config
-   python -m jcm.main --cfg job grid=echam_t63_l47_hybrid       # with overrides
-
-Config groups live under ``jcm/config/``: ``physics``, ``grid``, ``run``,
-``init``, ``terrain``, ``forcing``, ``diffusion``, ``configuration``.
-
-Validated configurations — the ``configuration`` group
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Composing a run by hand (``physics=… grid=… init=… run=… terrain=… forcing=…``)
-is powerful but easy to get subtly wrong — an isothermal cold start with no
-sponge, for instance, goes NaN within days at L47. The ``configuration`` group
-promotes each *known-good* combination to a single named composition, so one
-command is one validated configuration::
-
-   python -m jcm.main +configuration=t63-echam-jam     # T63L47 ECHAM + JAM aerosol
-   python -m jcm.main +configuration=speedy-t31        # SPEEDY T31L8 reference
-   python -m jcm.main +configuration=ma-t63-l95        # middle-atmosphere JAM sweep
-
-Note the leading ``+``: a configuration is *added* to the default composition and
-then overrides the physics/grid/init/run/terrain/forcing groups it selects. Each
-``jcm/config/configuration/*.yaml`` carries comments explaining WHY every setting
-is what it is (the dry-JW init, the production sponge, the semi-Lagrangian
-off-centering, the level-matched ozone, …), and is the single source of truth
-for that configuration — ``tools/benchmark.py`` and the release-validation
-matrix compose the very same yaml rather than a private override list. Override
-individual keys on top as usual, e.g.
-``python -m jcm.main +configuration=t63-echam-jam run.total_time=30``. The very
-same recipes are loadable from Python without touching Hydra — see
-:ref:`configurations-from-python` below.
-
-The whole ``jcm/config`` tree is also a **public, packaged** config tree: a
-downstream Hydra app (a coupled Earth-system CLI, say) reaches every jcm group
-through ``hydra.searchpath: [pkg://jcm.config]`` and can re-root a whole
-validated configuration under one of its own nodes with
-``+configuration@<node>=<name>``. That contract — the public group names, the
-load-bearing ``# @package _global_`` header plus absolute-override recipe style,
-and the group-rename policy (this release renamed the ``experiment`` group to
-``configuration``, so a searchpath user must change ``+experiment@<node>=`` to
-``+configuration@<node>=``) — is documented in
-:doc:`design/packaged_config_tree`.
-
-One run schema — no ``+``/``++`` guesswork for run keys
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Every ``run`` group (``default``, ``longrun``, ``smoke``, ``pyses_year``) now
-exposes the **same** complete set of keys. ``run/default.yaml`` is the base
-schema and the others inherit it (``defaults: [default, _self_]``), overriding
-only what they change. So any run key can be set with a plain override on any
-group — ``run=longrun run.checkpoint_path=/scratch/x.ckpt`` composes even though
-the old ``longrun`` had no ``checkpoint_path`` key. The rule is simply:
-**``run.<key>=<value>`` always works**; reserve the ``+`` (add-new-key) and
-``++`` (add-or-override) prefixes for keys *outside* the run schema.
-
-Online-aerosol (JAM) inputs default to ``auto``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-When a prognostic-aerosol package is active (``physics=echam-jam`` and its
-AeroCom variants), the prescribed-emission inputs — ``forcing.emissions_file``,
-``forcing.dms_file``, ``forcing.dust_file`` and ``forcing.oxidants_file`` —
-default to ``auto``. ``auto`` resolves the per-grid present-day bundle from the
-project data mirror for the composed grid (e.g. ``bundles/t63/emissions_pd.nc``)
-at build time, so ``python -m jcm.main +configuration=t63-echam-jam`` composes a
-fully-specified online-aerosol run with no hand-managed emission paths. For any
-non-JAM package these keys resolve to nothing; set an explicit path or ``hf://``
-bundle to override one, or ``null`` to opt out (the runner then warns the run is
-emission-free). ``auto`` always resolves the *present-day* ``*_pd`` bundle, so a
-transient by-date run (``forcing=amip``/``era5``) left on ``auto`` breathes
-present-day aerosol emissions over a historical circulation — the runner warns
-and names the keys; override ``forcing.emissions_file``/``forcing.oxidants_file``
-with year-matched products for a consistent transient run.
+   This guide drives the model from **Python**. To launch and manage runs from
+   the command line instead — the ``python -m jcm.main`` Hydra CLI, validated
+   ``+configuration=`` recipes, chunked/resumable production runs, Docker and
+   batch-queue patterns — see :doc:`running_at_scale`.
 
 Quick Start Examples
 --------------------
@@ -213,7 +117,7 @@ For a more realistic simulation with orography and time-varying boundary conditi
    ds.to_netcdf("output.nc")
 
 Canonical mirror-bundle forcing (``from_bundles``)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 :meth:`~jcm.forcing.ForcingData.from_bundles` is the Python door onto the same
 data-mirror bundles the CLI's ``auto`` defaults resolve — it composes the whole
@@ -236,7 +140,9 @@ through the *same* engine :mod:`jcm.runners` uses, so this is exactly the
 
    coords = get_coords(vertical_coords=get_echam_levels(47),
                        spectral_truncation=63)      # ECHAM T63L47 hybrid
-   physics = echam_physics(aerosol_module="jam")     # JAM prognostic aerosol
+   # JAM prognostic aerosol reads the 2-moment cloud scheme's process ledger,
+   # so it must be paired with cloud_scheme="2m".
+   physics = echam_physics(aerosol_module="jam", cloud_scheme="2m")
    terrain = TerrainData.from_coords(coords)
    model = Model(coords=coords, terrain=terrain, physics=physics)
 
@@ -252,8 +158,8 @@ through the *same* engine :mod:`jcm.runners` uses, so this is exactly the
 
 Unpublished grids / verticals degrade exactly as the CLI does (``auto`` inputs
 that the mirror does not carry resolve to nothing, with a warning), and
-``aerosol="macv2sp"`` raises a precise error until the MACv2-SP weights are
-staged on the mirror.
+``aerosol="macv2sp"`` wires the repo-packaged MACv2-SP plume file into the
+forcing.
 
 .. _configurations-from-python:
 
@@ -377,14 +283,13 @@ save_interval, total_time)`` as ``observer_xs``.
 **Logging**: ``Model(log_level=...)`` defaults to ``logging.WARNING`` and is
 applied to the ``jcm`` logger rather than the root logger, so jcm's warnings
 about a run stay audible without jcm reconfiguring logging for your
-application. Pass ``logging.CRITICAL`` to quieten it. The Hydra CLI exposes
-the same knob as ``run.log_level`` (also ``WARNING`` by default).
+application. Pass ``logging.CRITICAL`` to quieten it. (The Hydra CLI exposes
+the same knob as ``run.log_level``.)
 
 **Dynamical core**: Pass a backend explicitly when you need backend-specific
 configuration. ``Model(coords=...)`` remains the shorthand for constructing
-the shipped Dinosaur backend with default settings. The v2.0 Hydra CLI also
-uses Dinosaur; explicit backend selection is currently a Python-API workflow.
-An explicitly-constructed backend owns the time step: the Model adopts its
+the shipped Dinosaur backend with default settings. An
+explicitly-constructed backend owns the time step: the Model adopts its
 ``dt_seconds``, and passing a conflicting ``Model(time_step=...)`` raises
 (see "Choosing the time step" above).
 
@@ -477,7 +382,7 @@ The other builders follow the identical pattern:
 
   (Restoring a *checkpoint* to continue a preempted run of your own — keeping
   the elapsed clock — is the separate :func:`jcm.checkpoint.load_checkpoint`
-  path documented under "Checkpointing for preemptible runs" below.)
+  path documented under :doc:`running_at_scale`.)
 
 
 Calendar-aware durations and resampling
@@ -545,7 +450,9 @@ years to continue from the previous state:
 
 xarray's lazy loading means each year's slice only pulls the data it
 actually needs from disk, so this stays memory-efficient even for very
-long forcing records.
+long forcing records. (For unattended, preemptible long runs the Hydra
+runner's chunked/checkpointed loop does this for you — see
+:doc:`running_at_scale`.)
 
 Yearly forcing bundles
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -578,45 +485,6 @@ dust climatology under one ``forcing.years`` range. When you hand-assemble a
 physics expects.
 
 
-Checkpointing for preemptible runs
-----------------------------------
-
-Multi-day integrations on preemptible compute (spot instances, Slurm
-``--requeue`` queues, NRP Nautilus) can be killed at short notice. Set
-``run.checkpoint_path`` to make a chunked run resumable: after each
-chunk the runner persists the modal + physics state and the elapsed
-sim-day count to that file (atomic write via tmpfile + rename, so a
-kill mid-write leaves the previous checkpoint intact). When the same
-command is launched again with the file already in place, the run
-restores from the checkpoint and only steps the remaining chunks.
-
-.. code-block:: bash
-
-   python -m jcm.main physics=echam-rrtmgp grid=echam_t63_l47_hybrid \
-       run=longrun run.checkpoint_path=/scratch/$JOB_ID.ckpt
-
-The same primitives are available directly to bring-your-own-driver
-workflows via :py:mod:`jcm.checkpoint`:
-
-.. code-block:: python
-
-   from jcm.checkpoint import save_checkpoint, load_checkpoint
-
-   model.run(forcing=forcing, total_time=10)
-   save_checkpoint(model, '/scratch/run.ckpt', elapsed_days=10.0)
-
-   # ... later, in a fresh process ...
-   model = build_model(cfg)            # same coords + physics
-   model.bootstrap_state()             # populate template pytrees
-   elapsed = load_checkpoint(model, '/scratch/run.ckpt')
-   model.resume(forcing=forcing, total_time=20 - elapsed)
-
-The on-disk format is flax's msgpack codec applied to flattened lists
-of arrays — small (state pytrees are a few MB even at T63L47) and
-portable across hosts as long as the destination ``Model`` was built
-with the same coords and physics term composition.
-
-
 Nudging the model toward an external state
 -------------------------------------------
 
@@ -639,25 +507,7 @@ let everything else evolve freely, so the model gets the right
 synoptic-scale circulation while its physics still has the freedom to
 respond.
 
-**From config** the whole setup is one flag: ``nudging=era5`` pulls the
-run window from WeatherBench2's public cloud ERA5 (regridded to the
-model grid and cached locally by :mod:`jcm.data.era5`), and
-``init=era5`` starts the run from the ERA5 state at the same date:
-
-.. code-block:: console
-
-   $ python -m jcm.main physics=echam-rrtmgp grid=echam_t63_l47_hybrid \
-         init=era5 nudging=era5 run.start_date=2010-01-01 run.total_time=30
-
-Prefetch on a login node first when compute nodes lack internet
-(``python -m jcm.data.era5 --grid echam_t63_l47_hybrid --start
-2010-01-01 --end 2010-01-31 --init``). The WB2 stores carry 13 pressure
-levels up to 50 hPa, so nudging is automatically masked off above
-``nudging.min_pressure_hpa`` (default 60), and requires internet or a
-warm cache; see ``jcm/config/nudging/era5.yaml`` for the knobs
-(``tau_hours``, ``pbl_levels``, ``nudge_temperature``, ``freq``).
-
-**In code**, wire it manually against any reference dataset:
+To wire it manually against any reference dataset:
 
 .. code-block:: python
 
@@ -695,7 +545,9 @@ Nudging is dycore-agnostic — it's just another :class:`PhysicsTerm`,
 producing a gridpoint :class:`PhysicsTendency` that the dycore consumes
 through the standard physics-coupling path. The same setup works under
 SPEEDY, ECHAM, or any other physics package, on any
-:class:`DynamicalCore` backend.
+:class:`DynamicalCore` backend. The whole setup is also available as a single
+CLI flag (``nudging=era5``, pulling the run window from cloud ERA5) — see
+:doc:`running_at_scale`.
 
 Composing extra terms: the upper sponge
 ----------------------------------------
@@ -722,62 +574,6 @@ levels and everything above ``min_pressure_hpa``). See the
 :mod:`jcm.nudging` and :mod:`jcm.physics.dissipation.upper_sponge` module
 docstrings for the full set of knobs, and :doc:`design/composable_physics`
 for the composition API (``+``, ``replace``, ``remove``).
-
-Multi-Device Parallelization
------------------------------
-
-JCM supports multi-device parallelization using JAX's SPMD (Single Program Multiple Data) sharding. This allows you to split computation across multiple GPUs or TPUs for faster execution, especially useful for higher resolution simulations.
-
-If you don't specify ``spmd_mesh`` when building your coords, JCM runs on a single device by default. This is the recommended approach for smaller resolutions (T31, T42) or when you only have a single GPU/TPU available.
-
-Basic Concepts
-^^^^^^^^^^^^^^
-
-**SPMD Mesh**: Defines how to partition data across devices. The mesh has three dimensions corresponding to ``(x, y, z)`` or ``(longitude, latitude, vertical)``.
-
-**Sharding Strategy**: Typically, for SPEEDY Physics simulations,  you want to shard the longitude dimension first since it usually has the most grid points. 
-For Physics implementations with more layers (e.g. 32 or 64 layers) however, you may find that sharding the dycore in the vertical dimension to be most effective. 
-Future implementations may allow for more flexible sharding strategies.
-
-Enabling Parallelization
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-To enable multi-device parallelization, pass ``spmd_mesh`` to the coords helper
-(e.g. ``get_speedy_coords`` or ``get_coords``) and build the ``Model`` with those coords:
-
-.. code-block:: python
-
-   import jax
-   from jcm.model import Model
-   from jcm.physics.speedy.speedy_coords import get_speedy_coords
-
-   # Check available devices
-   print(f"Available devices: {jax.devices()}")
-   print(f"Number of devices: {len(jax.devices())}")
-
-   # Define a mesh to split longitude across 4 devices
-   # Mesh shape (4, 1, 1) means:
-   #   - Split longitude dimension across 4 devices
-   #   - Don't split latitude (1)
-   #   - Don't split vertical (1)
-   coords = get_speedy_coords(spmd_mesh=(4, 1, 1))
-   model = Model(coords=coords)
-   predictions = model.run(save_interval=5.0, total_time=30.0)
-
-Mesh Configuration Guidelines
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The product of mesh dimensions must equal the number of available devices:
-
-- ``(4, 1, 1)``: Split longitude across 4 devices
-- ``(2, 2, 1)``: Split longitude (2) and latitude (2) across 4 devices total
-- ``(8, 1, 1)``: Split longitude across 8 devices (for higher resolutions)
-
-**Rules of thumb:**
-
-1. Product of mesh dimensions = number of devices
-2. Longitude (x) usually has most grid points → split first
-3. Higher resolutions (T85+) benefit more from sharding
 
 Analyzing Output
 ----------------
@@ -882,6 +678,8 @@ coordinates, so ``p = a + b * p_s`` is reproducible from the file alone. See
 written before this convention was unified, where the interface axis was
 stored top-first.
 
+.. _overriding-constants:
+
 Overriding physical constants
 -----------------------------
 
@@ -921,12 +719,8 @@ both the dynamical core and the physics pick up the override:
    coords = get_speedy_coords(layers=8, spectral_truncation=31)
    model = Model(coords=coords)       # honours the override
 
-From the CLI, use the ``constants`` config group (applied before the model is
-built):
-
-.. code-block:: bash
-
-   python -m jcm.main +constants.grav=9.80665 +constants.rearth=6.4e6
+The CLI exposes the same override through the ``constants`` config group
+(``+constants.grav=9.80665``) — see :doc:`running_at_scale`.
 
 .. note::
 
@@ -955,6 +749,7 @@ built):
 Next Steps
 ----------
 
+- See :doc:`running_at_scale` to launch and manage runs from the Hydra CLI
 - See :doc:`design` to understand the model architecture
 - See :doc:`api` for detailed API documentation
 - Check example notebooks in the ``notebooks/`` directory of the GitHub repo

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -458,9 +458,11 @@ years to continue from the previous state:
 
 xarray's lazy loading means each year's slice only pulls the data it
 actually needs from disk, so this stays memory-efficient even for very
-long forcing records. (For unattended, preemptible long runs the Hydra
-runner's chunked/checkpointed loop does this for you — see
-:doc:`running_at_scale`.)
+long forcing records. (The Hydra runner's chunked/checkpointed loop — see
+:doc:`running_at_scale` — chunks the *integration* for preemptible runs,
+but it builds the full ``ForcingData`` up front; for a forcing record too
+large for memory, this manual per-year loop is the memory-efficient
+pattern.)
 
 Yearly forcing bundles
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -121,12 +121,17 @@ Canonical mirror-bundle forcing (``from_bundles``)
 
 :meth:`~jcm.forcing.ForcingData.from_bundles` is the Python door onto the same
 data-mirror bundles the CLI's ``auto`` defaults resolve — it composes the whole
-canonical input set for a composition in one call, fetching each per-grid bundle
-into the local Hugging Face cache. For a JAM (prognostic-aerosol) package it
-supplies the surface bundle, ozone, and the emission / DMS / dust / oxidant set;
-a non-JAM package gets surface + ozone only. It routes the composed config
-through the *same* engine :mod:`jcm.runners` uses, so this is exactly the
-``+configuration=t63-echam-jam`` run expressed in Python:
+canonical *forcing* set for a composition in one call, fetching each per-grid
+bundle into the local Hugging Face cache, through the same engine the CLI uses,
+so the two doors agree input-for-input. For a JAM (prognostic-aerosol) package
+it supplies the surface bundle, ozone, and the emission / DMS / dust / oxidant
+set; a non-JAM package gets surface + ozone only. Reach for it when composing
+your *own* model, as below. It supplies only the forcing: a validated
+end-to-end setup such as ``t63-echam-jam`` also pins the radiation scheme,
+aerosol core, activation variant, native-grid terrain and sponge, so to
+reproduce one of those use :func:`jcm.configurations.load`
+(:ref:`next section <configurations-from-python>`) rather than rebuilding it
+by hand.
 
 .. code-block:: python
 
@@ -141,9 +146,12 @@ through the *same* engine :mod:`jcm.runners` uses, so this is exactly the
    coords = get_coords(vertical_coords=get_echam_levels(47),
                        spectral_truncation=63)      # ECHAM T63L47 hybrid
    # JAM prognostic aerosol reads the 2-moment cloud scheme's process ledger,
-   # so it must be paired with cloud_scheme="2m".
-   physics = echam_physics(aerosol_module="jam", cloud_scheme="2m")
-   terrain = TerrainData.from_coords(coords)
+   # so it must be paired with cloud_scheme="2m"; RRTMGP radiation consumes
+   # the aerosol optics (the grey default would ignore them).
+   physics = echam_physics(aerosol_module="jam", cloud_scheme="2m",
+                           radiation_scheme="rrtmgp")
+   terrain = TerrainData.from_coords(coords)     # flat all-ocean; pass
+                                                 # terrain_file= for orography
    model = Model(coords=coords, terrain=terrain, physics=physics)
 
    # Surface (present-day), ozone and the JAM emission/dms/dust/oxidant bundles,

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -193,8 +193,10 @@ initial state is already applied — e.g. the dry-JW start for the ECHAM family)
    # (no DictConfig leaks out). Override any key with Hydra dotted syntax:
    exp = configurations.load("t63-echam-jam", **{"run.total_time": 30})
 
-pySES recipes load only when the optional ``pyses`` backend is installed
-(a clear error otherwise). For forcing alone, reach for
+Recipes selecting optional components need their extra installed — ``jcm[mam4]``
+for the JAM recipes (as in the example above), ``jcm[pyses]`` for the pySES
+backend, ``jcm[cosp]`` for the COSP variant — and fail with a clear
+``ModuleNotFoundError`` at load otherwise. For forcing alone, reach for
 :meth:`~jcm.forcing.ForcingData.from_bundles` above.
 
 Customizing the Model

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,6 +25,7 @@ Contents
    :caption: Contents:
 
    getting_started
+   running_at_scale
    speedy_physics
    echam_physics
    release_notes

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@ couples it to modular SPEEDY, Held-Suarez, and ECHAM-style physics packages.
 
 The main target configuration is ECHAM physics on the T63L47 hybrid
 grid with RRTMGP radiation
-(``physics=echam grid=echam_t63_l47_hybrid``). The SPEEDY package
+(``+configuration=t63-echam-rrtmgp``). The SPEEDY package
 remains the lightweight default for quick tests, tutorials, and
 optimization examples.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,9 +6,9 @@ in JAX. Its pluggable dynamical-core interface currently ships with the
 `Dinosaur <https://github.com/neuralgcm/dinosaur>`_ spectral backend and
 couples it to modular SPEEDY, Held-Suarez, and ECHAM-style physics packages.
 
-For the v2.0 release line, the main target configuration is ECHAM
-physics on the T63L47 hybrid grid with RRTMGP radiation
-(``physics=echam-rrtmgp grid=echam_t63_l47_hybrid``). The SPEEDY package
+The main target configuration is ECHAM physics on the T63L47 hybrid
+grid with RRTMGP radiation
+(``physics=echam grid=echam_t63_l47_hybrid``). The SPEEDY package
 remains the lightweight default for quick tests, tutorials, and
 optimization examples.
 

--- a/docs/source/running_at_scale.rst
+++ b/docs/source/running_at_scale.rst
@@ -1,0 +1,361 @@
+Running at scale — CLI, Hydra and batch jobs
+============================================
+
+The :doc:`getting_started` guide drives the model from Python. This page is the
+one place in the documentation that speaks **Hydra**: the ``python -m jcm.main``
+command-line interface, the config-group tree it composes, the ``+``/``++``
+override rules that trip people up, and the chunked/resumable, containerised and
+batch-queue patterns that production runs use. Everything a run needs — physics,
+grid, forcing, checkpointing — is expressible as ``python -m jcm.main`` with
+Hydra groups and overrides; there are no bespoke driver scripts.
+
+Command-line interface
+----------------------
+
+Most simulations can be launched without writing any Python. ``jcm/main.py`` is
+executable, so it can be invoked either as a module or directly::
+
+   ./jcm/main.py                                               # direct invocation
+   python -m jcm.main                                          # equivalent module form
+
+   # Default 10-day SPEEDY aquaplanet
+   python -m jcm.main
+
+   # ECHAM T63L47 with the production RRTMGP radiation (physics=echam IS the
+   # RRTMGP one-moment package; there is no separate ``echam-rrtmgp`` group)
+   python -m jcm.main physics=echam grid=echam_t63_l47_hybrid
+
+   # Held-Suarez dynamical-core test
+   python -m jcm.main physics=held_suarez grid=held_suarez_t31_l8 \
+       run.total_time=30 run.save_interval=1
+
+   # Chunked, resumable long run
+   python -m jcm.main physics=echam grid=echam_t63_l47_hybrid run=longrun
+
+The state-file modes (``run.mode=scm`` and ``run.mode=prescribed``) read a
+netCDF written by an earlier run::
+
+   python -m jcm.main run.mode=scm run.state_file=path/to/state.nc \
+       run.column.lat_deg=0 run.column.lon_deg=180
+
+Both the vertical orientation and the tracer list are handled for you: output
+files are surface-first and are flipped into the top-first physics frame on
+load, and with ``run.tracer_vars`` unset (the default) every tracer the
+configured physics declares — ``qc``/``qi`` for the one-moment cloud scheme,
+plus ``qnc``/``qni`` for the two-moment one — is loaded from the file when it
+carries it. Pass an explicit mapping to rename variables, or
+``run.tracer_vars={}`` to load none.
+
+Config groups
+-------------
+
+Config groups live under ``jcm/config/``. Selecting a different option for a
+group is a bare ``group=option`` override:
+
+============= =================================================================
+Group         What it selects
+============= =================================================================
+``physics``   ``speedy``, ``held_suarez``, ``echam`` (RRTMGP 1-moment),
+              ``echam-rrtmgp-2m``, ``echam-emulated-2m``, the ``echam-jam*``
+              prognostic-aerosol packages, …
+``grid``      ``speedy_t31_l8``, ``held_suarez_t31_l8``, the
+              ``echam_t{63,85,106,119}_l{47,95}_hybrid`` grids, …
+``run``       ``default``, ``longrun``, ``smoke``, ``pyses_year``
+``init``      ``isothermal``, ``balanced_isothermal``, ``jw``, ``era5``,
+              ``from_state``
+``terrain``   ``aquaplanet``, ``auto`` (native-grid orography), ``from_file``
+``forcing``   ``default``, ``amip``, ``era5``, ``from_file``, ``macv2_sp``
+``nudging``   ``none``, ``era5``
+``diffusion`` ``default``, ``strong``
+``dycore``    ``dinosaur`` (default), the ``pyses_*`` finite-volume backends
+============= =================================================================
+
+Inspect the available choices and the fully-composed config::
+
+   python -m jcm.main --help                                   # config-group choices
+   python -m jcm.main --cfg job                                # composed config
+   python -m jcm.main --cfg job grid=echam_t63_l47_hybrid      # with overrides
+
+Validated configurations — the ``configuration`` group
+-------------------------------------------------------
+
+Composing a run by hand (``physics=… grid=… init=… run=… terrain=… forcing=…``)
+is powerful but easy to get subtly wrong — an isothermal cold start with no
+sponge, for instance, goes NaN within days at L47. The ``configuration`` group
+promotes each *known-good* combination to a single named composition, so one
+command is one validated configuration::
+
+   python -m jcm.main +configuration=t63-echam-jam     # T63L47 ECHAM + JAM aerosol
+   python -m jcm.main +configuration=speedy-t31        # SPEEDY T31L8 reference
+   python -m jcm.main +configuration=ma-t63-l95        # middle-atmosphere JAM sweep
+
+Note the leading ``+``: a configuration is *added* to the default composition
+and then overrides the physics/grid/init/run/terrain/forcing groups it selects.
+Each ``jcm/config/configuration/*.yaml`` carries comments explaining WHY every
+setting is what it is (the dry-JW init, the production sponge, the
+semi-Lagrangian off-centering, the level-matched ozone, …), and is the single
+source of truth for that configuration — ``tools/benchmark.py`` and the
+release-validation matrix compose the very same yaml rather than a private
+override list. Override individual keys on top as usual, e.g.
+``python -m jcm.main +configuration=t63-echam-jam run.total_time=30``.
+
+The very same recipes are loadable from Python without touching Hydra via
+:func:`jcm.configurations.load` — see :ref:`configurations-from-python` in the
+getting-started guide.
+
+Override semantics: ``key=`` vs ``+key=`` vs ``++key=``
+-------------------------------------------------------
+
+Hydra distinguishes three override prefixes, and picking the wrong one is the
+most common CLI trap:
+
+============ ================================================================
+Prefix       Meaning
+============ ================================================================
+``key=v``    **Set an existing key.** Errors if the key is not already in the
+             composed config.
+``+key=v``   **Append a new key** that the config does not yet have. Errors if
+             it *does* already exist.
+``++key=v``  **Add-or-override** — set the key whether or not it exists.
+============ ================================================================
+
+Two consequences worth committing to memory:
+
+* **Every ``run`` group exposes the same complete key schema.**
+  ``run/default.yaml`` is the base schema and the others
+  (``longrun``, ``smoke``, ``pyses_year``) inherit it via
+  ``defaults: [default, _self_]``, overriding only what they change. So any run
+  key sets with a plain override on any group —
+  ``run=longrun run.checkpoint_path=/scratch/x.ckpt`` composes even though the
+  ``longrun`` yaml never mentions ``checkpoint_path``. The rule is simply:
+  **``run.<key>=<value>`` always works.**
+
+* **Reserve ``+``/``++`` for keys outside a group's schema.** A per-scheme
+  physics parameter block, for instance, is intentionally absent from
+  ``physics/echam.yaml`` (each field falls back to the scheme's
+  ``Parameters.default()``), so overriding one field needs the append prefix::
+
+     python -m jcm.main physics=echam \
+         +physics.terms.tiedtke_convection.params.entrpen=4e-4
+
+  Physical-constant overrides are the same story — ``constants`` starts as an
+  empty mapping, so each base field is *added*::
+
+     python -m jcm.main +constants.grav=9.80665 +constants.rearth=6.4e6
+
+  Constants are applied process-globally before the model is built; see
+  :ref:`overriding-constants` in the getting-started guide for the semantics and
+  caveats.
+
+Online-aerosol (JAM) inputs default to ``auto``
+------------------------------------------------
+
+When a prognostic-aerosol package is active (``physics=echam-jam`` and its
+AeroCom variants), the prescribed-emission inputs — ``forcing.emissions_file``,
+``forcing.dms_file``, ``forcing.dust_file`` and ``forcing.oxidants_file`` —
+default to ``auto``. ``auto`` resolves the per-grid present-day bundle from the
+project data mirror for the composed grid (e.g. ``bundles/t63/emissions_pd.nc``)
+at build time, so ``python -m jcm.main +configuration=t63-echam-jam`` composes a
+fully-specified online-aerosol run with no hand-managed emission paths. For any
+non-JAM package these keys resolve to nothing; set an explicit path or ``hf://``
+bundle to override one, or ``null`` to opt out (the runner then warns the run is
+emission-free). ``auto`` always resolves the *present-day* ``*_pd`` bundle, so a
+transient by-date run (``forcing=amip``/``era5``) left on ``auto`` breathes
+present-day aerosol emissions over a historical circulation — the runner warns
+and names the keys; override ``forcing.emissions_file``/``forcing.oxidants_file``
+with year-matched products for a consistent transient run.
+
+The data mirror — ``hf://`` paths
+----------------------------------
+
+Boundary-condition and emissions files can be pulled straight from the project
+data mirror on Hugging Face by prefixing any file path with ``hf://`` (fetch
+once on a node with internet — afterwards the local cache serves compute nodes
+offline)::
+
+   python -m jcm.main physics=echam-jam grid=echam_t63_l47_hybrid \
+       terrain=from_file terrain.file=hf://bundles/t63/terrain.nc \
+       forcing=from_file forcing.file=hf://bundles/t63/forcing_pd.nc
+
+See :doc:`design/data_mirror` for the full bundle catalogue. The Python door
+onto the same bundles is :meth:`jcm.forcing.ForcingData.from_bundles` (in the
+getting-started guide).
+
+Emulated radiation
+------------------
+
+``physics=echam-emulated-2m`` swaps RRTMGP for a GRU emulator trained to
+reproduce it — a settled 4.4x end-to-end at T63L47 (22.7 → 5.1 s per sim day).
+Trained weights ship with the package, so it runs out of the box::
+
+   python -m jcm.main physics=echam-emulated-2m grid=echam_t63_l47_hybrid
+
+Point ``physics.terms.nn_emulator_radiation.weights_file`` at another checkpoint
+to swap networks. The emulator sees ozone and CO2 but **not CH4 or N2O**, so
+runs varying those gases are refused with a pointer to ``physics=echam-rrtmgp-2m``
+(jax-gcm#738). See :doc:`design/radiation_nn_emulator` for the training workflow
+and the full accuracy/cost analysis.
+
+Chunked, resumable runs and checkpoints
+----------------------------------------
+
+Long integrations run in **chunks** with a health gate between them. Setting
+``run.chunk_days`` (``run=longrun`` uses 30) breaks the integration into pieces,
+writes each to ``{run.output_prefix}_day{N}.nc``, and runs
+:func:`jcm.diagnostics.check_health` after each one. With
+``run.bail_on_unhealthy`` (the runner default) the run aborts on the first
+unhealthy chunk instead of integrating a doomed state for hours; set it
+``false`` to log and keep going.
+
+Multi-day integrations on preemptible compute (spot instances, Slurm
+``--requeue`` queues, NRP Nautilus) can be killed at short notice. Set
+``run.checkpoint_path`` to make a chunked run resumable: after each chunk the
+runner persists the modal + physics state and the elapsed sim-day count to that
+file (atomic write via tmpfile + rename, so a kill mid-write leaves the previous
+checkpoint intact). When the same command is launched again with the file
+already in place, the run restores from the checkpoint and only steps the
+remaining chunks::
+
+   python -m jcm.main physics=echam grid=echam_t63_l47_hybrid \
+       run=longrun run.checkpoint_path=/scratch/$JOB_ID.ckpt
+
+Set ``run.archive_ckpt_every`` (sim-days; 0 = off) to also copy the rotating
+checkpoint to a dated, never-overwritten archive, so a later experiment can
+restart from before a slowly-developing failure.
+
+The same primitives are available directly to bring-your-own-driver workflows
+via :py:mod:`jcm.checkpoint`:
+
+.. code-block:: python
+
+   from jcm.checkpoint import save_checkpoint, load_checkpoint
+
+   model.run(forcing=forcing, total_time=10)
+   save_checkpoint(model, '/scratch/run.ckpt', elapsed_days=10.0)
+
+   # ... later, in a fresh process ...
+   model = build_model(cfg)            # same coords + physics
+   model.bootstrap_state()             # populate template pytrees
+   elapsed = load_checkpoint(model, '/scratch/run.ckpt')
+   model.resume(forcing=forcing, total_time=20 - elapsed)
+
+The on-disk format is flax's msgpack codec applied to flattened lists of arrays
+— small (state pytrees are a few MB even at T63L47) and portable across hosts as
+long as the destination ``Model`` was built with the same coords and physics
+term composition. (Warm-starting from an *equilibrated* state while resetting the
+clock is the separate :func:`jcm.initial_states.checkpoint_state` path in the
+getting-started guide.)
+
+Nudging from config
+-------------------
+
+Relaxing the model toward an external reference state ("nudging") is one flag on
+the CLI: ``nudging=era5`` pulls the run window from WeatherBench2's public cloud
+ERA5 (regridded to the model grid and cached locally by :mod:`jcm.data.era5`),
+and ``init=era5`` starts the run from the ERA5 state at the same date::
+
+   python -m jcm.main physics=echam grid=echam_t63_l47_hybrid \
+       init=era5 nudging=era5 run.start_date=2010-01-01 run.total_time=30
+
+Prefetch on a login node first when compute nodes lack internet
+(``python -m jcm.data.era5 --grid echam_t63_l47_hybrid --start 2010-01-01 --end
+2010-01-31 --init``). The WB2 stores carry 13 pressure levels up to 50 hPa, so
+nudging is automatically masked off above ``nudging.min_pressure_hpa`` (default
+60); see ``jcm/config/nudging/era5.yaml`` for the knobs (``tau_hours``,
+``pbl_levels``, ``nudge_temperature``, ``freq``). Wiring nudging in code against
+an arbitrary reference dataset is covered in the getting-started guide.
+
+Multi-device parallelization
+----------------------------
+
+JCM supports multi-device execution through JAX's SPMD (Single Program Multiple
+Data) sharding, splitting the computation across several GPUs or TPUs. The mesh
+is passed to the *coords* helper (so it is a Python-side choice even for CLI
+runs, which build coords from the ``grid`` group); if you never set
+``spmd_mesh`` JCM runs on a single device, which is the right default for
+smaller resolutions (T31, T42) or a single accelerator.
+
+The mesh has three dimensions, ``(x, y, z)`` = ``(longitude, latitude,
+vertical)``, and their product must equal the device count:
+
+.. code-block:: python
+
+   import jax
+   from jcm.model import Model
+   from jcm.physics.speedy.speedy_coords import get_speedy_coords
+
+   print(f"Available devices: {jax.devices()}")
+
+   # Split longitude across 4 devices: (4, 1, 1). Other layouts: (2, 2, 1)
+   # splits longitude and latitude 2x2; (8, 1, 1) uses 8 devices.
+   coords = get_speedy_coords(spmd_mesh=(4, 1, 1))
+   model = Model(coords=coords)
+   predictions = model.run(save_interval=5.0, total_time=30.0)
+
+Rules of thumb: longitude (x) usually has the most grid points, so split it
+first; physics with many layers (32/64) can benefit from vertical sharding of
+the dycore instead; and higher resolutions (T85+) gain the most from sharding.
+See :doc:`design/parallelization` for the sharding design and the strong-scaling
+results.
+
+Docker
+------
+
+Build the CUDA-enabled image locally::
+
+   docker build -t jcm .
+   docker run --rm --gpus all jcm physics=echam grid=echam_t63_l47_hybrid
+
+Arguments after the image name are passed straight to ``python -m jcm.main``.
+Mount ``/app/outputs`` to persist Hydra output directories::
+
+   docker run --rm --gpus all -v "$(pwd)/outputs:/app/outputs" jcm \
+       physics=echam grid=echam_t63_l47_hybrid run.total_time=30
+
+Kubernetes examples for the NRP Nautilus cluster are in ``deploy/k8s/``.
+
+GPU and batch-queue patterns
+----------------------------
+
+On a shared multi-GPU host, pin a run to one device with
+``CUDA_VISIBLE_DEVICES`` and keep it detached so it survives a disconnected
+shell, writing the state and a resumable checkpoint to fast scratch::
+
+   CUDA_VISIBLE_DEVICES=0 nohup python -m jcm.main \
+       +configuration=t63-echam-jam \
+       run.output_prefix=/scratch/$USER/run \
+       run.checkpoint_path=/scratch/$USER/run.ckpt \
+       run.total_time=365 > /scratch/$USER/run.log 2>&1 &
+
+On a PBS/Torque cluster the same command drops into a job script; because
+``run.checkpoint_path`` makes the run resumable, a walltime-limited job can
+requeue itself and pick up where it left off:
+
+.. code-block:: bash
+
+   #!/bin/bash
+   #PBS -l select=1:ngpus=1
+   #PBS -l walltime=12:00:00
+   cd "$PBS_O_WORKDIR"
+   python -m jcm.main +configuration=t63-echam-jam run=longrun \
+       run.total_time=365 \
+       run.checkpoint_path="$SCRATCH/$PBS_JOBID.ckpt"
+
+Point ``run.checkpoint_path`` at a path that persists across job restarts, and
+size ``run.chunk_days`` so at least one chunk completes comfortably inside the
+walltime.
+
+.. _packaged-config-tree:
+
+Downstream apps: the packaged config tree
+-----------------------------------------
+
+The whole ``jcm/config`` tree is a **public, packaged** Hydra config tree. A
+downstream Hydra app (a coupled Earth-system CLI, say) reaches every jcm group
+through ``hydra.searchpath: [pkg://jcm.config]`` and can re-root a whole
+validated configuration under one of its own nodes with
+``+configuration@<node>=<name>``. That contract — the public group names, the
+load-bearing ``# @package _global_`` header plus absolute-override recipe style,
+and the group-rename policy (this release renamed the ``experiment`` group to
+``configuration``, so a searchpath user must change ``+experiment@<node>=`` to
+``+configuration@<node>=``) — is documented in :doc:`design/packaged_config_tree`.

--- a/docs/source/running_at_scale.rst
+++ b/docs/source/running_at_scale.rst
@@ -58,8 +58,9 @@ Group         What it selects
 ``physics``   ``speedy``, ``held_suarez``, ``echam`` (RRTMGP 1-moment),
               ``echam-rrtmgp-2m``, ``echam-emulated-2m``, the ``echam-jam*``
               prognostic-aerosol packages, …
-``grid``      ``speedy_t31_l8``, ``held_suarez_t31_l8``, the
-              ``echam_t{63,85,106,119}_l{47,95}_hybrid`` grids, …
+``grid``      ``speedy_t31_l8``, ``held_suarez_t31_l8``,
+              ``echam_t{63,106,119}_l{47,95}_hybrid``,
+              ``echam_t85_l47_hybrid``, …
 ``run``       ``default``, ``longrun``, ``smoke``, ``pyses_year``
 ``init``      ``isothermal``, ``balanced_isothermal``, ``jw``, ``era5``,
               ``from_state``
@@ -328,9 +329,13 @@ shell, writing the state and a resumable checkpoint to fast scratch::
        run.checkpoint_path=/scratch/$USER/run.ckpt \
        run.total_time=365 > /scratch/$USER/run.log 2>&1 &
 
-On a PBS/Torque cluster the same command drops into a job script; because
-``run.checkpoint_path`` makes the run resumable, a walltime-limited job can
-requeue itself and pick up where it left off:
+On a PBS/Torque cluster the same command drops into a job script. The
+scheduler does not extend a job past its walltime, so a long run is a *chain*
+of jobs sharing one checkpoint: each job resumes from
+``run.checkpoint_path``, integrates until the walltime kills it, and the next
+job in the chain picks up at the last completed chunk. Once the run reaches
+``run.total_time`` a resubmitted job restores the checkpoint and exits
+immediately, so over-provisioning the chain is harmless:
 
 .. code-block:: bash
 
@@ -340,11 +345,18 @@ requeue itself and pick up where it left off:
    cd "$PBS_O_WORKDIR"
    python -m jcm.main +configuration=t63-echam-jam run=longrun \
        run.total_time=365 \
-       run.checkpoint_path="$SCRATCH/$PBS_JOBID.ckpt"
+       run.checkpoint_path="$SCRATCH/t63-echam-jam.ckpt"
 
-Point ``run.checkpoint_path`` at a path that persists across job restarts, and
-size ``run.chunk_days`` so at least one chunk completes comfortably inside the
-walltime.
+Submit the chain with ``afterany`` dependencies (each link starts only when
+the previous one ends, however it ended)::
+
+   jid=$(qsub run.pbs)
+   for i in $(seq 5); do jid=$(qsub -W depend=afterany:$jid run.pbs); done
+
+The checkpoint path must be **stable across jobs** — deriving it from
+``$PBS_JOBID`` would give every link a fresh checkpoint and restart the run
+from day zero. Size ``run.chunk_days`` so at least one chunk completes
+comfortably inside the walltime; progress only persists at chunk boundaries.
 
 .. _packaged-config-tree:
 

--- a/docs/source/running_at_scale.rst
+++ b/docs/source/running_at_scale.rst
@@ -216,7 +216,9 @@ Chunked, resumable runs and checkpoints
 
 Long integrations run in **chunks** with a health gate between them. Setting
 ``run.chunk_days`` (``run=longrun`` uses 30) breaks the integration into pieces,
-writes each to ``{run.output_prefix}_day{N}.nc``, and runs
+writes each to ``{run.output_prefix}_day{N}.nc`` — a **relative** prefix by
+default (``longrun``/``chunked_run``), so point it at a durable absolute path
+when the working directory is ephemeral (a container, a scratch job) — and runs
 :func:`jcm.diagnostics.check_health` after each one. With
 ``run.bail_on_unhealthy`` (the runner default) the run aborts on the first
 unhealthy chunk instead of integrating a doomed state for hours; set it
@@ -324,10 +326,15 @@ Build the CUDA-enabled image locally::
    docker run --rm --gpus all jcm +configuration=t63-echam-rrtmgp
 
 Arguments after the image name are passed straight to ``python -m jcm.main``.
-Mount ``/app/outputs`` to persist Hydra output directories::
+Mount a host directory and send the run's output into it — with ``--rm``,
+anything written outside the mount dies with the container, and a chunked
+configuration writes its per-chunk netCDFs to ``run.output_prefix``, not to
+Hydra's output directory::
 
    docker run --rm --gpus all -v "$(pwd)/outputs:/app/outputs" jcm \
-       +configuration=t63-echam-rrtmgp run.total_time=30
+       +configuration=t63-echam-rrtmgp run.total_time=30 \
+       run.output_prefix=/app/outputs/t63 \
+       run.checkpoint_path=/app/outputs/t63.ckpt
 
 Kubernetes examples for the NRP Nautilus cluster are in ``deploy/k8s/``.
 
@@ -360,6 +367,7 @@ immediately, so over-provisioning the chain is harmless:
    cd "$PBS_O_WORKDIR"
    python -m jcm.main +configuration=t63-echam-jam run=longrun \
        run.total_time=365 \
+       run.output_prefix="$SCRATCH/t63-echam-jam" \
        run.checkpoint_path="$SCRATCH/t63-echam-jam.ckpt"
 
 Submit the chain with ``afterany`` dependencies (each link starts only when

--- a/docs/source/running_at_scale.rst
+++ b/docs/source/running_at_scale.rst
@@ -187,9 +187,9 @@ data mirror on Hugging Face by prefixing any file path with ``hf://`` (fetch
 once on a node with internet — afterwards the local cache serves compute nodes
 offline)::
 
-   python -m jcm.main physics=echam-jam grid=echam_t63_l47_hybrid \
+   python -m jcm.main +configuration=t63-echam-jam \
        terrain=from_file terrain.file=hf://bundles/t63/terrain.nc \
-       forcing=from_file forcing.file=hf://bundles/t63/forcing_pd.nc
+       forcing.file=hf://bundles/t63/forcing_pd.nc
 
 See :doc:`design/data_mirror` for the full bundle catalogue. The Python door
 onto the same bundles is :meth:`jcm.forcing.ForcingData.from_bundles` (in the
@@ -200,9 +200,10 @@ Emulated radiation
 
 ``physics=echam-emulated-2m`` swaps RRTMGP for a GRU emulator trained to
 reproduce it — a settled 4.4x end-to-end at T63L47 (22.7 → 5.1 s per sim day).
-Trained weights ship with the package, so it runs out of the box::
+Trained weights ship with the package, so the validated recipe runs out of
+the box::
 
-   python -m jcm.main physics=echam-emulated-2m grid=echam_t63_l47_hybrid
+   python -m jcm.main +configuration=t63-echam-emulated-2m
 
 Point ``physics.terms.nn_emulator_radiation.weights_file`` at another checkpoint
 to swap networks. The emulator sees ozone and CO2 but **not CH4 or N2O**, so

--- a/docs/source/running_at_scale.rst
+++ b/docs/source/running_at_scale.rst
@@ -21,17 +21,20 @@ executable, so it can be invoked either as a module or directly::
    # Default 10-day SPEEDY aquaplanet
    python -m jcm.main
 
-   # ECHAM T63L47 with the production RRTMGP radiation (physics=echam IS the
-   # RRTMGP one-moment package; there is no separate ``echam-rrtmgp`` group)
-   python -m jcm.main physics=echam grid=echam_t63_l47_hybrid
+   # ECHAM T63L47 with the production RRTMGP radiation, via the validated
+   # recipe (see "Validated configurations" below). The bare composition
+   # ``physics=echam grid=echam_t63_l47_hybrid`` also parses, but inherits the
+   # isothermal cold start, aquaplanet terrain and sponge-less run defaults —
+   # a combination that goes NaN within days at L47.
+   python -m jcm.main +configuration=t63-echam-rrtmgp
 
    # Held-Suarez dynamical-core test
    python -m jcm.main physics=held_suarez grid=held_suarez_t31_l8 \
        run.total_time=30 run.save_interval=1
 
-   # Chunked, resumable long run (run=longrun enables chunking; resumability
-   # additionally needs a stable checkpoint path)
-   python -m jcm.main physics=echam grid=echam_t63_l47_hybrid run=longrun \
+   # Chunked, resumable long run (the recipe includes run=longrun's chunking;
+   # resumability additionally needs a stable checkpoint path)
+   python -m jcm.main +configuration=t63-echam-rrtmgp \
        run.checkpoint_path=/scratch/$USER/echam_t63.ckpt
 
 The state-file modes (``run.mode=scm`` and ``run.mode=prescribed``) read a
@@ -227,12 +230,13 @@ checkpoint intact). When the same command is launched again with the file
 already in place, the run restores from the checkpoint and only steps the
 remaining chunks::
 
-   python -m jcm.main physics=echam grid=echam_t63_l47_hybrid \
-       run=longrun run.checkpoint_path=/scratch/$JOB_ID.ckpt
+   python -m jcm.main +configuration=t63-echam-rrtmgp \
+       run.checkpoint_path=/scratch/$USER/echam_t63.ckpt
 
 Set ``run.archive_ckpt_every`` (sim-days; 0 = off) to also copy the rotating
-checkpoint to a dated, never-overwritten archive, so a later experiment can
-restart from before a slowly-developing failure.
+checkpoint to a dated, never-overwritten archive at the first chunk boundary
+past each interval multiple (the cadence need not divide ``run.chunk_days``),
+so a later experiment can restart from before a slowly-developing failure.
 
 The same primitives are available directly to bring-your-own-driver workflows
 via :py:mod:`jcm.checkpoint`:
@@ -266,7 +270,7 @@ ERA5 (regridded to the model grid and cached locally by :mod:`jcm.data.era5`),
 and ``init=era5`` starts the run from the ERA5 state at the same date.
 Cloud access needs the ``jcm[era5]`` extra (``gcsfs`` + ``zarr``)::
 
-   python -m jcm.main physics=echam grid=echam_t63_l47_hybrid \
+   python -m jcm.main +configuration=t63-echam-rrtmgp \
        init=era5 nudging=era5 run.start_date=2010-01-01 run.total_time=30
 
 Prefetch on a login node first when compute nodes lack internet
@@ -316,13 +320,13 @@ Docker
 Build the CUDA-enabled image locally::
 
    docker build -t jcm .
-   docker run --rm --gpus all jcm physics=echam grid=echam_t63_l47_hybrid
+   docker run --rm --gpus all jcm +configuration=t63-echam-rrtmgp
 
 Arguments after the image name are passed straight to ``python -m jcm.main``.
 Mount ``/app/outputs`` to persist Hydra output directories::
 
    docker run --rm --gpus all -v "$(pwd)/outputs:/app/outputs" jcm \
-       physics=echam grid=echam_t63_l47_hybrid run.total_time=30
+       +configuration=t63-echam-rrtmgp run.total_time=30
 
 Kubernetes examples for the NRP Nautilus cluster are in ``deploy/k8s/``.
 

--- a/docs/source/running_at_scale.rst
+++ b/docs/source/running_at_scale.rst
@@ -67,7 +67,8 @@ Group         What it selects
 ``forcing``   ``default``, ``amip``, ``era5``, ``from_file``, ``macv2_sp``
 ``nudging``   ``none``, ``era5``
 ``diffusion`` ``default``, ``strong``
-``dycore``    ``dinosaur`` (default), the ``pyses_*`` finite-volume backends
+``dycore``    ``dinosaur`` (default), the ``pyses_*`` spectral-element
+              (CAM-SE) backends
 ============= =================================================================
 
 Inspect the available choices and the fully-composed config::

--- a/docs/source/running_at_scale.rst
+++ b/docs/source/running_at_scale.rst
@@ -29,8 +29,10 @@ executable, so it can be invoked either as a module or directly::
    python -m jcm.main physics=held_suarez grid=held_suarez_t31_l8 \
        run.total_time=30 run.save_interval=1
 
-   # Chunked, resumable long run
-   python -m jcm.main physics=echam grid=echam_t63_l47_hybrid run=longrun
+   # Chunked, resumable long run (run=longrun enables chunking; resumability
+   # additionally needs a stable checkpoint path)
+   python -m jcm.main physics=echam grid=echam_t63_l47_hybrid run=longrun \
+       run.checkpoint_path=/scratch/$USER/echam_t63.ckpt
 
 The state-file modes (``run.mode=scm`` and ``run.mode=prescribed``) read a
 netCDF written by an earlier run::

--- a/docs/source/running_at_scale.rst
+++ b/docs/source/running_at_scale.rst
@@ -93,6 +93,13 @@ command is one validated configuration::
    python -m jcm.main +configuration=speedy-t31        # SPEEDY T31L8 reference
    python -m jcm.main +configuration=ma-t63-l95        # middle-atmosphere JAM sweep
 
+Some configurations need an **optional extra** on top of the base install: the
+JAM recipes (``*-jam*``, ``ma-*``) select the MAM4-JAX core and need
+``pip install jcm[mam4]``; the pySES recipes need ``jcm[pyses]``; the COSP
+satellite-simulator variant needs ``jcm[cosp]``; ERA5 init/nudging (below)
+needs ``jcm[era5]``. A missing extra fails at model construction
+(``ModuleNotFoundError``), not mid-run.
+
 Note the leading ``+``: a configuration is *added* to the default composition
 and then overrides the physics/grid/init/run/terrain/forcing groups it selects.
 Each ``jcm/config/configuration/*.yaml`` carries comments explaining WHY every
@@ -256,7 +263,8 @@ Nudging from config
 Relaxing the model toward an external reference state ("nudging") is one flag on
 the CLI: ``nudging=era5`` pulls the run window from WeatherBench2's public cloud
 ERA5 (regridded to the model grid and cached locally by :mod:`jcm.data.era5`),
-and ``init=era5`` starts the run from the ERA5 state at the same date::
+and ``init=era5`` starts the run from the ERA5 state at the same date.
+Cloud access needs the ``jcm[era5]`` extra (``gcsfs`` + ``zarr``)::
 
    python -m jcm.main physics=echam grid=echam_t63_l47_hybrid \
        init=era5 nudging=era5 run.start_date=2010-01-01 run.total_time=30

--- a/docs/source/v1_to_v2.rst
+++ b/docs/source/v1_to_v2.rst
@@ -106,7 +106,7 @@ For RRTMGP production runs, the CLI path remains the recommended default:
 
 .. code-block:: console
 
-   $ python -m jcm.main physics=echam grid=echam_t63_l47_hybrid
+   $ python -m jcm.main +configuration=t63-echam-rrtmgp
 
 Forcing and Calendars
 ---------------------

--- a/docs/source/v1_to_v2.rst
+++ b/docs/source/v1_to_v2.rst
@@ -106,7 +106,7 @@ For RRTMGP production runs, the CLI path remains the recommended default:
 
 .. code-block:: console
 
-   $ python -m jcm.main physics=echam-rrtmgp grid=echam_t63_l47_hybrid
+   $ python -m jcm.main physics=echam grid=echam_t63_l47_hybrid
 
 Forcing and Calendars
 ---------------------

--- a/jcm/runners.py
+++ b/jcm/runners.py
@@ -1817,7 +1817,13 @@ def run_chunked(
             save_checkpoint(model, ckpt_path, elapsed_days=elapsed_sim_days)
             print(f"  Saved checkpoint to {ckpt_path}")
             archive_every = float(cfg.run.get("archive_ckpt_every", 0.0) or 0.0)
-            if archive_every > 0 and abs(elapsed_sim_days % archive_every) < 1e-6:
+            # Archive at the first chunk boundary past each interval multiple,
+            # so the cadence need not divide chunk_days (30-day chunks with
+            # archive_ckpt_every=100 archive at days 120, 210, 300, ...).
+            if archive_every > 0 and (
+                int(elapsed_sim_days // archive_every)
+                > int((elapsed_sim_days - cur_chunk) // archive_every)
+            ):
                 import shutil
 
                 archive = f"{output_prefix}_day{int(elapsed_sim_days)}.ckpt"

--- a/jcm/runners.py
+++ b/jcm/runners.py
@@ -1819,14 +1819,22 @@ def run_chunked(
             archive_every = float(cfg.run.get("archive_ckpt_every", 0.0) or 0.0)
             # Archive at the first chunk boundary past each interval multiple,
             # so the cadence need not divide chunk_days (30-day chunks with
-            # archive_ckpt_every=100 archive at days 120, 210, 300, ...).
+            # archive_ckpt_every=100 archive at days 120, 210, 300, ...). The
+            # relative tolerance keeps a fractional cadence on schedule:
+            # elapsed accumulates by summing chunks, so a nominal 0.9 arrives
+            # as 0.8999999999999999 and would otherwise slip a whole chunk.
+            tol = 1e-6 * archive_every
             if archive_every > 0 and (
-                int(elapsed_sim_days // archive_every)
-                > int((elapsed_sim_days - cur_chunk) // archive_every)
+                int((elapsed_sim_days + tol) // archive_every)
+                > int((elapsed_sim_days - cur_chunk + tol) // archive_every)
             ):
                 import shutil
 
-                archive = f"{output_prefix}_day{int(elapsed_sim_days)}.ckpt"
+                # ``:g`` keeps whole-day archives named ``_day30`` while giving
+                # sub-day cadences a distinct name instead of colliding on the
+                # truncated integer day.
+                day = f"{elapsed_sim_days:g}".replace(".", "p")
+                archive = f"{output_prefix}_day{day}.ckpt"
                 shutil.copyfile(ckpt_path, archive)
                 print(f"  Archived checkpoint {archive}")
         elif ckpt_path:

--- a/jcm/runners_test.py
+++ b/jcm/runners_test.py
@@ -1080,6 +1080,32 @@ class TestModeDispatch(unittest.TestCase):
             archives = sorted(p.name for p in Path(tmpdir).glob("chunk_day*.ckpt"))
             self.assertEqual(archives, ["chunk_day2.ckpt", "chunk_day3.ckpt"])
 
+    def test_archive_interval_is_float_tolerant(self):
+        """A fractional cadence must not slip a chunk on binary rounding.
+
+        Summing 0.3-day chunks reaches 0.8999999999999999, so an exact
+        floor-quotient comparison would defer the nominal day-0.9 archive to
+        day 1.2. Sub-day archives also need distinct names (``_day0p9``),
+        while whole-day ones keep the plain ``_day30`` form.
+        """
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg = _compose([
+                "physics=held_suarez",
+                "grid=held_suarez_t31_l8",
+                "run.time_step=180",
+                "run.total_time=1.2",
+                "run.save_interval=0.3",
+                "run.chunk_days=0.3",
+                "run.archive_ckpt_every=0.9",
+                f"run.output_prefix={tmpdir}/chunk",
+                f"run.checkpoint_path={tmpdir}/run.ckpt",
+            ])
+            run(cfg)
+            archives = sorted(p.name for p in Path(tmpdir).glob("chunk_day*.ckpt"))
+            self.assertEqual(archives, ["chunk_day0p9.ckpt"])
+
     def test_chunked_resume_with_balanced_isothermal_init(self):
         """Resume-from-checkpoint bootstraps a template for state-based inits.
 

--- a/jcm/runners_test.py
+++ b/jcm/runners_test.py
@@ -1054,6 +1054,32 @@ class TestModeDispatch(unittest.TestCase):
             self.assertEqual(len(reports2), 1, "should run only the remaining chunk")
             self.assertAlmostEqual(reports2[0]["elapsed_days"], 2.0, places=5)
 
+    def test_archive_fires_on_interval_crossing_not_divisibility(self):
+        """``archive_ckpt_every`` need not divide ``chunk_days``.
+
+        With 1-day chunks and a 1.5-day cadence the boundaries never land on
+        an exact multiple; archiving keys on crossing each multiple, so the
+        day-2 boundary (first past 1.5) and day-3 boundary (first past 3.0)
+        both archive.
+        """
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg = _compose([
+                "physics=held_suarez",
+                "grid=held_suarez_t31_l8",
+                "run.time_step=180",
+                "run.total_time=3",
+                "run.save_interval=1",
+                "run.chunk_days=1",
+                "run.archive_ckpt_every=1.5",
+                f"run.output_prefix={tmpdir}/chunk",
+                f"run.checkpoint_path={tmpdir}/run.ckpt",
+            ])
+            run(cfg)
+            archives = sorted(p.name for p in Path(tmpdir).glob("chunk_day*.ckpt"))
+            self.assertEqual(archives, ["chunk_day2.ckpt", "chunk_day3.ckpt"])
+
     def test_chunked_resume_with_balanced_isothermal_init(self):
         """Resume-from-checkpoint bootstraps a template for state-based inits.
 


### PR DESCRIPTION
Closes #639.

Part 1 of the documentation restructure (with #640, #641). Three deliverables, three commits.

## What moved where

**README.md (218 → 95 lines) — shop front.** What jcm is, the three headline strengths from the issue discussion (flexibility: SPEEDY→full ECHAM+online-aerosol with one flag; differentiability: gradients of any output w.r.t. physics parameters / initial conditions / boundary conditions; efficiency: ~22.7 s/sim-day ECHAM T63L47+RRTMGP on one GPU, ~4x faster emulated), `pip install`, one verified Python quick start, doc links, citation, license.

- CLI quick-start block, `configuration`-group notes, `hf://` mirror example, emulated-radiation section, Docker/deployment → the new **running_at_scale** page.
- Physics-package overview → already covered by `echam_physics.rst` / `speedy_physics.rst` (linked).
- Dropped as duplicated: the notebook list (notebooks are self-describing and linked), the dev-install/testing instructions (kept in getting_started / developer docs), the "v2.0 release focus" banner command (redundant with the highlights + docs links).

**docs/source/getting_started.rst (962 → 757 lines) — Python-only.** One path: coords → terrain → physics factory → `Model` → `run` → `to_xarray`, matching what the notebooks do, featuring the #640-campaign Python doors: `jcm.configurations.load(name, **overrides)`, `ForcingData.from_bundles(...)`, `model.run(initial_state=...)` builders. All Hydra sections (CLI, configuration group, run schema, JAM `auto` inputs, checkpointing-from-CLI, nudging-from-config, SPMD guide) moved to running_at_scale; the surviving CLI mentions are one-line cross-references, no runnable Hydra content remains. The time-step section documents the 12-minute no-limit default resolved by `Model._resolve_time_step_minutes` (nothing on the page contradicts it; SPEEDY's own 30-min plateau is stated as such).

**docs/source/running_at_scale.rst (new, in the toctree) — the ONE Hydra-speaking page.** CLI invocation forms, config-group table (names verified against `jcm/config/`), `+configuration=<name>` recipes, an explicit `key=` / `+key=` / `++key=` semantics table with the two practical rules (the complete `run` schema needs no prefix; params/constants need `+`), JAM `auto` inputs, `hf://` mirror, emulated radiation, chunked/resumable runs + `run.checkpoint_path` + `run.archive_ckpt_every` + health gates (`run.chunk_days`, `run.bail_on_unhealthy` — names read from `jcm/config/run/default.yaml` and `jcm/runners.py::run_chunked`), nudging=era5, SPMD, Docker, and nohup-GPU / PBS batch templates built around checkpoint-resumability. Deeper detail is linked, not duplicated: `design/packaged_config_tree` (the `pkg://jcm.config` searchpath contract), `design/parallelization`, `design/data_mirror`, `design/radiation_nn_emulator`.

## Rule-4 sweep (other pages are Python-first)

Grepped every `docs/source/*.rst|*.md` for CLI/Hydra invocations:
- `v1_to_v2.rst:109` had the only other runnable CLI command — and it named `physics=echam-rrtmgp`, **a config group that does not exist** (`jcm/config/physics/` has no `echam-rrtmgp.yaml`; the RRTMGP one-moment package is `physics=echam`, and the `t63-echam-rrtmgp` *configuration* composes `override /physics: echam`). Fixed to `physics=echam`. The same stale name appeared in the old README/getting_started blocks, which no longer exist; `index.rst`'s parenthetical mention is left for #641's sibling scope (it names the target configuration, not a command).
- `release_notes.rst`, `api.rst`, `echam_physics.rst`: mentions are historical/prose (release notes describe what shipped), not user instructions — left alone.
- `docs/source/science/` and design docs untouched per the #641 split.

## Snippet corrections found by execution

- `echam_physics(aerosol_module="jam")` in the `from_bundles` example **raises on dev**: JAM requires `cloud_scheme="2m"` (it reads the 2M process-time ledger). Fixed and re-verified.
- The README quick start now omits `time_step` so the resolved-default behaviour is what's documented (SPEEDY T31L8 resolves 30 min — confirmed by running it).

## Verification

- **Executed** (CPU, semi-Lagrangian dinosaur on PYTHONPATH): the README/aquaplanet quick start end-to-end (20-day run, `to_xarray`, dt check); `configurations.available()` (19 recipes incl. `t63-echam-jam`, `speedy-t31`, `ma-t63-l95`); `echam_physics(aerosol_module="jam", cloud_scheme="2m")` build; every import on both pages (`ForcingData.from_bundles`/`from_dataset`/`expand_yearly_files`, `jcm.analysis.{global_mean,layer_pressure_thickness,column_integral,column_burden,area_weights}`, `initial_states.{jw_state,balanced_isothermal_state,era5_state,checkpoint_state}`, `jcm.checkpoint`, `jcm.nudging`, `UpperSponge`, `Model.{resume,prepare_observers,bootstrap_state}`); `load`/`from_bundles` signatures against the docs' kwargs.
- **By inspection** (yaml/source): every group/option name in the config-group table against `jcm/config/*/`; run-key names against `run/default.yaml`; chunk/health/checkpoint behaviour against `runners.py::run_chunked`; the 12-min default against `model.py::_DEFAULT_TIME_STEP_MINUTES` / `run/default.yaml`; recipe names against `jcm/config/configuration/`. CLI commands were not dry-run (mirror/network-touching).
- `cd docs && make html`: build succeeded; the 11 warnings are all pre-existing (autodoc docstrings, `release_notes.rst:40`, three unlisted design pages) — **zero from the new/edited pages**.
- `ruff check .` clean; `JAX_PLATFORMS=cpu pytest -n 12 -m "not slow" --cov=jcm --cov-fail-under=90`: 2440 passed, 7 skipped, coverage 95.72%.

## Added during review (7 Codex rounds, 11 findings — all verified against the code, then fixed)

Two of these are **code/infra**, not prose, and are the reason this PR is not docs-only:

- **`runners.run_chunked` archived on exact modulo**, so any `archive_ckpt_every` that did not divide `chunk_days` silently never archived (30-day chunks + `archive_ckpt_every=100` → first archive at day 300). It now archives at the first chunk boundary past each interval multiple, with a non-divisor regression test (`chunk_days=1`, `archive_every=1.5` → day-2 and day-3 archives).
- **`design/pyses_followups.md` was a one-line TODO checklist**, not a design doc — surfaced when adding the three untracked design pages to `design.rst`'s toctree (a CLAUDE.md requirement). Its live item is now **#770**; the file is deleted. The docs build is **zero-warning** (the body above says 11 pre-existing — that is now stale).

Prose corrections, each swept as a class rather than at the reported site:

- **Every runnable T63L47 command now composes `+configuration=<name>`.** A bare `physics=echam grid=echam_t63_l47_hybrid` inherits `init=isothermal`, aquaplanet terrain and a sponge-less `run` — the composition this very page calls NaN-in-days at L47. Eight sites (CLI page, Docker, ERA5, `v1_to_v2`, `index.rst` prose). The one surviving bare `physics=echam` is the deliberately gridless override-syntax snippet.
- **Chunked output goes to an absolute prefix.** `output_prefix` is relative by default, so a chunked run under `docker run --rm` wrote its per-chunk netCDFs to `/app` and discarded them; the PBS chain had the same exposure. (Regression from the recipe-routing fix above — caught in the next round.)
- **The PBS example now actually resumes**: one stable checkpoint path (a `$PBS_JOBID`-derived one restarts from day zero every link) plus an `afterany`-chained `qsub` loop, which terminates because a completed run restores and exits at the chunk-loop guard.
- **Optional extras are stated where they are needed** (`jcm[mam4]` for the JAM recipes, `jcm[pyses]`, `jcm[cosp]`, `jcm[era5]`) — a missing one fails at model construction.
- Grid table listed a nonexistent `echam_t85_l95_hybrid` (T85 ships L47 only); `pyses_*` was called finite-volume (it is CAM-SE spectral-element); the `index.rst` prose still named the nonexistent `physics=echam-rrtmgp` group; `from_bundles` claimed to be "exactly `+configuration=t63-echam-jam`" while building grey radiation, `arg2000`, the placeholder core and all-ocean terrain; the runner was said to stream forcing (it chunks the integration but builds the full `ForcingData` up front); `run=longrun` was called resumable (it only chunks — resumability needs a checkpoint path).

Gates re-run after the runner change: `ruff` clean, `JAX_PLATFORMS=cpu pytest -n 12 -m "not slow" --cov=jcm --cov-fail-under=90` → **2441 passed, 95.74%**; `make html` zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFu9rxRPLQ7qj3hwZf6zRE
