### PR TITLE
JAM aerosol regression statistics: drift and mass-closure gates, plus the tooling defects the release campaign surfaced

### DIFF
--- a/.claude/skills/derecho-jcm-runs/SKILL.md
+++ b/.claude/skills/derecho-jcm-runs/SKILL.md
@@ -127,7 +127,7 @@ tropospheric ozone column on any other grid. Prefer the mirror.
 scripts/watch_job.sh <jobid> <logfile> "<completion marker>"
 ```
 
-Use it as the command of a persistent `Monitor`. It encodes four lessons:
+Use it as the command of a persistent `Monitor`. It encodes five lessons:
 
 1. **Read the log once per check.** Grep the log into a variable, then both
    decide *and* report from those same bytes. Live NFS logs give stale re-reads,
@@ -137,8 +137,14 @@ Use it as the command of a persistent `Monitor`. It encodes four lessons:
    like a vanished job.
 4. **File existence is not success**: the driver writes chunk netCDFs *before*
    the NaN check. Verify the `NaN vars: 0/N` health line instead.
+5. **Match verdicts, not keywords**: `jcm.main` echoes the whole composed
+   config on stdout, so every log contains `bail_on_unhealthy: true`. A bare
+   `unhealthy` in `FAIL_RE` therefore failed every clean run.
 
 Filter Lmod's "unknown module" noise — it is harmless on these nodes.
+`scripts/watch_job_test.py` (standalone, like `mkjob_test.py` — pytest does
+not collect dotted directories) checks both halves: a clean log passes and a
+real verdict still fails.
 
 ## 7. Reading throughput correctly
 
@@ -148,8 +154,14 @@ must not be quoted. Use `Wall: X s this chunk`, discard chunk 1, and quote a
 rate only once the last two chunks agree.
 
 ```bash
-scripts/settled_rate.py <log> [--dt 15]   # per-chunk walls + convergence-checked rate
+scripts/settled_rate.py <PBS stdout log> [--dt 15]   # per-chunk walls + convergence-checked rate
 ```
+
+Give it the job's **stdout** log (`runs/<tag>.log`) — the `Wall: X s this
+chunk` lines are prints, so Hydra's `main.log` in the rundir has none of them.
+No PYTHONPATH is needed from either the in-repo or the installed
+`~/.claude/skills` copy: the script finds the repo's `tools/` by searching
+upward from itself and the working directory (`JCM_REPO` overrides).
 
 That script and `tools/benchmark.py` share `tools/chunk_timing.py`, so the
 same run cannot yield two different answers. `settled_rate.py` reads a log

--- a/.claude/skills/derecho-jcm-runs/SKILL.md
+++ b/.claude/skills/derecho-jcm-runs/SKILL.md
@@ -103,10 +103,10 @@ files, and a grid/level mismatch fails at generation, not in the queue.
 `--data local` keeps the legacy prepared-file behaviour (`JAM_INPUTS` /
 `JCM_EMISSIONS`, existence-checked before qsub). Its inputs are all
 grid-specific — level-resolved (ozone, oxidants) or horizontally
-validated (emissions, DMS, dust) — and **ozone is the dangerous one**:
-`forcing.ozone_file: auto` resolves only a *packaged* climatology
-(T63L47) and silently falls back to an ANALYTIC profile with ~7.6x the
-tropospheric ozone column on any other grid. Prefer the mirror.
+validated (emissions, DMS, dust). `forcing.ozone_file: auto` resolves the
+packaged climatology (T63L47) and then the mirror's per-grid bundle, and on
+a hybrid grid **raises** if neither resolves rather than substituting the
+analytic profile (~7.6x the tropospheric ozone column). Prefer the mirror.
 
 ## 5. PBS facts specific to this machine
 

--- a/.claude/skills/derecho-jcm-runs/scripts/settled_rate.py
+++ b/.claude/skills/derecho-jcm-runs/scripts/settled_rate.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 """Report a convergence-checked throughput from a finished jcm run log.
 
-    python settled_rate.py <run.log> [--chunk-days 5] [--dt 15]
+    python settled_rate.py <PBS stdout log> [--chunk-days 5] [--dt 15]
+
+The log is the job's stdout (``runs/<tag>.log``), not Hydra's ``main.log``:
+the per-chunk ``Wall:`` lines are prints and never reach the Hydra log.
 
 Post-hoc counterpart to ``tools/benchmark.py``: that one *drives* a run and
 samples GPU telemetry alongside; this one reads a log that already exists,
@@ -17,10 +20,33 @@ import argparse
 import pathlib
 import sys
 
-# tools/ lives at the repo root; this script sits four levels below it
-# (.claude/skills/derecho-jcm-runs/scripts/).
-_REPO = pathlib.Path(__file__).resolve().parents[4]
-sys.path.insert(0, str(_REPO / "tools"))
+import os
+
+
+def _find_tools() -> pathlib.Path:
+    """Locate the repo's ``tools/`` directory, wherever this script lives.
+
+    A fixed parent depth only works from the in-repo copy: the same skill
+    installed under ``~/.claude/skills/`` resolves to the home directory and
+    the ``chunk_timing`` import fails. Search upward from the script and from
+    the working directory for the module itself, honouring ``$JCM_REPO``
+    first, so ``settled_rate.py`` needs no PYTHONPATH from either location.
+    """
+    roots = []
+    if os.environ.get("JCM_REPO"):
+        roots.append(pathlib.Path(os.environ["JCM_REPO"]).expanduser())
+    roots += list(pathlib.Path(__file__).resolve().parents)
+    roots += list(pathlib.Path.cwd().resolve().parents) + [pathlib.Path.cwd()]
+    for root in roots:
+        if (root / "tools" / "chunk_timing.py").is_file():
+            return root / "tools"
+    raise SystemExit(
+        "cannot find the repo's tools/chunk_timing.py from "
+        f"{pathlib.Path(__file__).resolve()} or {pathlib.Path.cwd()} — run "
+        "this from inside a jax-gcm checkout, or set JCM_REPO to one.")
+
+
+sys.path.insert(0, str(_find_tools()))
 
 from chunk_timing import DEFAULT_TOL, analyse, parse_walls  # noqa: E402
 

--- a/.claude/skills/derecho-jcm-runs/scripts/watch_job.sh
+++ b/.claude/skills/derecho-jcm-runs/scripts/watch_job.sh
@@ -24,7 +24,13 @@ LOG="${2:?}"
 MARKER="${3:?}"
 POLL="${4:-300}"
 
-FAIL_RE='Traceback|unhealthy|RESOURCE_EXHAUSTED|not in struct|Error executing|CUDA_ERROR|Killed|Invalid horizontal'
+# Match the runner's health VERDICTS, not the word "unhealthy": jcm.main
+# echoes the composed config on stdout, so every log contains
+# "bail_on_unhealthy: true" and a bare 'unhealthy' failed every clean run.
+# The three real verdicts are runners.py's "*** atmosphere unhealthy at
+# day N" and "Checkpoint NOT updated (unhealthy chunk)", plus benchmark.py's
+# "because the run was unhealthy".
+FAIL_RE='Traceback|atmosphere unhealthy|unhealthy chunk|was unhealthy|RESOURCE_EXHAUSTED|not in struct|Error executing|CUDA_ERROR|Killed|Invalid horizontal'
 bad=0; gone=0
 
 while true; do

--- a/.claude/skills/derecho-jcm-runs/scripts/watch_job_test.py
+++ b/.claude/skills/derecho-jcm-runs/scripts/watch_job_test.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+"""Checks for watch_job.sh's failure-signature matching.
+
+    python watch_job_test.py
+
+Dependency-free and standalone, like ``mkjob_test.py``: pytest does not
+collect ``.claude`` (its default norecursedirs skips dotted directories).
+
+The guarded property is that a *clean* run is never reported as failed.
+``jcm.main`` echoes the whole composed config on stdout, so every run log
+contains ``bail_on_unhealthy: true``; a ``FAIL_RE`` containing a bare
+``unhealthy`` matched that line and reported every clean run unhealthy after
+two polls. The watcher must key on the runner's health *verdicts* instead.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPT = os.path.join(HERE, "watch_job.sh")
+
+# Lines a healthy run really prints: the Hydra config echo (jcm/main.py's
+# ``print(OmegaConf.to_yaml(cfg))``) plus ordinary chunk progress.
+CLEAN_LOG = """\
+run:
+  chunk_days: 5
+  bail_on_unhealthy: true
+  archive_ckpt_every: 30
+  mode: full
+  Saved checkpoint to /scratch/run/checkpoint.msgpack
+  NaN vars: 0/252
+  Wall: 120.0s this chunk
+Chunk done: 12.5 sim days/hr
+MX_ECHAM_JAM_T63_L47_DEADBEEF_COMPLETE
+"""
+
+# The three verdicts the tooling actually emits when a run IS unhealthy:
+# jcm/runners.py's bail message and its checkpoint notice, and
+# tools/benchmark.py's kept-scratch line.
+VERDICTS = [
+    "*** atmosphere unhealthy at day 45: ['q_max'] ***",
+    "  Checkpoint NOT updated (unhealthy chunk) — restart from ckpt",
+    "- **kept** at /scratch/x because the run was unhealthy — investigate",
+]
+
+
+def fail_re() -> str:
+    """Extract FAIL_RE from the script, so the test scores the real value."""
+    text = open(SCRIPT).read()
+    match = re.search(r"^FAIL_RE='([^']*)'", text, re.M)
+    assert match, "FAIL_RE not found in watch_job.sh"
+    return match.group(1)
+
+
+def _grep(pattern: str, content: str) -> list[str]:
+    """Reproduce the script's own ``grep -aiE ... | grep -av Lmod`` filter."""
+    rx = re.compile(pattern, re.I)
+    return [ln for ln in content.splitlines()
+            if rx.search(ln) and "Lmod" not in ln]
+
+
+def test_config_echo_does_not_match():
+    hits = _grep(fail_re(), CLEAN_LOG)
+    assert not hits, f"clean log matched FAIL_RE: {hits}"
+
+
+def test_real_verdicts_still_match():
+    pattern = fail_re()
+    for line in VERDICTS:
+        assert _grep(pattern, line), f"verdict no longer matched: {line}"
+
+
+def _watch(log_text: str, marker: str = "RUN_COMPLETE"):
+    """Run watch_job.sh once against a static log; return (code, stdout)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        log = os.path.join(tmp, "job.log")
+        open(log, "w").write(log_text)
+        # Stub qstat so the watcher never shells out to a real scheduler.
+        bindir = os.path.join(tmp, "bin")
+        os.mkdir(bindir)
+        qstat = os.path.join(bindir, "qstat")
+        open(qstat, "w").write("#!/bin/sh\nexit 0\n")
+        os.chmod(qstat, 0o755)
+        env = dict(os.environ, PATH=bindir + os.pathsep + os.environ["PATH"])
+        proc = subprocess.run(
+            ["bash", SCRIPT, "12345.desched", log, marker, "0"],
+            capture_output=True, text=True, env=env, timeout=60)
+        return proc.returncode, proc.stdout
+
+
+def test_end_to_end_clean_run_completes():
+    code, out = _watch(CLEAN_LOG, marker="MX_ECHAM_JAM_T63_L47_DEADBEEF_COMPLETE")
+    assert code == 0, out
+    assert "COMPLETE" in out and "FAILED" not in out
+
+
+def test_end_to_end_unhealthy_run_fails():
+    log = CLEAN_LOG.replace("Chunk done", VERDICTS[0] + "\nChunk done")
+    code, out = _watch(log, marker="MX_ECHAM_JAM_T63_L47_DEADBEEF_COMPLETE")
+    assert code == 1, out
+    assert "FAILED" in out
+
+
+def test_end_to_end_nan_count_still_fails():
+    log = CLEAN_LOG.replace("NaN vars: 0/252", "NaN vars: 7/252")
+    code, out = _watch(log, marker="MX_ECHAM_JAM_T63_L47_DEADBEEF_COMPLETE")
+    assert code == 1, out
+
+
+def main() -> int:
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS  {name}")
+            except AssertionError as exc:
+                failures += 1
+                print(f"FAIL  {name}: {exc}")
+    print("OVERALL:", "PASS" if not failures else "FAIL")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/devbox-jcm-runs/SKILL.md
+++ b/.claude/skills/devbox-jcm-runs/SKILL.md
@@ -129,8 +129,8 @@ PYTHONPATH=<worktree> $PY -c "import rrtmgp,os; print(os.path.dirname(rrtmgp.__f
 
 Terrain, forcing and ozone are **packaged in the repo** (`jcm/data/bc/t63/`)
 and `forcing.ozone_file: auto` resolves the right one — pass no ozone
-override. See `jcm-run` for the full explanation and the ANALYTIC-fallback
-warning to watch for. There is no scratch-purge concern here, unlike Derecho's
+override. See `jcm-run` for the full explanation; on a hybrid grid `auto`
+raises rather than falling back, so a resolution failure is loud. There is no scratch-purge concern here, unlike Derecho's
 prepared JAM aux inputs.
 
 ## Reference points (this machine)

--- a/.claude/skills/jcm-benchmark/SKILL.md
+++ b/.claude/skills/jcm-benchmark/SKILL.md
@@ -142,10 +142,11 @@ entirely in an A/B at the same `--chunk-days` — but do not quote a
 **The run must be a real one.** This is a production configuration made
 shorter and more instrumented, not a reduced-physics proxy: real orography,
 real SSTs, the packaged CMIP6 ozone, JW init and the production sponge. Check
-the log line `forcing.ozone_file=auto resolved to .../t63/ozone.nc` — if it
-warns about the **ANALYTIC** ozone profile instead, the radiation is seeing
-~7.6x the tropospheric ozone column and the benchmark is measuring the wrong
-workload.
+the log line `forcing.ozone_file=auto resolved to .../t63/ozone.nc`. On a
+hybrid grid an unresolvable `auto` now raises rather than degrading, so this
+cannot pass silently; on a **sigma** grid it still warns about the **ANALYTIC**
+profile, and there the radiation is seeing ~7.6x the tropospheric ozone column
+and the benchmark is measuring the wrong workload.
 
 **A NaN'd run is not a benchmark.** The tool reports `nan_any` and exits
 non-zero. Timing from a run that blew up mid-flight is meaningless — fix the

--- a/.claude/skills/jcm-run/SKILL.md
+++ b/.claude/skills/jcm-run/SKILL.md
@@ -115,14 +115,18 @@ A T63L47 ECHAM run started from an isothermal cold start with no sponge
 - **Ozone**: `forcing.ozone_file: auto` is the shipped default and resolves a
   packaged climatology matching the grid (`jcm/data/bc/t63/ozone.nc` — already
   on L47 levels, already S→N). Leave it alone. Confirm in the log:
-  `forcing.ozone_file=auto resolved to .../t63/ozone.nc`. If instead you see a
-  warning about the **ANALYTIC** profile, the grid did not match and the run
-  has ~7.6× the tropospheric ozone column — a large clear-sky OLR bias, and
-  not a valid basis for any radiation comparison.
-  Preferred fix for any other grid: the HF mirror ships level-resolved
-  ozone per grid — `forcing.ozone_file=hf://bundles/<grid>_l<levels>/ozone_pd.nc`
-  (prefetch on a node with internet). Regenerating a packaged file with
-  `jcm.data.bc.interpolate_ozone` remains possible for offline work.
+  `forcing.ozone_file=auto resolved to .../t63/ozone.nc`. On a hybrid grid
+  `auto` now **raises** rather than degrading if it resolves nothing: the
+  analytic profile carries ~7.6× the tropospheric ozone column, a large
+  clear-sky OLR bias and not a valid basis for any radiation comparison. The
+  error distinguishes a missing product from a cold cache and names the remedy.
+  For any other grid `auto` also consults the HF mirror's level-resolved
+  bundles; set one explicitly with
+  `forcing.ozone_file=hf://bundles/<grid>_l<levels>/ozone_pd.nc` (prefetch on a
+  node with internet), or regenerate a packaged file with
+  `jcm.data.bc.interpolate_ozone` for offline work. `forcing.ozone_file=analytic`
+  takes the analytic profile deliberately; a **sigma** grid, for which no ozone
+  product exists, still warns and falls back.
 
 ## Watching a run
 

--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -21,6 +21,7 @@ JAX-GCM is designed to be a fully differentiable climate model that balances eas
    design/aerosol_optics_diagnostics
    design/radiation_nn_emulator
    design/aerocom_erfari_sampling
+   design/jam_regression
    design/data_mirror
    design/packaged_config_tree
    design/test_suite_memory

--- a/docs/source/design/dinosaur_sl_jam_configuration.md
+++ b/docs/source/design/dinosaur_sl_jam_configuration.md
@@ -34,8 +34,10 @@ Load-bearing pieces:
 - **`run=longrun`** — carries the calibrated upper sponge (10 levels,
   1.5 h, `target_T_K=250`). Without it the model top refrigerates
   (T_min < 100 K by day ~135).
-- **`forcing.ozone_file: auto`** (default) — the packaged climatological
-  ozone. The analytic fallback biases clear-sky OLR ~12 W/m² low.
+- **`forcing.ozone_file: auto`** (default) — the packaged or mirrored
+  climatological ozone. `auto` now raises on a hybrid grid it cannot
+  resolve; the analytic profile biases clear-sky OLR ~12 W/m² low and is
+  reached only via `ozone_file=analytic`.
 
 ## Timestep: why dt = 15 min
 

--- a/docs/source/design/jam_regression.md
+++ b/docs/source/design/jam_regression.md
@@ -1,0 +1,235 @@
+# JAM aerosol regression statistics
+
+*Issue #762, statistics half. The spun-up-state half is deliberately not done —
+see "Not yet done" below.*
+
+A JAM release-validation member is a 365-day GPU run whose aerosol can be badly
+wrong for eleven months without any existing gate noticing. The August-2026
+T63 L47 year is the worked example: sulfate sat inside its climatological
+anchor range all year and then grew by two orders of magnitude over the final
+forty days, while temperature, surface pressure and the primary species stayed
+flat. A range gate with ×3 slack first fails in the last fortnight of a run
+that was already unusable by day 300.
+
+This document says which statistics `tools/release_validation/aerosol_stats.py`
+computes, why each one exists, and what tolerance each is scored against.
+
+## The statistic set
+
+Everything is an area-weighted global mean, computed chunk by chunk (a JAM year
+is ~60 GB of output and is never opened as one array) and then reduced over the
+record.
+
+| statistic | why it exists |
+|---|---|
+| `burden_<sp>_mg_m2` for so4, bc, du, ss, poa, soa | the loading itself, against the AeroCom-magnitude anchors. Includes the **cloud-borne** phase, which is 20–25 % of sulfate mass and which the report omitted until #762. |
+| `dlnB_dt_<sp>_per_day` over the final six months | the runaway detector — see below. |
+| `lifetime_<sp>_days` for so4, bc, du, ss | burden ÷ deposition separates "source too big" from "sink too small" in one number. A burden time series alone cannot. |
+| `budget_residual_<sp>` and `budget_residual_max` | mass conservation: does what came in, minus what left, equal the change in what is held? |
+| `so4_frac_above_500hPa` | #658 was a *free-tropospheric* accumulation: 85 % of the growth sat above 600 hPa while the boundary layer looked fine. A column burden hides that; this does not. |
+| `so4_nh_sh_ratio`, `so4_burden_60_90N_mg_m2` | anthropogenic sulfate is a Northern-Hemisphere phenomenon (observed ratio ≈ 3). A run whose sulfur has migrated to the Southern Hemisphere or the pole is wrong even at the right global mean. |
+| `aod_550`, `angstrom` | the radiative quantity the aerosol exists to produce, and a size-distribution check that a mass burden cannot give. |
+| `cdnc_900hPa_cm3`, `N100_900hPa_cm3` | the aerosol–cloud pathway. Activation can fail while every burden is correct. |
+| `r_dry_<mode>_um` at the lowest level | the modal radii the optics and the removal rates both key off. A drifting mode radius changes AOD and lifetime together, which makes it invisible in either alone. |
+| `dyn_frac_per_step_<sp>` | mass the *transport* created or destroyed, per step, as a fraction of the advected mass — from the #713 in-step gauge. See "Transport, not physics" below. |
+
+### Where the numbers come from
+
+* Burdens integrate `q·Δp/g` over the column, summing **interstitial**
+  (`m_<sp>_<mode>`) and **cloud-borne** (`jam_cloud_borne.mc_<sp>_<mode>`) mass
+  over the modes carrying each species.
+* Deposition is `dry_* + wet_*`. It does **not** add `conv_scav_flux.*`: the
+  wet-deposition term already folds in-plume convective scavenging into
+  `wet_*`, so a third term would double-count that sink.
+* The sulfate budget is the whole **sulfur family**, because `emi_so4` is only a
+  few per cent of the real sulfate source — the rest arrives as SO₂ and DMS and
+  passes through the gas reservoirs before it is aerosol. Sources are
+  `emi_so2 + emi_dms + emi_so4`, storage is the sulfate burden plus the SO₂,
+  DMS and H₂SO₄ column burdens, and every carrier is converted to **sulfate
+  aerosol mass** using jcm's own `so4` species — ammonium bisulfate,
+  115.0 g/mol (`jam/species.py`), *not* SO₄ at 96.06. Using the wrong one
+  understates the source by 20 % and turns a modest closure error into an
+  apparent leak.
+* SOA is not scored for closure at all. Its source is condensation of the SOAG
+  gas, which has no `emi_*` channel, so a residual computed for it measures a
+  missing diagnostic rather than a mass leak.
+
+## The two tolerance tiers
+
+**Tier 1 — absolute physics gates.** These are not tuning targets. They are
+statements about what the model must do regardless of how well calibrated it is,
+so they are the same number for every member and every release.
+
+| gate | limit |
+|---|---|
+| `\|d ln B/dt\|` per species, final six months | `< 0.002 /day` |
+| `\|budget residual\|`, max over species | `< 5 %` |
+| `dyn_frac_per_step_<sp>` | `< 0.1 % per step` |
+
+**Tier 2 — climatological anchors.** The existing per-species ranges in
+`tools/jam_burden_report.py`'s `_SPECIES` table, widened by the release gate's
+×3 slack. Unchanged by #762; a "did the model produce a plausible planetary
+loading" check, not a calibration.
+
+**Tier 3 — regression tolerances**, for comparing a run against a stored
+reference: `max(3σ, 15 % relative)`. σ is the standard error of the record mean,
+with the effective sample size taken from the chunk series' own lag-1
+autocorrelation, `N_eff = N(1−a)/(1+a)`. Neither half alone works: 5-day burden
+samples are strongly autocorrelated, so an uncorrected σ is far too small
+(≈ 1 % of the annual mean, which every real change would trip), while a flat
+15 % would let a slow bias through on a quiet statistic.
+
+## The drift gate is the runaway detector
+
+An aerosol runaway is multiplicative — a fixed factor per unit time — so the
+right statistic is the slope of `ln B`, not of `B`. That makes one threshold
+work for every species regardless of its loading, and makes a merely noisy but
+stationary burden average to zero.
+
+The window is the **final six months**. A from-zero spin-up year ramps for its
+first months by design; scoring the whole record would call that ramp a
+runaway. Tropospheric burdens equilibrate in weeks (lifetimes ~4–7 days), so
+six months is comfortably past the ramp while still long enough that a slope of
+0.002 /day is resolvable above the noise.
+
+`0.002 /day` is a factor e over ~500 days: a burden that genuinely has not
+settled may still move that much over a validation year, but the ×60-in-40-days
+growth of a #658-class runaway exceeds it by an order of magnitude, and — the
+point of the gate — so does the much gentler growth those runaways show for
+months *before* they become visible. On the August-2026 year the gate fails on
+sulfate at day 300, on a window that ends before the burden leaves its anchor
+range at all.
+
+A species the run never carries (SOA with no SOAG production, say) has a
+correctly-zero burden and no drift to measure; it is skipped rather than scored
+as NaN.
+
+## The closure gate, and its sign
+
+The residual is `(Σ emitted − Σ deposited − ΔB) / Σ emitted` over the record.
+Its **sign** is the diagnosis:
+
+* **Negative** — more mass was deposited than ever entered the column. No
+  missing ledger entry can produce that. It is mass creation, and it is a defect
+  in the physics.
+* **Positive** — emitted mass is unaccounted for. That is what a real leak looks
+  like, but it is *also* exactly what a missing sink **diagnostic** looks like.
+  On output written before the #722 removal-ledger fix, `dry_*` omits the Slinn
+  turbulent/Brownian deposition entirely (it captures only ~31 % of the dust dry
+  sink), so a positive residual on such a run is expected by construction. The
+  gate says so in its own message instead of reporting a leak.
+
+The drift gate reads burdens only, never the deposition ledger, so it stays
+trustworthy either way. That separation is deliberate: the two gates must not
+fail for the same reason.
+
+## Transport, not physics: what the August-2026 runaway actually was
+
+The runaway this whole gate set was built to catch turned out not to be an
+aerosol-physics defect at all. It was the **semi-Lagrangian tracer transport
+failing to conserve mass**, and it is fixed by #720.
+
+The mechanism is one-signed, which is why it compounded. SL interpolation does
+not conserve `∫q·dp`, and under the quasi-monotone limiter the error has a
+preferred direction wherever a strong sink leaves sharp minima: clipping an
+interpolation undershoot at a minimum can only *add* mass. Strong scavenging
+and sedimentation produce exactly that state, so every step added a little
+sulfate and dust, and a per-step error of order 1e-3 became orders of magnitude
+over a year.
+
+Two consequences for these gates:
+
+* The **`budget_dyn_<sp>` gauge (#713) is the direct measurement**, and it is
+  what `dyn_frac_per_step_<sp>` scores. The burden-drift gate sees the symptom
+  months later; this sees the cause in one chunk. The limit is set at the
+  honest per-step magnitude (0.1 %) rather than at the fixer's tolerance,
+  because the failure is *systematic* accumulation, not the size of any single
+  step's error.
+* dev's remedy, `_fix_nodal_tracer_mass` (`jcm/dycore/dinosaur/dycore.py`), is
+  an ECMWF-style **proportional global mass fixer**: one factor per tracer per
+  step, clipped to `[2/3, 1.5]`, restoring the post-transport total to the
+  pre-transport one. It stops the accumulation, but it is a *global rescale* —
+  it does not repair the **distribution**, so mass wrongly moved between
+  regions stays wrongly placed and only the total is corrected. **#521
+  (positive-definite tracer transport) remains the faithful cure**; the fixer
+  is the stopgap that makes year-long runs usable meanwhile. The gate is set
+  ~500× tighter than the fixer's clip so it fires long before the fixer
+  saturates.
+
+**Follow-up.** The fixer's rescale factor is computed inside
+`_fix_nodal_tracer_mass` and is **not exported**, so a run cannot be checked
+for the factor reaching its clip — the condition the fixer's own docstring says
+"must surface in the `budget_dyn_*` gauge". Exporting it as a per-tracer
+diagnostic would let the gate distinguish "transport error the fixer absorbed"
+from "transport error the fixer could not absorb"; until then the gate scores
+`budget_dyn` alone, which is the post-fix residual.
+
+The gate is scored only when the run saved a Hydra config to read its timestep
+from, and only on output that carries the gauge at all — pre-#713 runs, the
+August-2026 year included, have neither, so on those the block reports the gate
+as unscored rather than silently passing it.
+
+## Both output vertical conventions
+
+Per the "Inspecting model output" rule in `CLAUDE.md`, no statistic here selects
+a level by a bare index.
+
+* A level near a target pressure (900 hPa for the number diagnostics, the
+  lowest layer for the modal radii) is found by searching the file's own
+  `pressure_full` for the nearest mean pressure.
+* "Above 500 hPa" is a mask on the 4-D `pressure_full` field, not a slice.
+* Layer thicknesses come from `jam_burden_report._layer_dp`. Post-#710 files run
+  both vertical axes surface-first, which is what `jcm.analysis`
+  assumes. Pre-#710 files store interfaces **TOA-first** while their `level`
+  fields stay surface-first, so differencing the interfaces yields a Δp reversed
+  against the tracers — pairing stratospheric layer masses with the boundary
+  layer. Those files are detected from the pressure values themselves rather
+  than from the axis labels (a pre-#710 `level_i` is a bare integer index with
+  no `positive` attribute to read) and the Δp is reversed.
+
+The size of that second defect is worth recording: on the August-2026 year the
+uncorrected Δp gives a column-integrated water vapour of 1.1 kg/m², against
+29.5 kg/m² corrected. Every burden computed from a pre-#710 file before this
+fix was wrong by a comparable factor.
+
+## Not yet done: the spun-up state (#762's other half)
+
+Issue #762 asks for two things. This document covers the statistics; the
+**published spun-up JAM state** is deliberately not delivered, and #762 stays
+open for it.
+
+The plan, unchanged:
+
+* The artefact is a full `jcm.checkpoint.save_checkpoint` msgpack per grid
+  (T63 L47 and T63 L95), produced by the release-validation matrix itself:
+  year 1, then `launch.py --resume` for a year 2 once the year-1 aerosol gates
+  above pass, publishing the day-730 state as
+  `bundles/<grid>/init_states/echam_jam_year2.msgpack`.
+* It is published **through the data engine** — a `_MANIFEST_PRODUCTS` row,
+  sha256 in the registry, publication-gated — not by hand, like every other
+  mirror artefact.
+* Consumption is **opt-in** via new `ma-t63-l47-warm` / `ma-t63-l95-warm`
+  configurations (base + `init=from_state`), never a production default: a
+  default warm start would hide exactly the cold-start regressions the matrix
+  exists to catch.
+
+Two things block it, and neither is a matter of effort:
+
+1. **The aerosol mass budget is open.** A spun-up state is a *frozen* copy of
+   the model's aerosol; publishing one taken from a run whose sulfate budget
+   does not close would enshrine the defect and hand every warm-started run a
+   contaminated aerosol population. The gates in this document are the
+   precondition — there is no year-2 state to publish until a year-1 run passes
+   them.
+2. **Issue #731** — a checkpoint breaks when a diagnostic struct gains a leaf —
+   is a prerequisite for any state with a shelf life, and is its own PR. A
+   published state that stops loading on the next physics change is worse than
+   no published state.
+
+The secondary check that state would enable is also specified and also waiting:
+a 10-day T63 L47 warm-start regression test against a stored
+`default_statistics.nc`, `@pytest.mark.slow` and gated by
+`JCM_RUN_GPU_INTEGRATION_TESTS=1`, mirroring the existing ECHAM T63L47
+integration test. It could never replace the gates above — ten days is far too
+short to see a slow runaway — which is why the statistics half is the half that
+was worth doing first.

--- a/docs/source/design/jam_regression.md
+++ b/docs/source/design/jam_regression.md
@@ -129,6 +129,20 @@ a species the run does not carry, a window too short, a run with no
 is printed as `UNSCORED` with its reason. A missing row is otherwise
 indistinguishable from a row that passed.
 
+An UNSCORED gate is reported but does **not** fail the exit code, deliberately:
+its commonest causes are the operator's own `--last-n` and a species the
+configuration does not carry, and failing those would make the tool unusable
+for the windows it is documented to support. Scoring *nothing at all* is the
+exception and does exit non-zero. Statistics that carry an absolute gate are
+also exempt from the tier-3 reference comparison for the same reason — being
+correctly unscored there must not become a hard failure against a reference
+that happens to have the number.
+
+The flux integral runs on **chunk centres**, not the end-of-chunk day the
+filenames carry: a chunk holds a time average, which belongs at the middle of
+its window. Under the uniform cadence of a real run the offset cancels, but
+naming it keeps the quadrature honest if the cadence ever varies.
+
 ## The closure gate, and its sign
 
 The residual is `(Σ emitted − Σ deposited − ΔB) / Σ emitted` over the record.

--- a/docs/source/design/jam_regression.md
+++ b/docs/source/design/jam_regression.md
@@ -50,9 +50,11 @@ record.
   115.0 g/mol (`jam/species.py`), *not* SO₄ at 96.06. Using the wrong one
   understates the source by 20 % and turns a modest closure error into an
   apparent leak.
-* SOA is not scored for closure at all. Its source is condensation of the SOAG
-  gas, which has no `emi_*` channel, so a residual computed for it measures a
-  missing diagnostic rather than a mass leak.
+* SOA is not scored for closure at all. `emi_soa` exists but carries only
+  primary emission, which is zero in the supported configurations; SOA's real
+  source is condensation of the SOAG gas, and no `emi_*` channel accounts for
+  it. A residual computed for SOA would therefore measure an unrepresented
+  source rather than a mass leak.
 
 ## The two tolerance tiers
 
@@ -72,7 +74,12 @@ so they are the same number for every member and every release.
 loading" check, not a calibration.
 
 **Tier 3 — regression tolerances**, for comparing a run against a stored
-reference: `max(3σ, 15 % relative)`. σ is the standard error of the record mean,
+reference: `max(3σ, 15 % relative, an absolute floor)`. The floor matters
+because a legitimately-zero reference — an unused species' burden — would
+otherwise give a zero tolerance that any nonzero value fails. Statistics with an
+absolute gate of their own (drift, closure, dynamics) are **not** scored here:
+their references are ~1e-3, so a relative tolerance would be tighter than the
+gate they already have. σ is the standard error of the record mean,
 with the effective sample size taken from the chunk series' own lag-1
 autocorrelation, `N_eff = N(1−a)/(1+a)`. Neither half alone works: 5-day burden
 samples are strongly autocorrelated, so an uncorrected σ is far too small
@@ -102,7 +109,25 @@ range at all.
 
 A species the run never carries (SOA with no SOAG production, say) has a
 correctly-zero burden and no drift to measure; it is skipped rather than scored
-as NaN.
+as NaN, and the **climatological anchor gate skips it on the same grounds** —
+the two tiers must not contradict each other about the same species on adjacent
+lines of one report.
+
+The window itself has a floor. A least-squares slope carries noise
+`σ_resid / (Δt·√(N(N²−1)/12))`; at the 5-day output cadence and the ~0.07
+log-burden scatter of a settled species, three of those falls below the
+0.002/day limit only past **90 days**. `health.py --last-n` is the documented
+way to score the settled months, and on a shorter window the fitted slope is
+noise — so below that span the statistic is reported **UNSCORED**, with the
+number of days it needs, rather than gated. The closure residual takes the same
+floor: its storage term is a single endpoint difference, which over a few
+chunks swamps the flux integral it is compared against.
+
+**No gate ever passes by absence.** Anything that could not be evaluated —
+a species the run does not carry, a window too short, a run with no
+`budget_dyn_*` gauge or no timestep to express the dynamics gate per step —
+is printed as `UNSCORED` with its reason. A missing row is otherwise
+indistinguishable from a row that passed.
 
 ## The closure gate, and its sign
 
@@ -110,8 +135,10 @@ The residual is `(Σ emitted − Σ deposited − ΔB) / Σ emitted` over the re
 Its **sign** is the diagnosis:
 
 * **Negative** — more mass was deposited than ever entered the column. No
-  missing ledger entry can produce that. It is mass creation, and it is a defect
-  in the physics.
+  missing ledger entry can produce that, so it is mass creation. It does *not*
+  say where: the ledger carries emission, deposition and storage but no
+  transport term, so a negative residual indicts the model, not the physics
+  specifically — the dynamics gate below is what separates the two.
 * **Positive** — emitted mass is unaccounted for. That is what a real leak looks
   like, but it is *also* exactly what a missing sink **diagnostic** looks like.
   On output written before the #722 removal-ledger fix, `dry_*` omits the Slinn

--- a/docs/source/developer.rst
+++ b/docs/source/developer.rst
@@ -161,12 +161,15 @@ prints milliseconds per step for the dynamical core, each direction of the
 dynamics/physics bridge, and every physics term individually, alongside the
 fraction of device time it could not attribute cleanly.
 
-The default window is two radiation sub-cycles. Resist lengthening it: the
-profiler's event buffer holds about a million events and a T63L47 JAM step
-emits ~19,000 kernels, so a longer window overflows it and undercounts. The
-short window loses nothing, because kernel shapes are static and the model
-takes no data-dependent branches, so a step's cost does not vary with the
-state.
+The default window is one radiation sub-cycle — 10 steps at T63L47's 12 min
+step and 2 h radiation. Resist lengthening it: the profiler's event buffer
+holds about a million events and a T63L47 JAM step emits ~19,000 kernels, so a
+longer window overflows it and undercounts. The window must *also* span a whole
+number of sub-cycles, so on that configuration one cycle is the only window
+both admissible and within the buffer; the previous two-cycle default sat on
+the ceiling and failed. The short window loses nothing, because kernel shapes
+are static and the model takes no data-dependent branches, so a step's cost
+does not vary with the state.
 
 The attribution works because :mod:`jcm.profiling` wraps the dycore call, the
 bridge and each :class:`~jcm.physics.physics_term.PhysicsTerm` in a
@@ -184,7 +187,10 @@ outside every loop and branch in the step, so each must show up in the
 attribution exactly once per step. It fails — naming the labels — if any of the
 three is missing (the HLO-metadata join broke, so every number would be
 misattributed) or if any is short of the step count (the event buffer
-overflowed, so every number would be an undercount).
+overflowed, so every number would be an undercount). The overflow error names
+the largest window that is both within the buffer and a whole number of
+sub-cycles, or says plainly that no admissible window fits when even one cycle
+is too long.
 
 Note that ``profile_terms.py`` disables CUDA graph capture — otherwise every
 kernel reports the same synthetic instruction and nothing is attributable — so

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -167,7 +167,15 @@ by hand.
 Unpublished grids / verticals degrade exactly as the CLI does (``auto`` inputs
 that the mirror does not carry resolve to nothing, with a warning), and
 ``aerosol="macv2sp"`` wires the repo-packaged MACv2-SP plume file into the
-forcing.
+forcing. Ozone is the exception, in both doors: ``ozone_file: auto``
+**raises** on a hybrid grid when neither the packaged climatology nor the
+mirror bundle resolves — the analytic profile carries ~7.6× the tropospheric
+ozone column and biases clear-sky OLR ~12 W/m² low, so it is never substituted
+silently. Ask for it with ``forcing.ozone_file=analytic``. The error
+distinguishes a missing product (build one with
+``jcm.data.bc.interpolate_ozone``) from a cold Hugging Face cache (warm it on
+a networked node). A sigma grid, for which no ozone product exists at all,
+still falls back with a warning.
 
 .. _configurations-from-python:
 

--- a/jcm/config/configuration/ma-t119-l47.yaml
+++ b/jcm/config/configuration/ma-t119-l47.yaml
@@ -18,8 +18,10 @@
 #    left as the group's ??? so a missing path fails loudly.
 #  - forcing=from_file + hf:// present-day T63 SST bundle, interpolated to
 #    T119 by the loader. forcing.ozone_file: supply a level-matched L47
-#    T119 ozone file (no mirror bundle exists); left as auto here, which
-#    warns + falls back to the analytic profile if none is packaged.
+#    T119 ozone file (no mirror bundle exists). Left as auto, which now
+#    RAISES here naming that requirement (#774) rather than substituting
+#    the analytic profile — same 'fail loudly' treatment as terrain.file
+#    above. forcing.ozone_file=analytic accepts the profile deliberately.
 #  - forcing.{emissions,dms,dust,oxidants}_file=null: T119 has NO mirror
 #    bundle, so the JAM ``auto`` default cannot resolve them (the per-grid
 #    bundles only exist for t63/t106 — jcm/data/mirror/build_mirror.py's

--- a/jcm/config/configuration/ma-t119-l95.yaml
+++ b/jcm/config/configuration/ma-t119-l95.yaml
@@ -18,8 +18,10 @@
 #    left as the group's ??? so a missing path fails loudly.
 #  - forcing=from_file + hf:// present-day T63 SST bundle, interpolated to
 #    T119 by the loader. forcing.ozone_file: supply a level-matched L95
-#    T119 ozone file (no mirror bundle exists); left as auto here, which
-#    warns + falls back to the analytic profile if none is packaged.
+#    T119 ozone file (no mirror bundle exists). Left as auto, which now
+#    RAISES here naming that requirement (#774) rather than substituting
+#    the analytic profile — same 'fail loudly' treatment as terrain.file
+#    above. forcing.ozone_file=analytic accepts the profile deliberately.
 #  - forcing.{emissions,dms,dust,oxidants}_file=null: T119 has NO mirror
 #    bundle, so the JAM ``auto`` default cannot resolve them (the per-grid
 #    bundles only exist for t63/t106 — jcm/data/mirror/build_mirror.py's

--- a/jcm/config/configuration/t106-echam-1m.yaml
+++ b/jcm/config/configuration/t106-echam-1m.yaml
@@ -18,7 +18,8 @@
 #    sub-grid-orography fields.
 #  - forcing=from_file + hf:// present-day bundle: prescribed SST/sea-ice from
 #    the project data mirror (fetched once into the local HF cache). Ozone
-#    stays forcing.ozone_file: auto unless a level-matched bundle is set.
+#    stays forcing.ozone_file: auto, which resolves the packaged
+#    climatology then the mirror bundle and RAISES if neither fits.
 #  - run=longrun: 30-day health-gated chunks with the settled production
 #    upper sponge (levels=10, target_T_K=250) that stabilises the JW-dry
 #    stratosphere; the 12-min L47/L95 step now comes from the shared default (run/default.yaml).

--- a/jcm/config/configuration/t106-echam-2m.yaml
+++ b/jcm/config/configuration/t106-echam-2m.yaml
@@ -18,7 +18,8 @@
 #    sub-grid-orography fields.
 #  - forcing=from_file + hf:// present-day bundle: prescribed SST/sea-ice from
 #    the project data mirror (fetched once into the local HF cache). Ozone
-#    stays forcing.ozone_file: auto unless a level-matched bundle is set.
+#    stays forcing.ozone_file: auto, which resolves the packaged
+#    climatology then the mirror bundle and RAISES if neither fits.
 #  - run=longrun: 30-day health-gated chunks with the settled production
 #    upper sponge (levels=10, target_T_K=250) that stabilises the JW-dry
 #    stratosphere; the 12-min L47/L95 step now comes from the shared default (run/default.yaml).

--- a/jcm/config/configuration/t63-echam-1m.yaml
+++ b/jcm/config/configuration/t63-echam-1m.yaml
@@ -18,7 +18,8 @@
 #    sub-grid-orography fields.
 #  - forcing=from_file + hf:// present-day bundle: prescribed SST/sea-ice from
 #    the project data mirror (fetched once into the local HF cache). Ozone
-#    stays forcing.ozone_file: auto unless a level-matched bundle is set.
+#    stays forcing.ozone_file: auto, which resolves the packaged
+#    climatology then the mirror bundle and RAISES if neither fits.
 #  - run=longrun: 30-day health-gated chunks with the settled production
 #    upper sponge (levels=10, target_T_K=250) that stabilises the JW-dry
 #    stratosphere; the 12-min L47/L95 step now comes from the shared default (run/default.yaml).

--- a/jcm/config/configuration/t63-echam-emulated-2m.yaml
+++ b/jcm/config/configuration/t63-echam-emulated-2m.yaml
@@ -21,7 +21,8 @@
 #    sub-grid-orography fields.
 #  - forcing=from_file + hf:// present-day bundle: prescribed SST/sea-ice from
 #    the project data mirror (fetched once into the local HF cache). Ozone
-#    stays forcing.ozone_file: auto unless a level-matched bundle is set.
+#    stays forcing.ozone_file: auto, which resolves the packaged
+#    climatology then the mirror bundle and RAISES if neither fits.
 #  - run=longrun: 30-day health-gated chunks with the settled production
 #    upper sponge (levels=10, target_T_K=250) that stabilises the JW-dry
 #    stratosphere; the 12-min L47/L95 step now comes from the shared default (run/default.yaml).

--- a/jcm/config/configuration/t63-echam-jam-aerocom-optics.yaml
+++ b/jcm/config/configuration/t63-echam-jam-aerocom-optics.yaml
@@ -19,7 +19,8 @@
 #    sub-grid-orography fields.
 #  - forcing=from_file + hf:// present-day bundle: prescribed SST/sea-ice from
 #    the project data mirror (fetched once into the local HF cache). Ozone
-#    stays forcing.ozone_file: auto unless a level-matched bundle is set.
+#    stays forcing.ozone_file: auto, which resolves the packaged
+#    climatology then the mirror bundle and RAISES if neither fits.
 #  - run=longrun: 30-day health-gated chunks with the settled production
 #    upper sponge (levels=10, target_T_K=250) that stabilises the JW-dry
 #    stratosphere; the 12-min L47/L95 step now comes from the shared default (run/default.yaml).

--- a/jcm/config/configuration/t63-echam-jam-aerocom.yaml
+++ b/jcm/config/configuration/t63-echam-jam-aerocom.yaml
@@ -19,7 +19,8 @@
 #    sub-grid-orography fields.
 #  - forcing=from_file + hf:// present-day bundle: prescribed SST/sea-ice from
 #    the project data mirror (fetched once into the local HF cache). Ozone
-#    stays forcing.ozone_file: auto unless a level-matched bundle is set.
+#    stays forcing.ozone_file: auto, which resolves the packaged
+#    climatology then the mirror bundle and RAISES if neither fits.
 #  - run=longrun: 30-day health-gated chunks with the settled production
 #    upper sponge (levels=10, target_T_K=250) that stabilises the JW-dry
 #    stratosphere; the 12-min L47/L95 step now comes from the shared default (run/default.yaml).

--- a/jcm/config/configuration/t63-echam-jam.yaml
+++ b/jcm/config/configuration/t63-echam-jam.yaml
@@ -20,7 +20,8 @@
 #    sub-grid-orography fields.
 #  - forcing=from_file + hf:// present-day bundle: prescribed SST/sea-ice from
 #    the project data mirror (fetched once into the local HF cache). Ozone
-#    stays forcing.ozone_file: auto unless a level-matched bundle is set.
+#    stays forcing.ozone_file: auto, which resolves the packaged
+#    climatology then the mirror bundle and RAISES if neither fits.
 #  - run=longrun: 30-day health-gated chunks with the settled production
 #    upper sponge (levels=10, target_T_K=250) that stabilises the JW-dry
 #    stratosphere; the 12-min L47/L95 step now comes from the shared default (run/default.yaml).

--- a/jcm/config/configuration/t63-echam-rrtmgp-2m.yaml
+++ b/jcm/config/configuration/t63-echam-rrtmgp-2m.yaml
@@ -18,7 +18,8 @@
 #    sub-grid-orography fields.
 #  - forcing=from_file + hf:// present-day bundle: prescribed SST/sea-ice from
 #    the project data mirror (fetched once into the local HF cache). Ozone
-#    stays forcing.ozone_file: auto unless a level-matched bundle is set.
+#    stays forcing.ozone_file: auto, which resolves the packaged
+#    climatology then the mirror bundle and RAISES if neither fits.
 #  - run=longrun: 30-day health-gated chunks with the settled production
 #    upper sponge (levels=10, target_T_K=250) that stabilises the JW-dry
 #    stratosphere; the 12-min L47/L95 step now comes from the shared default (run/default.yaml).

--- a/jcm/config/configuration/t63-echam-rrtmgp.yaml
+++ b/jcm/config/configuration/t63-echam-rrtmgp.yaml
@@ -18,7 +18,8 @@
 #    sub-grid-orography fields.
 #  - forcing=from_file + hf:// present-day bundle: prescribed SST/sea-ice from
 #    the project data mirror (fetched once into the local HF cache). Ozone
-#    stays forcing.ozone_file: auto unless a level-matched bundle is set.
+#    stays forcing.ozone_file: auto, which resolves the packaged
+#    climatology then the mirror bundle and RAISES if neither fits.
 #  - run=longrun: 30-day health-gated chunks with the settled production
 #    upper sponge (levels=10, target_T_K=250) that stabilises the JW-dry
 #    stratosphere; the 12-min L47/L95 step now comes from the shared default (run/default.yaml).

--- a/jcm/config/forcing/default.yaml
+++ b/jcm/config/forcing/default.yaml
@@ -3,10 +3,13 @@
 kind: default
 
 # Ozone climatology netCDF. ``auto`` (default) picks the packaged
-# ``jcm/data/bc/<grid>/ozone.nc`` matching the model grid, warning and
-# falling back to the analytical profile when none fits (that profile
-# biases clear-sky OLR ~12 W/m² low). Explicit path, or ``null`` for the
-# analytical profile without the warning.
+# ``jcm/data/bc/<grid>/ozone.nc`` matching the model grid, then the mirror's
+# per-grid bundle, and RAISES when neither resolves — the analytical profile
+# carries ~7.6x the tropospheric ozone column and biases clear-sky OLR ~12 W/m²
+# low, so it is never substituted silently. Also accepts an explicit path, or
+# ``analytic`` (``null``) to select that profile deliberately. A sigma grid is
+# the exception: no ozone product exists on sigma levels, so ``auto`` warns and
+# uses the analytic profile there.
 ozone_file: auto
 
 # --- Prescribed-emission inputs (JAM / online aerosol) -----------------------

--- a/jcm/config/forcing/from_file.yaml
+++ b/jcm/config/forcing/from_file.yaml
@@ -51,10 +51,11 @@ oxidants_available_years: null
 align: auto
 
 # Ozone climatology netCDF, pre-interpolated to model levels (see
-# ``jcm.data.bc.interpolate_ozone``). ``auto`` (default) resolves the
-# packaged ``jcm/data/bc/<grid>/ozone.nc``, warning and falling back to
-# the analytical profile when none fits (~12 W/m² OLR low bias). ``null``
-# forces the analytical profile silently.
+# ``jcm.data.bc.interpolate_ozone``). ``auto`` (default) resolves the packaged
+# ``jcm/data/bc/<grid>/ozone.nc`` then the mirror bundle, and raises when
+# neither fits — the analytical profile's ~12 W/m² OLR low bias must be chosen,
+# not inherited. ``analytic`` (or ``null``) chooses it; a sigma grid, which has
+# no ozone product at all, still falls back with a warning.
 ozone_file: auto
 
 # --- Prescribed-emission inputs (JAM / online aerosol) -----------------------

--- a/jcm/forcing.py
+++ b/jcm/forcing.py
@@ -430,7 +430,8 @@ class ForcingData:
         ``forcing.macv2_file`` so the real plume weights are attached — the file
         is resolution-invariant and shipped in the wheel, so it needs no mirror
         fetch. Unpublished-grid / sigma degradations (``auto`` → nothing) mirror
-        the CLI for the other products. ``fetch``
+        the CLI for the other products; ``auto`` ozone likewise mirrors the CLI
+        in RAISING on a hybrid grid it cannot resolve (#774). ``fetch``
         (default: the HF cache) pre-resolves the composed surface bundle via the
         engine; the ``auto`` products use the cache.
 

--- a/jcm/forcing_assembly.py
+++ b/jcm/forcing_assembly.py
@@ -126,6 +126,15 @@ def _resolve_auto_ozone(coords):
         return packaged
     token = _grid_token(coords)
     product = mm.product_for_key(manifest, "ozone_file")
+    if product is None:
+        # Same guard tools/benchmark.py applies: the manifest declares no auto
+        # ozone product, so there is nothing to fetch and no path to name.
+        raise FileNotFoundError(
+            "forcing.ozone_file=auto: no packaged ozone matches this grid "
+            f"({nlon}x{nlat}, {nlev} levels) and the mirror manifest declares "
+            "no automatic ozone product at all. Point forcing.ozone_file at a "
+            "climatology, or set forcing.ozone_file=analytic."
+        )
     rel = mm.bundle_path(manifest, product, token, nlev)
     from jcm.data.remote import fetch
     try:

--- a/jcm/forcing_assembly.py
+++ b/jcm/forcing_assembly.py
@@ -84,18 +84,27 @@ def _resolve_auto_ozone(coords):
     resolve_packaged`); (2) the data mirror's per-grid ``bundles/<grid>_l<nlev>/
     ozone_pd.nc`` (cache-first fetch — works offline once cached; the loader
     rejects any grid mismatch). Grid identity is then fully validated by
-    ``OzoneClimatology.from_file``. Returns ``None`` when neither stage finds a
-    file — the caller warns and falls back to the analytic profile, whose ~7.6×
-    tropospheric ozone column biases clear-sky OLR ~12 W/m² low.
+    ``OzoneClimatology.from_file``.
 
-    Auto resolves to ``None`` on a **sigma** grid: every ozone product (packaged
-    and mirror alike) is written by ``jcm.data.bc.interpolate_ozone`` onto the
-    model's *hybrid*-level centre pressures and mapped level-for-level, so a
-    sigma grid that merely shares a published (token, nlev) would wire
-    stratospheric-pressure ozone onto unrelated sigma levels — the same silent
-    corruption the oxidant gate rejects (the manifest's hybrid-only verticals).
-    ``OzoneClimatology.from_file`` only cross-checks shape and lat/lon, not the
-    vertical coordinate, so nothing downstream would catch it.
+    **Raises** when neither stage resolves on a hybrid grid, the same rule
+    ``terrain.kind=auto`` follows: a silently substituted ozone climatology
+    corrupts the run just as a substituted terrain does — the analytic profile
+    carries ~7.6× the tropospheric ozone column and biases clear-sky OLR ~12
+    W/m² low. The mirror fetch is attempted for *any* grid, as before (the
+    manifest's grid list can lag what is staged); the manifest is consulted
+    only to classify the failure, because the remedies differ — an unpublished
+    combination is a missing *product* (build one), a published one that will
+    not fetch is a *transport* failure (warm the cache). Take the analytic
+    profile deliberately with ``forcing.ozone_file=analytic``.
+
+    Returns ``None`` on a **sigma** grid, the one non-error case: every ozone
+    product (packaged and mirror alike) is written by
+    ``jcm.data.bc.interpolate_ozone`` onto the model's *hybrid*-level centre
+    pressures and mapped level-for-level, so a sigma grid that merely shares a
+    published (token, nlev) would wire stratospheric-pressure ozone onto
+    unrelated sigma levels — the same silent corruption the oxidant gate rejects.
+    No hybrid-free product exists for the caller to have configured, so this
+    warns and falls back rather than demanding an opt-out from every sigma run.
     """
     if _vertical_kind(coords) != "hybrid":
         logger.warning(
@@ -110,24 +119,40 @@ def _resolve_auto_ozone(coords):
         return None
     nlon, nlat = (int(v) for v in coords.horizontal.nodal_shape)
     nlev = int(coords.nodal_shape[0])
-    packaged = ir.resolve_packaged(mm.load_manifest(), "ozone_packaged",
+    manifest = mm.load_manifest()
+    packaged = ir.resolve_packaged(manifest, "ozone_packaged",
                                    nlev=nlev, nlat=nlat, nlon=nlon)
     if packaged is not None:
         return packaged
     token = _grid_token(coords)
-    from jcm.data.remote import bundle_file
+    product = mm.product_for_key(manifest, "ozone_file")
+    rel = mm.bundle_path(manifest, product, token, nlev)
+    from jcm.data.remote import fetch
     try:
-        return str(bundle_file(f"{token}_l{nlev}", "ozone_pd.nc"))
-    except Exception as e:  # noqa: BLE001 — degrade, but LOUDLY
-        # Warning, not info: the analytic-profile fallback biases
-        # clear-sky OLR ~12 W/m² and the generic no-packaged-file
-        # warning downstream does not mention the failed mirror fetch.
-        logger.warning(
-            "auto-ozone: mirror fetch bundles/%s_l%d/ozone_pd.nc failed "
-            "(%s); falling back to the analytic ozone profile.",
-            token, nlev, e,
-        )
-    return None
+        return str(fetch(rel))
+    except Exception as e:  # noqa: BLE001 — re-raised with the remedy
+        # The fetch is attempted for ANY grid — the manifest's grid list can
+        # lag what is actually staged, and a user may have staged their own
+        # bundle — so publication is consulted only to say WHICH failure this
+        # was, and therefore which remedy applies.
+        if mm.is_published(manifest, product, token, nlev, "hybrid"):
+            raise RuntimeError(
+                f"forcing.ozone_file=auto: {rel} is published but could not "
+                f"be fetched ({type(e).__name__}: {e}). That is a transport "
+                "failure, not a missing product: warm the Hugging Face cache "
+                "on a networked node (or point HF_HOME at one that already "
+                "holds it) and retry. forcing.ozone_file=analytic opts out of "
+                "the climatology instead."
+            ) from e
+        raise FileNotFoundError(
+            f"forcing.ozone_file=auto: no packaged ozone matches this grid "
+            f"({nlon}x{nlat}, {nlev} levels) and the data mirror carries no "
+            f"{rel} ({type(e).__name__}: {e}). Build one with "
+            "jcm.data.bc.interpolate_ozone and point forcing.ozone_file at "
+            "it, or set forcing.ozone_file=analytic to accept the analytic "
+            "profile (~7.6x the tropospheric ozone column; clear-sky OLR "
+            "~12 W/m2 low)."
+        ) from e
 
 
 def _resolve_auto_terrain(coords):
@@ -407,11 +432,14 @@ def assemble_spectral_forcing(forcing_cfg, coords):
 def _attach_ozone(forcing, forcing_cfg, coords):
     """Load the ozone climatology and attach to ``forcing``.
 
-    ``ozone_file: auto`` (the shipped default) resolves a packaged
-    climatology matching the grid via ``_resolve_auto_ozone``; no match
-    degrades to the analytic ozone profile with a warning. An explicit
-    path is loaded strictly (errors on any mismatch). ``null`` disables
-    the climatology silently (analytic profile, no warning).
+    ``ozone_file: auto`` (the shipped default) resolves a packaged or
+    mirrored climatology matching the grid via ``_resolve_auto_ozone``, and
+    RAISES when it cannot — a silently substituted ozone climatology corrupts
+    the run, so ``auto`` behaves like ``terrain.kind=auto``. An explicit path
+    is loaded strictly (errors on any mismatch). ``analytic`` (or ``null``)
+    selects the analytic profile deliberately, which is the only way to get
+    it. A sigma grid is the one case ``auto`` still degrades: no ozone product
+    exists for that vertical family (see ``_resolve_auto_ozone``).
 
     When ``forcing`` is ``None`` (``kind: default``) and an ozone file IS
     given, build the parent struct via ``default_forcing(...)`` so the
@@ -431,18 +459,17 @@ def _attach_ozone(forcing, forcing_cfg, coords):
     if ozone_file in (None, "", "null"):
         provenance.record_fact("ozone_source", "analytic (no ozone_file)")
         return forcing
+    if ozone_file == "analytic":
+        # The explicit opt-in. Named rather than ``null`` so a config that
+        # wants the analytic profile says so, and so the run's provenance
+        # records a choice rather than an omission.
+        provenance.record_fact("ozone_source", "analytic (explicit)")
+        return forcing
     if ozone_file == "auto":
         ozone_file = _resolve_auto_ozone(coords)
-        if ozone_file is None:
+        if ozone_file is None:      # sigma grid; _resolve_auto_ozone warned
             provenance.record_fact(
-                "ozone_source", "analytic (auto found no packaged match)")
-            logging.warning(
-                "forcing.ozone_file=auto: no packaged jcm/data/bc/*/ozone.nc "
-                "matches this grid — falling back to the ANALYTIC ozone "
-                "profile, whose ~7.6x tropospheric ozone column biases "
-                "clear-sky OLR low by ~12 W/m2. Prepare a climatology with "
-                "jcm.data.bc.interpolate_ozone for production radiation."
-            )
+                "ozone_source", "analytic (auto: no product for a sigma grid)")
             return forcing
         logging.info("forcing.ozone_file=auto resolved to %s", ozone_file)
     import numpy as np

--- a/jcm/runners.py
+++ b/jcm/runners.py
@@ -928,16 +928,24 @@ def _build_pyses_forcing(_forcing_cfg, dycore, coords):
 
         cand = (Path(str(resources.files("jcm")))
                 / "data" / "bc" / "t63" / "ozone.nc")
-        if cand.exists():
-            ozone_file = str(cand)
-        else:
-            logging.warning(
-                "forcing.ozone_file=auto: packaged t63/ozone.nc missing "
-                "— pySES run falls back to the ANALYTIC ozone profile "
-                "(~12 W/m2 clear-sky OLR low bias)."
+        if not cand.exists():
+            # Same rule as the spectral path (#774): a silently substituted
+            # ozone climatology corrupts the run, so ``auto`` that resolves to
+            # nothing raises. The packaged file ships in the wheel, so this
+            # only fires on a damaged install.
+            raise FileNotFoundError(
+                "forcing.ozone_file=auto: the packaged jcm/data/bc/t63/"
+                "ozone.nc the pySES path interpolates from is missing, so no "
+                "ozone climatology can be resolved. Reinstall jcm, point "
+                "forcing.ozone_file at a 12-month climatology, or set "
+                "forcing.ozone_file=analytic to accept the analytic profile "
+                "(~7.6x the tropospheric ozone column; clear-sky OLR ~12 "
+                "W/m2 low)."
             )
-            ozone_file = None
-    elif ozone_file in ("", "null", "none"):
+        ozone_file = str(cand)
+    elif ozone_file in ("", "null", "none", "analytic"):
+        # ``analytic`` is the explicit opt-in to the analytic profile (#774);
+        # it must never reach _resolve_data_path as a filename.
         ozone_file = None
     if isinstance(ozone_file, str) and "{year}" in ozone_file:
         # Transient ozone is genuinely unsupported on the pySES path (unlike

--- a/jcm/runners_test.py
+++ b/jcm/runners_test.py
@@ -472,7 +472,12 @@ class TestAutoOzoneDefault(unittest.TestCase):
         self.assertLess(float(o3.max()), 20.0)
         self.assertGreater(float(o3.min()), 0.0)
 
-    def test_auto_miss_warns_and_falls_back(self):
+    def test_auto_miss_warns_and_falls_back_on_a_sigma_grid(self):
+        """A sigma grid is the one case ``auto`` may still degrade.
+
+        Every ozone product is on hybrid-level pressures, so there is no
+        product a sigma run could have been expected to configure.
+        """
         from jcm.runners import build_forcing
 
         cfg = _compose(["physics=echam", "grid=echam_t42_l8_sigma"])
@@ -484,6 +489,63 @@ class TestAutoOzoneDefault(unittest.TestCase):
         self.assertTrue(any("ANALYTIC ozone" in m for m in logs.output))
         # ``kind: default`` with no attachments returns None (aquaplanet
         # built later); either way no ozone climatology must be loaded.
+        if forcing is not None:
+            self.assertFalse(bool(forcing.ozone_climatology.is_loaded()))
+
+    def test_auto_raises_when_no_product_exists_for_the_grid(self):
+        """A hybrid grid with no ozone product must refuse, not degrade.
+
+        ``terrain.kind=auto`` already raises for the same reason: a silently
+        substituted climatology (~7.6x the tropospheric ozone column) produces
+        a run that completes and reports healthy with invalid radiation (#774).
+        """
+        from unittest import mock
+
+        from jcm.runners import _resolve_auto_ozone
+
+        # T85 hybrid: no packaged bc/*/ozone.nc matches and the mirror
+        # publishes ozone for t63/t106 only. The fetch is still attempted
+        # (the manifest's grid list can lag what is staged) and fails.
+        cfg = _compose(["physics=echam", "grid=echam_t85_l47_hybrid"])
+        coords = build_coords(cfg)
+        with mock.patch("jcm.data.remote.fetch",
+                        side_effect=FileNotFoundError("no such bundle")):
+            with self.assertRaises(FileNotFoundError) as ctx:
+                _resolve_auto_ozone(coords)
+        message = str(ctx.exception)
+        self.assertIn("interpolate_ozone", message)
+        self.assertIn("analytic", message)
+
+    def test_auto_distinguishes_a_transport_failure(self):
+        """A published bundle that will not fetch is a cache problem.
+
+        The remedy differs from a missing product, so the two must not share
+        one message — a cold cache on an offline compute node is entirely
+        recoverable and used to degrade silently.
+        """
+        from unittest import mock
+
+        from jcm.runners import _resolve_auto_ozone
+
+        cfg = _compose(["physics=echam", "grid=echam_t106_l47_hybrid"])
+        coords = build_coords(cfg)
+        with mock.patch("jcm.data.remote.fetch",
+                        side_effect=FileNotFoundError("not in the cache")):
+            with self.assertRaises(RuntimeError) as ctx:
+                _resolve_auto_ozone(coords)
+        message = str(ctx.exception)
+        self.assertIn("transport failure", message)
+        self.assertIn("cache", message)
+
+    def test_analytic_is_an_explicit_opt_in(self):
+        """``ozone_file=analytic`` takes the analytic profile deliberately."""
+        from jcm.runners import build_forcing
+
+        cfg = _compose(["physics=echam", "grid=echam_t63_l47_hybrid"])
+        coords = build_coords(cfg)
+        cfg.forcing.kind = "default"
+        cfg.forcing.ozone_file = "analytic"
+        forcing = build_forcing(cfg, coords)
         if forcing is not None:
             self.assertFalse(bool(forcing.ozone_climatology.is_loaded()))
 

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -257,6 +257,38 @@ def _auto_emission_files(cfg) -> list[str]:
     return out
 
 
+def _auto_ozone_files(cfg) -> list[str]:
+    """``hf://`` ozone bundle ``forcing.ozone_file=auto`` resolves to.
+
+    The same lazy-resolution gap :func:`_auto_emission_files` covers: ``auto``
+    is the shipped default and is resolved inside model construction, so the
+    literal-path walk cannot see it. jcm REFUSES an unresolvable ``auto`` ozone
+    rather than substituting the analytic profile (#774), which makes a cold
+    cache a hard failure the prefetch can prevent.
+
+    The packaged ``jcm/data/bc/*/ozone.nc`` may pre-empt the mirror bundle for
+    a grid it matches, so this can warm one file the run then does not open —
+    cheaper than resolving packaged shapes here, and it removes the cold-cache
+    failure for every grid.
+    """
+    forcing = cfg.get("forcing") or {}
+    if str(forcing.get("ozone_file", "auto")) != "auto":
+        return []
+    grid = cfg.get("grid") or {}
+    trunc, nlev = grid.get("spectral_truncation"), grid.get("layers")
+    if trunc is None or nlev is None:
+        return []
+    mm = _load_mirror_manifest()
+    manifest = mm.load_manifest()
+    product = mm.product_for_key(manifest, "ozone_file")
+    token = f"t{int(trunc)}"
+    if product is None or not mm.is_published(
+            manifest, product, token, int(nlev),
+            str(grid.get("vertical", "hybrid"))):
+        return []
+    return ["hf://" + mm.bundle_path(manifest, product, token, int(nlev))]
+
+
 # Per-product ``available_years`` override each ``{year}`` forcing key honours,
 # mirroring ``jcm.runners._product_available_years`` — a preset may mix yearly
 # products with different coverage (era5 surface files run to 2024 while the
@@ -276,8 +308,9 @@ def _preset_data_files(overrides: list[str]) -> list[str]:
     Walks the COMPOSED forcing/terrain/dycore config for keys ending in
     ``file`` and returns the concrete paths, skipping ``auto``/``null``/``none``
     (resolved lazily at build time) and unset ``???`` values — then ADDS the
-    ``auto`` emission bundles a JAM preset resolves lazily (see
-    :func:`_auto_emission_files`), which the ``file``-key walk cannot see.
+    ``auto`` emission and ozone bundles resolved lazily at build time (see
+    :func:`_auto_emission_files`, :func:`_auto_ozone_files`), which the
+    ``file``-key walk cannot see.
 
     A ``{year}`` pattern (transient emissions/oxidants/ozone/surface bundles)
     is EXPANDED to its concrete yearly files here — over ``forcing.years`` and
@@ -334,6 +367,7 @@ def _preset_data_files(overrides: list[str]) -> list[str]:
             # ``*_available_years`` overrides live under ``forcing``).
             _add(v, _available_for(k) if group == "forcing" else None)
     out += _auto_emission_files(cfg)
+    out += _auto_ozone_files(cfg)
     return out
 
 

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -341,7 +341,10 @@ def _preset_data_files(overrides: list[str]) -> list[str]:
         # A ``{year}`` scalar expands to its yearly-file list; a plain path
         # passes through. Lists name several independent products — expand each
         # element with the same coverage clamp (mirrors _forcing_products).
-        if isinstance(v, str) and v not in ("auto", "null", "none", "???"):
+        # ``analytic`` joins the sentinels: it selects the analytic ozone
+        # profile (#774), not a file, and must not reach the prefetch.
+        if isinstance(v, str) and v not in ("auto", "null", "none", "???",
+                                            "analytic"):
             expanded = expand(v, years, available)
             if isinstance(expanded, (list, tuple)):
                 out.extend(str(x) for x in expanded)

--- a/tools/jam_burden_report.py
+++ b/tools/jam_burden_report.py
@@ -60,7 +60,34 @@ _EMIS_SPECIES = {"so4": ("so2", 96.0 / 64.0), "bc": ("bc", 1.0),
 # implementation. ``_area_weights`` preserves the tool's "no lat -> None"
 # contract; ``jcm.analysis.area_weights`` returns Gauss-Legendre-exact weights
 # for dinosaur output grids (cos(lat) only for non-Gaussian grids).
-_layer_dp = layer_pressure_thickness
+def _interfaces_are_toa_first(ds: xr.Dataset) -> bool:
+    """Report whether ``pressure_half`` runs top-down (pre-#710 files).
+
+    Read from the pressure values themselves rather than from the axis
+    labels, so a file whose ``level_i`` is a bare integer index is still
+    oriented correctly. See ``docs/source/design/jam_regression.md``.
+    """
+    ph = ds["pressure_half"]
+    other = [d for d in ph.dims if d != "level_i"]
+    prof = np.asarray(ph.mean(other).values) if other else np.asarray(ph.values)
+    return bool(prof[0] < prof[-1])
+
+
+def _layer_dp(ds: xr.Dataset) -> xr.DataArray:
+    """Per-layer Δp [Pa] aligned with the ``level`` axis of the 3-D fields.
+
+    Post-#710 files run both vertical axes surface-first, which is what
+    :func:`jcm.analysis.layer_pressure_thickness` assumes. Pre-#710 files
+    store interfaces TOA-first while ``level`` fields stay surface-first, so
+    the differenced Δp is reversed to align; without that, ``q·Δp`` pairs the
+    thinnest stratospheric layers with the boundary layer and every burden is
+    wrong. The model's own ``pressure_thickness`` diagnostic is already on the
+    ``level`` axis and never needs the flip.
+    """
+    dp = layer_pressure_thickness(ds)
+    if "pressure_thickness" not in ds and _interfaces_are_toa_first(ds):
+        return dp.isel(level=slice(None, None, -1))
+    return dp
 
 
 def _area_weights(ds: xr.Dataset):
@@ -75,7 +102,12 @@ def _wmean(da: xr.DataArray, weights) -> float:
 
 def burden(ds: xr.Dataset, species: str, modes) -> xr.DataArray | None:
     """Time-mean column burden [mg/m²] of a species summed over modes."""
-    names = [f"{p}_{species}_{m}" for m in modes for p in ("m", "mc")]
+    # Interstitial ``m_<sp>_<mode>`` are top-level tracers; the cloud-borne
+    # phase is a carry diagnostic and is written under the flattened
+    # ``jam_cloud_borne.`` namespace (bare ``mc_`` kept for hand-built files).
+    names = [f"{p}_{species}_{m}"
+             for m in modes
+             for p in ("m", "mc", "jam_cloud_borne.mc")]
     present = [n for n in names if n in ds]
     if not present:
         return None

--- a/tools/jam_burden_report_test.py
+++ b/tools/jam_burden_report_test.py
@@ -1,10 +1,12 @@
-"""Tests for the JAM burden report's layer-Δp helper.
+"""Tests for the JAM burden report's layer-Δp and burden helpers.
 
-Only ``_layer_dp`` is covered here: it is the piece with a real correctness
-choice (prefer the model's own ``pressure_thickness`` diagnostic, fall back to
-differencing ``pressure_half``), and the one that #710-era orientation bugs hid
-in. Synthetic Datasets keep the test GPU-free and model-free; ``tools/`` is
-outside the ``jcm`` coverage target, so this stays deliberately light.
+These are the two pieces with a real correctness choice: ``_layer_dp`` picks
+between the model's own ``pressure_thickness`` diagnostic and differencing
+``pressure_half``, and orients the result for both output conventions; and
+``burden`` has to find the cloud-borne phase under the namespace the writer
+actually emits. Synthetic Datasets keep the test GPU-free and model-free;
+``tools/`` is outside the ``jcm`` coverage target, so this stays deliberately
+light.
 """
 
 from __future__ import annotations
@@ -17,6 +19,7 @@ import xarray as xr
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import jam_burden_report as jbr  # noqa: E402
+import jcm.constants as c  # noqa: E402
 
 
 def _base_vars(dp_level):
@@ -65,3 +68,57 @@ def test_both_paths_agree():
         np.asarray(jbr._layer_dp(with_diag)),
         np.asarray(jbr._layer_dp(without)),
     )
+
+
+def test_pre_710_interfaces_are_reversed_to_match_level_fields():
+    """Pre-#710 files store interfaces TOA-first, ``level`` fields surface-first.
+
+    The Δp handed back must be on the ``level`` axis' orientation, so a
+    surface-heavy layer lines up with the boundary layer, not the stratosphere.
+    """
+    dp_level = np.array([300.0, 250.0, 150.0, 100.0])   # surface-first
+    ph_toa_first = np.concatenate([[0.0], np.cumsum(dp_level[::-1])])
+    ds = xr.Dataset({"pressure_half": (("time", "level_i"), ph_toa_first[None])})
+    np.testing.assert_allclose(np.asarray(jbr._layer_dp(ds)), dp_level[None])
+
+
+def test_post_710_interfaces_are_left_alone():
+    dp_level = np.array([300.0, 250.0, 150.0, 100.0])
+    ph_sfc_first = np.concatenate([[800.0], 800.0 - np.cumsum(dp_level)])
+    ds = xr.Dataset(
+        {"pressure_half": (("time", "level_i"), ph_sfc_first[None])},
+        coords={"level_i": ("level_i", np.linspace(1.0, 0.0, 5),
+                            {"positive": "down"})},
+    )
+    np.testing.assert_allclose(np.asarray(jbr._layer_dp(ds)), dp_level[None])
+
+
+def _two_phase_dataset():
+    """One layer, one column: interstitial 2 kg/kg + cloud-borne 3 kg/kg."""
+    return xr.Dataset(
+        {
+            "pressure_thickness": (("time", "level", "lat"),
+                                   np.full((1, 1, 1), float(c.grav))),
+            "m_so4_acc": (("time", "level", "lat"), np.full((1, 1, 1), 2.0)),
+            "jam_cloud_borne.mc_so4_acc": (("time", "level", "lat"),
+                                           np.full((1, 1, 1), 3.0)),
+        },
+        coords={"lat": [0.0]},
+    )
+
+
+def test_burden_includes_the_cloud_borne_namespace():
+    # dp/g = 1 kg/m² of air, so the burden is (2 + 3) kg/m² -> 5e6 mg/m².
+    col = jbr.burden(_two_phase_dataset(), "so4", ("acc",))
+    np.testing.assert_allclose(np.asarray(col), 5.0e6)
+
+
+def test_burden_omitting_cloud_borne_would_be_lower():
+    """Guards the regression: interstitial alone is a different number."""
+    ds = _two_phase_dataset().drop_vars("jam_cloud_borne.mc_so4_acc")
+    np.testing.assert_allclose(np.asarray(jbr.burden(ds, "so4", ("acc",))),
+                               2.0e6)
+
+
+def test_burden_is_none_without_tracers():
+    assert jbr.burden(_two_phase_dataset(), "du", ("acc",)) is None

--- a/tools/profile_terms.py
+++ b/tools/profile_terms.py
@@ -47,14 +47,13 @@ hidden:
 A third consequence is a hard ceiling on the window. The profiler's event
 buffer holds ~1e6 events and a T63L47 JAM step emits ~19,000 kernels, so ~20
 steps is all that fits at that resolution; past it the profiler stops recording
-and the averages silently come out low. The default window is ONE radiation
-sub-cycle for that reason — two sat on the ceiling and overflowed at
-ma-t63-l47, and since the window must also span a whole number of sub-cycles
-that left no usable default for the very configuration this tool is for. The
-tool fails rather than reports if the buffer overflows, naming the largest
-window that is both admissible and within the buffer. Nothing is lost by the short window: kernel shapes are static
-and the model takes no data-dependent branches, so a step's cost does not vary
-with the state.
+and the averages silently come out low. The window must also span a whole
+number of radiation sub-cycles, so the default is ONE sub-cycle: the largest
+window that satisfies both. The tool fails rather than reports if the buffer
+overflows, naming the largest window that is both admissible and within it.
+Nothing is lost by the short window: kernel shapes are static and the model
+takes no data-dependent branches, so a step's cost does not vary with the
+state.
 
 Methodology follows the ``jcm-benchmark`` skill: run only on a verified-free
 GPU, discard the compile pass, and quote steady state only.
@@ -798,23 +797,19 @@ def main(argv=None) -> int:
                    help="configuration to profile (shared with benchmark.py)")
     p.add_argument("--gpu", type=int, required=True,
                    help="GPU index; must be free (see tools/gpu_util.py)")
-    # Default: ONE radiation sub-cycle (10 steps at dt=12 min, 2 h radiation).
-    # Not a whole simulated day, though that is the intuitive choice, and not
-    # two sub-cycles, which was the previous default.
+    # Default: ONE radiation sub-cycle (10 steps at dt=12 min, 2 h radiation),
+    # not a whole simulated day, for two reasons.
     #
     # A longer window is not needed: every kernel in a step has a static shape
     # and the model takes no data-dependent branches, so a step's cost does not
     # vary with the state or the time of day. Once the window spans a whole
-    # number of radiation sub-cycles the per-step average is already exact, and
-    # further steps only reduce timing jitter.
+    # number of sub-cycles the per-step average is exact; further steps only
+    # reduce timing jitter.
     #
     # And it does not fit: the profiler's event buffer holds ~1e6 events and a
-    # T63L47 JAM step emits ~19,000 kernels, so ~20 steps is the ceiling at
-    # that resolution — which the old two-cycle default sat exactly on, so it
-    # overflowed on ma-t63-l47, the flagship config this tool exists for. With
-    # the whole-sub-cycle rule that left ``--steps 10`` as the only admissible
-    # value and made the default unusable. One sub-cycle is the largest window
-    # that is both admissible and reliably within the buffer.
+    # T63L47 JAM step emits ~19,000 kernels, so ~20 steps is the ceiling there.
+    # Since the window must also span a whole sub-cycle, one cycle is the
+    # largest window that is both admissible and reliably inside the buffer.
     p.add_argument("--cycles", type=int, default=1,
                    help="radiation sub-cycles to trace (default 1: the "
                         "largest window that fits the profiler's event buffer "

--- a/tools/profile_terms.py
+++ b/tools/profile_terms.py
@@ -4,7 +4,7 @@
 Usage::
 
     python tools/profile_terms.py --preset ma-t63-l47 --gpu 3
-    python tools/profile_terms.py --preset ma-t63-l47 --gpu 3 --cycles 4
+    python tools/profile_terms.py --preset ma-t63-l47 --gpu 3
     python tools/profile_terms.py --preset speedy-t31 --gpu 0 --outdir /tmp/p
 
 Writes ``report.md``, ``result.json`` and the raw trace to
@@ -47,9 +47,12 @@ hidden:
 A third consequence is a hard ceiling on the window. The profiler's event
 buffer holds ~1e6 events and a T63L47 JAM step emits ~19,000 kernels, so ~20
 steps is all that fits at that resolution; past it the profiler stops recording
-and the averages silently come out low. The default window is two radiation
-sub-cycles for that reason, and the tool fails rather than reports if the
-buffer overflows. Nothing is lost by the short window: kernel shapes are static
+and the averages silently come out low. The default window is ONE radiation
+sub-cycle for that reason — two sat on the ceiling and overflowed at
+ma-t63-l47, and since the window must also span a whole number of sub-cycles
+that left no usable default for the very configuration this tool is for. The
+tool fails rather than reports if the buffer overflows, naming the largest
+window that is both admissible and within the buffer. Nothing is lost by the short window: kernel shapes are static
 and the model takes no data-dependent branches, so a step's cost does not vary
 with the state.
 
@@ -755,12 +758,25 @@ def check_trace_completeness(steps_seen: dict[str, int], steps: int,
         )
     worst = min(seen.values())
     if worst < steps:
-        fits = max(cycle, worst // cycle * cycle)
+        # Name the largest window that is BOTH within the buffer and a whole
+        # number of sub-cycles -- the only kind the window gate will accept.
+        # Below one sub-cycle there is no such window, and suggesting one
+        # would send the user round the same failure again.
+        fits = worst // cycle * cycle
+        remedy = (
+            f"Profile a shorter window: --steps {fits} or fewer "
+            f"(a multiple of the {cycle}-step sub-cycle)."
+            if fits else
+            f"No admissible window fits: the buffer holds only {worst} steps "
+            f"but the window must span a whole {cycle}-step radiation "
+            "sub-cycle. Profile a cheaper configuration, or shorten the "
+            "sub-cycle with a smaller run.radiation_interval."
+        )
         raise SystemExit(
             f"the trace covers only {worst} of the {steps} steps run "
             f"({n_kernels} kernels captured; per-probe {seen}), so the "
             "profiler's event buffer overflowed and every number would be an "
-            f"undercount. Profile a shorter window: --steps {fits} or fewer."
+            f"undercount. {remedy}"
         )
 
 
@@ -782,22 +798,27 @@ def main(argv=None) -> int:
                    help="configuration to profile (shared with benchmark.py)")
     p.add_argument("--gpu", type=int, required=True,
                    help="GPU index; must be free (see tools/gpu_util.py)")
-    # Default: two radiation sub-cycles (20 steps at dt=12 min). Not a whole
-    # simulated day, though that is the intuitive choice, for two reasons.
+    # Default: ONE radiation sub-cycle (10 steps at dt=12 min, 2 h radiation).
+    # Not a whole simulated day, though that is the intuitive choice, and not
+    # two sub-cycles, which was the previous default.
     #
-    # It is not needed: every kernel in a step has a static shape and the model
-    # takes no data-dependent branches, so a step's cost does not vary with the
-    # state or the time of day. Once the window spans a whole number of
-    # radiation sub-cycles the per-step average is already exact, and further
-    # steps only reduce timing jitter.
+    # A longer window is not needed: every kernel in a step has a static shape
+    # and the model takes no data-dependent branches, so a step's cost does not
+    # vary with the state or the time of day. Once the window spans a whole
+    # number of radiation sub-cycles the per-step average is already exact, and
+    # further steps only reduce timing jitter.
     #
-    # And it does not fit: the profiler's event buffer holds ~1e6 events, and a
+    # And it does not fit: the profiler's event buffer holds ~1e6 events and a
     # T63L47 JAM step emits ~19,000 kernels, so ~20 steps is the ceiling at
-    # that resolution. A one-day (120-step) window silently recorded 20 steps
-    # and reported a 4x undercount. --days is still available for cheaper
-    # configurations; the run fails loudly if the buffer overflows.
-    p.add_argument("--cycles", type=int, default=2,
-                   help="radiation sub-cycles to trace (default 2)")
+    # that resolution — which the old two-cycle default sat exactly on, so it
+    # overflowed on ma-t63-l47, the flagship config this tool exists for. With
+    # the whole-sub-cycle rule that left ``--steps 10`` as the only admissible
+    # value and made the default unusable. One sub-cycle is the largest window
+    # that is both admissible and reliably within the buffer.
+    p.add_argument("--cycles", type=int, default=1,
+                   help="radiation sub-cycles to trace (default 1: the "
+                        "largest window that fits the profiler's event buffer "
+                        "at T63L47 JAM)")
     p.add_argument("--days", type=float, default=None,
                    help="simulated days to trace; overrides --cycles")
     p.add_argument("--steps", type=int, default=None,

--- a/tools/profile_terms_test.py
+++ b/tools/profile_terms_test.py
@@ -9,6 +9,7 @@ trace events, so it needs neither a GPU nor a model.
 from __future__ import annotations
 
 import pathlib
+import re
 import sys
 
 import pytest
@@ -467,3 +468,43 @@ def test_completeness_rejects_a_short_trace_when_all_probes_are_present():
 def test_completeness_accepts_a_full_trace():
     """Every probe present at the full step count passes silently."""
     assert pt.check_trace_completeness(_full(20), 20, 12345, cycle=10) is None
+
+
+def test_default_window_is_one_sub_cycle():
+    """The shipped default must be admissible on the flagship config.
+
+    ``ma-t63-l47`` runs dt=12 min with 2 h radiation, so a sub-cycle is 10
+    steps and the profiler's buffer holds about 20. The old two-cycle default
+    sat exactly on that ceiling and overflowed, and because the window must
+    also span a whole sub-cycle, ``--steps 10`` was the only admissible value —
+    i.e. the default was unusable for the configuration the tool exists for.
+    """
+    src = pathlib.Path(pt.__file__).read_text()
+    match = re.search(r'"--cycles",\s*type=int,\s*default=(\d+)', src)
+    assert match, "--cycles default not found"
+    assert int(match.group(1)) == 1
+
+
+def test_default_window_fits_the_event_buffer_at_t63l47():
+    """One sub-cycle at T63L47 stays inside the ~1e6-event buffer."""
+    steps = 1 * 10                      # --cycles 1 x 10-step sub-cycle
+    assert steps * 19_000 < 1_000_000
+
+
+def test_completeness_says_so_when_no_admissible_window_fits():
+    """Below one sub-cycle there is no shorter window to suggest.
+
+    Rounding down to a multiple of the sub-cycle gives zero, and naming
+    ``--steps 0`` (or the old ``max(cycle, ...)``, which is longer than what
+    fitted) would send the user round the same failure again.
+    """
+    from jcm import profiling
+
+    seen = _full(20)
+    seen[profiling.DYNAMICS] = 4        # fewer steps than one 10-step cycle
+    with pytest.raises(SystemExit) as e:
+        pt.check_trace_completeness(seen, 20, 12345, cycle=10)
+    msg = str(e.value)
+    assert "No admissible window fits" in msg
+    assert "radiation_interval" in msg
+    assert "--steps 0" not in msg

--- a/tools/release_validation/README.md
+++ b/tools/release_validation/README.md
@@ -52,11 +52,52 @@ scores the settled ~200 days of a from-zero spin-up year (full spin-up is
 dialects. Post the table to the release issue; compare settled sim-days/hr
 against the baselines in #638 (>15% drop = runtime regression).
 
+### The JAM aerosol block
+
+On a run whose saved variables show JAM is composed (modal mass tracers
+plus a `jam_*` diagnostic namespace), `health.py` adds the statistics from
+`aerosol_stats.py` — also runnable on its own:
+
+```bash
+python tools/release_validation/aerosol_stats.py $SCRATCH/jam_runs/mx_<member>_<tag>
+```
+
+It reduces each chunk file separately (a JAM year is ~60 GB and must never
+be opened as one array, so budget ~40 min for a full T63 L47 year;
+`--series-out` saves the reduction and `--series-in` re-scores it without
+re-reading the run) and reports per-species burdens including the
+cloud-borne phase, their logarithmic drift over the final six months,
+lifetimes, the mass-budget residual, sulfate's upper-level and hemispheric
+distribution, AOD/Ångström, near-surface CDNC and N100, and the modal dry
+radii. Three of those are **absolute gates**, not climatological ranges:
+`|d ln B/dt| < 0.002 /day`, `|budget residual| < 5 %`, and the per-step
+dynamics residual `budget_dyn/mass < 0.1 %/step` from the #713 in-step gauge
+(unscored on output that predates it, or in a run directory with no saved
+Hydra config to read the timestep from). They exist
+because an aerosol runaway (#658) stays inside a ×3-slack range gate until
+its final fortnight — the drift statistic is what sees it coming, and the
+residual says whether the cause is a source or a sink.
+
+The residual's **sign** matters. Negative (more deposited than entered) is
+mass creation and cannot be explained away. Positive (emitted mass
+unaccounted for) is what a missing sink *diagnostic* also looks like, and on
+output written before the #722 removal-ledger fix `dry_*` omits Slinn dry
+deposition entirely — so the gate names that caveat instead of calling it a
+leak. The drift gate reads burdens only and is unaffected either way.
+
+The dynamics gate answers a different question from both: whether the
+*transport* conserved mass. The August-2026 runaway was semi-Lagrangian
+non-conservation, not aerosol physics — see the design doc.
+
+Non-JAM members skip the block. Rationale and the regression tolerance tiers:
+`docs/source/design/jam_regression.md`.
+
 Lean by construction: `matrix.yaml` members reference the validated
 preset table in `tools/benchmark.py` (`PRESETS` — the single home of
 known-good override sets), `health.py`'s burden gates derive from
 `tools/jam_burden_report.py`'s shared species/anchor table (anchor
-range × slack 3), and per-grid inputs resolve automatically
-(`terrain=auto`, `forcing.ozone_file=auto` fall back to the mirror).
+range × slack 3) applied to `aerosol_stats.py`'s annual means, and
+per-grid inputs resolve automatically (`terrain=auto`,
+`forcing.ozone_file=auto`), prefetched at submit time by `launch.py`.
 SPEEDY profile facts (default run group + init; the longrun sponge
 spans the whole L8 atmosphere) live with its preset in benchmark.py.

--- a/tools/release_validation/README.md
+++ b/tools/release_validation/README.md
@@ -71,9 +71,8 @@ lifetimes, the mass-budget residual, sulfate's upper-level and hemispheric
 distribution, AOD/Ångström, near-surface CDNC and N100, and the modal dry
 radii. Three of those are **absolute gates**, not climatological ranges:
 `|d ln B/dt| < 0.002 /day`, `|budget residual| < 5 %`, and the per-step
-dynamics residual `budget_dyn/mass < 0.1 %/step` from the #713 in-step gauge
-(unscored on output that predates it, or in a run directory with no saved
-Hydra config to read the timestep from). They exist
+dynamics residual `budget_dyn/mass < 0.1 %/step` from the #713 in-step gauge.
+They exist
 because an aerosol runaway (#658) stays inside a ×3-slack range gate until
 its final fortnight — the drift statistic is what sees it coming, and the
 residual says whether the cause is a source or a sink.
@@ -86,8 +85,16 @@ deposition entirely — so the gate names that caveat instead of calling it a
 leak. The drift gate reads burdens only and is unaffected either way.
 
 The dynamics gate answers a different question from both: whether the
-*transport* conserved mass. The August-2026 runaway was semi-Lagrangian
-non-conservation, not aerosol physics — see the design doc.
+*transport* conserved mass. The runaway that motivated these gates was
+semi-Lagrangian non-conservation, not aerosol physics — see the design doc.
+
+**Nothing passes by absence.** The drift and closure statistics need a window
+of at least 90 days (below that a fitted slope is its own noise), the dynamics
+gate needs both the gauge and a timestep, and a species the run does not carry
+has no burden to score. Every one of those is printed as `UNSCORED` with its
+reason and counted in the summary line, because a missing row would otherwise
+be indistinguishable from one that passed. Use `--last-n` to pick the settled
+months, not to shrink the window below the floor.
 
 Non-JAM members skip the block. Rationale and the regression tolerance tiers:
 `docs/source/design/jam_regression.md`.

--- a/tools/release_validation/README.md
+++ b/tools/release_validation/README.md
@@ -96,6 +96,15 @@ reason and counted in the summary line, because a missing row would otherwise
 be indistinguishable from one that passed. Use `--last-n` to pick the settled
 months, not to shrink the window below the floor.
 
+**An UNSCORED gate does not fail the exit code, by design.** The commonest
+causes are the user's own `--last-n` and a species the configuration does not
+carry, and failing those would make the tool unusable for the windows it is
+documented to support — so the report names them and the exit status ignores
+them. The one exception: scoring *nothing at all* exits non-zero, because a
+report that measured nothing has not passed anything and a harness reading only
+the return code would otherwise see success. A release gate that wants a
+stricter rule should read the `UNSCORED` lines, which is what they are for.
+
 Non-JAM members skip the block. Rationale and the regression tolerance tiers:
 `docs/source/design/jam_regression.md`.
 

--- a/tools/release_validation/aerosol_stats.py
+++ b/tools/release_validation/aerosol_stats.py
@@ -6,11 +6,10 @@ release gate can score, and applies the two tolerance tiers described in
 
 * **absolute physics gates** — the exponential drift ``|d ln B/dt|`` of every
   species' burden over the final six months, the mass-budget residual, and the
-  per-step dynamics residual from the #713 in-step gauge.
-  These are the runaway detector: the August-2026 T63 L47 year grew sulfate
-  13 -> 771 mg/m2 in its last forty days while temperature and surface
-  pressure stayed flat, and a climatological range gate with x3 slack only
-  notices that in the final fortnight.
+  per-step dynamics residual from the #713 in-step gauge. These are the runaway
+  detector: an aerosol runaway grows multiplicatively with the meteorology
+  entirely normal, so a climatological range gate does not notice it until the
+  final fortnight of a year that was unusable months earlier.
 * **climatological anchors** — the shared ``jam_burden_report._SPECIES``
   ranges widened by the release gate's slack, unchanged.
 * **regression tolerances** — ``max(3 sigma, 15 %)`` against a reference run
@@ -72,12 +71,13 @@ LIFETIME_SPECIES = ("so4", "bc", "du", "ss")
 PRIMARY_BUDGET_SPECIES = ("bc", "du", "ss", "poa")
 
 #: Kilograms of sulfate AEROSOL per kilogram of each sulfur carrier, so the
-#: whole family can be totalled in one mass unit. jcm's ``so4`` tracer is
-#: ammonium bisulfate NH4HSO4 at 115.0 g/mol (``jam/species.py``) — not SO4 at
-#: 96.06 — so converting SO2 (64.06) and DMS (62.13) emissions with the sulfate
-#: molar mass instead understates the source by 20 % and turns a modest closure
-#: error into an apparent leak.
-_M_SO4_AEROSOL = 0.115
+#: whole family can be totalled in one mass unit. Read from jcm's own species
+#: table rather than restated: the ``so4`` tracer is ammonium bisulfate, not
+#: SO4, and converting SO2/DMS emissions with the SO4 molar mass instead
+#: understates the sulfate source by 20 %.
+from jcm.physics.aerosol.jam.species import SPECIES as _JAM_SPECIES  # noqa: E402
+
+_M_SO4_AEROSOL = _JAM_SPECIES["so4"].molar_mass
 _SULFUR_CARRIERS = {"so2": _M_SO4_AEROSOL / 0.0640648,     # 1.795
                     "dms": _M_SO4_AEROSOL / 0.0621324,     # 1.851
                     "h2so4": _M_SO4_AEROSOL / 0.0980784,   # 1.172
@@ -89,35 +89,40 @@ _S_FAMILY_GASES = ("so2", "dms", "h2so4")
 _S_FAMILY_EMIS = ("so2", "dms", "so4")
 
 #: Dynamics-conservation gate. ``budget_dyn_<sp>`` (#713) is the mass the
-#: transport machinery created or destroyed per step, so ``|dyn|*dt/mass`` is
-#: the fractional error the semi-Lagrangian advection commits each step. Its
-#: honest magnitude is O(1e-3) per step and one-signed under a strong sink,
-#: which is how it compounded into the August-2026 runaway; 0.1 %/step is
-#: therefore set AT that magnitude, to trip on a transport error that has
-#: become systematic rather than on ordinary interpolation noise. It is also
-#: ~500x tighter than the [2/3, 1.5] clip on dev's proportional mass fixer,
-#: so the gate fires long before the fixer saturates.
+#: transport created or destroyed per step, so ``|dyn|*dt/mass`` is the
+#: fractional error semi-Lagrangian advection commits each step. Set AT that
+#: error's honest magnitude, so it trips on a transport error that has become
+#: systematic rather than on ordinary interpolation noise, and ~500x tighter
+#: than the [2/3, 1.5] clip on the proportional mass fixer.
 DYN_RESIDUAL_PER_STEP = 1.0e-3
 
-#: Absolute physics gates (see the design doc). The drift limit is set so a
-#: burden may change by a factor e over the ~500 days it takes to matter, but
-#: not by the factor 60 in 40 days a #658-class runaway produces. The drift
-#: statistic reads burdens only, so it is independent of the deposition ledger
-#: and is the gate to trust when the ledger is incomplete.
+#: Absolute physics gates (see the design doc). The drift limit admits a
+#: factor e over ~500 days — slower than any runaway, faster than a burden that
+#: has genuinely settled. It reads burdens only, so it stays trustworthy when
+#: the deposition ledger is incomplete.
 DRIFT_LIMIT_PER_DAY = 0.002
 BUDGET_RESIDUAL_LIMIT = 0.05
 
-#: The closure gate's sign carries information, and the two directions have
-#: different diagnoses. A NEGATIVE residual means more mass was deposited than
-#: entered the column: no missing ledger entry can produce that, so it is mass
-#: creation. A POSITIVE one means emitted mass is unaccounted for, which a
-#: *missing sink diagnostic* looks exactly like — and on output written before
-#: the #722 removal-ledger fix, ``dry_*`` omits the Slinn turbulent/Brownian
-#: deposition entirely (it captures only ~31 % of the dust dry sink), so a
-#: positive residual on such a run is expected and is not evidence of a leak.
+#: The closure gate's sign carries the diagnosis. NEGATIVE means more mass was
+#: deposited than entered the column, which no missing ledger entry can produce
+#: — it is mass creation. POSITIVE means emitted mass is unaccounted for, which
+#: a missing sink *diagnostic* looks exactly like: before the #722 ledger fix
+#: ``dry_*`` omits Slinn deposition, so a positive residual on such output is
+#: expected rather than evidence of a leak.
 _POSITIVE_RESIDUAL_CAVEAT = (
     "unaccounted emission; on output written before the #722 removal-ledger "
     "fix, dry_* omits Slinn dry deposition and reads positive by construction")
+
+#: Shortest window on which the drift and closure statistics are scored. A
+#: least-squares slope has noise ``sigma_resid / (dt * sqrt(N(N^2-1)/12))``; at
+#: the 5-day output cadence and the ~0.07 log-burden scatter of a settled
+#: species, 3 sigma of that falls below ``DRIFT_LIMIT_PER_DAY`` only past ~90
+#: days. On a shorter fit the statistic is noise, so it is reported UNSCORED
+#: rather than gated — the same "not measurable is not scored" rule the drift
+#: statistic already applies to a species the run does not carry. The closure
+#: residual shares the limit: its storage term is one endpoint difference, which
+#: over a few chunks swamps the flux integral it is compared against.
+MIN_WINDOW_DAYS = 90.0
 
 #: Regression tolerance: whichever of a 3-sigma excursion and a 15 % relative
 #: change is larger. 3 sigma alone is far too tight for a well-sampled mean
@@ -125,6 +130,27 @@ _POSITIVE_RESIDUAL_CAVEAT = (
 #: through on a noisy statistic.
 _N_SIGMA = 3.0
 _REL_TOLERANCE = 0.15
+
+#: Statistics the regression tier does NOT score: each has an absolute physics
+#: gate of its own, and their references are ~1e-3, so a 15 % relative
+#: tolerance would be tighter than the gate and fail every real run.
+_GATED_PREFIXES = ("dlnB_dt_", "budget_residual", "dyn_frac_per_step_")
+
+#: Absolute tolerance floors [statistic units], so a reference that is legibly
+#: zero (an unused species' burden) does not collapse the tolerance to zero and
+#: fail on any nonzero value. Matched by prefix, longest first.
+_TOLERANCE_FLOORS = {
+    "burden_": 0.05,            # mg/m2
+    "so4_burden_": 0.05,        # mg/m2
+    "lifetime_": 0.1,           # days
+    "aod_550": 0.002,
+    "angstrom": 0.02,
+    "cdnc_": 1.0,               # cm-3
+    "N100_": 1.0,               # cm-3
+    "r_dry_": 0.001,            # um
+    "so4_frac_above_500hPa": 0.01,
+    "so4_nh_sh_ratio": 0.05,
+}
 
 #: Pressure [Pa] used for the near-surface aerosol-number diagnostics, and the
 #: divide separating the free troposphere reservoir from the boundary layer.
@@ -140,16 +166,32 @@ def is_jam_run(ds: xr.Dataset) -> bool:
     """Report whether ``ds`` carries JAM's prognostic modal aerosol tracers.
 
     Detected from the variables present rather than from a config file, so a
-    run directory alone is enough. Requires an interstitial mass tracer *and*
-    a JAM-specific diagnostic namespace, so a MACv2-SP run (which publishes
-    AOD but no ``m_<sp>_<mode>``) is not mistaken for one.
+    run directory alone is enough. The test is the interstitial mass tracers
+    alone: they are what every statistic here is built from, and a MACv2-SP run
+    (which publishes AOD but no ``m_<sp>_<mode>``) has none. Requiring a
+    ``jam_*`` diagnostic namespace as well would let a JAM run with a trimmed
+    output set skip the aerosol gates silently, which is the one outcome this
+    block exists to prevent — a trimmed run is a misconfiguration to name (see
+    :func:`missing_jam_diagnostics`), not a reason to skip.
     """
-    has_mass = any(re.fullmatch(r"m_[a-z0-9]+_[a-z]+", str(v))
-                   for v in ds.data_vars)
-    has_jam = any(str(v).startswith(("jam_state.", "jam_cloud_borne.",
-                                     "jam_optics.", "jam_band_optics."))
-                  for v in ds.data_vars)
-    return has_mass and has_jam
+    return any(re.fullmatch(r"m_[a-z0-9]+_[a-z]+", str(v))
+               for v in ds.data_vars)
+
+
+def missing_jam_diagnostics(ds: xr.Dataset) -> list[str]:
+    """JAM diagnostic namespaces absent from a run that carries JAM tracers.
+
+    Their absence does not stop the burdens being computed, but it does silently
+    drop the cloud-borne phase, the optics and the modal radii from the report,
+    so it is named rather than left to be inferred from missing rows.
+    """
+    present = {str(v).split(".", 1)[0] for v in ds.data_vars if "." in str(v)}
+    wanted = ("jam_cloud_borne", "jam_state")
+    optics = ("jam_optics", "jam_band_optics")
+    missing = [n for n in wanted if n not in present]
+    if not any(n in present for n in optics):
+        missing.append("/".join(optics))
+    return missing
 
 
 def _band_indices(ds: xr.Dataset, lo: float, hi: float) -> np.ndarray:
@@ -336,9 +378,21 @@ def standard_error(values: np.ndarray) -> float:
     return float(np.std(v, ddof=1) / np.sqrt(n_eff))
 
 
-def regression_tolerance(reference: float, sigma: float) -> float:
-    """``max(3 sigma, 15 % of the reference)`` — see the design doc."""
-    return max(_N_SIGMA * sigma, _REL_TOLERANCE * abs(reference))
+def tolerance_floor(name: str) -> float:
+    """Absolute tolerance floor for a statistic, by longest matching prefix."""
+    matches = [v for k, v in _TOLERANCE_FLOORS.items() if name.startswith(k)]
+    return max(matches) if matches else 0.0
+
+
+def regression_tolerance(reference: float, sigma: float,
+                         floor: float = 0.0) -> float:
+    """``max(3 sigma, 15 % of the reference, an absolute floor)``.
+
+    The floor is what keeps a legitimately-zero reference — an unused species'
+    burden — from collapsing the tolerance to zero and failing on any nonzero
+    value. See the design doc.
+    """
+    return max(_N_SIGMA * sigma, _REL_TOLERANCE * abs(reference), floor)
 
 
 def _budget_residual(days, series, species) -> float | None:
@@ -356,12 +410,10 @@ def _budget_residual(days, series, species) -> float | None:
         return None
 
     def integral(key):
-        # The storage term is a difference between the FIRST and LAST chunk
-        # means, i.e. between chunk centres, so the flux integral must cover
-        # that same interval: the chunks after the first, times the span
-        # between the centres. Averaging all N chunks over an (N-1)-chunk span
-        # understates the integral by 1/N — 1.4 % on a 73-chunk year, but 25 %
-        # on a four-chunk window, straight into a residual gated at 5 %.
+        # The storage term differences the first and last chunk MEANS, i.e.
+        # chunk centres, so the flux integral spans the same interval: the
+        # chunks after the first, times the centre-to-centre span. Averaging
+        # all N chunks over an (N-1)-chunk span understates it by 1/N.
         v = series.get(key)
         return None if v is None else float(np.nanmean(v[1:])) * span * 86400e6
 
@@ -393,7 +445,13 @@ def _budget_residual(days, series, species) -> float | None:
             deposited += contribution
     if not np.isfinite(emitted) or emitted <= 0:
         return None
-    return float((emitted - deposited - (stored[-1] - stored[0])) / emitted)
+    residual = float((emitted - deposited - (stored[-1] - stored[0])) / emitted)
+    # The storage endpoints are as capable of being NaN as the emission was: a
+    # chunk missing a burden or a gas reservoir poisons the difference. A NaN
+    # here would score as a gate FAIL for something never measured, and would
+    # win ``max(..., key=abs)`` too, since every comparison against NaN is
+    # False.
+    return residual if np.isfinite(residual) else None
 
 
 def summarize(days: np.ndarray, series: dict[str, np.ndarray],
@@ -411,14 +469,13 @@ def summarize(days: np.ndarray, series: dict[str, np.ndarray],
         if b is None:
             continue
         stats[f"burden_{species}_mg_m2"] = float(np.nanmean(b))
-        # Emit the drift only when it could actually be fitted. A species the
-        # run never carries (soa with no SOAG production) and a record too
-        # short for a slope both yield NaN, and a NaN scored against the gate
-        # reads as a FAIL for something that was never measured — which is how
-        # ``health.py --last-n 2`` on a healthy run reported an aerosol
-        # failure. Not measurable is "not scored", not "failed".
+        # Emit the drift only where it is measurable: a species the run does
+        # not carry yields NaN, and a window shorter than MIN_WINDOW_DAYS
+        # yields a slope dominated by its own noise. Both are reported
+        # unscored (see :func:`unscored_gates`) rather than gated, because a
+        # gate FAIL for something never measured is worse than no number.
         drift = log_drift(days, b)
-        if np.isfinite(drift):
+        if np.isfinite(drift) and span_days >= MIN_WINDOW_DAYS:
             stats[f"dlnB_dt_{species}_per_day"] = drift
 
     for species in LIFETIME_SPECIES:
@@ -438,7 +495,8 @@ def summarize(days: np.ndarray, series: dict[str, np.ndarray],
 
     residuals = {}
     for species in ("so4",) + PRIMARY_BUDGET_SPECIES:
-        r = _budget_residual(days, series, species)
+        r = (_budget_residual(days, series, species)
+             if span_days >= MIN_WINDOW_DAYS else None)
         if r is not None:
             residuals[species] = r
             stats[f"budget_residual_{species}"] = r
@@ -518,6 +576,11 @@ def compare_to_reference(stats: dict[str, float],
     for key in sorted(reference):
         if key not in stats or key == "record_days":
             continue
+        # Statistics with an absolute physics gate are not scored here too:
+        # their references are ~1e-3, so a relative tolerance would be tighter
+        # than their own gate.
+        if key.startswith(_GATED_PREFIXES):
+            continue
         value, ref = stats[key], reference[key]
         sigma = 0.0
         if series is not None:
@@ -526,9 +589,52 @@ def compare_to_reference(stats: dict[str, float],
                 if candidate in series:
                     sigma = standard_error(series[candidate])
                     break
-        tol = regression_tolerance(ref, sigma)
+        tol = regression_tolerance(ref, sigma, tolerance_floor(key))
         ok = abs(value - ref) <= tol
         rows.append((key, value, f"{ref:.5g} +- {tol:.3g}", bool(ok)))
+    return rows
+
+
+def unscored_gates(days: np.ndarray, series: dict[str, np.ndarray],
+                   timestep_seconds: float | None = None
+                   ) -> list[tuple[str, str]]:
+    """Gates that could NOT be evaluated, each with the reason.
+
+    A gate that is absent from :func:`physics_gates` has passed nothing — it
+    was never run. Reporting the absence is what stops a run with no dynamics
+    gauge, or a window too short to fit a slope, from reading as clean.
+    Returns ``(gate_name, reason)`` pairs for the caller to print.
+    """
+    span = float(days[-1] - days[0]) if days.size > 1 else 0.0
+    short_slope = (f"window spans {span:.0f} days; a slope needs "
+                   f"{MIN_WINDOW_DAYS:.0f} to rise above its own fit noise")
+    short_budget = (f"window spans {span:.0f} days; the storage endpoints "
+                    f"swamp the flux integral below {MIN_WINDOW_DAYS:.0f}")
+    rows: list[tuple[str, str]] = []
+
+    for species in _SPECIES:
+        b = series.get(f"burden_{species}")
+        if b is None:
+            continue
+        name = f"dlnB_dt_{species}_per_day"
+        if not np.any(np.isfinite(b) & (b > 0)):
+            rows.append((name, "the run carries no burden of this species"))
+        elif span < MIN_WINDOW_DAYS:
+            rows.append((name, short_slope))
+
+    if span < MIN_WINDOW_DAYS:
+        rows.append(("budget_residual_max", short_budget))
+
+    # The dynamics gate needs BOTH the #713 in-step gauge and a timestep to
+    # express it per step; say which is missing rather than omitting the row.
+    has_gauge = any(k.startswith("budget_dyn_") for k in series)
+    if not has_gauge:
+        rows.append(("dyn_frac_per_step", "the run publishes no budget_dyn_* "
+                                          "gauge (output predates #713)"))
+    elif not timestep_seconds:
+        rows.append(("dyn_frac_per_step", "no run timestep is available "
+                     "(.hydra/config.yaml absent, or run.time_step is null as "
+                     "on the pySES backend), and the gate is per step"))
     return rows
 
 
@@ -608,6 +714,11 @@ def main() -> int:
         loaded = np.load(args.series_in)
         days = loaded["_days"]
         series = {k: loaded[k] for k in loaded.files if k != "_days"}
+        if args.last_n:
+            # Applied here too: silently ignoring it would score a different
+            # window than the one asked for.
+            days = days[-args.last_n:]
+            series = {k: v[-args.last_n:] for k, v in series.items()}
     else:
         files = run_files(args.run_dir)
         if not files:
@@ -620,11 +731,11 @@ def main() -> int:
         np.savez(args.series_out, _days=days, **series)
     dt = timestep_seconds(args.run_dir) if args.run_dir else None
     stats = summarize(days, series, dt)
-    if dt is None:
-        print("NOTE  no .hydra/config.yaml timestep — the dynamics-"
-              "conservation gate is not scored\n")
     gates = physics_gates(stats)
     print(format_table(stats, gates))
+    unscored = unscored_gates(days, series, dt)
+    for name, reason in unscored:
+        print(f"UNSCORED  {name}: {reason}")
     ok = all(row[3] for row in gates)
 
     if args.reference:
@@ -640,7 +751,10 @@ def main() -> int:
                   f"{'PASS' if good else 'FAIL'}")
         ok = ok and all(row[3] for row in rows)
 
-    print("\nAEROSOL:", "PASS" if ok else "FAIL")
+    # Say how much was actually measured: a PASS over zero scored gates is
+    # not the same result as a PASS over all of them.
+    print(f"\nAEROSOL: {'PASS' if ok else 'FAIL'} "
+          f"({len(gates)} gate(s) scored, {len(unscored)} unscored)")
     return 0 if ok else 1
 
 

--- a/tools/release_validation/aerosol_stats.py
+++ b/tools/release_validation/aerosol_stats.py
@@ -162,6 +162,25 @@ _ANGSTROM_KEYS = ("jam_optics.angstrom", "jam_band_optics.angstrom",
                   "ang4487aer")
 
 
+#: ``np.trapezoid`` is numpy >= 2.0; ``np.trapz`` is its pre-2.0 spelling.
+#: numpy is unpinned in requirements.txt, so accept either.
+_trapezoid = getattr(np, "trapezoid", None) or np.trapz
+
+
+def chunk_centres(days: np.ndarray) -> np.ndarray:
+    """Mid-times of the averaging windows whose labels are ``days``.
+
+    Output chunks are labelled by their END day and hold time *averages*, so a
+    chunk mean belongs at the window's centre. The first window is taken to
+    start at day 0, each later one at its predecessor's label. Under a uniform
+    cadence this is a constant offset that cancels in both the trapezoid and
+    the storage difference; under a varying one it does not.
+    """
+    days = np.asarray(days, dtype=float)
+    starts = np.concatenate([[0.0], days[:-1]])
+    return 0.5 * (starts + days)
+
+
 def is_jam_run(ds: xr.Dataset) -> bool:
     """Report whether ``ds`` carries JAM's prognostic modal aerosol tracers.
 
@@ -411,18 +430,22 @@ def _budget_residual(days, series, species) -> float | None:
     if span <= 0 or days.size < 2:
         return None
 
+    nodes = chunk_centres(days)
+
     def integral(key):
-        # Trapezoidal against ``days``, between the first and last chunk
-        # MEANS — the same two endpoints the storage term differences. The
-        # samples are chunk means attributable to their own window, so a
-        # right-endpoint rectangle rule (dropping the first sample) is short
-        # by half a chunk times the endpoint change: on a 90-day window a
-        # seasonal swing in the sink can exceed the closure threshold on that
-        # alone. Trapezoid also handles a non-uniform chunk cadence.
+        # Trapezoidal between the first and last chunk MEANS — the same two
+        # endpoints the storage term differences. A right-endpoint rectangle
+        # rule (dropping the first sample) integrates a half-chunk-shifted
+        # window instead, short by half a chunk times the endpoint change: on
+        # a 90-day window a seasonal swing in the sink can exceed the closure
+        # threshold on that alone. The abscissa is chunk CENTRES, which is
+        # where a chunk mean belongs; under a uniform cadence the offset from
+        # the filename's end-of-chunk day cancels, but under a varying one it
+        # does not, and only the centres put the nodes in the right places.
         v = series.get(key)
         if v is None or not np.all(np.isfinite(v)):
             return None
-        return float(np.trapezoid(v, days)) * 86400e6
+        return float(_trapezoid(v, nodes)) * 86400e6
 
     # EVERY component is required. A missing ledger field is not a zero
     # contribution: treating it as one fabricates a residual and then gates
@@ -589,17 +612,18 @@ def compare_to_reference(stats: dict[str, float],
     for key in sorted(reference):
         if key == "record_days":
             continue
+        # The exemption comes FIRST. These carry their own absolute gates, and
+        # ``summarize`` omits them precisely when they could not be measured —
+        # so scoring their absence here would hard-fail a run for a gate it has
+        # already, correctly, reported as UNSCORED.
+        if key.startswith(_GATED_PREFIXES):
+            continue
         if key not in stats:
             # The reference has it and this run does not: the diagnostic was
             # removed. Skipping would report PASS for the regression that
             # deleted the very statistic being compared.
             rows.append((key, float("nan"),
                          f"{reference[key]:.5g} (absent from this run)", False))
-            continue
-        # Statistics with an absolute physics gate are not scored here too:
-        # their references are ~1e-3, so a relative tolerance would be tighter
-        # than their own gate.
-        if key.startswith(_GATED_PREFIXES):
             continue
         value, ref = stats[key], reference[key]
         sigma = 0.0
@@ -635,6 +659,10 @@ def unscored_gates(days: np.ndarray, series: dict[str, np.ndarray],
     for species in _SPECIES:
         b = series.get(f"burden_{species}")
         if b is None:
+            # No tracers for it at all. Reported here so the standalone
+            # scorer says what health.py says.
+            rows.append((f"burden_{species}_mg_m2",
+                         "the output carries no mass tracers for this species"))
             continue
         name = f"dlnB_dt_{species}_per_day"
         if not np.any(np.isfinite(b) & (b > 0)):
@@ -703,7 +731,10 @@ def anchor_gates(stats: dict[str, float]) -> list[tuple[str, float, str, bool]]:
     for species, (lo, hi) in BURDEN_RANGES.items():
         key = f"burden_{species}_mg_m2"
         value = stats.get(key)
-        if value is None or value == 0.0:
+        # A NaN burden would score FAIL through ``lo <= nan <= hi`` being
+        # False — a gate failure for something never measured, the mirror of
+        # the case the closure residual already guards.
+        if value is None or value == 0.0 or not np.isfinite(value):
             continue
         rows.append((key, value, f"[{lo:g}, {hi:g}]", bool(lo <= value <= hi)))
     return rows
@@ -833,12 +864,26 @@ def main() -> int:
     unscored = unscored_gates(days, series, dt)
     for name, reason in unscored:
         print(f"UNSCORED  {name}: {reason}")
-    ok = all(row[3] for row in gates)
+    # An individual UNSCORED gate is deliberately NOT a failure: the commonest
+    # cause is the user's own ``--last-n``, or a species the configuration does
+    # not carry, and failing those would make the tool unusable for the windows
+    # it is documented to support. Scoring NOTHING is different — a report that
+    # measured nothing has not passed anything, and a harness reading only the
+    # exit code would otherwise see success.
+    ok = bool(gates) and all(row[3] for row in gates)
 
     if args.reference:
         loaded = np.load(args.reference)
-        ref_series = {k: loaded[k] for k in loaded.files if k != "_days"}
-        ref = summarize(loaded["_days"], ref_series)
+        # Same metadata filter as the --series-in path: underscore keys belong
+        # to the reduction, not to the statistics. The reference's own
+        # timestep is used so its dynamics gates are built the same way.
+        ref_series = {k: loaded[k] for k in loaded.files
+                      if not k.startswith("_")}
+        ref_dt = None
+        if "_timestep_seconds" in loaded.files:
+            stored = float(loaded["_timestep_seconds"])
+            ref_dt = stored if np.isfinite(stored) and stored > 0 else None
+        ref = summarize(loaded["_days"], ref_series, ref_dt)
         rows = compare_to_reference(stats, ref, series)
         print(f"\n{'regression vs reference':<34}{'value':>14}  "
               f"{'expected':<24}result")

--- a/tools/release_validation/aerosol_stats.py
+++ b/tools/release_validation/aerosol_stats.py
@@ -398,9 +398,11 @@ def regression_tolerance(reference: float, sigma: float,
 def _budget_residual(days, series, species) -> float | None:
     """Compute ``(emitted - deposited - dB) / emitted`` over the record.
 
-    The fluxes are chunk means of ``kg/m2/s``, so their record mean times the
-    record length is the time integral; ``dB`` is the change in the chunk-mean
-    burden between the first and last chunk. For sulfate the ledger is the
+    The fluxes are chunk means of ``kg/m2/s``, integrated trapezoidally over
+    ``days`` between the first and last chunk means; ``dB`` differences the
+    chunk-mean burden at those same two endpoints. Every component must be
+    present: a missing one returns ``None`` (reported unscored) rather than
+    counting as zero. For sulfate the ledger is the
     whole sulfur family in SO4-equivalent mass (SO2 and DMS emissions are the
     real sulfate source; ``emi_so4`` alone is a few per cent of it), and the
     stored mass includes the gas-phase reservoirs.
@@ -410,13 +412,22 @@ def _budget_residual(days, series, species) -> float | None:
         return None
 
     def integral(key):
-        # The storage term differences the first and last chunk MEANS, i.e.
-        # chunk centres, so the flux integral spans the same interval: the
-        # chunks after the first, times the centre-to-centre span. Averaging
-        # all N chunks over an (N-1)-chunk span understates it by 1/N.
+        # Trapezoidal against ``days``, between the first and last chunk
+        # MEANS — the same two endpoints the storage term differences. The
+        # samples are chunk means attributable to their own window, so a
+        # right-endpoint rectangle rule (dropping the first sample) is short
+        # by half a chunk times the endpoint change: on a 90-day window a
+        # seasonal swing in the sink can exceed the closure threshold on that
+        # alone. Trapezoid also handles a non-uniform chunk cadence.
         v = series.get(key)
-        return None if v is None else float(np.nanmean(v[1:])) * span * 86400e6
+        if v is None or not np.all(np.isfinite(v)):
+            return None
+        return float(np.trapezoid(v, days)) * 86400e6
 
+    # EVERY component is required. A missing ledger field is not a zero
+    # contribution: treating it as one fabricates a residual and then gates
+    # it, which is a false pass or a false failure rather than the "unscored"
+    # the caller would get from None.
     if species == "so4":
         # Every carrier converted to sulfate-AEROSOL mass, the unit the
         # burden and the deposition ledger are already in.
@@ -430,8 +441,9 @@ def _budget_residual(days, series, species) -> float | None:
             return None
         for gas in _S_FAMILY_GASES:
             reservoir = series.get(f"gas_{gas}")
-            if reservoir is not None:
-                stored = stored + reservoir * _SULFUR_CARRIERS[gas]
+            if reservoir is None:
+                return None     # a gas reservoir omitted, not empty
+            stored = stored + reservoir * _SULFUR_CARRIERS[gas]
     else:
         emitted = integral(f"emi_{species}")
         stored = series.get(f"burden_{species}")
@@ -441,8 +453,9 @@ def _budget_residual(days, series, species) -> float | None:
     deposited = 0.0
     for prefix in ("dry", "wet"):
         contribution = integral(f"{prefix}_{species}")
-        if contribution is not None:
-            deposited += contribution
+        if contribution is None:
+            return None         # a removal ledger omitted, not zero
+        deposited += contribution
     if not np.isfinite(emitted) or emitted <= 0:
         return None
     residual = float((emitted - deposited - (stored[-1] - stored[0])) / emitted)
@@ -574,7 +587,14 @@ def compare_to_reference(stats: dict[str, float],
     """
     rows = []
     for key in sorted(reference):
-        if key not in stats or key == "record_days":
+        if key == "record_days":
+            continue
+        if key not in stats:
+            # The reference has it and this run does not: the diagnostic was
+            # removed. Skipping would report PASS for the regression that
+            # deleted the very statistic being compared.
+            rows.append((key, float("nan"),
+                         f"{reference[key]:.5g} (absent from this run)", False))
             continue
         # Statistics with an absolute physics gate are not scored here too:
         # their references are ~1e-3, so a relative tolerance would be tighter
@@ -618,7 +638,11 @@ def unscored_gates(days: np.ndarray, series: dict[str, np.ndarray],
             continue
         name = f"dlnB_dt_{species}_per_day"
         if not np.any(np.isfinite(b) & (b > 0)):
-            rows.append((name, "the run carries no burden of this species"))
+            reason = "the run carries no burden of this species"
+            rows.append((name, reason))
+            # The anchor gate skips it on the same grounds, so say so rather
+            # than leaving a silently missing tier-2 row.
+            rows.append((f"burden_{species}_mg_m2", reason))
         elif span < MIN_WINDOW_DAYS:
             rows.append((name, short_slope))
 
@@ -655,6 +679,33 @@ def unscored_gates(days: np.ndarray, series: dict[str, np.ndarray],
         rows.append(("dyn_frac_per_step", "no run timestep is available "
                      "(.hydra/config.yaml absent, or run.time_step is null as "
                      "on the pySES backend), and the gate is per step"))
+    return rows
+
+
+#: Climatological anchor gate (tier 2): the shared ``_SPECIES`` ranges widened
+#: each way by this factor. A "did the model produce a plausible planetary
+#: loading" check, not a tuning target.
+BURDEN_SLACK = 3.0
+
+BURDEN_RANGES = {sp: (lo / BURDEN_SLACK, hi * BURDEN_SLACK)
+                 for sp, (_modes, (lo, hi)) in _SPECIES.items()}
+
+
+def anchor_gates(stats: dict[str, float]) -> list[tuple[str, float, str, bool]]:
+    """Score the annual burdens against the climatological anchor ranges.
+
+    Shared so the standalone scorer and ``health.py`` apply the same tier-2
+    check: a stationary run with a wildly excessive burden has zero drift and
+    can close its ledger, so the physics gates alone would pass it. A species
+    the run does not carry is left to :func:`unscored_gates`.
+    """
+    rows = []
+    for species, (lo, hi) in BURDEN_RANGES.items():
+        key = f"burden_{species}_mg_m2"
+        value = stats.get(key)
+        if value is None or value == 0.0:
+            continue
+        rows.append((key, value, f"[{lo:g}, {hi:g}]", bool(lo <= value <= hi)))
     return rows
 
 
@@ -777,7 +828,7 @@ def main() -> int:
         np.savez(args.series_out, _days=days,
                  _timestep_seconds=np.array(dt if dt else np.nan), **series)
     stats = summarize(days, series, dt)
-    gates = physics_gates(stats)
+    gates = anchor_gates(stats) + physics_gates(stats)
     print(format_table(stats, gates))
     unscored = unscored_gates(days, series, dt)
     for name, reason in unscored:

--- a/tools/release_validation/aerosol_stats.py
+++ b/tools/release_validation/aerosol_stats.py
@@ -1,0 +1,634 @@
+"""Aerosol regression statistics for a finished JAM run (#762).
+
+Reduces a year-long JAM run directory to a small set of scalars that a
+release gate can score, and applies the two tolerance tiers described in
+``docs/source/design/jam_regression.md``:
+
+* **absolute physics gates** — the exponential drift ``|d ln B/dt|`` of every
+  species' burden over the final six months, the mass-budget residual, and the
+  per-step dynamics residual from the #713 in-step gauge.
+  These are the runaway detector: the August-2026 T63 L47 year grew sulfate
+  13 -> 771 mg/m2 in its last forty days while temperature and surface
+  pressure stayed flat, and a climatological range gate with x3 slack only
+  notices that in the final fortnight.
+* **climatological anchors** — the shared ``jam_burden_report._SPECIES``
+  ranges widened by the release gate's slack, unchanged.
+* **regression tolerances** — ``max(3 sigma, 15 %)`` against a reference run
+  (``--reference``), with ``sigma`` the standard error of the annual mean
+  estimated from the chunk series' own lag-1 autocorrelation. No reference is
+  vendored: the reference has to be a run that passes the absolute gates
+  above, and none does yet (see the design doc's "Not yet done").
+
+Everything is computed chunk by chunk: a year of T63 L47 JAM output is ~60 GB
+and must never be held open as one array. :func:`collect` reduces each chunk
+file to scalars and returns the 5-day series; :func:`summarize` turns that
+series into the statistic set.
+
+Both output vertical conventions are supported. Levels are chosen by their
+*pressure*, read from the file's own ``pressure_full``, never by a bare index
+(see the "Inspecting model output" rule in ``CLAUDE.md``), and the layer
+thicknesses come from :func:`jam_burden_report._layer_dp`, which orients
+pre-#710 TOA-first interfaces onto the surface-first ``level`` axis.
+
+Usage:
+    python tools/release_validation/aerosol_stats.py <run_dir>
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import re
+import sys
+from pathlib import Path
+
+import numpy as np
+import xarray as xr
+
+# Source-checkout bootstrap: repo root (for ``jcm``) and tools/ (for the
+# sibling ``jam_burden_report``) before the imports that need them.
+_TOOLS = Path(__file__).resolve().parents[1]
+_REPO = Path(__file__).resolve().parents[2]
+for _p in (str(_REPO), str(_TOOLS)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from jcm.analysis import area_weights, column_integral, global_mean  # noqa: E402
+from jam_burden_report import _SPECIES, _layer_dp, burden  # noqa: E402
+
+#: Species carrying a lifetime statistic — those whose removal is dominated by
+#: the two published deposition ledgers (``dry_*`` sedimentation and ``wet_*``
+#: scavenging, which already includes in-plume convective removal).
+LIFETIME_SPECIES = ("so4", "bc", "du", "ss")
+
+#: Species whose emitted mass is a complete source inventory, so
+#: ``emi - dep - dB`` is expected to close. ``soa`` is excluded: its source is
+#: condensation of the SOAG gas, which has no ``emi_*`` channel, so a residual
+#: computed for it would measure a missing diagnostic, not a mass leak.
+PRIMARY_BUDGET_SPECIES = ("bc", "du", "ss", "poa", "moa")
+
+#: Kilograms of sulfate AEROSOL per kilogram of each sulfur carrier, so the
+#: whole family can be totalled in one mass unit. jcm's ``so4`` tracer is
+#: ammonium bisulfate NH4HSO4 at 115.0 g/mol (``jam/species.py``) — not SO4 at
+#: 96.06 — so converting SO2 (64.06) and DMS (62.13) emissions with the sulfate
+#: molar mass instead understates the source by 20 % and turns a modest closure
+#: error into an apparent leak.
+_M_SO4_AEROSOL = 0.115
+_SULFUR_CARRIERS = {"so2": _M_SO4_AEROSOL / 0.0640648,     # 1.795
+                    "dms": _M_SO4_AEROSOL / 0.0621324,     # 1.851
+                    "h2so4": _M_SO4_AEROSOL / 0.0980784,   # 1.172
+                    "so4": 1.0}
+#: Gas reservoirs and emission channels of that family. The gases are stored
+#: as raw column burdens by :func:`chunk_reduction`; the conversion above is
+#: applied here, in the ledger, so the reduction stays unit-neutral.
+_S_FAMILY_GASES = ("so2", "dms", "h2so4")
+_S_FAMILY_EMIS = ("so2", "dms", "so4")
+
+#: Dynamics-conservation gate. ``budget_dyn_<sp>`` (#713) is the mass the
+#: transport machinery created or destroyed per step, so ``|dyn|*dt/mass`` is
+#: the fractional error the semi-Lagrangian advection commits each step. Its
+#: honest magnitude is O(1e-3) per step and one-signed under a strong sink,
+#: which is how it compounded into the August-2026 runaway; 0.1 %/step is
+#: therefore set AT that magnitude, to trip on a transport error that has
+#: become systematic rather than on ordinary interpolation noise. It is also
+#: ~500x tighter than the [2/3, 1.5] clip on dev's proportional mass fixer,
+#: so the gate fires long before the fixer saturates.
+DYN_RESIDUAL_PER_STEP = 1.0e-3
+
+#: Absolute physics gates (see the design doc). The drift limit is set so a
+#: burden may change by a factor e over the ~500 days it takes to matter, but
+#: not by the factor 60 in 40 days a #658-class runaway produces. The drift
+#: statistic reads burdens only, so it is independent of the deposition ledger
+#: and is the gate to trust when the ledger is incomplete.
+DRIFT_LIMIT_PER_DAY = 0.002
+BUDGET_RESIDUAL_LIMIT = 0.05
+
+#: The closure gate's sign carries information, and the two directions have
+#: different diagnoses. A NEGATIVE residual means more mass was deposited than
+#: entered the column: no missing ledger entry can produce that, so it is mass
+#: creation. A POSITIVE one means emitted mass is unaccounted for, which a
+#: *missing sink diagnostic* looks exactly like — and on output written before
+#: the #722 removal-ledger fix, ``dry_*`` omits the Slinn turbulent/Brownian
+#: deposition entirely (it captures only ~31 % of the dust dry sink), so a
+#: positive residual on such a run is expected and is not evidence of a leak.
+_POSITIVE_RESIDUAL_CAVEAT = (
+    "unaccounted emission; on output written before the #722 removal-ledger "
+    "fix, dry_* omits Slinn dry deposition and reads positive by construction")
+
+#: Regression tolerance: whichever of a 3-sigma excursion and a 15 % relative
+#: change is larger. 3 sigma alone is far too tight for a well-sampled mean
+#: (sigma is ~1 % of the annual mean); 15 % alone would let a slow bias
+#: through on a noisy statistic.
+_N_SIGMA = 3.0
+_REL_TOLERANCE = 0.15
+
+#: Pressure [Pa] used for the near-surface aerosol-number diagnostics, and the
+#: divide separating the free troposphere reservoir from the boundary layer.
+_CDNC_PRESSURE = 90000.0
+_UPPER_LEVEL_PRESSURE = 50000.0
+
+_AOD_KEYS = ("jam_optics.aod_550", "jam_band_optics.aod_550")
+_ANGSTROM_KEYS = ("jam_optics.angstrom", "jam_band_optics.angstrom",
+                  "ang4487aer")
+
+
+def is_jam_run(ds: xr.Dataset) -> bool:
+    """Report whether ``ds`` carries JAM's prognostic modal aerosol tracers.
+
+    Detected from the variables present rather than from a config file, so a
+    run directory alone is enough. Requires an interstitial mass tracer *and*
+    a JAM-specific diagnostic namespace, so a MACv2-SP run (which publishes
+    AOD but no ``m_<sp>_<mode>``) is not mistaken for one.
+    """
+    has_mass = any(re.fullmatch(r"m_[a-z0-9]+_[a-z]+", str(v))
+                   for v in ds.data_vars)
+    has_jam = any(str(v).startswith(("jam_state.", "jam_cloud_borne.",
+                                     "jam_optics.", "jam_band_optics."))
+                  for v in ds.data_vars)
+    return has_mass and has_jam
+
+
+def _band_indices(ds: xr.Dataset, lo: float, hi: float) -> np.ndarray:
+    lat = np.asarray(ds["lat"].values, dtype=float)
+    return np.nonzero((lat >= lo) & (lat <= hi))[0]
+
+
+def _band_mean(da: xr.DataArray, weights: xr.DataArray,
+               ds: xr.Dataset, lo: float, hi: float) -> float:
+    """Area-weighted mean of ``da`` over the latitude band [lo, hi]."""
+    idx = _band_indices(ds, lo, hi)
+    if idx.size == 0:
+        return float("nan")
+    return float(global_mean(da.isel(lat=idx), weights.isel(lat=idx)))
+
+
+def nearest_pressure_level(ds: xr.Dataset, pressure: float) -> int:
+    """Index on the ``level`` axis whose mean pressure is nearest ``pressure``.
+
+    The index is *derived* from the file's own ``pressure_full`` rather than
+    assumed, which is what makes the selection valid under either vertical
+    convention.
+    """
+    pf = ds["pressure_full"]
+    prof = pf.mean([d for d in pf.dims if d != "level"])
+    return int(np.argmin(np.abs(np.asarray(prof.values) - pressure)))
+
+
+def _optional_key(ds: xr.Dataset, keys) -> str | None:
+    for key in keys:
+        if key in ds:
+            return key
+    return None
+
+
+def chunk_reduction(ds: xr.Dataset) -> dict[str, float]:
+    """Reduce one output chunk to the scalars the statistics are built from.
+
+    Returns global (and, for sulfate, hemispheric/polar/upper-level) means of
+    burdens, the emission and deposition fluxes, and the optics/number
+    diagnostics. Time is averaged out here: a chunk is one 5-day sample.
+    """
+    weights = area_weights(ds)
+    dp = _layer_dp(ds)
+    out: dict[str, float] = {}
+
+    def tmean(da):
+        return da.mean("time") if "time" in da.dims else da
+
+    burdens = {}
+    for species, (modes, _range) in _SPECIES.items():
+        col = burden(ds, species, modes)
+        if col is None:
+            continue
+        col = col.compute()
+        burdens[species] = col
+        out[f"burden_{species}"] = float(global_mean(col, weights))
+
+    if "so4" in burdens:
+        col = burdens["so4"]
+        out["so4_nh"] = _band_mean(col, weights, ds, 0.0, 90.0)
+        out["so4_sh"] = _band_mean(col, weights, ds, -90.0, 0.0)
+        out["so4_60_90N"] = _band_mean(col, weights, ds, 60.0, 90.0)
+        # Upper-level share: mask on the file's own pressure field, so no
+        # level ordering is assumed.
+        names = [f"{p}_so4_{m}"
+                 for m in _SPECIES["so4"][0]
+                 for p in ("m", "mc", "jam_cloud_borne.mc")]
+        q = sum(ds[n] for n in names if n in ds)
+        aloft = q.where(ds["pressure_full"] < _UPPER_LEVEL_PRESSURE, 0.0)
+        col_aloft = tmean(column_integral(aloft, dp)) * 1e6
+        out["so4_above_500hPa"] = float(global_mean(col_aloft, weights))
+
+    # Sulfur-family gas burdens [mg/m2] as carried, for the closure test; the
+    # conversion to sulfate-aerosol mass belongs to the ledger.
+    for gas in _S_FAMILY_GASES:
+        name = f"g_{gas}"
+        if name in ds:
+            col = tmean(column_integral(ds[name], dp)) * 1e6
+            out[f"gas_{gas}"] = float(global_mean(col, weights))
+
+    # #713 in-step budget gauges: column mass of the ADVECTED tracers and the
+    # dynamics residual. Interstitial only (the host never transports the
+    # cloud-borne carry), so the two share a denominator.
+    for prefix in ("budget_mass", "budget_dyn"):
+        for var in ds.data_vars:
+            name = str(var)
+            if name.startswith(f"{prefix}_") and ds[var].ndim <= 3:
+                out[name] = float(global_mean(tmean(ds[var]), weights))
+
+    for prefix in ("emi", "dry", "wet"):
+        for var in ds.data_vars:
+            name = str(var)
+            # ``emi_bb_*`` comes along as a separate key; it is a *split* of
+            # ``emi_*``, never added to it.
+            if name.startswith(f"{prefix}_") and ds[var].ndim <= 3:
+                out[name] = float(global_mean(tmean(ds[var]), weights))
+
+    aod_key = _optional_key(ds, _AOD_KEYS)
+    if aod_key:
+        out["aod_550"] = float(global_mean(tmean(ds[aod_key]), weights))
+    ang_key = _optional_key(ds, _ANGSTROM_KEYS)
+    if ang_key:
+        out["angstrom"] = float(global_mean(tmean(ds[ang_key]), weights))
+
+    k_cdnc = (nearest_pressure_level(ds, _CDNC_PRESSURE)
+              if "pressure_full" in ds else None)
+    if k_cdnc is not None and "activated_cdnc" in ds:
+        # m^-3 -> cm^-3.
+        cdnc = tmean(ds["activated_cdnc"]).isel(level=k_cdnc)
+        out["cdnc_900hPa_cm3"] = float(global_mean(cdnc, weights)) * 1e-6
+    if k_cdnc is not None and "aerocom_N100" in ds:
+        n100 = tmean(ds["aerocom_N100"]).isel(level=k_cdnc)
+        out["N100_900hPa_cm3"] = float(global_mean(n100, weights)) * 1e-6
+
+    if "jam_state.r_dry" in ds and "pressure_full" in ds:
+        k_sfc = int(np.argmax(np.asarray(
+            ds["pressure_full"].mean([d for d in ds["pressure_full"].dims
+                                      if d != "level"]).values)))
+        r_dry = tmean(ds["jam_state.r_dry"]).isel(level=k_sfc)
+        for i, mode in enumerate(np.asarray(ds["mode"].values)):
+            out[f"r_dry_{str(mode)}_um"] = float(
+                global_mean(r_dry.isel(mode=i), weights)) * 1e6
+
+    return out
+
+
+def collect(files) -> tuple[np.ndarray, dict[str, np.ndarray]]:
+    """Reduce every chunk file to scalars; return ``(days, series)``.
+
+    Files are opened and closed one at a time — a year of JAM output does not
+    fit in memory, and the statistics only ever need per-chunk reductions.
+    """
+    days: list[float] = []
+    rows: list[dict[str, float]] = []
+    for path in files:
+        match = re.search(r"day(\d+)", str(path))
+        with xr.open_dataset(path) as ds:
+            rows.append(chunk_reduction(ds))
+        days.append(float(match.group(1)) if match else float(len(days)))
+    keys = sorted({k for row in rows for k in row})
+    series = {k: np.array([row.get(k, np.nan) for row in rows], dtype=float)
+              for k in keys}
+    return np.asarray(days, dtype=float), series
+
+
+def log_drift(days: np.ndarray, values: np.ndarray,
+              window_days: float = 182.5) -> float:
+    """``d ln B / dt`` [1/day] from a least-squares fit over the last window.
+
+    A logarithmic slope is the right statistic for an aerosol burden because
+    the failure mode is multiplicative: a runaway grows by a fixed factor per
+    unit time, so it shows up as a slope that is large regardless of the
+    species' absolute loading, while a merely noisy but stationary burden
+    averages to zero.
+    """
+    good = np.isfinite(values) & (values > 0)
+    if good.sum() < 3:
+        return float("nan")
+    d, v = days[good], values[good]
+    sel = d >= (d[-1] - window_days)
+    if sel.sum() < 3:
+        sel = np.ones_like(d, dtype=bool)
+    return float(np.polyfit(d[sel], np.log(v[sel]), 1)[0])
+
+
+def standard_error(values: np.ndarray) -> float:
+    """Estimate the standard error of the mean of an autocorrelated series.
+
+    ``N_eff = N (1 - a) / (1 + a)`` with ``a`` the lag-1 autocorrelation of the
+    chunk series — the usual first-order correction, which is what makes the
+    3-sigma tier meaningful for a burden whose 5-day samples are anything but
+    independent. Negative ``a`` is clipped to zero (never claim *more*
+    independent samples than there are chunks).
+    """
+    v = np.asarray(values, dtype=float)
+    v = v[np.isfinite(v)]
+    n = v.size
+    if n < 4 or np.allclose(v, v[0]):
+        return 0.0 if n else float("nan")
+    a = float(np.corrcoef(v[:-1], v[1:])[0, 1])
+    a = min(max(a, 0.0), 0.99)
+    n_eff = max(n * (1.0 - a) / (1.0 + a), 1.0)
+    return float(np.std(v, ddof=1) / np.sqrt(n_eff))
+
+
+def regression_tolerance(reference: float, sigma: float) -> float:
+    """``max(3 sigma, 15 % of the reference)`` — see the design doc."""
+    return max(_N_SIGMA * sigma, _REL_TOLERANCE * abs(reference))
+
+
+def _budget_residual(days, series, species) -> float | None:
+    """Compute ``(emitted - deposited - dB) / emitted`` over the record.
+
+    The fluxes are chunk means of ``kg/m2/s``, so their record mean times the
+    record length is the time integral; ``dB`` is the change in the chunk-mean
+    burden between the first and last chunk. For sulfate the ledger is the
+    whole sulfur family in SO4-equivalent mass (SO2 and DMS emissions are the
+    real sulfate source; ``emi_so4`` alone is a few per cent of it), and the
+    stored mass includes the gas-phase reservoirs.
+    """
+    span = float(days[-1] - days[0])
+    if span <= 0:
+        return None
+
+    def integral(key):
+        v = series.get(key)
+        return None if v is None else float(np.nanmean(v)) * span * 86400e6
+
+    if species == "so4":
+        # Every carrier converted to sulfate-AEROSOL mass, the unit the
+        # burden and the deposition ledger are already in.
+        contributions = [integral(f"emi_{c}") for c in _S_FAMILY_EMIS]
+        if any(e is None for e in contributions):
+            return None
+        emitted = sum(e * _SULFUR_CARRIERS[c]
+                      for e, c in zip(contributions, _S_FAMILY_EMIS))
+        stored = series.get("burden_so4")
+        if stored is None:
+            return None
+        for gas in _S_FAMILY_GASES:
+            reservoir = series.get(f"gas_{gas}")
+            if reservoir is not None:
+                stored = stored + reservoir * _SULFUR_CARRIERS[gas]
+    else:
+        emitted = integral(f"emi_{species}")
+        stored = series.get(f"burden_{species}")
+        if emitted is None or stored is None:
+            return None
+
+    deposited = 0.0
+    for prefix in ("dry", "wet"):
+        contribution = integral(f"{prefix}_{species}")
+        if contribution is not None:
+            deposited += contribution
+    if not np.isfinite(emitted) or emitted <= 0:
+        return None
+    return float((emitted - deposited - (stored[-1] - stored[0])) / emitted)
+
+
+def summarize(days: np.ndarray, series: dict[str, np.ndarray],
+              timestep_seconds: float | None = None) -> dict[str, float]:
+    """Build the statistic set from the series returned by :func:`collect`.
+
+    Every entry is a single number a gate or a stored reference can be
+    compared against; the rationale for each is in the design doc.
+    """
+    stats: dict[str, float] = {}
+    span_days = float(days[-1] - days[0]) if days.size > 1 else 0.0
+
+    for species in _SPECIES:
+        b = series.get(f"burden_{species}")
+        if b is None:
+            continue
+        stats[f"burden_{species}_mg_m2"] = float(np.nanmean(b))
+        # A species the run never carries (soa with no SOAG production, say)
+        # has no logarithmic drift to measure; emitting NaN would fail the
+        # gate for a burden that is correctly zero.
+        if np.any(np.isfinite(b) & (b > 0)):
+            stats[f"dlnB_dt_{species}_per_day"] = log_drift(days, b)
+
+    for species in LIFETIME_SPECIES:
+        b = series.get(f"burden_{species}")
+        if b is None:
+            continue
+        # ``wet_*`` already includes in-plume convective scavenging (the
+        # transport term's flux is folded into it in wetdep_term.py), so
+        # adding ``conv_scav_flux.*`` here would double-count that sink.
+        sink = 0.0
+        for prefix in ("dry", "wet"):
+            v = series.get(f"{prefix}_{species}")
+            if v is not None:
+                sink += float(np.nanmean(v)) * 86400e6   # kg/m2/s -> mg/m2/day
+        if sink > 0:
+            stats[f"lifetime_{species}_days"] = float(np.nanmean(b)) / sink
+
+    residuals = {}
+    for species in ("so4",) + PRIMARY_BUDGET_SPECIES:
+        r = _budget_residual(days, series, species)
+        if r is not None:
+            residuals[species] = r
+            stats[f"budget_residual_{species}"] = r
+    if residuals:
+        stats["budget_residual_max"] = max(residuals.values(), key=abs)
+
+    if "so4_above_500hPa" in series and "burden_so4" in series:
+        aloft = float(np.nanmean(series["so4_above_500hPa"]))
+        total = float(np.nanmean(series["burden_so4"]))
+        if total > 0:
+            stats["so4_frac_above_500hPa"] = aloft / total
+    if "so4_nh" in series and "so4_sh" in series:
+        sh = float(np.nanmean(series["so4_sh"]))
+        if sh > 0:
+            stats["so4_nh_sh_ratio"] = float(np.nanmean(series["so4_nh"])) / sh
+    if "so4_60_90N" in series:
+        stats["so4_burden_60_90N_mg_m2"] = float(np.nanmean(
+            series["so4_60_90N"]))
+
+    for key in ("aod_550", "angstrom", "cdnc_900hPa_cm3", "N100_900hPa_cm3"):
+        if key in series:
+            stats[key] = float(np.nanmean(series[key]))
+    for key in series:
+        if key.startswith("r_dry_"):
+            stats[key] = float(np.nanmean(series[key]))
+
+    # Dynamics conservation: the transport residual as a fraction of the
+    # advected mass, per step. Needs the run's timestep; without it the
+    # statistic is not emitted (and its gate is therefore not scored).
+    if timestep_seconds:
+        for key in series:
+            if not key.startswith("budget_dyn_"):
+                continue
+            species = key[len("budget_dyn_"):]
+            mass = series.get(f"budget_mass_{species}")
+            if mass is None:
+                continue
+            mean_mass = float(np.nanmean(mass))
+            if mean_mass > 0:
+                stats[f"dyn_frac_per_step_{species}"] = abs(
+                    float(np.nanmean(series[key])) * timestep_seconds
+                    / mean_mass)
+
+    stats["record_days"] = span_days
+    return stats
+
+
+def timestep_seconds(run_dir: str) -> float | None:
+    """Read the run.s timestep [s] from the Hydra config saved beside it.
+
+    Returned as ``None`` when the run directory has no ``.hydra/config.yaml``
+    (a hand-assembled directory, or output copied without it), which makes the
+    dynamics-conservation gate unscored rather than wrong.
+    """
+    cfg = Path(run_dir) / ".hydra" / "config.yaml"
+    if not cfg.is_file():
+        return None
+    import yaml
+    loaded = yaml.safe_load(cfg.read_text()) or {}
+    minutes = (loaded.get("run") or {}).get("time_step")
+    return float(minutes) * 60.0 if minutes else None
+
+
+def compare_to_reference(stats: dict[str, float],
+                         reference: dict[str, float],
+                         series: dict[str, np.ndarray] | None = None
+                         ) -> list[tuple[str, float, str, bool]]:
+    """Score this run's statistics against a stored reference (tier 3).
+
+    The tolerance is ``max(3 sigma, 15 %)``. ``sigma`` comes from the *current*
+    run's own chunk series where one is available, so a statistic that is
+    genuinely noisy in this configuration is not held to the precision of a
+    quiet one; without a series the 15 % floor decides. Returns the same
+    ``(name, value, limit, ok)`` rows the gate functions use.
+    """
+    rows = []
+    for key in sorted(reference):
+        if key not in stats or key == "record_days":
+            continue
+        value, ref = stats[key], reference[key]
+        sigma = 0.0
+        if series is not None:
+            for candidate in (key, key.removesuffix("_mg_m2"),
+                              f"burden_{key.removeprefix('burden_')}"):
+                if candidate in series:
+                    sigma = standard_error(series[candidate])
+                    break
+        tol = regression_tolerance(ref, sigma)
+        ok = abs(value - ref) <= tol
+        rows.append((key, value, f"{ref:.5g} +- {tol:.3g}", bool(ok)))
+    return rows
+
+
+def physics_gates(stats: dict[str, float]) -> list[tuple[str, float, str, bool]]:
+    """Score the absolute physics gates; returns ``(name, value, gate, ok)``.
+
+    These are not tuning targets: a burden that grows exponentially, or a
+    species whose mass ledger does not close, is a defect at any loading.
+    """
+    rows = []
+    for key, value in sorted(stats.items()):
+        if key.startswith("dlnB_dt_"):
+            ok = np.isfinite(value) and abs(value) < DRIFT_LIMIT_PER_DAY
+            rows.append((key, value, f"|x| < {DRIFT_LIMIT_PER_DAY:g} /day",
+                         bool(ok)))
+    for key, value in sorted(stats.items()):
+        if key.startswith("dyn_frac_per_step_"):
+            ok = np.isfinite(value) and value < DYN_RESIDUAL_PER_STEP
+            rows.append((key, value,
+                         f"x < {DYN_RESIDUAL_PER_STEP:.1%}/step", bool(ok)))
+    if "budget_residual_max" in stats:
+        value = stats["budget_residual_max"]
+        ok = np.isfinite(value) and abs(value) < BUDGET_RESIDUAL_LIMIT
+        limit = f"|x| < {BUDGET_RESIDUAL_LIMIT:.0%}"
+        if not ok and np.isfinite(value) and value > 0:
+            limit += f" ({_POSITIVE_RESIDUAL_CAVEAT})"
+        rows.append(("budget_residual_max", value, limit, bool(ok)))
+    return rows
+
+
+def format_table(stats: dict[str, float],
+                 gates: list[tuple[str, float, str, bool]]) -> str:
+    """Human-readable report of the statistic set and the physics gates."""
+    lines = [f"{'statistic':<34}{'value':>14}", "-" * 48]
+    for key, value in sorted(stats.items()):
+        if isinstance(value, str):
+            lines.append(f"{key:<34}{value:>14}")
+        else:
+            lines.append(f"{key:<34}{value:>14.5g}")
+    if not gates:
+        return "\n".join(lines)
+    lines += ["", f"{'physics gate':<34}{'value':>14}  {'limit':<20}result",
+              "-" * 76]
+    notes = []
+    for name, value, limit, ok in gates:
+        head, _, note = limit.partition(" (")
+        lines.append(f"{name:<34}{value:>14.5g}  {head:<20}"
+                     f"{'PASS' if ok else 'FAIL'}")
+        if note:
+            notes.append(f"NOTE  {name}: {note.rstrip(')')}")
+    lines += notes
+    return "\n".join(lines)
+
+
+def run_files(run_dir: str) -> list[str]:
+    """Chunk files of a run directory, in day order."""
+    return sorted(glob.glob(f"{run_dir}/*_day*.nc"),
+                  key=lambda f: int(re.search(r"day(\d+)", f).group(1)))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("run_dir", nargs="?", default=None)
+    ap.add_argument("--last-n", type=int, default=None,
+                    help="use only the last N chunks (default: all)")
+    ap.add_argument("--series-out", default=None,
+                    help="save the per-chunk reductions to this .npz")
+    ap.add_argument("--series-in", default=None,
+                    help="re-score a saved .npz instead of reading the run "
+                         "(reducing a year of JAM output takes ~40 min)")
+    ap.add_argument("--reference", default=None,
+                    help="a .npz of a reference run's series; adds the "
+                         "regression comparison (max(3 sigma, 15 %%))")
+    args = ap.parse_args()
+
+    if args.series_in:
+        loaded = np.load(args.series_in)
+        days = loaded["_days"]
+        series = {k: loaded[k] for k in loaded.files if k != "_days"}
+    else:
+        files = run_files(args.run_dir)
+        if not files:
+            print(f"FAIL  no chunk files in {args.run_dir}")
+            return 1
+        if args.last_n:
+            files = files[-args.last_n:]
+        days, series = collect(files)
+    if args.series_out:
+        np.savez(args.series_out, _days=days, **series)
+    dt = timestep_seconds(args.run_dir) if args.run_dir else None
+    stats = summarize(days, series, dt)
+    if dt is None:
+        print("NOTE  no .hydra/config.yaml timestep — the dynamics-"
+              "conservation gate is not scored\n")
+    gates = physics_gates(stats)
+    print(format_table(stats, gates))
+    ok = all(row[3] for row in gates)
+
+    if args.reference:
+        loaded = np.load(args.reference)
+        ref_series = {k: loaded[k] for k in loaded.files if k != "_days"}
+        ref = summarize(loaded["_days"], ref_series)
+        rows = compare_to_reference(stats, ref, series)
+        print(f"\n{'regression vs reference':<34}{'value':>14}  "
+              f"{'expected':<24}result")
+        print("-" * 80)
+        for name, value, limit, good in rows:
+            print(f"{name:<34}{value:>14.5g}  {limit:<24}"
+                  f"{'PASS' if good else 'FAIL'}")
+        ok = ok and all(row[3] for row in rows)
+
+    print("\nAEROSOL:", "PASS" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/release_validation/aerosol_stats.py
+++ b/tools/release_validation/aerosol_stats.py
@@ -624,6 +624,26 @@ def unscored_gates(days: np.ndarray, series: dict[str, np.ndarray],
 
     if span < MIN_WINDOW_DAYS:
         rows.append(("budget_residual_max", short_budget))
+    else:
+        # A species missing from ``budget_residual_max`` is a species whose
+        # mass was never checked, and the maximum over an incomplete subset
+        # cannot see a leak confined to the species it omits. Report each
+        # omission, and the aggregate when nothing at all could be closed.
+        closed = []
+        for species in ("so4",) + PRIMARY_BUDGET_SPECIES:
+            if f"burden_{species}" not in series:
+                continue        # the run does not carry it; nothing to close
+            if _budget_residual(days, series, species) is None:
+                rows.append((
+                    f"budget_residual_{species}",
+                    "the mass ledger is incomplete — a missing emi_*/dry_*/"
+                    "wet_* diagnostic, or a non-finite burden endpoint"))
+            else:
+                closed.append(species)
+        if not closed:
+            rows.append(("budget_residual_max",
+                         "no species had a complete mass ledger to close "
+                         "against; no closure was checked"))
 
     # The dynamics gate needs BOTH the #713 in-step gauge and a timestep to
     # express it per step; say which is missing rather than omitting the row.
@@ -689,10 +709,20 @@ def format_table(stats: dict[str, float],
     return "\n".join(lines)
 
 
+#: A saved chunk is ``<prefix>_day<N>.nc``. ``run.snapshot_interval`` writes
+#: ``<prefix>_day<N>_snapshots.nc`` beside it, which a ``*_day*.nc`` glob also
+#: matches — those are 2-D snapshot streams with no ``pressure_half``, so they
+#: would break the column integral, and any that did parse would double-count
+#: the day. Anchored on the extension, they are excluded.
+CHUNK_FILE = re.compile(r"_day(\d+)\.nc$")
+
+
 def run_files(run_dir: str) -> list[str]:
-    """Chunk files of a run directory, in day order."""
-    return sorted(glob.glob(f"{run_dir}/*_day*.nc"),
-                  key=lambda f: int(re.search(r"day(\d+)", f).group(1)))
+    """Chunk files of a run directory, in day order (snapshots excluded)."""
+    matched = ((m, f) for f, m in
+               ((f, CHUNK_FILE.search(f)) for f in glob.glob(f"{run_dir}/*.nc"))
+               if m)
+    return [f for _m, f in sorted(matched, key=lambda mf: int(mf[0].group(1)))]
 
 
 def main() -> int:
@@ -708,12 +738,25 @@ def main() -> int:
     ap.add_argument("--reference", default=None,
                     help="a .npz of a reference run's series; adds the "
                          "regression comparison (max(3 sigma, 15 %%))")
+    ap.add_argument("--timestep-minutes", type=float, default=None,
+                    help="override the run timestep the dynamics gate needs "
+                         "(default: the run's Hydra config, or the one saved "
+                         "with --series-out)")
     args = ap.parse_args()
 
+    dt = None
     if args.series_in:
         loaded = np.load(args.series_in)
         days = loaded["_days"]
-        series = {k: loaded[k] for k in loaded.files if k != "_days"}
+        # Underscore keys are the reduction's own metadata, not statistics.
+        series = {k: loaded[k] for k in loaded.files if not k.startswith("_")}
+        # The timestep travels WITH the reduction: re-scoring a saved series
+        # has no run directory to read it from, and without it every
+        # dynamics-conservation gate would silently drop out of a re-score
+        # that the original scored.
+        if "_timestep_seconds" in loaded.files:
+            stored = float(loaded["_timestep_seconds"])
+            dt = stored if np.isfinite(stored) and stored > 0 else None
         if args.last_n:
             # Applied here too: silently ignoring it would score a different
             # window than the one asked for.
@@ -727,9 +770,12 @@ def main() -> int:
         if args.last_n:
             files = files[-args.last_n:]
         days, series = collect(files)
+        dt = timestep_seconds(args.run_dir)
+    if args.timestep_minutes:
+        dt = args.timestep_minutes * 60.0
     if args.series_out:
-        np.savez(args.series_out, _days=days, **series)
-    dt = timestep_seconds(args.run_dir) if args.run_dir else None
+        np.savez(args.series_out, _days=days,
+                 _timestep_seconds=np.array(dt if dt else np.nan), **series)
     stats = summarize(days, series, dt)
     gates = physics_gates(stats)
     print(format_table(stats, gates))

--- a/tools/release_validation/aerosol_stats.py
+++ b/tools/release_validation/aerosol_stats.py
@@ -65,7 +65,11 @@ LIFETIME_SPECIES = ("so4", "bc", "du", "ss")
 #: ``emi - dep - dB`` is expected to close. ``soa`` is excluded: its source is
 #: condensation of the SOAG gas, which has no ``emi_*`` channel, so a residual
 #: computed for it would measure a missing diagnostic, not a mass leak.
-PRIMARY_BUDGET_SPECIES = ("bc", "du", "ss", "poa", "moa")
+#: ``moa`` is excluded for a different reason — it has emission and deposition
+#: ledgers but no entry in the shared ``_SPECIES`` anchor table, so no burden
+#: is computed for it and there is no storage term to close against. Adding it
+#: needs a climatological anchor range, which is a calibration decision.
+PRIMARY_BUDGET_SPECIES = ("bc", "du", "ss", "poa")
 
 #: Kilograms of sulfate AEROSOL per kilogram of each sulfur carrier, so the
 #: whole family can be totalled in one mass unit. jcm's ``so4`` tracer is
@@ -348,12 +352,18 @@ def _budget_residual(days, series, species) -> float | None:
     stored mass includes the gas-phase reservoirs.
     """
     span = float(days[-1] - days[0])
-    if span <= 0:
+    if span <= 0 or days.size < 2:
         return None
 
     def integral(key):
+        # The storage term is a difference between the FIRST and LAST chunk
+        # means, i.e. between chunk centres, so the flux integral must cover
+        # that same interval: the chunks after the first, times the span
+        # between the centres. Averaging all N chunks over an (N-1)-chunk span
+        # understates the integral by 1/N — 1.4 % on a 73-chunk year, but 25 %
+        # on a four-chunk window, straight into a residual gated at 5 %.
         v = series.get(key)
-        return None if v is None else float(np.nanmean(v)) * span * 86400e6
+        return None if v is None else float(np.nanmean(v[1:])) * span * 86400e6
 
     if species == "so4":
         # Every carrier converted to sulfate-AEROSOL mass, the unit the
@@ -401,11 +411,15 @@ def summarize(days: np.ndarray, series: dict[str, np.ndarray],
         if b is None:
             continue
         stats[f"burden_{species}_mg_m2"] = float(np.nanmean(b))
-        # A species the run never carries (soa with no SOAG production, say)
-        # has no logarithmic drift to measure; emitting NaN would fail the
-        # gate for a burden that is correctly zero.
-        if np.any(np.isfinite(b) & (b > 0)):
-            stats[f"dlnB_dt_{species}_per_day"] = log_drift(days, b)
+        # Emit the drift only when it could actually be fitted. A species the
+        # run never carries (soa with no SOAG production) and a record too
+        # short for a slope both yield NaN, and a NaN scored against the gate
+        # reads as a FAIL for something that was never measured — which is how
+        # ``health.py --last-n 2`` on a healthy run reported an aerosol
+        # failure. Not measurable is "not scored", not "failed".
+        drift = log_drift(days, b)
+        if np.isfinite(drift):
+            stats[f"dlnB_dt_{species}_per_day"] = drift
 
     for species in LIFETIME_SPECIES:
         b = series.get(f"burden_{species}")

--- a/tools/release_validation/aerosol_stats_test.py
+++ b/tools/release_validation/aerosol_stats_test.py
@@ -604,3 +604,100 @@ class TestJamDetection:
 
     def test_a_complete_run_reports_nothing_missing(self):
         assert A.missing_jam_diagnostics(synthetic_chunk()) == []
+
+
+class TestChunkDiscovery:
+    """``run.snapshot_interval`` writes a second stream beside the chunks."""
+
+    def _run_dir(self, tmp_path):
+        for name in ("mx_day5.nc", "mx_day10.nc", "mx_day100.nc",
+                     "mx_day5_snapshots.nc", "mx_day10_snapshots.nc",
+                     "mx.nc", "mx_day5.nc.provenance.json"):
+            (tmp_path / name).write_text("")
+        return tmp_path
+
+    def test_snapshot_streams_are_not_chunks(self, tmp_path):
+        found = [pathlib.Path(f).name
+                 for f in A.run_files(str(self._run_dir(tmp_path)))]
+        assert found == ["mx_day5.nc", "mx_day10.nc", "mx_day100.nc"]
+
+    def test_ordering_is_numeric_not_lexical(self, tmp_path):
+        found = A.run_files(str(self._run_dir(tmp_path)))
+        assert [int(A.CHUNK_FILE.search(f).group(1)) for f in found] == [
+            5, 10, 100]
+
+
+class TestIncompleteLedgerIsUnscored:
+    """A species absent from ``budget_residual_max`` was never checked."""
+
+    def _days(self, n=40):
+        return np.arange(5.0, 5.0 * n + 5.0, 5.0)
+
+    def test_a_species_with_no_ledger_is_reported(self):
+        days = self._days()
+        n = days.size
+        emi = np.full(n, 1.0 / 86400e6)
+        series = {"burden_bc": np.full(n, 5.0), "emi_bc": emi,
+                  "dry_bc": np.zeros(n), "wet_bc": emi,
+                  # du carries a burden but no emission diagnostic at all.
+                  "burden_du": np.full(n, 20.0)}
+        reasons = dict(A.unscored_gates(days, series))
+        assert "budget_residual_du" in reasons
+        assert "ledger is incomplete" in reasons["budget_residual_du"]
+        assert "budget_residual_bc" not in reasons
+
+    def test_no_closable_species_reports_the_aggregate_gate(self):
+        """Otherwise a run passes its drift gates with no closure at all."""
+        days = self._days()
+        series = {"burden_bc": np.full(days.size, 5.0)}   # no ledger anywhere
+        stats = A.summarize(days, series)
+        assert "budget_residual_max" not in stats
+        reasons = dict(A.unscored_gates(days, series))
+        assert "no species had a complete mass ledger" in reasons[
+            "budget_residual_max"]
+
+    def test_a_complete_ledger_is_not_reported_unscored(self):
+        days = self._days()
+        n = days.size
+        emi = np.full(n, 1.0 / 86400e6)
+        series = {"burden_bc": np.full(n, 5.0), "emi_bc": emi,
+                  "dry_bc": np.zeros(n), "wet_bc": emi}
+        reasons = dict(A.unscored_gates(days, series))
+        assert not any(k.startswith("budget_residual") for k in reasons)
+
+
+class TestSeriesRoundTrip:
+    """The reduction must carry everything a re-score needs."""
+
+    def _write(self, tmp_path, dt_minutes):
+        run = tmp_path / "run"
+        run.mkdir()
+        (run / ".hydra").mkdir()
+        (run / ".hydra" / "config.yaml").write_text(
+            f"run:\n  time_step: {dt_minutes}\n")
+        return run
+
+    def test_timestep_travels_with_the_series(self, tmp_path):
+        n = 40
+        days = np.arange(5.0, 5.0 * n + 5.0, 5.0)
+        out = tmp_path / "reduced.npz"
+        np.savez(out, _days=days, _timestep_seconds=np.array(720.0),
+                 burden_bc=np.full(n, 3.0),
+                 budget_mass_bc=np.full(n, 4.0e-6),
+                 budget_dyn_bc=np.zeros(n))
+        loaded = np.load(out)
+        series = {k: loaded[k] for k in loaded.files if not k.startswith("_")}
+        dt = float(loaded["_timestep_seconds"])
+        # With the timestep the dynamics gate is scored; without it, it is not.
+        assert "dyn_frac_per_step_bc" in A.summarize(days, series, dt)
+        assert "dyn_frac_per_step_bc" not in A.summarize(days, series, None)
+        assert "dyn_frac_per_step" not in dict(
+            A.unscored_gates(days, series, dt))
+
+    def test_metadata_keys_never_become_statistics(self, tmp_path):
+        out = tmp_path / "reduced.npz"
+        np.savez(out, _days=np.arange(3.0), _timestep_seconds=np.array(720.0),
+                 burden_bc=np.zeros(3))
+        loaded = np.load(out)
+        series = {k: loaded[k] for k in loaded.files if not k.startswith("_")}
+        assert set(series) == {"burden_bc"}

--- a/tools/release_validation/aerosol_stats_test.py
+++ b/tools/release_validation/aerosol_stats_test.py
@@ -1,0 +1,431 @@
+"""Tests for the JAM aerosol regression statistics (#762).
+
+Everything here runs on synthetic Datasets: the point of the module is the
+arithmetic (orientation handling, log-drift, budget closure, the gates), and a
+hand-built Dataset is the only way to know the right answer. Both output
+vertical conventions are exercised, because the module's whole job on a real
+run directory is to give the same numbers for either.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import numpy as np
+import xarray as xr
+
+_HERE = pathlib.Path(__file__).resolve().parent
+for _p in (str(_HERE), str(_HERE.parent), str(_HERE.parents[1])):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import aerosol_stats as A  # noqa: E402
+import jcm.constants as c  # noqa: E402
+
+_LAT = np.array([-45.0, 45.0])
+_LON = np.array([0.0, 180.0])
+_DP = np.array([300.0, 250.0, 250.0, 200.0]) * 100.0   # surface-first, Pa
+
+
+def _pressures(surface_first: bool):
+    """Mid-level and interface pressures for a 4-layer synthetic column."""
+    half_sfc_first = np.concatenate([[1000e2], 1000e2 - np.cumsum(_DP)])
+    full_sfc_first = 0.5 * (half_sfc_first[:-1] + half_sfc_first[1:])
+    if surface_first:
+        return full_sfc_first, half_sfc_first
+    return full_sfc_first, half_sfc_first[::-1]
+
+
+def _field(values):
+    """Broadcast a per-level profile onto (time, level, lon, lat)."""
+    return np.broadcast_to(np.asarray(values, float)[None, :, None, None],
+                           (1, len(_DP), len(_LON), len(_LAT))).copy()
+
+
+def synthetic_chunk(*, surface_first_interfaces=True, so4_profile=None,
+                    aloft_only=False, extra=None) -> xr.Dataset:
+    """Build a minimal JAM-like output chunk in one of the two conventions.
+
+    ``surface_first_interfaces=False`` reproduces a pre-#710 file: ``level``
+    fields stay surface-first while ``pressure_half`` runs TOA-first and
+    ``level_i`` is a bare index carrying no attributes.
+    """
+    full, half = _pressures(surface_first_interfaces)
+    if so4_profile is None:
+        so4_profile = np.array([4.0, 0.0, 0.0, 0.0]) if aloft_only is False \
+            else np.array([0.0, 0.0, 0.0, 4.0])
+    q_dims = ("time", "level", "lon", "lat")
+    data = {
+        "pressure_full": (q_dims, _field(full)),
+        "pressure_half": (("time", "level_i", "lon", "lat"),
+                          np.broadcast_to(half[None, :, None, None],
+                                          (1, len(_DP) + 1, len(_LON),
+                                           len(_LAT))).copy()),
+        "m_so4_acc": (q_dims, _field(so4_profile)),
+        "jam_cloud_borne.mc_so4_acc": (q_dims, _field(so4_profile)),
+        "jam_state.r_dry": (("time", "mode", "level", "lon", "lat"),
+                            np.full((1, 1, len(_DP), len(_LON), len(_LAT)),
+                                    1e-7)),
+        "activated_cdnc": (q_dims, _field(np.full(len(_DP), 1.0e8))),
+        "jam_optics.aod_550": (("time", "lon", "lat"),
+                               np.full((1, len(_LON), len(_LAT)), 0.12)),
+        "emi_so2": (("time", "lon", "lat"),
+                    np.zeros((1, len(_LON), len(_LAT)))),
+    }
+    coords = {"lat": _LAT, "lon": _LON, "mode": ["acc"]}
+    if surface_first_interfaces:
+        coords["level_i"] = ("level_i", np.linspace(1.0, 0.0, len(_DP) + 1),
+                             {"positive": "down"})
+    if extra:
+        data.update(extra)
+    return xr.Dataset(data, coords=coords)
+
+
+class TestConventions:
+    def test_both_conventions_give_the_same_burden(self):
+        post = A.chunk_reduction(synthetic_chunk(surface_first_interfaces=True))
+        pre = A.chunk_reduction(synthetic_chunk(surface_first_interfaces=False))
+        assert np.isclose(post["burden_so4"], pre["burden_so4"])
+
+    def test_burden_value_includes_both_phases(self):
+        # 4 kg/kg in the bottom layer only, dp = 300 hPa, both phases:
+        # 2 x 4 x 3e4 / g kg/m² -> mg/m².
+        stats = A.chunk_reduction(synthetic_chunk())
+        expected = 2 * 4.0 * 3.0e4 / float(c.grav) * 1e6
+        assert np.isclose(stats["burden_so4"], expected, rtol=1e-6)
+
+    def test_the_two_fixtures_really_are_different_conventions(self):
+        """Guards the fixtures: the convention marker CLAUDE.md names.
+
+        Post-#710 output carries a real ``level_i`` sigma coordinate with a
+        ``positive`` attribute and surface-first interfaces; pre-#710 output
+        has a bare index and TOA-first interfaces. If the fixtures ever stop
+        differing, the agreement test above becomes vacuous.
+        """
+        post = synthetic_chunk(surface_first_interfaces=True)
+        pre = synthetic_chunk(surface_first_interfaces=False)
+        assert post["level_i"].attrs.get("positive") == "down"
+        assert "level_i" not in pre.coords
+        post_half = np.asarray(post["pressure_half"][0, :, 0, 0])
+        pre_half = np.asarray(pre["pressure_half"][0, :, 0, 0])
+        assert post_half[0] > post_half[-1]      # surface-first
+        assert pre_half[0] < pre_half[-1]        # TOA-first
+
+    def test_nearest_pressure_level_is_orientation_free(self):
+        for surface_first in (True, False):
+            ds = synthetic_chunk(surface_first_interfaces=surface_first)
+            k = A.nearest_pressure_level(ds, 85000.0)
+            # 850 hPa sits in the lowest layer, which is index 0 on the
+            # surface-first ``level`` axis under BOTH conventions.
+            assert k == 0
+
+    def test_upper_level_fraction_uses_pressure_not_index(self):
+        for surface_first in (True, False):
+            low = A.chunk_reduction(synthetic_chunk(
+                surface_first_interfaces=surface_first, aloft_only=False))
+            high = A.chunk_reduction(synthetic_chunk(
+                surface_first_interfaces=surface_first, aloft_only=True))
+            assert np.isclose(low["so4_above_500hPa"], 0.0)
+            assert np.isclose(high["so4_above_500hPa"], high["burden_so4"])
+
+
+class TestDetection:
+    def test_jam_run_detected(self):
+        assert A.is_jam_run(synthetic_chunk())
+
+    def test_non_jam_run_not_detected(self):
+        ds = xr.Dataset({"macsp.od550aer": (("lat",), np.zeros(2))},
+                        coords={"lat": _LAT})
+        assert not A.is_jam_run(ds)
+
+
+def _series(days, values, **extra):
+    series = {"burden_so4": np.asarray(values, float)}
+    series.update({k: np.asarray(v, float) for k, v in extra.items()})
+    return np.asarray(days, float), series
+
+
+class TestDrift:
+    def test_stationary_series_has_no_drift(self):
+        rng = np.random.default_rng(0)
+        days = np.arange(5, 370, 5, dtype=float)
+        values = 3.0 + 0.1 * rng.standard_normal(days.size)
+        assert abs(A.log_drift(days, values)) < A.DRIFT_LIMIT_PER_DAY
+
+    def test_super_exponential_tail_is_caught(self):
+        """A #658-class runaway: flat for most of the year, then blows up."""
+        days = np.arange(5, 370, 5, dtype=float)
+        values = np.full(days.size, 3.0)
+        tail = days >= 320
+        values[tail] = 3.0 * np.exp(0.12 * (days[tail] - 320.0))
+        drift = A.log_drift(days, values)
+        assert drift > A.DRIFT_LIMIT_PER_DAY
+
+    def test_drift_uses_only_the_final_window(self):
+        """A spin-up ramp in the first half must not count as drift."""
+        days = np.arange(5, 370, 5, dtype=float)
+        values = np.where(days < 180, np.exp(0.02 * days), np.exp(0.02 * 180))
+        assert abs(A.log_drift(days, values)) < A.DRIFT_LIMIT_PER_DAY
+
+
+class TestUncertainty:
+    def test_autocorrelation_inflates_the_standard_error(self):
+        rng = np.random.default_rng(1)
+        white = rng.standard_normal(200)
+        red = np.empty_like(white)
+        red[0] = white[0]
+        for i in range(1, red.size):
+            red[i] = 0.9 * red[i - 1] + white[i]
+        assert A.standard_error(red) > A.standard_error(white)
+
+    def test_constant_series_has_zero_error(self):
+        assert A.standard_error(np.full(20, 2.0)) == 0.0
+
+    def test_regression_tolerance_takes_the_larger_tier(self):
+        # Tiny sigma: the 15 % floor wins.
+        assert np.isclose(A.regression_tolerance(10.0, 1e-6), 1.5)
+        # Large sigma: 3 sigma wins.
+        assert np.isclose(A.regression_tolerance(10.0, 1.0), 3.0)
+
+
+class TestBudget:
+    def _closed(self, leak_fraction=0.0):
+        """Emission 1 mg/m²/day of bc, all deposited, burden steady."""
+        days = np.arange(0.0, 366.0, 5.0)
+        n = days.size
+        emi = np.full(n, 1.0 / 86400e6)
+        dep = emi * (1.0 - leak_fraction)
+        return days, {"burden_bc": np.full(n, 5.0),
+                      "emi_bc": emi,
+                      "dry_bc": np.zeros(n),
+                      "wet_bc": dep}
+
+    def test_closed_budget_has_no_residual(self):
+        days, series = self._closed()
+        assert abs(A._budget_residual(days, series, "bc")) < 1e-9
+
+    def test_a_leak_is_reported_at_its_size(self):
+        days, series = self._closed(leak_fraction=0.3)
+        assert np.isclose(A._budget_residual(days, series, "bc"), 0.3,
+                          rtol=1e-6)
+
+    def test_storage_change_counts_against_the_residual(self):
+        """Mass that accumulates is not a leak — it is in the burden."""
+        days, series = self._closed(leak_fraction=0.3)
+        span = days[-1] - days[0]
+        growth = 0.3 * 1.0 * span          # mg/m², the un-deposited mass
+        series["burden_bc"] = 5.0 + growth * (days - days[0]) / span
+        assert abs(A._budget_residual(days, series, "bc")) < 1e-6
+
+    def test_sulfur_family_uses_so2_and_dms_emissions(self):
+        days = np.arange(0.0, 366.0, 5.0)
+        n = days.size
+        # 1 mg of SULFATE AEROSOL per m² per day, arriving as SO2 and all
+        # deposited as so4. The conversion is the sulfate-aerosol molar mass
+        # (NH4HSO4, 115 g/mol) over SO2's, not 96.06 over SO2's.
+        emi_so2 = np.full(n, 1.0 / 86400e6) / A._SULFUR_CARRIERS["so2"]
+        series = {"burden_so4": np.full(n, 4.0),
+                  "gas_so2": np.zeros(n), "gas_dms": np.zeros(n),
+                  "gas_h2so4": np.zeros(n),
+                  "emi_so2": emi_so2, "emi_dms": np.zeros(n),
+                  "emi_so4": np.zeros(n),
+                  "dry_so4": np.zeros(n), "wet_so4": np.full(n, 1.0 / 86400e6)}
+        assert abs(A._budget_residual(days, series, "so4")) < 1e-6
+
+    def test_sulfate_carrier_ratios_are_the_aerosol_molar_mass(self):
+        """NH4HSO4 (115 g/mol), the species jcm's ``so4`` tracer carries."""
+        assert np.isclose(A._SULFUR_CARRIERS["so2"], 1.795, atol=1e-3)
+        assert np.isclose(A._SULFUR_CARRIERS["dms"], 1.851, atol=1e-3)
+
+    def test_gas_reservoirs_convert_to_sulfate_mass(self):
+        """Sulfur stored as SO2 counts as the sulfate it will become."""
+        days = np.arange(0.0, 366.0, 5.0)
+        n = days.size
+        # Nothing emitted or deposited; the aerosol burden falls by exactly
+        # the sulfate equivalent of the SO2 the column gained.
+        gas = np.linspace(0.0, 10.0, n)
+        series = {"burden_so4": 40.0 - gas * A._SULFUR_CARRIERS["so2"],
+                  "gas_so2": gas, "gas_dms": np.zeros(n),
+                  "gas_h2so4": np.zeros(n),
+                  "emi_so2": np.full(n, 1.0 / 86400e6),
+                  "emi_dms": np.zeros(n), "emi_so4": np.zeros(n),
+                  "dry_so4": np.zeros(n), "wet_so4": np.zeros(n)}
+        residual = A._budget_residual(days, series, "so4")
+        # The storage change cancels exactly, leaving only the emission.
+        assert np.isclose(residual, 1.0, atol=1e-9)
+
+    def test_soa_is_not_scored(self):
+        """SOA's source is the SOAG gas, which has no ``emi_*`` channel."""
+        assert "soa" not in A.PRIMARY_BUDGET_SPECIES
+
+
+class TestDynamicsConservation:
+    """The #713 in-step gauge: transport that does not conserve mass.
+
+    The August-2026 runaway was semi-Lagrangian transport creating mass, not a
+    physics defect, so it needs its own gate — the burden drift sees the
+    symptom, this sees the cause.
+    """
+
+    def _series(self, dyn_per_second, mass=4.0e-6, n=40):
+        days = np.arange(5.0, 5.0 * n + 5.0, 5.0)
+        return days, {"budget_mass_so4": np.full(n, mass),
+                      "budget_dyn_so4": np.full(n, dyn_per_second),
+                      "burden_so4": np.full(n, mass * 1e6)}
+
+    def test_a_conservative_core_passes(self):
+        # 1e-5 of the mass per 720 s step.
+        days, series = self._series(4.0e-6 * 1e-5 / 720.0)
+        stats = A.summarize(days, series, timestep_seconds=720.0)
+        assert np.isclose(stats["dyn_frac_per_step_so4"], 1e-5, rtol=1e-6)
+        assert all(ok for name, _v, _l, ok in A.physics_gates(stats)
+                   if name.startswith("dyn_"))
+
+    def test_a_leaking_transport_trips_the_gate(self):
+        # 1 % of the mass created per step — ten times the limit.
+        days, series = self._series(4.0e-6 * 1e-2 / 720.0)
+        stats = A.summarize(days, series, timestep_seconds=720.0)
+        failed = [name for name, _v, _l, ok in A.physics_gates(stats)
+                  if not ok]
+        assert "dyn_frac_per_step_so4" in failed
+
+    def test_destruction_trips_it_too(self):
+        """The residual is signed; either direction is non-conservation."""
+        days, series = self._series(-4.0e-6 * 1e-2 / 720.0)
+        stats = A.summarize(days, series, timestep_seconds=720.0)
+        assert stats["dyn_frac_per_step_so4"] > A.DYN_RESIDUAL_PER_STEP
+
+    def test_unscored_without_a_timestep(self):
+        """Pre-#713 output has no gauge, and a copied rundir has no config."""
+        days, series = self._series(4.0e-6 * 1e-2 / 720.0)
+        stats = A.summarize(days, series, timestep_seconds=None)
+        assert not any(k.startswith("dyn_frac_per_step_") for k in stats)
+        assert not any(name.startswith("dyn_")
+                       for name, *_rest in A.physics_gates(stats))
+
+    def test_timestep_is_read_from_the_saved_hydra_config(self, tmp_path):
+        (tmp_path / ".hydra").mkdir()
+        (tmp_path / ".hydra" / "config.yaml").write_text(
+            "run:\n  time_step: 12\n")
+        assert A.timestep_seconds(str(tmp_path)) == 720.0
+
+    def test_timestep_is_none_without_a_config(self, tmp_path):
+        assert A.timestep_seconds(str(tmp_path)) is None
+
+    def test_chunk_reduction_picks_up_the_gauge_fields(self):
+        n_lon, n_lat = len(_LON), len(_LAT)
+        extra = {
+            "budget_mass_so4": (("time", "lon", "lat"),
+                                np.full((1, n_lon, n_lat), 4.0e-6)),
+            "budget_dyn_so4": (("time", "lon", "lat"),
+                               np.full((1, n_lon, n_lat), 5.0e-14)),
+        }
+        out = A.chunk_reduction(synthetic_chunk(extra=extra))
+        assert np.isclose(out["budget_mass_so4"], 4.0e-6)
+        assert np.isclose(out["budget_dyn_so4"], 5.0e-14)
+
+
+class TestGates:
+    def _stats(self, values, **extra):
+        days, series = _series(np.arange(5, 370, 5, dtype=float), values,
+                               **extra)
+        return A.summarize(days, series)
+
+    def test_clean_run_passes(self):
+        rng = np.random.default_rng(2)
+        days = np.arange(5, 370, 5, dtype=float)
+        values = 3.0 + 0.05 * rng.standard_normal(days.size)
+        stats = self._stats(values)
+        rows = A.physics_gates(stats)
+        assert rows and all(ok for *_rest, ok in rows)
+
+    def test_runaway_run_fails_the_drift_gate(self):
+        days = np.arange(5, 370, 5, dtype=float)
+        values = np.full(days.size, 3.0)
+        tail = days >= 320
+        values[tail] = 3.0 * np.exp(0.12 * (days[tail] - 320.0))
+        rows = A.physics_gates(self._stats(values))
+        failed = [name for name, _v, _lim, ok in rows if not ok]
+        assert "dlnB_dt_so4_per_day" in failed
+
+    def test_species_the_run_never_carries_has_no_drift_statistic(self):
+        """A correctly-zero burden must not fail the drift gate on a NaN."""
+        n = 73
+        days = np.arange(5, 370, 5, dtype=float)[:n]
+        stats = A.summarize(days, {"burden_soa": np.zeros(n)})
+        assert stats["burden_soa_mg_m2"] == 0.0
+        assert "dlnB_dt_soa_per_day" not in stats
+        assert all(ok for *_rest, ok in A.physics_gates(stats))
+
+    def test_lifetime_is_burden_over_deposition(self):
+        n = 73
+        days = np.arange(5, 370, 5, dtype=float)[:n]
+        series = {"burden_so4": np.full(n, 4.0),
+                  "dry_so4": np.zeros(n),
+                  "wet_so4": np.full(n, 1.0 / 86400e6)}   # 1 mg/m²/day
+        stats = A.summarize(days, series)
+        assert np.isclose(stats["lifetime_so4_days"], 4.0)
+
+    def test_hemispheric_ratio_and_upper_fraction(self):
+        n = 20
+        days = np.arange(5, 5 * n + 5, 5, dtype=float)
+        series = {"burden_so4": np.full(n, 4.0),
+                  "so4_nh": np.full(n, 6.0), "so4_sh": np.full(n, 2.0),
+                  "so4_60_90N": np.full(n, 1.5),
+                  "so4_above_500hPa": np.full(n, 1.0)}
+        stats = A.summarize(days, series)
+        assert np.isclose(stats["so4_nh_sh_ratio"], 3.0)
+        assert np.isclose(stats["so4_frac_above_500hPa"], 0.25)
+        assert np.isclose(stats["so4_burden_60_90N_mg_m2"], 1.5)
+
+    def test_a_positive_residual_names_the_incomplete_ledger(self):
+        """Emitted mass unaccounted for looks exactly like a missing sink.
+
+        On output written before the #722 removal-ledger fix, ``dry_*`` omits
+        Slinn dry deposition, so the gate must say so rather than report a leak.
+        """
+        stats = {"budget_residual_max": 0.4}
+        (name, value, limit, ok), = A.physics_gates(stats)
+        assert name == "budget_residual_max" and not ok
+        assert "#722" in limit
+        assert "#722" in A.format_table(stats, A.physics_gates(stats))
+
+    def test_a_negative_residual_is_unambiguous_mass_creation(self):
+        """No missing ledger entry can deposit more mass than entered."""
+        stats = {"budget_residual_max": -0.4}
+        (_name, _value, limit, ok), = A.physics_gates(stats)
+        assert not ok and "#722" not in limit
+
+    def test_regression_comparison_passes_a_matching_run(self):
+        stats = self._stats(np.full(73, 3.0))
+        rows = A.compare_to_reference(stats, dict(stats))
+        assert rows and all(ok for *_rest, ok in rows)
+
+    def test_regression_comparison_catches_a_shifted_burden(self):
+        """A 30 % shift is past the 15 % floor even on a quiet statistic."""
+        stats = self._stats(np.full(73, 3.0))
+        reference = dict(stats, burden_so4_mg_m2=3.0 * 1.3)
+        failed = [name for name, _v, _l, ok
+                  in A.compare_to_reference(stats, reference) if not ok]
+        assert "burden_so4_mg_m2" in failed
+
+    def test_a_noisy_statistic_gets_the_wider_tolerance(self):
+        """3 sigma wins over the 15 % floor when the series is noisy."""
+        rng = np.random.default_rng(3)
+        days = np.arange(5, 370, 5, dtype=float)
+        values = 3.0 + 2.0 * rng.standard_normal(days.size)
+        series = {"burden_so4": values}
+        stats = A.summarize(days, series)
+        reference = dict(stats, burden_so4_mg_m2=stats["burden_so4_mg_m2"] * 1.2)
+        without = A.compare_to_reference(stats, reference)
+        with_series = A.compare_to_reference(stats, reference, series)
+        picked = lambda rows: dict(  # noqa: E731
+            (name, ok) for name, _v, _l, ok in rows)["burden_so4_mg_m2"]
+        assert not picked(without)      # 15 % floor alone rejects a 20 % shift
+        assert picked(with_series)      # 3 sigma of a noisy series accepts it
+
+    def test_format_table_reports_every_gate(self):
+        stats = self._stats(np.full(73, 3.0))
+        text = A.format_table(stats, A.physics_gates(stats))
+        assert "dlnB_dt_so4_per_day" in text and "PASS" in text

--- a/tools/release_validation/aerosol_stats_test.py
+++ b/tools/release_validation/aerosol_stats_test.py
@@ -205,6 +205,22 @@ class TestBudget:
         days, series = self._closed()
         assert abs(A._budget_residual(days, series, "bc")) < 1e-9
 
+    def test_the_flux_integral_matches_the_storage_interval(self):
+        """A short record must not read as a leak from a window mismatch.
+
+        The storage term spans chunk CENTRES, so the flux integral must too;
+        averaging all N chunks over an (N-1)-chunk span understates it by 1/N,
+        which on a four-chunk window is 25 % into a gate set at 5 %.
+        """
+        for n_chunks in (4, 10, 73):
+            days = np.arange(5.0, 5.0 * n_chunks + 5.0, 5.0)
+            emi = np.full(n_chunks, 1.0 / 86400e6)      # 1 mg/m²/day
+            series = {"burden_bc": np.full(n_chunks, 5.0),
+                      "emi_bc": emi, "dry_bc": np.zeros(n_chunks),
+                      "wet_bc": emi}
+            residual = A._budget_residual(days, series, "bc")
+            assert abs(residual) < 1e-9, n_chunks
+
     def test_a_leak_is_reported_at_its_size(self):
         days, series = self._closed(leak_fraction=0.3)
         assert np.isclose(A._budget_residual(days, series, "bc"), 0.3,
@@ -258,6 +274,19 @@ class TestBudget:
     def test_soa_is_not_scored(self):
         """SOA's source is the SOAG gas, which has no ``emi_*`` channel."""
         assert "soa" not in A.PRIMARY_BUDGET_SPECIES
+
+    def test_every_budget_species_has_a_burden_to_close_against(self):
+        """A species with no burden can never be scored — do not advertise it.
+
+        ``moa`` has emi/dry/wet ledgers but no entry in the shared anchor
+        table, so ``burden_moa`` is never computed and its residual would be
+        silently dropped from ``budget_residual_max``.
+        """
+        from jam_burden_report import _SPECIES
+        for species in A.PRIMARY_BUDGET_SPECIES:
+            assert species in _SPECIES, species
+        for species in A.LIFETIME_SPECIES:
+            assert species in _SPECIES, species
 
 
 class TestDynamicsConservation:
@@ -356,6 +385,13 @@ class TestGates:
         stats = A.summarize(days, {"burden_soa": np.zeros(n)})
         assert stats["burden_soa_mg_m2"] == 0.0
         assert "dlnB_dt_soa_per_day" not in stats
+        assert all(ok for *_rest, ok in A.physics_gates(stats))
+
+    def test_a_record_too_short_to_fit_is_not_scored(self):
+        """``--last-n 2`` on a healthy run must not report an aerosol failure."""
+        stats = A.summarize(np.array([355.0, 360.0]),
+                            {"burden_so4": np.array([2.0, 2.1])})
+        assert "dlnB_dt_so4_per_day" not in stats
         assert all(ok for *_rest, ok in A.physics_gates(stats))
 
     def test_lifetime_is_burden_over_deposition(self):

--- a/tools/release_validation/aerosol_stats_test.py
+++ b/tools/release_validation/aerosol_stats_test.py
@@ -701,3 +701,142 @@ class TestSeriesRoundTrip:
         loaded = np.load(out)
         series = {k: loaded[k] for k in loaded.files if not k.startswith("_")}
         assert set(series) == {"burden_bc"}
+
+
+class TestEveryClosureComponentRequired:
+    """A missing ledger field is not a zero contribution."""
+
+    def _closed(self, n=40):
+        days = np.arange(5.0, 5.0 * n + 5.0, 5.0)
+        emi = np.full(n, 1.0 / 86400e6)
+        return days, {"burden_bc": np.full(n, 5.0), "emi_bc": emi,
+                      "dry_bc": np.zeros(n), "wet_bc": emi}
+
+    def test_baseline_closes(self):
+        days, series = self._closed()
+        assert abs(A._budget_residual(days, series, "bc")) < 1e-9
+
+    def test_a_missing_removal_ledger_is_unscored_not_fabricated(self):
+        for dropped in ("dry_bc", "wet_bc"):
+            days, series = self._closed()
+            del series[dropped]
+            assert A._budget_residual(days, series, "bc") is None, dropped
+
+    def test_dropping_wet_would_otherwise_fabricate_a_full_leak(self):
+        """Guards the specific wrong answer: wet carries the whole sink."""
+        days, series = self._closed()
+        del series["wet_bc"]
+        # Treating the absence as zero deposition gives residual == 1.0.
+        deposited_as_zero = 1.0
+        assert A._budget_residual(days, series, "bc") is None
+        stats = A.summarize(days, series)
+        assert stats.get("budget_residual_bc") != deposited_as_zero
+        assert "budget_residual_bc" not in stats
+
+    def test_a_missing_gas_reservoir_is_unscored(self):
+        n = 40
+        days = np.arange(5.0, 5.0 * n + 5.0, 5.0)
+        emi = np.full(n, 1.0 / 86400e6)
+        base = {"burden_so4": np.full(n, 4.0),
+                "gas_so2": np.zeros(n), "gas_dms": np.zeros(n),
+                "gas_h2so4": np.zeros(n),
+                "emi_so2": emi, "emi_dms": np.zeros(n), "emi_so4": np.zeros(n),
+                "dry_so4": np.zeros(n), "wet_so4": np.zeros(n)}
+        assert A._budget_residual(days, dict(base), "so4") is not None
+        for gas in ("gas_so2", "gas_dms", "gas_h2so4"):
+            series = dict(base)
+            del series[gas]
+            assert A._budget_residual(days, series, "so4") is None, gas
+
+
+class TestFluxIntegration:
+    """The flux integral must span the same interval as the storage term."""
+
+    def test_a_linearly_varying_flux_integrates_exactly(self):
+        n = 40
+        days = np.arange(5.0, 5.0 * n + 5.0, 5.0)
+        # Emission ramps 1 -> 3 mg/m2/day; trapezoid is exact for a ramp.
+        emi_mg = np.linspace(1.0, 3.0, n)
+        emi = emi_mg / 86400e6
+        span = days[-1] - days[0]
+        expected = 0.5 * (emi_mg[0] + emi_mg[-1]) * span       # mg/m2
+        series = {"burden_bc": np.full(n, 5.0), "emi_bc": emi,
+                  "dry_bc": np.zeros(n), "wet_bc": emi}
+        # A closed budget: deposition equals emission, burden steady.
+        assert abs(A._budget_residual(days, series, "bc")) < 1e-9
+        # And the integral itself is the trapezoidal one, not a right-endpoint
+        # rectangle rule (which would be high by half a chunk x the change).
+        rect = float(np.mean(emi_mg[1:])) * span
+        assert not np.isclose(rect, expected)
+        assert np.isclose(float(np.trapezoid(emi, days)) * 86400e6, expected)
+
+    def test_a_seasonal_sink_swing_does_not_fabricate_a_leak(self):
+        """The failure mode: a varying sink tripping the 5 % closure gate."""
+        n = 19                                   # the 90-day minimum window
+        days = np.arange(5.0, 5.0 * n + 5.0, 5.0)
+        # Sink doubles across the window; emission matches it exactly, so the
+        # budget is closed by construction and the burden is steady.
+        flux = np.linspace(1.0, 3.0, n) / 86400e6
+        series = {"burden_bc": np.full(n, 5.0), "emi_bc": flux,
+                  "dry_bc": np.zeros(n), "wet_bc": flux}
+        residual = A._budget_residual(days, series, "bc")
+        assert abs(residual) < A.BUDGET_RESIDUAL_LIMIT
+        assert abs(residual) < 1e-9
+
+    def test_a_nan_flux_sample_is_unscored(self):
+        n = 40
+        days = np.arange(5.0, 5.0 * n + 5.0, 5.0)
+        emi = np.full(n, 1.0 / 86400e6)
+        emi[5] = np.nan
+        series = {"burden_bc": np.full(n, 5.0), "emi_bc": emi,
+                  "dry_bc": np.zeros(n), "wet_bc": np.full(n, 1.0 / 86400e6)}
+        assert A._budget_residual(days, series, "bc") is None
+
+
+class TestReferenceCompleteness:
+    def test_a_statistic_the_run_lost_fails(self):
+        """A regression that deletes a diagnostic must not report PASS."""
+        reference = {"burden_so4_mg_m2": 3.0, "aod_550": 0.12}
+        stats = {"burden_so4_mg_m2": 3.0}          # aod_550 no longer emitted
+        rows = A.compare_to_reference(stats, reference)
+        failed = {name: limit for name, _v, limit, ok in rows if not ok}
+        assert "aod_550" in failed
+        assert "absent" in failed["aod_550"]
+
+    def test_a_matching_run_still_passes(self):
+        reference = {"burden_so4_mg_m2": 3.0, "aod_550": 0.12}
+        rows = A.compare_to_reference(dict(reference), reference)
+        assert rows and all(ok for *_r, ok in rows)
+
+
+class TestAnchorGates:
+    """Tier 2 must apply wherever the statistics are scored."""
+
+    def test_an_excessive_burden_fails_the_anchor(self):
+        stats = {"burden_so4_mg_m2": 500.0}
+        (name, _v, _l, ok), = A.anchor_gates(stats)
+        assert name == "burden_so4_mg_m2" and not ok
+
+    def test_a_plausible_burden_passes(self):
+        assert all(ok for *_r, ok in A.anchor_gates({"burden_so4_mg_m2": 3.0}))
+
+    def test_a_species_the_run_lacks_is_not_anchor_scored(self):
+        assert A.anchor_gates({"burden_soa_mg_m2": 0.0}) == []
+        n = 40
+        days = np.arange(5.0, 5.0 * n + 5.0, 5.0)
+        reasons = dict(A.unscored_gates(days, {"burden_soa": np.zeros(n)}))
+        assert "burden_soa_mg_m2" in reasons
+
+    def test_a_stationary_excessive_run_is_not_a_clean_pass(self):
+        """Zero drift and a closed ledger must not excuse a huge burden."""
+        n = 40
+        days = np.arange(5.0, 5.0 * n + 5.0, 5.0)
+        emi = np.full(n, 1.0 / 86400e6)
+        series = {"burden_so4": np.full(n, 500.0), "emi_so4": emi,
+                  "emi_so2": np.zeros(n), "emi_dms": np.zeros(n),
+                  "gas_so2": np.zeros(n), "gas_dms": np.zeros(n),
+                  "gas_h2so4": np.zeros(n),
+                  "dry_so4": np.zeros(n), "wet_so4": emi}
+        stats = A.summarize(days, series)
+        assert all(ok for *_r, ok in A.physics_gates(stats))    # drift/closure fine
+        assert not all(ok for *_r, ok in A.anchor_gates(stats))  # anchor is not

--- a/tools/release_validation/aerosol_stats_test.py
+++ b/tools/release_validation/aerosol_stats_test.py
@@ -191,8 +191,12 @@ class TestUncertainty:
 
 class TestBudget:
     def _closed(self, leak_fraction=0.0):
-        """Emission 1 mg/m²/day of bc, all deposited, burden steady."""
-        days = np.arange(0.0, 366.0, 5.0)
+        """Emission 1 mg/m²/day of bc, all deposited, burden steady.
+
+        Chunk labels start at the first chunk's END day, as the output files
+        do; a day-0 label would name a zero-length averaging window.
+        """
+        days = np.arange(5.0, 371.0, 5.0)
         n = days.size
         emi = np.full(n, 1.0 / 86400e6)
         dep = emi * (1.0 - leak_fraction)
@@ -726,12 +730,10 @@ class TestEveryClosureComponentRequired:
         """Guards the specific wrong answer: wet carries the whole sink."""
         days, series = self._closed()
         del series["wet_bc"]
-        # Treating the absence as zero deposition gives residual == 1.0.
-        deposited_as_zero = 1.0
+        # Treating the absence as zero deposition would give residual == 1.0;
+        # the point is that no residual is produced at all.
         assert A._budget_residual(days, series, "bc") is None
-        stats = A.summarize(days, series)
-        assert stats.get("budget_residual_bc") != deposited_as_zero
-        assert "budget_residual_bc" not in stats
+        assert "budget_residual_bc" not in A.summarize(days, series)
 
     def test_a_missing_gas_reservoir_is_unscored(self):
         n = 40
@@ -750,38 +752,87 @@ class TestEveryClosureComponentRequired:
 
 
 class TestFluxIntegration:
-    """The flux integral must span the same interval as the storage term."""
+    """The flux integral must span the same interval as the storage term.
 
-    def test_a_linearly_varying_flux_integrates_exactly(self):
-        n = 40
+    Every assertion here has to DISCRIMINATE the quadrature. Setting the sink
+    equal to the source makes the residual identically zero for any linear
+    functional, so such a test passes under the rectangle rule too and pins
+    nothing; these use a source and sink with different shapes.
+    """
+
+    @staticmethod
+    def _rectangle_residual(days, series, species):
+        """Compute the superseded right-endpoint rule, for tests to reject."""
+        span = float(days[-1] - days[0])
+
+        def integral(key):
+            return float(np.mean(series[key][1:])) * span * 86400e6
+
+        emitted = integral(f"emi_{species}")
+        deposited = integral(f"dry_{species}") + integral(f"wet_{species}")
+        stored = series[f"burden_{species}"]
+        return (emitted - deposited - (stored[-1] - stored[0])) / emitted
+
+    def _ramped_sink(self, n=19):
+        """Constant source, sink ramping 1->3 over a 90-day window.
+
+        Emission and deposition integrate to the same total and the burden is
+        steady, so the budget closes exactly — under the correct quadrature.
+        """
         days = np.arange(5.0, 5.0 * n + 5.0, 5.0)
-        # Emission ramps 1 -> 3 mg/m2/day; trapezoid is exact for a ramp.
-        emi_mg = np.linspace(1.0, 3.0, n)
-        emi = emi_mg / 86400e6
-        span = days[-1] - days[0]
-        expected = 0.5 * (emi_mg[0] + emi_mg[-1]) * span       # mg/m2
-        series = {"burden_bc": np.full(n, 5.0), "emi_bc": emi,
-                  "dry_bc": np.zeros(n), "wet_bc": emi}
-        # A closed budget: deposition equals emission, burden steady.
+        return days, {"burden_bc": np.full(n, 5.0),
+                      "emi_bc": np.full(n, 2.0 / 86400e6),
+                      "dry_bc": np.zeros(n),
+                      "wet_bc": np.linspace(1.0, 3.0, n) / 86400e6}
+
+    def test_a_ramped_sink_closes(self):
+        days, series = self._ramped_sink()
+        assert abs(A._budget_residual(days, series, "bc")) < 1e-12
+
+    def test_the_superseded_rule_would_not_close(self):
+        """Guards the fix: reverting `integral()` must break this suite.
+
+        The rectangle rule reads a 2.8 % leak on a budget that closes — the
+        half-chunk-times-endpoint-change error, at a size comparable to the
+        5 % gate it feeds.
+        """
+        days, series = self._ramped_sink()
+        rect = self._rectangle_residual(days, series, "bc")
+        assert abs(rect) > 0.02
+        # ... and large enough to matter against the gate it feeds.
+        assert abs(rect) > 0.5 * A.BUDGET_RESIDUAL_LIMIT
+
+    def test_a_ramped_source_closes_too(self):
+        """The same, with the shapes swapped, so neither side is privileged."""
+        n = 19
+        days = np.arange(5.0, 5.0 * n + 5.0, 5.0)
+        series = {"burden_bc": np.full(n, 5.0),
+                  "emi_bc": np.linspace(1.0, 3.0, n) / 86400e6,
+                  "dry_bc": np.zeros(n),
+                  "wet_bc": np.full(n, 2.0 / 86400e6)}
+        assert abs(A._budget_residual(days, series, "bc")) < 1e-12
+        assert abs(self._rectangle_residual(days, series, "bc")) > 0.02
+
+    def test_real_storage_growth_is_accounted(self):
+        """A burden that genuinely grows must show up, not cancel."""
+        n = 19
+        days = np.arange(5.0, 5.0 * n + 5.0, 5.0)
+        emi = np.full(n, 2.0 / 86400e6)
+        span = A.chunk_centres(days)[-1] - A.chunk_centres(days)[0]
+        growth = 0.10 * 2.0 * span          # 10 % of the emitted mass retained
+        series = {"burden_bc": 5.0 + growth * np.linspace(0.0, 1.0, n),
+                  "emi_bc": emi, "dry_bc": np.zeros(n),
+                  "wet_bc": emi * 0.9}
         assert abs(A._budget_residual(days, series, "bc")) < 1e-9
-        # And the integral itself is the trapezoidal one, not a right-endpoint
-        # rectangle rule (which would be high by half a chunk x the change).
-        rect = float(np.mean(emi_mg[1:])) * span
-        assert not np.isclose(rect, expected)
-        assert np.isclose(float(np.trapezoid(emi, days)) * 86400e6, expected)
 
-    def test_a_seasonal_sink_swing_does_not_fabricate_a_leak(self):
-        """The failure mode: a varying sink tripping the 5 % closure gate."""
-        n = 19                                   # the 90-day minimum window
-        days = np.arange(5.0, 5.0 * n + 5.0, 5.0)
-        # Sink doubles across the window; emission matches it exactly, so the
-        # budget is closed by construction and the burden is steady.
-        flux = np.linspace(1.0, 3.0, n) / 86400e6
-        series = {"burden_bc": np.full(n, 5.0), "emi_bc": flux,
-                  "dry_bc": np.zeros(n), "wet_bc": flux}
-        residual = A._budget_residual(days, series, "bc")
-        assert abs(residual) < A.BUDGET_RESIDUAL_LIMIT
-        assert abs(residual) < 1e-9
+    def test_chunk_centres_are_the_window_midpoints(self):
+        """The abscissa: filenames give the END day, a mean sits at the middle."""
+        np.testing.assert_allclose(A.chunk_centres(np.array([5.0, 10.0, 15.0])),
+                                   [2.5, 7.5, 12.5])
+        # Non-uniform cadence: the centres track the varying window lengths,
+        # which is the case a fixed end-day abscissa gets wrong.
+        np.testing.assert_allclose(A.chunk_centres(np.array([10.0, 15.0, 35.0])),
+                                   [5.0, 12.5, 25.0])
 
     def test_a_nan_flux_sample_is_unscored(self):
         n = 40

--- a/tools/release_validation/aerosol_stats_test.py
+++ b/tools/release_validation/aerosol_stats_test.py
@@ -292,8 +292,8 @@ class TestBudget:
 class TestDynamicsConservation:
     """The #713 in-step gauge: transport that does not conserve mass.
 
-    The August-2026 runaway was semi-Lagrangian transport creating mass, not a
-    physics defect, so it needs its own gate — the burden drift sees the
+    Transport that creates mass is a different failure from aerosol physics
+    that creates mass, and needs its own gate: the burden drift sees the
     symptom, this sees the cause.
     """
 
@@ -465,3 +465,142 @@ class TestGates:
         stats = self._stats(np.full(73, 3.0))
         text = A.format_table(stats, A.physics_gates(stats))
         assert "dlnB_dt_so4_per_day" in text and "PASS" in text
+
+
+class TestMinimumWindow:
+    """No statistic whose fit is noise-dominated may reach a gate."""
+
+    def _series(self, n):
+        days = np.arange(5.0, 5.0 * n + 5.0, 5.0)
+        rng = np.random.default_rng(4)
+        return days, {"burden_bc": 3.0 * np.exp(0.05 * rng.standard_normal(n))}
+
+    def test_short_window_is_unscored_not_failed(self):
+        days, series = self._series(4)               # 15 days
+        stats = A.summarize(days, series)
+        assert "dlnB_dt_bc_per_day" not in stats
+        assert not any(name.startswith("dlnB_dt_")
+                       for name, *_ in A.physics_gates(stats))
+        reasons = dict(A.unscored_gates(days, series))
+        assert "dlnB_dt_bc_per_day" in reasons
+        assert "90" in reasons["dlnB_dt_bc_per_day"]
+
+    def test_long_window_is_scored(self):
+        days, series = self._series(40)              # 195 days
+        stats = A.summarize(days, series)
+        assert "dlnB_dt_bc_per_day" in stats
+        assert not any(name.startswith("dlnB_dt_")
+                       for name, _r in A.unscored_gates(days, series))
+
+    def test_short_window_does_not_score_the_residual_either(self):
+        n = 4
+        days = np.arange(5.0, 5.0 * n + 5.0, 5.0)
+        emi = np.full(n, 1.0 / 86400e6)
+        series = {"burden_bc": np.full(n, 5.0), "emi_bc": emi,
+                  "dry_bc": np.zeros(n), "wet_bc": np.zeros(n)}
+        stats = A.summarize(days, series)
+        assert "budget_residual_max" not in stats
+        assert "budget_residual_max" in dict(A.unscored_gates(days, series))
+
+    def test_a_stationary_species_is_not_failed_by_a_short_fit(self):
+        """The regression this guard exists for: --last-n on a settled run."""
+        rng = np.random.default_rng(5)
+        for n in (3, 4, 6):
+            days = np.arange(5.0, 5.0 * n + 5.0, 5.0)
+            series = {"burden_bc": 3.0 * np.exp(0.05 *
+                                                rng.standard_normal(n))}
+            stats = A.summarize(days, series)
+            assert all(ok for *_r, ok in A.physics_gates(stats)), n
+
+
+class TestNothingPassesByAbsence:
+    def test_missing_gauge_is_reported_even_with_a_timestep(self):
+        """Pre-#713 output has a config but no gauge: still must not be silent."""
+        n = 40
+        days = np.arange(5.0, 5.0 * n + 5.0, 5.0)
+        series = {"burden_bc": np.full(n, 3.0)}
+        stats = A.summarize(days, series, timestep_seconds=720.0)
+        assert not any(name.startswith("dyn_")
+                       for name, *_ in A.physics_gates(stats))
+        reason = dict(A.unscored_gates(days, series, 720.0))["dyn_frac_per_step"]
+        assert "budget_dyn" in reason and "713" in reason
+
+    def test_missing_timestep_is_reported_when_the_gauge_is_present(self):
+        n = 40
+        days = np.arange(5.0, 5.0 * n + 5.0, 5.0)
+        series = {"burden_bc": np.full(n, 3.0),
+                  "budget_mass_bc": np.full(n, 4.0e-6),
+                  "budget_dyn_bc": np.zeros(n)}
+        reason = dict(A.unscored_gates(days, series, None))["dyn_frac_per_step"]
+        assert "timestep" in reason
+
+    def test_a_scored_dynamics_gate_is_not_reported_unscored(self):
+        n = 40
+        days = np.arange(5.0, 5.0 * n + 5.0, 5.0)
+        series = {"burden_bc": np.full(n, 3.0),
+                  "budget_mass_bc": np.full(n, 4.0e-6),
+                  "budget_dyn_bc": np.zeros(n)}
+        assert "dyn_frac_per_step" not in dict(
+            A.unscored_gates(days, series, 720.0))
+
+    def test_species_the_run_does_not_carry_is_reported(self):
+        n = 40
+        days = np.arange(5.0, 5.0 * n + 5.0, 5.0)
+        series = {"burden_soa": np.zeros(n)}
+        assert "carries no burden" in dict(
+            A.unscored_gates(days, series))["dlnB_dt_soa_per_day"]
+
+
+class TestResidualNaNGuard:
+    def test_a_nan_storage_endpoint_yields_no_residual(self):
+        n = 40
+        days = np.arange(5.0, 5.0 * n + 5.0, 5.0)
+        burden = np.full(n, 5.0)
+        burden[-1] = np.nan
+        emi = np.full(n, 1.0 / 86400e6)
+        series = {"burden_bc": burden, "emi_bc": emi,
+                  "dry_bc": np.zeros(n), "wet_bc": emi}
+        assert A._budget_residual(days, series, "bc") is None
+        stats = A.summarize(days, series)
+        assert "budget_residual_bc" not in stats
+        assert "budget_residual_max" not in stats
+        assert all(ok for *_r, ok in A.physics_gates(stats))
+
+
+class TestRegressionTiers:
+    def test_gated_statistics_are_not_double_scored(self):
+        n = 40
+        days = np.arange(5.0, 5.0 * n + 5.0, 5.0)
+        series = {"burden_bc": np.full(n, 3.0)}
+        stats = A.summarize(days, series)
+        names = [name for name, *_ in A.compare_to_reference(stats, stats)]
+        assert not any(n_.startswith(A._GATED_PREFIXES) for n_ in names)
+        assert "burden_bc_mg_m2" in names
+
+    def test_a_zero_reference_gets_an_absolute_floor(self):
+        """A zero tolerance would fail any nonzero value against a zero reference."""
+        assert A.tolerance_floor("burden_soa_mg_m2") > 0
+        tol = A.regression_tolerance(0.0, 0.0,
+                                     A.tolerance_floor("burden_soa_mg_m2"))
+        assert tol > 0
+        rows = A.compare_to_reference({"burden_soa_mg_m2": 0.0},
+                                      {"burden_soa_mg_m2": 0.0})
+        assert all(ok for *_r, ok in rows)
+
+    def test_the_floor_does_not_swallow_a_real_change(self):
+        rows = A.compare_to_reference({"burden_so4_mg_m2": 3.0},
+                                      {"burden_so4_mg_m2": 0.0})
+        assert not rows[0][3]
+
+
+class TestJamDetection:
+    def test_a_trimmed_jam_run_is_still_detected(self):
+        """Mass tracers alone: a trimmed output set must not skip the gates."""
+        ds = synthetic_chunk().drop_vars(
+            ["jam_state.r_dry", "jam_cloud_borne.mc_so4_acc",
+             "jam_optics.aod_550"])
+        assert A.is_jam_run(ds)
+        assert A.missing_jam_diagnostics(ds)
+
+    def test_a_complete_run_reports_nothing_missing(self):
+        assert A.missing_jam_diagnostics(synthetic_chunk()) == []

--- a/tools/release_validation/health.py
+++ b/tools/release_validation/health.py
@@ -43,8 +43,8 @@ for _p in (str(_REPO), str(_TOOLS)):
 from jcm.analysis import area_weights, global_mean  # noqa: E402
 from jam_burden_report import _SPECIES  # noqa: E402
 from aerosol_stats import (  # noqa: E402
-    _AOD_KEYS, collect, format_table, is_jam_run, physics_gates, summarize,
-    timestep_seconds)
+    _AOD_KEYS, collect, format_table, is_jam_run, missing_jam_diagnostics,
+    physics_gates, summarize, timestep_seconds, unscored_gates)
 
 #: Gate slack: the release gate is the climatological anchor range from
 #: the shared species table widened by this factor each way — a "did the
@@ -151,6 +151,7 @@ def main():
     # before #640), MACv2-SP runs publish macsp.od550aer; whichever is present
     # is the scheme's AOD. The JAM keys are shared with aerosol_stats so a run
     # the aerosol block can score is never skipped here.
+    _aod_names = "/".join(_AOD_KEYS + ("macsp.od550aer",))
     aod = None
     for key in _AOD_KEYS + ("macsp.od550aer",):
         if key in ds:
@@ -159,8 +160,7 @@ def main():
     if aod is not None:
         check("aod_550", wmean(aod, weights), *RANGES["aod_550"])
     else:
-        print("NOTE  no AOD field found "
-              "(jam_optics.aod_550/macsp.od550aer); skipping")
+        print(f"NOTE  no AOD field found ({_aod_names}); skipping")
 
     # JAM aerosol block (#762). The statistics are built chunk by chunk
     # (a year of JAM output does not fit in memory), so this takes the file
@@ -170,28 +170,42 @@ def main():
     # closure — the latter are what catch a slow runaway that stays inside a
     # x3-slack range gate until its final fortnight.
     if is_jam_run(ds):
+        for namespace in missing_jam_diagnostics(ds):
+            print(f"NOTE  no {namespace}.* diagnostics saved; the aerosol "
+                  "statistics that read them are absent from the report")
         days, series = collect(files)
         # The dynamics-conservation gate is per STEP, so it needs the run's
-        # timestep; without a saved Hydra config it stays unscored.
+        # timestep; ``unscored_gates`` reports it when either is missing.
         dt = timestep_seconds(a.run_dir)
         stats = summarize(days, series, dt)
-        if dt is None:
-            print("NOTE  no .hydra/config.yaml timestep — the dynamics-"
-                  "conservation gate is not scored")
         for sp, (lo, hi) in BURDEN_RANGES.items():
             key = f"burden_{sp}_mg_m2"
             if key not in stats:
                 print(f"NOTE  no {sp} mass tracers; skipping burden")
+                continue
+            if stats[key] == 0.0:
+                # A species the run does not carry is exempted from the drift
+                # gate; the anchor gate must agree, or the two tiers contradict
+                # each other on the same line of the report.
+                print(f"NOTE  {sp} burden is identically zero — the run "
+                      "carries no such aerosol; anchor gate not scored")
                 continue
             check(key, stats[key], lo, hi)
         for name, value, limit, good in physics_gates(stats):
             print(f"{'PASS' if good else 'FAIL'}  {name} = {value:.4g} "
                   f"(expected {limit})")
             ok = ok and good
+        unscored = unscored_gates(days, series, dt)
+        for name, reason in unscored:
+            print(f"UNSCORED  {name}: {reason}")
+        if unscored:
+            print(f"NOTE  {len(unscored)} aerosol gate(s) could not be "
+                  "evaluated; they have passed nothing")
         print()
         print(format_table(stats, []))
     else:
-        print("NOTE  not a JAM run; skipping the aerosol statistics")
+        print("NOTE  no m_<species>_<mode> aerosol tracers in the output — "
+              "not a JAM run; skipping the aerosol statistics")
 
     if a.log:
         walls = re.findall(r"Wall: ([0-9.]+)s this chunk", open(a.log).read())

--- a/tools/release_validation/health.py
+++ b/tools/release_validation/health.py
@@ -41,7 +41,10 @@ for _p in (str(_REPO), str(_TOOLS)):
 # tools/jam_burden_report.py (it includes cloud-borne tracers and the
 # pressure_half level-orientation handling).
 from jcm.analysis import area_weights, global_mean  # noqa: E402
-from jam_burden_report import _SPECIES, burden  # noqa: E402
+from jam_burden_report import _SPECIES  # noqa: E402
+from aerosol_stats import (  # noqa: E402
+    _AOD_KEYS, collect, format_table, is_jam_run, physics_gates, summarize,
+    timestep_seconds)
 
 #: Gate slack: the release gate is the climatological anchor range from
 #: the shared species table widened by this factor each way — a "did the
@@ -144,10 +147,12 @@ def main():
     t_low = ds["temperature"].isel(level=0)
     check("near_surface_T", wmean(t_low, weights), *RANGES["near_surface_T"])
 
-    # 550 nm AOD — JAM publishes jam_optics.aod_550, MACv2-SP runs
-    # publish macsp.od550aer; whichever is present is the scheme's AOD.
+    # 550 nm AOD — JAM publishes jam_optics.aod_550 (jam_band_optics.aod_550
+    # before #640), MACv2-SP runs publish macsp.od550aer; whichever is present
+    # is the scheme's AOD. The JAM keys are shared with aerosol_stats so a run
+    # the aerosol block can score is never skipped here.
     aod = None
-    for key in ("jam_optics.aod_550", "macsp.od550aer"):
+    for key in _AOD_KEYS + ("macsp.od550aer",):
         if key in ds:
             aod = ds[key]
             break
@@ -157,17 +162,36 @@ def main():
         print("NOTE  no AOD field found "
               "(jam_optics.aod_550/macsp.od550aer); skipping")
 
-    # Per-species global burdens (JAM runs): the shared ``burden`` sums
-    # interstitial + cloud-borne mass over the species' modes and
-    # integrates q·Δp/g from the file's own pressure_half.
-    if any(re.fullmatch(r"m_\w+_\w+", v) for v in ds.data_vars):
+    # JAM aerosol block (#762). The statistics are built chunk by chunk
+    # (a year of JAM output does not fit in memory), so this takes the file
+    # list rather than the opened Dataset. Two tiers, per
+    # ``docs/source/design/jam_regression.md``: the climatological anchor
+    # ranges, and the absolute physics gates on burden drift and mass-budget
+    # closure — the latter are what catch a slow runaway that stays inside a
+    # x3-slack range gate until its final fortnight.
+    if is_jam_run(ds):
+        days, series = collect(files)
+        # The dynamics-conservation gate is per STEP, so it needs the run's
+        # timestep; without a saved Hydra config it stays unscored.
+        dt = timestep_seconds(a.run_dir)
+        stats = summarize(days, series, dt)
+        if dt is None:
+            print("NOTE  no .hydra/config.yaml timestep — the dynamics-"
+                  "conservation gate is not scored")
         for sp, (lo, hi) in BURDEN_RANGES.items():
-            col = burden(ds, sp, _SPECIES[sp][0])
-            if col is None:
+            key = f"burden_{sp}_mg_m2"
+            if key not in stats:
                 print(f"NOTE  no {sp} mass tracers; skipping burden")
                 continue
-            check(f"burden_{sp}_mg_m2",
-                  float(global_mean(col.compute(), weights)), lo, hi)
+            check(key, stats[key], lo, hi)
+        for name, value, limit, good in physics_gates(stats):
+            print(f"{'PASS' if good else 'FAIL'}  {name} = {value:.4g} "
+                  f"(expected {limit})")
+            ok = ok and good
+        print()
+        print(format_table(stats, []))
+    else:
+        print("NOTE  not a JAM run; skipping the aerosol statistics")
 
     if a.log:
         walls = re.findall(r"Wall: ([0-9.]+)s this chunk", open(a.log).read())

--- a/tools/release_validation/health.py
+++ b/tools/release_validation/health.py
@@ -40,15 +40,10 @@ for _p in (str(_REPO), str(_TOOLS)):
 # tools/jam_burden_report.py (it includes cloud-borne tracers and the
 # pressure_half level-orientation handling).
 from jcm.analysis import area_weights, global_mean  # noqa: E402
-from jam_burden_report import _SPECIES  # noqa: E402
 from aerosol_stats import (  # noqa: E402
-    _AOD_KEYS, collect, format_table, is_jam_run, missing_jam_diagnostics,
-    physics_gates, run_files, summarize, timestep_seconds, unscored_gates)
-
-#: Gate slack: the release gate is the climatological anchor range from
-#: the shared species table widened by this factor each way — a "did the
-#: model produce a plausible planetary loading" gate, not a tuning target.
-_BURDEN_SLACK = 3.0
+    _AOD_KEYS, BURDEN_RANGES, anchor_gates, collect, format_table, is_jam_run,
+    missing_jam_diagnostics, physics_gates, run_files, summarize,
+    timestep_seconds, unscored_gates)
 
 RANGES = {
     "toa_net_wm2": (-10.0, 10.0),
@@ -60,13 +55,6 @@ RANGES = {
     # so use --last-n to score the settled months.
     "aod_550": (0.02, 0.35),
 }
-
-# Burden gates derive from the shared anchor table (see _BURDEN_SLACK).
-BURDEN_RANGES = {
-    sp: (lo / _BURDEN_SLACK, hi * _BURDEN_SLACK)
-    for sp, (_modes, (lo, hi)) in _SPECIES.items()
-}
-
 
 def wmean(da, weights):
     """Time-mean, area-weighted global mean (over the horizontal dims)."""
@@ -179,20 +167,13 @@ def main():
         # timestep; ``unscored_gates`` reports it when either is missing.
         dt = timestep_seconds(a.run_dir)
         stats = summarize(days, series, dt)
-        for sp, (lo, hi) in BURDEN_RANGES.items():
-            key = f"burden_{sp}_mg_m2"
-            if key not in stats:
+        for sp in BURDEN_RANGES:
+            if f"burden_{sp}_mg_m2" not in stats:
                 print(f"NOTE  no {sp} mass tracers; skipping burden")
-                continue
-            if stats[key] == 0.0:
-                # A species the run does not carry is exempted from the drift
-                # gate; the anchor gate must agree, or the two tiers contradict
-                # each other on the same line of the report.
-                print(f"NOTE  {sp} burden is identically zero — the run "
-                      "carries no such aerosol; anchor gate not scored")
-                continue
-            check(key, stats[key], lo, hi)
-        for name, value, limit, good in physics_gates(stats):
+        # Anchors and physics gates share one implementation with the
+        # standalone scorer, so the two commands cannot disagree about a run.
+        for name, value, limit, good in (anchor_gates(stats)
+                                         + physics_gates(stats)):
             print(f"{'PASS' if good else 'FAIL'}  {name} = {value:.4g} "
                   f"(expected {limit})")
             ok = ok and good

--- a/tools/release_validation/health.py
+++ b/tools/release_validation/health.py
@@ -18,7 +18,6 @@ settled sim-days/hr (last chunk wall) for runtime-regression tracking.
 Exit code 0 = all checks pass.
 """
 import argparse
-import glob
 import re
 import sys
 from pathlib import Path
@@ -44,7 +43,7 @@ from jcm.analysis import area_weights, global_mean  # noqa: E402
 from jam_burden_report import _SPECIES  # noqa: E402
 from aerosol_stats import (  # noqa: E402
     _AOD_KEYS, collect, format_table, is_jam_run, missing_jam_diagnostics,
-    physics_gates, summarize, timestep_seconds, unscored_gates)
+    physics_gates, run_files, summarize, timestep_seconds, unscored_gates)
 
 #: Gate slack: the release gate is the climatological anchor range from
 #: the shared species table widened by this factor each way — a "did the
@@ -84,8 +83,10 @@ def main():
                     help="use only the last N chunks (default: all)")
     a = ap.parse_args()
 
-    files = sorted(glob.glob(f"{a.run_dir}/*_day*.nc"),
-                   key=lambda f: int(re.search(r"day(\d+)", f).group(1)))
+    # Same discovery as aerosol_stats.run_files, so the two cannot disagree
+    # about which files are chunks (``run.snapshot_interval`` writes a
+    # ``_day<N>_snapshots.nc`` stream that a ``*_day*.nc`` glob also matches).
+    files = run_files(a.run_dir)
     if not files:
         print(f"FAIL  no chunk files in {a.run_dir}")
         return 1

--- a/tools/release_validation/launch.py
+++ b/tools/release_validation/launch.py
@@ -169,7 +169,12 @@ def overrides(name: str, m: dict, d: dict, rundir: str) -> list[str]:
            f"run.output_prefix={rundir}/{name}",
            # checkpoint_path is now a universal run key (the run schema is one
            # base -- #640), so a plain override sets it on every run group.
-           f"run.checkpoint_path={rundir}/checkpoint.msgpack"]
+           f"run.checkpoint_path={rundir}/checkpoint.msgpack",
+           # Permanent archives alongside the rotating checkpoint, so a
+           # member whose failure develops slowly still has a state from
+           # before the onset to restart from.
+           "run.archive_ckpt_every="
+           f"{m.get('archive_ckpt_every', d.get('archive_ckpt_every', 0))}"]
     if m.get("jam_inputs"):
         ovs += jam_aux(grid, m["jam_inputs"])
     return ovs

--- a/tools/release_validation/launch.py
+++ b/tools/release_validation/launch.py
@@ -161,7 +161,15 @@ def prefetch(ovs: list[str]) -> list[str]:
     compute node with no network (#774).
     """
     missing = []
-    for path in _preset_data_files(ovs):
+    try:
+        paths = _preset_data_files(ovs)
+    except Exception as e:                  # noqa: BLE001 — reported, not raised
+        # Enumeration itself reaches the mirror manifest (the ``auto`` ozone and
+        # emission bundles), so it can fail for the same reasons a fetch can.
+        # Report it as this member's problem rather than aborting the whole
+        # plan with a traceback.
+        return [f"could not enumerate inputs ({type(e).__name__}: {e})"]
+    for path in paths:
         if path.startswith("hf://"):
             try:
                 _hf_fetch(path[len("hf://"):])

--- a/tools/release_validation/launch.py
+++ b/tools/release_validation/launch.py
@@ -7,7 +7,9 @@ Each member of ``matrix.yaml`` references a validated preset in
 ``tools/benchmark.py``'s ``PRESETS`` (the single home of known-good
 override sets) and becomes a PBS job running a full-output year on one
 A100. Per-grid inputs resolve automatically inside jcm (``terrain=auto``,
-``forcing.ozone_file=auto``); JAM members additionally need the aux
+``forcing.ozone_file=auto``) and are PREFETCHED here, on the submitting
+(networked) node, so a member whose inputs are unavailable refuses at submit
+time instead of after hours of GPU; JAM members additionally need the aux
 inputs staged per
 ``jcm/data/mirror/SOURCES.md`` (dms/dust/oxidants + emissions on the
 model grid) via the ``JAM_INPUTS``/``JCM_EMISSIONS`` environment.
@@ -30,7 +32,8 @@ import yaml
 HERE = Path(__file__).parent
 HOME = os.environ["HOME"]
 sys.path.insert(0, str(HERE.parent))
-from benchmark import PRESETS  # noqa: E402
+from benchmark import (  # noqa: E402
+    PRESETS, _hf_fetch, _preset_data_files)
 
 
 def jam_aux(grid: str, levels: str) -> list[str]:
@@ -148,6 +151,27 @@ def check_fresh(rundir: str, resume: bool) -> None:
             "default is the repo HEAD short SHA).")
 
 
+def prefetch(ovs: list[str]) -> list[str]:
+    """Download every input a member resolves to; return the unavailable ones.
+
+    Mirrors ``tools/benchmark.py``'s pre-GPU preflight, including the
+    lazily-resolved ``auto`` bundles (emissions, ozone) the literal-path walk
+    cannot see. A matrix member is a ten-hour GPU job, so an input that cannot
+    be resolved must fail here rather than inside model construction on a
+    compute node with no network (#774).
+    """
+    missing = []
+    for path in _preset_data_files(ovs):
+        if path.startswith("hf://"):
+            try:
+                _hf_fetch(path[len("hf://"):])
+            except Exception as e:              # unreachable or absent
+                missing.append(f"{path}  ({type(e).__name__}: {e})")
+        elif not Path(path).exists():
+            missing.append(path)
+    return missing
+
+
 def overrides(name: str, m: dict, d: dict, rundir: str) -> list[str]:
     # Presets may carry their own output plumbing (the pyses ones set
     # run.checkpoint_path); ours must win, so strip conflicting keys
@@ -217,6 +241,8 @@ def main(argv=None):
                     help="continue an existing run rather than refusing to "
                          "start on top of its checkpoint")
     ap.add_argument("--submit", action="store_true")
+    ap.add_argument("--no-prefetch", action="store_true",
+                    help="skip the input preflight (offline job generation)")
     ap.add_argument("--account",
                     default=os.environ.get("PBS_ACCOUNT", "UCSD0085"))
     a = ap.parse_args(argv)
@@ -240,6 +266,26 @@ def main(argv=None):
     plan = [(name, f"mx_{name.replace('-', '_')}_{run_tag}") for name in wanted]
     for _, tag in plan:
         check_fresh(f"{scratch}/jam_runs/{tag}", a.resume)
+
+    # Preflight every member's inputs before writing any job: a matrix launch
+    # that cannot resolve an input should fail whole, on the node that still
+    # has network, not member by member inside a queued job.
+    if not a.no_prefetch:
+        missing = {}
+        for name, tag in plan:
+            unavailable = prefetch(
+                overrides(tag, cfg["members"][name], d,
+                          f"{scratch}/jam_runs/{tag}"))
+            if unavailable:
+                missing[name] = unavailable
+        if missing:
+            report = "\n".join(f"  {name}:\n    " + "\n    ".join(paths)
+                                for name, paths in missing.items())
+            raise SystemExit(
+                "these members reference inputs that are not available "
+                f"here:\n{report}\nStage them per "
+                "jcm/data/mirror/SOURCES.md, or pass --no-prefetch to "
+                "generate the jobs anyway.")
 
     for name, tag in plan:
         m = cfg["members"][name]

--- a/tools/release_validation/launch_test.py
+++ b/tools/release_validation/launch_test.py
@@ -24,6 +24,17 @@ REPO = pathlib.Path(__file__).resolve().parents[2]
 MEMBER = "speedy-t31"          # the cheapest member: no JAM aux-input lookup
 
 
+@pytest.fixture(autouse=True)
+def offline(monkeypatch):
+    """Keep the input preflight off the network in every test.
+
+    The preflight's own behaviour is tested below by re-patching
+    ``_preset_data_files`` with a known input list.
+    """
+    monkeypatch.setattr(launch, "_hf_fetch", lambda rel: rel)
+    monkeypatch.setattr(launch, "_preset_data_files", lambda ovs: [])
+
+
 @pytest.fixture
 def scratch(tmp_path, monkeypatch):
     """Return a throwaway SCRATCH, so rundirs never touch the real one."""
@@ -169,3 +180,56 @@ def test_archive_setting_is_a_real_run_key():
     default = yaml.safe_load(
         (REPO / "jcm" / "config" / "run" / "default.yaml").read_text())
     assert "archive_ckpt_every" in default
+
+
+def test_prefetch_downloads_every_hf_input(monkeypatch):
+    """Every ``hf://`` input a member resolves to is pulled before submitting.
+
+    A matrix member is a ten-hour GPU job; an input that cannot be resolved
+    must fail on the submitting node, which has network, rather than inside
+    model construction on a compute node that does not (#774).
+    """
+    fetched = []
+    monkeypatch.setattr(launch, "_hf_fetch", lambda rel: fetched.append(rel))
+    monkeypatch.setattr(
+        launch, "_preset_data_files",
+        lambda ovs: ["hf://bundles/t63/terrain.nc",
+                     "hf://bundles/t63_l47/ozone_pd.nc"])
+    assert launch.prefetch(["physics=echam"]) == []
+    assert fetched == ["bundles/t63/terrain.nc", "bundles/t63_l47/ozone_pd.nc"]
+
+
+def test_prefetch_reports_an_unavailable_input(monkeypatch):
+    def boom(rel):
+        raise FileNotFoundError(f"hf://{rel} is not in the local cache")
+
+    monkeypatch.setattr(launch, "_hf_fetch", boom)
+    monkeypatch.setattr(launch, "_preset_data_files",
+                        lambda ovs: ["hf://bundles/t63_l47/ozone_pd.nc"])
+    missing = launch.prefetch([])
+    assert len(missing) == 1 and "ozone_pd.nc" in missing[0]
+
+
+def test_prefetch_reports_a_missing_local_input(monkeypatch, tmp_path):
+    monkeypatch.setattr(launch, "_preset_data_files",
+                        lambda ovs: [str(tmp_path / "nope.nc")])
+    assert launch.prefetch([]) == [str(tmp_path / "nope.nc")]
+
+
+def test_launch_refuses_when_an_input_is_unavailable(scratch, repo, monkeypatch):
+    """No job file is written when the preflight fails."""
+    monkeypatch.setattr(launch, "prefetch",
+                        lambda ovs: ["hf://bundles/t63_l47/ozone_pd.nc"])
+    with pytest.raises(SystemExit) as exc:
+        _launch(repo, "--tag", "prefetchfail")
+    assert "ozone_pd.nc" in str(exc.value)
+    assert not list((repo / "runs").glob("*.pbs"))
+
+
+def test_no_prefetch_generates_jobs_offline(scratch, repo, monkeypatch):
+    called = []
+    monkeypatch.setattr(launch, "prefetch",
+                        lambda ovs: called.append(ovs) or [])
+    _launch(repo, "--tag", "offlinegen", "--no-prefetch")
+    assert not called
+    assert list((repo / "runs").glob("*.pbs"))

--- a/tools/release_validation/launch_test.py
+++ b/tools/release_validation/launch_test.py
@@ -159,13 +159,18 @@ def test_submit_qsubs_the_written_job(scratch, repo, monkeypatch):
     assert calls == [["qsub", str(path)]]
 
 
-def test_jam_members_archive_a_pre_onset_checkpoint():
+def test_jam_members_archive_a_pre_onset_checkpoint(monkeypatch):
     """JAM members must keep permanent archives, not only the rotating pair.
 
     A JAM aerosol runaway develops over weeks, so by the time it is visible
     both ``checkpoint.msgpack`` and its ``.prev`` have been written from
     poisoned state and there is nothing left to restart from before the onset.
+
+    ``jam_aux`` is stubbed out: it globs ``$JAM_INPUTS`` and exits when the
+    staged oxidant/emission files are absent, which is every machine but a
+    prepared one. The override under test does not come from it.
     """
+    monkeypatch.setattr(launch, "jam_aux", lambda grid, levels: [])
     cfg = yaml.safe_load((pathlib.Path(launch.HERE) / "matrix.yaml").read_text())
     for name, member in cfg["members"].items():
         ovs = launch.overrides(name, member, cfg["defaults"], "/tmp/rundir")

--- a/tools/release_validation/launch_test.py
+++ b/tools/release_validation/launch_test.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 
 import pytest
+import yaml
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import launch  # noqa: E402
@@ -145,3 +146,26 @@ def test_submit_qsubs_the_written_job(scratch, repo, monkeypatch):
     _launch(repo, "--tag", "aaa1111", "--submit")
     path = repo / "runs" / "mx_speedy_t31_aaa1111.pbs"
     assert calls == [["qsub", str(path)]]
+
+
+def test_jam_members_archive_a_pre_onset_checkpoint():
+    """JAM members must keep permanent archives, not only the rotating pair.
+
+    A JAM aerosol runaway develops over weeks, so by the time it is visible
+    both ``checkpoint.msgpack`` and its ``.prev`` have been written from
+    poisoned state and there is nothing left to restart from before the onset.
+    """
+    cfg = yaml.safe_load((pathlib.Path(launch.HERE) / "matrix.yaml").read_text())
+    for name, member in cfg["members"].items():
+        ovs = launch.overrides(name, member, cfg["defaults"], "/tmp/rundir")
+        setting = [o for o in ovs if o.startswith("run.archive_ckpt_every=")]
+        assert len(setting) == 1, name
+        expected = 30 if "jam" in name else 0
+        assert setting[0] == f"run.archive_ckpt_every={expected}", name
+
+
+def test_archive_setting_is_a_real_run_key():
+    """Guards against a silently-ignored Hydra override."""
+    default = yaml.safe_load(
+        (REPO / "jcm" / "config" / "run" / "default.yaml").read_text())
+    assert "archive_ckpt_every" in default

--- a/tools/release_validation/matrix.yaml
+++ b/tools/release_validation/matrix.yaml
@@ -7,6 +7,12 @@ defaults:
   chunk_days: 5
   save_interval: 5
   hours: 10
+  # Permanent checkpoint archives, in sim-days (0 = off). Only the JAM
+  # members set one: their failure mode is a slow aerosol runaway, and by the
+  # time it is visible the rotating checkpoint and its .prev have both been
+  # written from poisoned state, leaving nothing to restart from before the
+  # onset. 30 days costs ~12 archives a year at ~1 GB each.
+  archive_ckpt_every: 0
 
 members:
   speedy-t31:        {preset: speedy-t31, hours: 2}
@@ -14,5 +20,7 @@ members:
   echam-1m-t106:     {preset: t106-echam-1m}
   echam-2m-t63:      {preset: t63-echam-2m}
   echam-2m-t106:     {preset: t106-echam-2m}
-  echam-jam-t63-l47: {preset: ma-t63-l47, jam_inputs: l47}
-  echam-jam-t63-l95: {preset: ma-t63-l95, jam_inputs: l95, hours: 12}
+  echam-jam-t63-l47: {preset: ma-t63-l47, jam_inputs: l47,
+                      archive_ckpt_every: 30}
+  echam-jam-t63-l95: {preset: ma-t63-l95, jam_inputs: l95, hours: 12,
+                      archive_ckpt_every: 30}


### PR DESCRIPTION
Part of #762 (statistics half; the spun-up state is blocked on the aerosol mass budget)

Closes #774.

Six separable commits plus a review-response commit. The first two are the
substance; the rest are tooling defects this release campaign surfaced.

## 1. `burden()` was wrong on every real file (#762, #722)

Two independent defects in the one function the report *and* the release gates
share:

* The cloud-borne phase lives in the physics carry, so `ComposablePhysics`
  flattens it to `jam_cloud_borne.mc_<sp>_<mode>`; `burden()` looked only for a
  bare `mc_<sp>_<mode>` and silently dropped 20-25 % of sulfate mass.
* **Pre-#710 files store `pressure_half` TOA-first while their `level` fields
  are surface-first**, so differencing the interfaces produced a Δp reversed
  against the tracers — stratospheric layer masses weighting the boundary
  layer. Orientation is now read from the pressure values themselves (a
  pre-#710 `level_i` is a bare integer index with no `positive` attribute).

The size of the second one, measured on the Aug-20 run with an external
invariant rather than an assertion about itself:

| Δp orientation | column-integrated water vapour |
|---|---|
| corrected | **29.5 kg/m²** |
| as written | 1.1 kg/m² |

So every burden previously reported from a pre-#710 file was wrong by a
comparable factor. Numbers below supersede the earlier audit's.

## 2. `tools/release_validation/aerosol_stats.py` + the aerosol block in `health.py`

The statistic set and the two tolerance tiers from the design brief, with the
rationale in the new `docs/source/design/jam_regression.md`. Chunks are reduced
one file at a time (a JAM year is ~60 GB; ~40 min for a T63L47 year) and the
reduction can be saved (`--series-out`) and re-scored without re-reading it.

Four decisions I would want a reviewer to check:

* **Lifetime denominator is `dry_* + wet_*`, not `+ conv_scav_flux.*`.** The
  wetdep term already folds in-plume convective scavenging into `wet_*`
  (`wetdep_term.py`), so the brief's third term would double-count that sink.
* **Sulfate closure is the whole sulfur family, in sulfate-AEROSOL mass.**
  `emi_so4` is a few per cent of the real source; the rest arrives as SO₂/DMS
  through the gas reservoirs. The conversion uses jcm's own `so4` species —
  NH₄HSO₄ at 115.0 g/mol (`jam/species.py`), not SO₄ at 96.06 — a 20 %
  difference in the source term. SOA is not scored: its source is the SOAG gas,
  which has no `emi_*` channel.
* **The residual's sign is the diagnosis.** Negative (more deposited than
  entered) is mass creation and cannot be explained away. Positive is
  indistinguishable from a missing sink *diagnostic*, and on output written
  before the #722 removal-ledger fix `dry_*` omits Slinn dry deposition
  entirely — so the gate names that caveat instead of reporting a leak. The
  drift gate reads burdens only and is unaffected either way.
* **A third absolute gate: `dyn_frac_per_step_<sp> < 0.1 %/step`,** scoring the
  #713 in-step `budget_dyn_*` gauge against the advected mass. The Aug-20
  runaway turned out to be **semi-Lagrangian transport creating mass, not
  aerosol physics** — one-signed because the quasi-monotone limiter can only
  *add* mass when it clips an undershoot at a minimum, which is exactly the
  state strong scavenging produces. #720 fixes it with a proportional global
  mass fixer; **#521 (positive-definite transport) remains the faithful cure**,
  since a global rescale restores the total without repairing the
  *distribution*. The limit sits at the honest per-step interpolation magnitude
  and ~500× tighter than the fixer's `[2/3, 1.5]` clip. The fixer's rescale
  factor is not exported, so the gate scores `budget_dyn` alone; exporting it
  is recorded as the follow-up in the design doc. **This gate is unscored on
  the Aug-20 run** — pre-#713 output carries no gauge — which the block says
  rather than silently passing.

### Exercised for real on `$SCRATCH/jam_runs/mx_echam_jam_t63_l47`

The completed Aug-20 T63 L47 JAM year (pre-#710 file, both conventions
therefore exercised). **The drift and closure gates trip, as required.**

Full year (days 5-365):

```
statistic                                  value
------------------------------------------------
aod_550                                  0.17642
budget_residual_bc                       0.32728
budget_residual_du                       -1.2385
budget_residual_max                      -17.352
budget_residual_poa                       0.3113
budget_residual_so4                      -17.352
budget_residual_ss                      -0.18242
burden_bc_mg_m2                           1.0655
burden_du_mg_m2                           145.32
burden_poa_mg_m2                          6.1451
burden_so4_mg_m2                          80.763
burden_soa_mg_m2                               0
burden_ss_mg_m2                            3.894
cdnc_900hPa_cm3                            180.7
dlnB_dt_bc_per_day                    -0.0010903
dlnB_dt_du_per_day                      0.014645
dlnB_dt_poa_per_day                   -0.0034536
dlnB_dt_so4_per_day                     0.022044
dlnB_dt_ss_per_day                     0.0042484
lifetime_bc_days                          43.061
lifetime_du_days                          2.0089
lifetime_so4_days                         5.2957
lifetime_ss_days                         0.32781
r_dry_acc_um                            0.065041
r_dry_ait_um                            0.021441
r_dry_cor_um                             0.82037
r_dry_pcm_um                            0.043536
record_days                                  360
so4_burden_60_90N_mg_m2                   1.3787
so4_frac_above_500hPa                    0.74268
so4_nh_sh_ratio                         0.030618

physics gate                               value  limit               result
----------------------------------------------------------------------------
dlnB_dt_bc_per_day                    -0.0010903  |x| < 0.002 /day    PASS
dlnB_dt_du_per_day                      0.014645  |x| < 0.002 /day    FAIL
dlnB_dt_poa_per_day                   -0.0034536  |x| < 0.002 /day    FAIL
dlnB_dt_so4_per_day                     0.022044  |x| < 0.002 /day    FAIL
dlnB_dt_ss_per_day                     0.0042484  |x| < 0.002 /day    FAIL
budget_residual_max                      -17.352  |x| < 5%            FAIL

AEROSOL: FAIL
```

**What it reports.** Sulfate's burden grows at `d ln B/dt = +0.022 /day` over
the final six months — eleven times the gate — and the sulfur ledger closes at
**-1735 %**: seventeen times more sulfate is deposited over the year than
enters the column as SO₂, DMS and primary sulfate combined. The sign is
negative, so this is mass **creation**, not the pre-#722 `dry_*` caveat. Dust
and POA fail the drift gate too; `so4_frac_above_500hPa = 0.74` and
`so4_nh_sh_ratio = 0.031` (observed ≈ 3) localise it to the free troposphere
and the Southern Hemisphere, which is the #658 signature.

The point of the gate is that it does not need the visible blow-up. Scoring
**only days 100-300**, before the burden leaves its anchor range at all:

| statistic | days 100-300 | verdict |
|---|---|---|
| `burden_so4_mg_m2` | 10.13 | inside the ×3-slack anchor gate |
| `dlnB_dt_so4_per_day` | **+0.0041** | **FAIL** (2× the limit) |
| `dlnB_dt_poa_per_day` | **+0.0034** | **FAIL** |
| `budget_residual_so4` | **-0.347** | **FAIL** (35 % excess deposition) |
| `lifetime_so4_days` | 6.38 | plausible — the lifetime alone hides it |
| `so4_nh_sh_ratio` | 0.276 | already inverted |

So both gates fire ~200 days before the range gate would have. The -35 %
closure figure is consistent with the independent leak diagnostic's ~29 %
(different window bounds and storage term).

## 3. `run.archive_ckpt_every=30` for the JAM members

The rotating `checkpoint.msgpack` and its `.prev` are two chunks apart, so a
slowly-developing runaway poisons every surviving checkpoint. Twelve permanent
archives a year at ~1 GB each let a diagnosis restart from before the onset.

## 4. Watcher false positive, and `settled_rate.py`'s import path

`jcm.main` prints the composed Hydra config on stdout, so **every** PBS log
contains `bail_on_unhealthy: true` — which `FAIL_RE`'s bare `unhealthy` matched
case-insensitively, exiting 1 on the first two polls of every clean run. Now
matched against the runner's three real verdicts. Sweeping the rest of
`FAIL_RE` against the composed config of every release-validation preset found
no other collision. `watch_job_test.py` drives the script end to end and fails
on the previous regex.

Same directory, same failure class: `settled_rate.py` found
`tools/chunk_timing.py` by a fixed parent depth, which is only right for the
in-repo copy — the installed `~/.claude/skills/` copy died with
`ModuleNotFoundError: chunk_timing`. It now searches upward from itself and the
working directory (`JCM_REPO` overrides). Verified with no PYTHONPATH from an
unrelated cwd against `mx_echam_1m_t63_f5c8b354`: **161.4 sim-days/hr**. Both
usage lines now say the log is the PBS **stdout** log, not Hydra's `main.log`
(the `Wall:` lines are prints, which is why the rundir log reports "no chunk
timings").

## 5. `ozone_file=auto` fails loudly; the matrix prefetches (Closes #774)

`auto` degraded to the analytic profile — ~7.6× the tropospheric ozone column,
clear-sky OLR ~12 W/m² low — on a cold HF cache, and the run then completed and
reported healthy. `terrain.kind=auto` already raises for exactly this reason.

`auto` now raises on a hybrid grid, and the mirror manifest distinguishes the
two failures: an unpublished (grid, nlev, vertical) is a missing **product**
(build one with `jcm.data.bc.interpolate_ozone`), a published one that will not
fetch is a **transport** failure (warm the cache). New `ozone_file=analytic` is
the explicit opt-in, named rather than reusing `null` so the choice appears in
the run's provenance.

**A sigma grid stays a warned fallback** — that is the one judgement call here.
Every ozone product is on hybrid-level centre pressures, so no product exists
that a SPEEDY or Held-Suarez run could have been expected to configure;
demanding an opt-out from all of them would be noise, not safety. Say if you'd
rather it raised there too.

`launch.py` had no prefetch at all, so a matrix member resolved inputs lazily
on the compute node — where the cold cache bites. It now runs benchmark.py's
preflight over every member before writing any job (`--no-prefetch` to
generate offline). And benchmark.py's preflight enumerated the `auto`
*emission* bundles but not the `auto` *ozone* bundle, so neither path covered
the reported failure; `_auto_ozone_files` closes that.

## 6. `docs/source/design/jam_regression.md`

The statistic set and why each exists, the three tolerance tiers, the drift
gate as the runaway detector, both output conventions, and an explicit
**"Not yet done"** section for #762's other half — the published spun-up state
is blocked on the aerosol mass budget these gates measure (freezing a
population whose sulfate does not conserve would hand every warm-started run a
contaminated aerosol) and on #731. The plan is written down so the issue stays
partially open on purpose.

## 7. Review response

Codex is out of review credits on this repo right now, so the review was the
local multi-agent pass the `jcm-local-ci` skill prescribes. It found seven
real defects, all fixed in the last commit. Two would have broken things:

* `launch_test`'s new matrix test iterated **every** member, and `overrides()`
  calls `jam_aux` for the JAM ones — which globs `$JAM_INPUTS` and `SystemExit`s
  when the staged oxidant files are absent. **It would have failed CI**; it
  passed here only because those files happen to exist on this account.
* `ozone_file=analytic` was unknown to the **pySES** forcing builder (it has its
  own ozone resolution) and to benchmark.py's prefetch sentinel list — the first
  would `open_dataset("analytic")`, the second would abort a matrix launch with
  "missing input: analytic". pySES `auto` now raises too, so the two backends
  agree with the rule the config comments state.

Two were arithmetic in the new statistics:

* The flux integral averaged all N chunk means but multiplied by the (N−1)-chunk
  span between the first and last chunk **centres** — understating it by 1/N.
  1.4 % on a 73-chunk year, **25 % on a four-chunk window**, into a gate set at
  5 %.
* The drift statistic was emitted whenever any burden sample was positive, but
  `log_drift` returns NaN below three samples and a NaN scores as FAIL — so
  `health.py --last-n 2` on a **healthy** run reported an aerosol failure.

And three of coverage that was advertised but absent: `moa` was listed as
budget-scored yet has no anchor-table entry, so no burden is computed for it and
its residual was silently dropped (removed, with a test pinning that every
scored species has a burden to close against); and the two T119 configurations'
comments still described the old warn-and-fall-back behaviour.

I kept these as **one review-response commit** rather than squashing them into
the six above, so the loop is visible.

## Verification

* `ruff check .` clean.
* `tools/` suite serially: 166 passed before the review fixes, 68 in the
  touched files after. `watch_job_test.py` and `mkjob_test.py` (standalone —
  pytest does not collect dotted directories): pass.
* Local fast gate on the pre-review tree: **2462 passed, 0 failed, coverage
  95.22 %** (≥ 90 required). Both gates re-run on the final tree — result in a
  comment below.
* `health.py` exercised end to end on a real JAM run (block runs, gates fire)
  and on a real MACv2-SP run (block skipped, AOD still scored).
* The Δp orientation fix validated against an **external** invariant, not its
  own assertion: column water vapour 29.5 kg/m² corrected vs 1.1 kg/m² as
  written.

Not verified: the design doc's Sphinx build (docs are not in CI); the
`~/.claude/skills/` **installed** copy of `derecho-jcm-runs` still carries the
old `settled_rate.py` and `watch_job.sh` and needs re-syncing from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4x2keECpxEf5JvJ5rM3ty
