### PR TITLE
Dust source gating, CAM emission split/sizes, and a real 10 m emission wind (#768, #723)

### DIFF
--- a/.claude/skills/derecho-jcm-runs/reference/data_paths.md
+++ b/.claude/skills/derecho-jcm-runs/reference/data_paths.md
@@ -14,7 +14,7 @@ Per Gaussian grid `<g>` (t63, t106):
     bundles/<g>/terrain.nc                 GMTED2010 SSO + fractional ERA5 land mask
     bundles/<g>/forcing_{pd,pi}.nc         PCMDI-AMIP SST/ice + ERA5 land climatology
     bundles/<g>/emissions_{pd,pi}.nc       CEDS+BB4CMIP7, 4 super-sectors x 3 species
-    bundles/<g>/dms.nc, dust.nc            Lana 2011; 0.23x0.31 deg erodibility
+    bundles/<g>/dms.nc, dust_erodibility.nc  Lana 2011; 0.23x0.31 deg erodibility
     bundles/<g>_<l>/ozone_{pd,pi}.nc       FZJ CMIP7, pre-interpolated per level count
     bundles/<g>_<l>/oxidants_{pd,pi}.nc    WACCM CCMI full-lid, per level count
 

--- a/.claude/skills/derecho-jcm-runs/scripts/mkjob.py
+++ b/.claude/skills/derecho-jcm-runs/scripts/mkjob.py
@@ -32,19 +32,43 @@ EMISSIONS = os.environ.get(
 # Prepared aux inputs (purge-eligible on scratch — see reference/data_paths.md).
 AUX_FILES = {
     "dms_file": f"{JAM_INPUTS}/dms_lana2011_climo_t63.nc",
+    # The corrected (unclipped) build — the reader REFUSES a pre-#768 file
+    # whose weights were capped at 1, so a stale one must fail at submission.
     "dust_file": f"{JAM_INPUTS}/dust_erodibility_cam_f05_t63.nc",
     "oxidants_file": f"{JAM_INPUTS}/oxidants_cam_echam_l47_2014_t63.nc",
 }
 
 
 def check_inputs(a) -> None:
-    """Fail before qsub if a required input file is missing (scratch purges)."""
+    """Fail before qsub if a required input file is missing or unusable.
+
+    Existence is not enough for the dust map: a pre-#768 build whose weights
+    were capped at 1 is refused by ``jcm.forcing.read_dust_source``, and the
+    run would then die at model build inside the job rather than here.
+    """
     needed = [("emissions", a.emissions), *AUX_FILES.items()]
     missing = [f"{k}: {v}" for k, v in needed if not os.path.exists(v)]
     if missing:
         sys.exit("MISSING INPUT FILES (scratch is purge-eligible; see "
                  "reference/data_paths.md to regenerate):\n  " +
                  "\n  ".join(missing))
+    dust = AUX_FILES["dust_file"]
+    try:
+        import xarray as xr
+
+        from jcm.forcing import is_clipped_erodibility
+        with xr.open_dataset(dust) as ds:
+            clipped = is_clipped_erodibility(ds["pot_source"].values)
+    except Exception:                     # noqa: BLE001 - advisory check only
+        clipped = False
+    if clipped:
+        sys.exit(
+            f"CLIPPED DUST MAP: {dust} was built before #768 (weights capped "
+            "at 1) and jcm.forcing.read_dust_source refuses it. Rebuild with\n"
+            "  python tools/prep_jam_aux_inputs.py --target-truncation 63 "
+            f"--outdir {JAM_INPUTS}\n"
+            "or use --data mirror, which resolves bundles/<grid>/"
+            "dust_erodibility.nc.")
 
 
 def grid_tags(grid: str) -> tuple[str, str]:

--- a/.claude/skills/derecho-jcm-runs/scripts/mkjob.py
+++ b/.claude/skills/derecho-jcm-runs/scripts/mkjob.py
@@ -70,7 +70,7 @@ def fetch_bundles(a) -> dict[str, str]:
         "forcing": f"bundles/{gtag}/forcing_{era}.nc",
         "emissions_file": f"bundles/{gtag}/emissions_{era}.nc",
         "dms_file": f"bundles/{gtag}/dms.nc",
-        "dust_file": f"bundles/{gtag}/dust.nc",
+        "dust_file": f"bundles/{gtag}/dust_erodibility.nc",
         "oxidants_file": f"bundles/{gtag}_{ltag}/oxidants_{era}.nc",
         "ozone_file": f"bundles/{gtag}_{ltag}/ozone_{era}.nc",
     }

--- a/docs/design/jam.md
+++ b/docs/design/jam.md
@@ -216,9 +216,10 @@ model grid and flipped to model order; a mismatched grid raises):
   e.g. `emiss_fields_dms_sea_monthly_T63.nc`). Converted to kg-DMS/m³ at load
   so `DmsEmissions`' `piston_velocity · dms_seawater` product is directly a
   kg/m²/s flux; `_FillValue` land cells → 0.
-- `forcing.dust_file` — potential-dust-source map (`pot_source`, 0–1,
-  e.g. `dust_potential_sources_T63.nc`), clipped to `DustEmissions`' [0, 1]
-  erodibility contract (the file's `-1` missing marker → 0).
+- `forcing.dust_file` — dust source map (`pot_source`). Two conventions are
+  supported, selected by `physics.jam_dust_source`; only the lower bound is
+  imposed at load (the file's `-1` missing marker and NaN → 0). See
+  "Dust source gating" below.
 - `forcing.oxidants_file` — monthly `OH/NO3/O3/H2O2_VMR_avrg` mole fractions on
   ECHAM hybrid model levels (e.g. `ham_oxidants_monthly_T63L47_macc.nc` with
   `grid=echam_t63_l47_hybrid`). Levels are mapped one-to-one onto the model
@@ -263,6 +264,101 @@ carbon; `SO2`→gas; `num_*`→number; the energy-sector `*_ene_vertical` 3-D
 layer(s) at GCM resolution). This reproduces CESM's global budget, including the
 **2.5 % primary-sulfate split recovered to 3 decimals** — the validation
 counterpart to the differentiable path.
+
+## Natural emissions: source gating, emitted size, and the 10 m wind
+
+Three corrections to the natural-emission terms (#768, #723), all grounded in
+CAM/CLM's Zender-2003 dust chain and ECHAM's `vdiff` surface-layer diagnostic.
+
+### The emission wind is 10 m, not the lowest model level
+
+Gong sea salt (`u10**3.41`) and Nightingale DMS (`k_w ~ u10**2`) are fitted to
+the 10 m wind; HAMMOZ passes `vphysc%velo10m`. Reading the lowest full level
+instead — ~33 m at L47 — inflates sea salt by 37-46 % and DMS by 20-25 %.
+
+`TteTkeVerticalDiffusion` now publishes `VerticalDiffusionData.wind_10m`, the
+ECHAM/ICON `nsurf_diag` reduction of the lowest-level wind along the same
+surface-layer profile that produced the drag:
+
+```
+bn  = ln(z1/z0m)                              neutral profile factor
+bm  = bn * sqrt(CM_n|U| / CM|U|)              stability-corrected
+red = [ln(1 + (e^bn - 1)*10/z1) + merge] / bm
+merge = -(bn - bm)*10/z1                      stable   (CM|U| < CM_n|U|)
+      = -ln(1 + (e^(bn-bm) - 1)*10/z1)        unstable
+```
+
+Building it from the per-tile `CM·|U|` the surface stress already uses means the
+10 m wind cannot drift from the momentum exchange, and the stable/unstable
+branch needs no separate Richardson number (the two branches meet continuously
+at `Ri = 0`, where `CM|U| = CM_n|U|`). Emission terms read it through
+`emissions/surface_wind.py`; with no vdiff term composed there is no surface
+layer to reduce through and they fall back to the lowest level. Emissions run
+before vdiff in the ECHAM ordering, so the value is one step old — the same lag
+the dust term's `u*` already carries.
+
+### Dust source gating
+
+`forcing.dust_source` is a *prescribed* erodibility; the physics it needs
+around it is CLM's, because CAM's `dust_flux_in` arrives from CLM already
+masked. The term now applies, per column:
+
+| factor | reference | field used |
+| --- | --- | --- |
+| erodibility, zeroed below 0.1, **not** bounded above | CAM `dust_model.F90` `soil_erod_threshold` | `forcing.dust_source` |
+| land fraction | CLM operates on land columns | `terrain.fmask` |
+| snow-free fraction | CLM `lnd_frc_mbl` | `forcing.snowc_am` |
+| unfrozen fraction (ramp over the 2 K below `tmelt`) | CLM `liqfrac` | `forcing.stl_am` |
+| `u*t` x `sqrt(1 + 1.21*(100*(w - w_thr))^0.68)` | Fecan (1999), CLM `frc_thr_wet_fct` | `forcing.soilw_am` |
+
+`source_kind` (`physics.jam_dust_source`) chooses how the map itself is read:
+`cam_erodibility` is CAM's geomorphic basin factor `mbl_bsn_fct_geo`, an
+unbounded 0-5.7 weight — clipping it at 1 truncated 15 % of the global source
+weight, concentrated in exactly the closed basins that are the world's
+strongest sources — while `tegen_potential` is a HAMMOZ potential-source
+fraction in [0, 1] that needs no threshold because its own preprocessing
+embeds the land-cover mask. The default is `cam_erodibility`, matching the map
+the data mirror ships.
+
+**Known gap.** CLM's vegetation gate `1 - VAI/0.3` has no counterpart: no LAI,
+VAI or land-cover field exists on `ForcingData`/`TerrainData`. It matters
+because the basin factor is purely topographic — the Amazon (7.2 % of global
+source weight, peak 4.40) and Congo (3.5 %, peak 2.16) carry *larger* values
+than the Sahara, and in CAM they emit nothing only because CLM's LAI gate
+zeroes them. Here the Fecan moisture factor suppresses them (~3.4x higher
+`u*t` at 0.95 relative wetness) but does not eliminate them. Adding the field
+is issue #777; a monthly VAI-masked map would also be the natural
+`tegen_potential` product.
+
+### Emitted number comes from the emitted size, not the mode's size
+
+Freshly emitted particles are not at their mode's equilibrium size, so
+converting an emitted mass flux to number with the mode geometry
+(`rho/number_factor` at `dgnum`) is wrong by the cube of the size ratio. CAM
+and the CESM emission-file generator both use the volume-mean diameter of the
+*emission* size distribution, `x_mton = 6/(pi rho D^3)`:
+
+| species / class | D [um] | source |
+| --- | --- | --- |
+| dust accumulation (0.1-1 um bin) | 0.7806 | CAM `dust_common::dust_set_params` |
+| dust coarse (1-10 um bin) | 3.8983 | same |
+| primary carbon (BC, POA) | 0.134 | CMIP7 `num_bc_a4`/`num_pom_a4` `mapping_equation` |
+| accumulation sulfate (surface, biomass) | 0.134 | `num_so4_a1_ag` |
+| accumulation sulfate (energy/industry, shipping) | 0.261 | `num_so4_a1_ene_vertical`, `num_so4_a1_ship_slv` |
+| Aitken sulfate | 0.0504 | `num_so4_a2_res_trs` |
+
+For accumulation dust this is 1.54e15 #/kg against the 1.17e17 #/kg the mode's
+0.11 um `dgnum` gives — 75x. Every diameter is a differentiable parameter
+(`DustParameters.emission_diameter`, `EmissionParameters.emission_diameter`),
+not static config, so the emitted number stays calibratable like the rest of
+the physics.
+
+The dust mass split also follows CAM's `dust_emis_sclfctr`: 2.1 %
+accumulation / 97.9 % coarse over those two bins, replacing an assumed
+10/90. (CAM's third, 1.65e-5 Aitken share has no home in a population whose
+Aitken mode carries no dust.) Sea salt needs neither correction: it already
+partitions the Gong spectrum across the modes and derives its number from the
+same spectrum.
 
 ## Status and caveats
 

--- a/docs/design/jam.md
+++ b/docs/design/jam.md
@@ -315,9 +315,25 @@ Because taking it silently would mean emitting 37-46 % too much sea salt, the
 emission terms publish a per-column flag `wind_10m_model_level` — 1 where the
 model level was used, 0 where the diagnosed wind was — zeroed every step with
 the other emission diagnostics. It is 1 on step 1 of a cold start and 0
-thereafter, and the JAM integration test asserts exactly that per step.
+thereafter; `seasalt_test.py` (`test_fallback_is_taken_on_step_one_and_never_again`
+and its companions) asserts exactly that per step, against the zero-filled carry
+a cold start begins with and a populated one thereafter. The JAM integration
+test adds the end-to-end check that no column is still flagged after six steps.
 
-`check_health` **reports** the chunk's fraction rather than failing on it, and
+**The three terms behave differently on step 1 of a cold start, deliberately.**
+Dust emits nothing (its carried `u*` is zero, and a saltation threshold has no
+defensible value without a surface layer, so `DustEmissions` has no `u*`
+default at all); sea salt and DMS emit from the lowest model level and flag it
+(`|U|` at ~33 m is a defensible approximation of `u10` — it is what the model
+did on every step before #723); and `EchamSurface` has no step-1 case, because
+it runs after vdiff. Unifying them would make one of the three worse: dust
+would have to invent a wind, or sea salt would have to discard a step of a
+legitimate flux for symmetry's sake. The asymmetry follows from what each
+quantity is, and is stated here rather than in three docstrings.
+
+`check_health` **reports** the chunk's fraction — averaged over every save
+interval in the chunk, so the bootstrap step cannot hide in an interval the
+report does not look at — rather than failing on it, and
 the distinction is the point. Under `output_averages` the saved field is an
 interval *mean*, so a cold start's one legitimate fallback step reads `1/N` —
 the identical value a single defective step mid-chunk would give. No per-chunk

--- a/docs/design/jam.md
+++ b/docs/design/jam.md
@@ -333,16 +333,21 @@ quantity is, and is stated here rather than in three docstrings.
 
 `check_health` **reports** the chunk's fraction — averaged over every save
 interval in the chunk, so the bootstrap step cannot hide in an interval the
-report does not look at — rather than failing on it, and
-the distinction is the point. Under `output_averages` the saved field is an
-interval *mean*, so a cold start's one legitimate fallback step reads `1/N` —
-the identical value a single defective step mid-chunk would give. No per-chunk
-rule can separate them, and making the fraction fatal aborted a healthy 30-day
-validation run at day 5 on `1/480`, losing the chunk because the bail path
-skips the checkpoint. A wrong-but-finite emission wind is a bias, not a
-blowup, so it belongs in the report the chunk prints (`Emis wind: ...`), where
-a persistent fallback shows as ~100 % every chunk, and the per-step invariant
-stays where it can be checked exactly — in the unit tests.
+report does not look at — and fails the chunk only on a *persistent* fallback.
+The distinction matters. Under `output_averages` the saved field is an interval
+*mean*, so a cold start's one legitimate fallback step reads `1/N`, the
+identical value a single defective step mid-chunk would give: no rule can
+separate those, and treating `> 0` as fatal aborted a healthy 30-day validation
+run at day 5 on `1/480`, losing the chunk because the bail path skips the
+checkpoint. A fallback that never stops is separable, though — no vdiff term,
+or `wind_10m` never published, reads `1.0` in *every* chunk and costs +37-46 %
+sea salt for the whole run. So the gate is `chunk_idx > 0 and frac > 0.5`:
+after the first chunk the flag can only be zero, and the one legitimate way to
+read `1.0` (a first chunk that is itself a single step) can only be chunk 0.
+That needs no timestep and no cold-start flag — which is what the earlier
+one-step exemption needed, and crashed on for configs whose dycore owns the
+timestep. A single-chunk run degrades to report-only, and the per-step
+invariant stays where it can be checked exactly, in the unit tests.
 
 ### Dust source gating
 

--- a/docs/design/jam.md
+++ b/docs/design/jam.md
@@ -315,8 +315,18 @@ Because taking it silently would mean emitting 37-46 % too much sea salt, the
 emission terms publish a per-column flag `wind_10m_model_level` — 1 where the
 model level was used, 0 where the diagnosed wind was — zeroed every step with
 the other emission diagnostics. It is 1 on step 1 of a cold start and 0
-thereafter; a run in which it stays non-zero is a bug, and the JAM integration
-test asserts exactly that.
+thereafter, and the JAM integration test asserts exactly that per step.
+
+`check_health` **reports** the chunk's fraction rather than failing on it, and
+the distinction is the point. Under `output_averages` the saved field is an
+interval *mean*, so a cold start's one legitimate fallback step reads `1/N` —
+the identical value a single defective step mid-chunk would give. No per-chunk
+rule can separate them, and making the fraction fatal aborted a healthy 30-day
+validation run at day 5 on `1/480`, losing the chunk because the bail path
+skips the checkpoint. A wrong-but-finite emission wind is a bias, not a
+blowup, so it belongs in the report the chunk prints (`Emis wind: ...`), where
+a persistent fallback shows as ~100 % every chunk, and the per-step invariant
+stays where it can be checked exactly — in the unit tests.
 
 ### Dust source gating
 

--- a/docs/design/jam.md
+++ b/docs/design/jam.md
@@ -291,11 +291,32 @@ merge = -(bn - bm)*10/z1                      stable   (CM|U| < CM_n|U|)
 Building it from the per-tile `CM·|U|` the surface stress already uses means the
 10 m wind cannot drift from the momentum exchange, and the stable/unstable
 branch needs no separate Richardson number (the two branches meet continuously
-at `Ri = 0`, where `CM|U| = CM_n|U|`). Emission terms read it through
-`emissions/surface_wind.py`; with no vdiff term composed there is no surface
-layer to reduce through and they fall back to the lowest level. Emissions run
-before vdiff in the ECHAM ordering, so the value is one step old — the same lag
-the dust term's `u*` already carries.
+at `Ri = 0`, where `CM|U| = CM_n|U|`). The profile factor is built from the
+`zepdu2`-floored speed the coefficients themselves used (`max(|U|, 1 m/s)`),
+or ECHAM's calm-wind floor would be misread as a stability signal; the
+reduction it yields then multiplies the true wind.
+
+Emission terms read the result through `emissions/surface_wind.py`. They run
+*before* vdiff in the ECHAM ordering, so the value is one step old. This is
+the **declared** cross-step carry — `vertical_diffusion` is one of the slots
+`Physics.initial_carry_state` seeds — i.e. the deliberate pattern #673
+distinguishes from an accidental stale `.get()`, and the same lag the dust
+term's `u*` already carries. When #673's `carry_slots` check lands this read
+is one to declare explicitly.
+
+**The fallback to the lowest model level is bootstrap-only, by construction.**
+The 10 m wind *cannot* exist on step 1 of a cold start: emissions run first,
+and the `vertical_diffusion` carry slot is seeded zero-filled
+(`initial_carry_state`; verified — `surface_friction_velocity` and `wind_10m`
+are both exactly 0 there), so no surface layer has been diagnosed yet.
+(A resumed run carries a real 10 m wind and never takes the fallback; nor does
+a composition with no vdiff term, where there is no surface layer at all.)
+Because taking it silently would mean emitting 37-46 % too much sea salt, the
+emission terms publish a per-column flag `wind_10m_model_level` — 1 where the
+model level was used, 0 where the diagnosed wind was — zeroed every step with
+the other emission diagnostics. It is 1 on step 1 of a cold start and 0
+thereafter; a run in which it stays non-zero is a bug, and the JAM integration
+test asserts exactly that.
 
 ### Dust source gating
 

--- a/docs/source/design/data_mirror.md
+++ b/docs/source/design/data_mirror.md
@@ -190,9 +190,11 @@ inventory):
 - `soilw_am` is the SPEEDY soil-availability **fraction** in [0, 1],
   computed from ERA5 volumetric layers with the `jcm.data.bc.compile`
   formula (vegetation-gated deep layer, wilting/capacity thresholds);
-  `snowc` is likewise the snow-cover fraction `min(1, sd/sd2sc)`. Both
-  follow the packaged files' conventions exactly (see the `bundles.py`
-  docstring).
+  `snowc` is likewise the snow-cover fraction `min(1, sd/sd2sc)`, **zero
+  by construction where snow never melts** (ice sheets: their albedo is
+  already in the static `alb`, and blending toward fresh-snow albedo
+  would double-count it), so it is not an ice-sheet mask. Both follow the
+  packaged files' conventions exactly (see the `bundles.py` docstring).
 - The packaged T63 `orosig` was ≈0 everywhere; the GMTED-derived bundles
   supply a real mean-slope field, so SSO gravity-wave drag will behave
   differently (more drag) than with the packaged terrain. The gradient

--- a/docs/source/design/data_mirror.md
+++ b/docs/source/design/data_mirror.md
@@ -21,7 +21,7 @@ climatology arrays alongside the transient series.
 
 **Tier B — per-grid bundles** (`bundles/<grid>/`), the files the model
 reads directly: `terrain.nc`, `forcing_{pi,pd}.nc`,
-`emissions_{pi,pd}.nc`, `dms.nc`, `dust.nc`, and per level count
+`emissions_{pi,pd}.nc`, `dms.nc`, `dust_erodibility.nc`, and per level count
 (`<grid>_l{47,95}/`) `ozone_{pi,pd}.nc` and `oxidants_{pi,pd}.nc`.
 
 **Yearly transient AMIP bundles** (issue #610) sit alongside the era
@@ -120,7 +120,7 @@ python -m jcm.main physics=echam-jam grid=echam_t63_l47_hybrid \
     forcing=from_file forcing.file=hf://bundles/t63/forcing_pd.nc \
     forcing.emissions_file=hf://bundles/t63/emissions_pd.nc \
     forcing.dms_file=hf://bundles/t63/dms.nc \
-    forcing.dust_file=hf://bundles/t63/dust.nc \
+    forcing.dust_file=hf://bundles/t63/dust_erodibility.nc \
     forcing.oxidants_file=hf://bundles/t63_l47/oxidants_pd.nc \
     forcing.ozone_file=hf://bundles/t63_l47/ozone_pd.nc
 ```

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -140,7 +140,9 @@ with year-matched products for a consistent transient run.
 ``cam_erodibility`` (default)
    CAM's geomorphic basin factor ``mbl_bsn_fct_geo`` — an **unbounded** weight
    (0-5.7), zeroed below 0.1 as CAM does. This is what the mirror bundle
-   ``bundles/<grid>/dust.nc`` carries.
+   ``bundles/<grid>/dust_erodibility.nc`` carries. (The legacy
+   ``bundles/<grid>/dust.nc`` is the pre-#768 build whose weights were
+   capped at 1; the reader refuses it.)
 ``tegen_potential``
    A HAMMOZ-style potential-source **fraction** in [0, 1] whose preprocessing
    already embeds the vegetation/land-cover mask, so no threshold is applied.

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -141,8 +141,9 @@ with year-matched products for a consistent transient run.
    CAM's geomorphic basin factor ``mbl_bsn_fct_geo`` — an **unbounded** weight
    (0-5.7), zeroed below 0.1 as CAM does. This is what the mirror bundle
    ``bundles/<grid>/dust_erodibility.nc`` carries. (The legacy
-   ``bundles/<grid>/dust.nc`` is the pre-#768 build whose weights were
-   capped at 1; the reader refuses it.)
+   ``bundles/<grid>/dust.nc`` is the pre-#768 build whose weights were capped
+   at 1. The reader refuses it on every grid — the check is tolerant, because
+   regridding a clipped map leaves its maximum a hair either side of 1.)
 ``tegen_potential``
    A HAMMOZ-style potential-source **fraction** in [0, 1] whose preprocessing
    already embeds the vegetation/land-cover mask, so no threshold is applied.

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -134,6 +134,21 @@ present-day aerosol emissions over a historical circulation — the runner warns
 and names the keys; override ``forcing.emissions_file``/``forcing.oxidants_file``
 with year-matched products for a consistent transient run.
 
+``forcing.dust_file`` carries a source map in one of two conventions, and
+``physics.jam_dust_source`` says which one the file follows:
+
+``cam_erodibility`` (default)
+   CAM's geomorphic basin factor ``mbl_bsn_fct_geo`` — an **unbounded** weight
+   (0-5.7), zeroed below 0.1 as CAM does. This is what the mirror bundle
+   ``bundles/<grid>/dust.nc`` carries.
+``tegen_potential``
+   A HAMMOZ-style potential-source **fraction** in [0, 1] whose preprocessing
+   already embeds the vegetation/land-cover mask, so no threshold is applied.
+
+Either way the dust term gates the map at run time by land fraction, snow
+cover, frozen ground and soil moisture, so a source map alone no longer emits
+dust from ice sheets or open ocean.
+
 Quick Start Examples
 --------------------
 

--- a/jcm/config/forcing/default.yaml
+++ b/jcm/config/forcing/default.yaml
@@ -36,9 +36,9 @@ emissions_file: auto
 # nmol/L; ``bundles/<grid>/dms.nc``). Drives ``DmsEmissions``.
 dms_file: auto
 
-# Dust-source/erodibility monthly climatology (HAMMOZ ``pot_source
-# (time, lat, lon)`` in [0, 1]; ``bundles/<grid>/dust.nc``). Drives
-# ``DustEmissions``.
+# Dust source/erodibility map (``pot_source``;
+# ``bundles/<grid>/dust_erodibility.nc``). Drives ``DustEmissions``;
+# ``physics.jam_dust_source`` says which convention the file follows.
 dust_file: auto
 
 # Oxidant monthly climatology on the model's hybrid levels (HAMMOZ/MACC

--- a/jcm/config/forcing/from_file.yaml
+++ b/jcm/config/forcing/from_file.yaml
@@ -77,8 +77,9 @@ emissions_file: auto
 # ``DmsEmissions``.
 dms_file: auto
 
-# Dust-source/erodibility monthly climatology (``bundles/<grid>/dust.nc``);
-# drives ``DustEmissions``.
+# Dust source/erodibility map (``bundles/<grid>/dust_erodibility.nc``);
+# drives ``DustEmissions``. Which convention it follows is
+# ``physics.jam_dust_source``.
 dust_file: auto
 
 # Oxidant monthly climatology on the model's hybrid levels

--- a/jcm/config/physics/echam-jam.yaml
+++ b/jcm/config/physics/echam-jam.yaml
@@ -28,6 +28,14 @@ jam_microphysics: mam4_jax  # the MAM4-JAX core (#490); "placeholder" for κ-Kö
 jam_arg_variant: ghosh2025  # or arg2000
 jam_aqueous_scheme: full
 
+# Which convention the prescribed dust source map (forcing.dust_file) follows.
+# cam_erodibility (default): CAM's geomorphic basin factor mbl_bsn_fct_geo, an
+# unbounded weight zeroed below 0.1 (dust_model.F90) — what the mirror bundle
+# carries. tegen_potential: a HAMMOZ-style potential-source FRACTION in [0, 1]
+# whose preprocessing already embeds the vegetation/land-cover mask, so no
+# threshold is applied. Set it to match the file, not the other way round.
+jam_dust_source: cam_erodibility
+
 # Explicit cloud-borne aerosol phase (#602). true (default) carries and cycles
 # the mc_*/nc_* mirror tracers: ARG activation transfer + resuspension,
 # in-droplet wet removal, dry deposition, and the aqueous sulfate split. false

--- a/jcm/data/mirror/SOURCES.md
+++ b/jcm/data/mirror/SOURCES.md
@@ -11,7 +11,7 @@ Regridding always starts from the highest-resolution product available.
 | AMIP SST + sea ice | `.../input4MIPs_raw/input4MIPs/CMIP7/CMIP/PCMDI/PCMDI-AMIP-1-1-10` (`tos`, `tosbcs`, `siconc`) | 1°, 1870–2022 |
 | Ozone (CMIP7) | `.../input4MIPs_raw/input4MIPs/CMIP7/CMIP/FZJ/FZJ-CMIP-ozone-1-0` (`vmro3`) | 1.9×2.5°, 66 plev to ~1e-4 hPa |
 | ERA5 land climatology | `/glade/campaign/collections/rda/data/d633001/e5.moda.an.sfc` (`stl1`, `swvl1`, `sd`, `skt`, `fal`) | 0.25° monthly means |
-| Dust erodibility | `/glade/campaign/cesm/cesmdata/inputdata/atm/cam/dst/dst_0.23x0.31_c130710.nc` | 0.23×0.31° |
+| Dust erodibility (`mbl_bsn_fct_geo`, an UNBOUNDED 0–5.7 basin-factor weight — never capped at 1, #768) | `/glade/campaign/cesm/cesmdata/inputdata/atm/cam/dst/dst_0.23x0.31_c130710.nc` | 0.23×0.31° |
 | DMS seawater (Lana 2011) | `.../inputdata/atm/cam/chem/ocnexch/Csw_DMS_Lana2011_f09f09_1750_2100_20200717a.nc` | 0.9×1.25° |
 | Oxidants OH/HO2/NO3/H2O2/O3, full lid (BUNDLED) | `/glade/p/cesmdata/cseg/inputdata/atm/cam/ozone/oxid_ozone_WACCM_CCMI_REFC1_f.e11.FWTREFC1.<decade>.f19_f19.ccmi34.001_monthly.nc` (decades 1850s–2000s) | 1.9×2.5°, L66 to ~6e-6 hPa |
 | Oxidants, year-specific fallback | `.../inputdata/atm/cam/chem/trop_mozart_aero/oxid/oxid_1.9x2.5_L26_1850-2015_c20181106.nc` (`--oxid-source cam`) | 1.9×2.5°, L26 |

--- a/jcm/data/mirror/build_mirror.py
+++ b/jcm/data/mirror/build_mirror.py
@@ -88,7 +88,7 @@ _MANIFEST_PRODUCTS: tuple[dict, ...] = (
      "grids": "gaussian", "levels": False, "coverage": None,
      "alignment": "climatology", "key": "dms_file", "auto": True,
      "staged": True},
-    {"name": "dust", "path": "bundles/{grid}/dust.nc",
+    {"name": "dust", "path": "bundles/{grid}/dust_erodibility.nc",
      "grids": "gaussian", "levels": False, "coverage": None,
      "alignment": "climatology", "key": "dust_file", "auto": True,
      "staged": True},
@@ -361,9 +361,13 @@ def stage_bundles() -> None:
         g = UPLOAD / "bundles" / grid
         shutil.copy(BUILD / "aux" / f"dms_lana2011_climo_t{trunc[grid]}.nc",
                     g / "dms.nc")
+        # Published under its own name, not the legacy ``dust.nc``: that file
+        # is the pre-#768 build whose values were capped at 1, and the runtime
+        # fetch is cache-first, so re-staging in place would leave warm caches
+        # silently on the truncated map.
         shutil.copy(BUILD / "aux" /
                     f"dust_erodibility_cam_f05_t{trunc[grid]}.nc",
-                    g / "dust.nc")
+                    g / "dust_erodibility.nc")
 
     d = UPLOAD / "bundles" / "ne30pg3"
     d.mkdir(parents=True, exist_ok=True)

--- a/jcm/data/mirror_manifest.json
+++ b/jcm/data/mirror_manifest.json
@@ -106,7 +106,7 @@
       "staged": true
     },
     "dust": {
-      "path": "bundles/{grid}/dust.nc",
+      "path": "bundles/{grid}/dust_erodibility.nc",
       "source": "mirror",
       "grids": [
         "t106",

--- a/jcm/diagnostics.py
+++ b/jcm/diagnostics.py
@@ -80,12 +80,18 @@ def aerosol_budget_report(ds, dt_seconds: float) -> list[str]:
     return lines
 
 
-def check_health(ds, chunk_idx: int, elapsed_days: float) -> tuple[bool, dict]:
+def check_health(ds, chunk_idx: int, elapsed_days: float,
+                 cold_start_step_seconds: float | None = None) -> tuple[bool, dict]:
     """Inspect ``ds`` for atmosphere-blowup signatures.
 
     ``ds`` is the xarray Dataset returned by
     ``ModelPredictions.to_xarray()``. The function looks at the *last*
     timestep in the dataset.
+
+    ``cold_start_step_seconds`` is the model timestep when this chunk is the
+    first of a COLD start (not a resume), and ``None`` otherwise. It exempts
+    exactly one thing: a first chunk short enough to end on the model's very
+    first step, where the emission-wind fallback below is legitimate.
 
     Returns
     -------
@@ -148,10 +154,17 @@ def check_health(ds, chunk_idx: int, elapsed_days: float) -> tuple[bool, dict]:
 
     # Emission wind provenance (#723): the surface-flux schemes fall back to
     # the lowest model level only on step 1, so any column still flagged in a
-    # saved chunk means they are emitting ~40 % too much sea salt.
+    # saved chunk means they are emitting ~40 % too much sea salt. The one
+    # legitimate case is a cold start's first chunk that is itself a single
+    # step, which ends ON that step — common in tests, SCM and smoke configs.
     if "wind_10m_model_level" in ds:
         flag = ds["wind_10m_model_level"].isel(time=-1).values
         report["emission_wind_model_level_frac"] = float(np.nanmean(flag))
+        report["emission_wind_bootstrap_chunk"] = bool(
+            chunk_idx == 0
+            and cold_start_step_seconds is not None
+            and elapsed_days * 86400.0 <= 1.5 * cold_start_step_seconds
+        )
 
     ok = True
     reasons: list[str] = []
@@ -169,7 +182,8 @@ def check_health(ds, chunk_idx: int, elapsed_days: float) -> tuple[bool, dict]:
     if report.get("q_max_gkg", 0) > 100:
         ok = False
         reasons.append(f"q_max={report['q_max_gkg']:.1f} g/kg (> 100)")
-    if report.get("emission_wind_model_level_frac", 0) > 0:
+    if (report.get("emission_wind_model_level_frac", 0) > 0
+            and not report.get("emission_wind_bootstrap_chunk", False)):
         ok = False
         reasons.append(
             "emission wind fell back to the lowest model level in "

--- a/jcm/diagnostics.py
+++ b/jcm/diagnostics.py
@@ -80,18 +80,12 @@ def aerosol_budget_report(ds, dt_seconds: float) -> list[str]:
     return lines
 
 
-def check_health(ds, chunk_idx: int, elapsed_days: float,
-                 cold_start_step_seconds: float | None = None) -> tuple[bool, dict]:
+def check_health(ds, chunk_idx: int, elapsed_days: float) -> tuple[bool, dict]:
     """Inspect ``ds`` for atmosphere-blowup signatures.
 
     ``ds`` is the xarray Dataset returned by
     ``ModelPredictions.to_xarray()``. The function looks at the *last*
     timestep in the dataset.
-
-    ``cold_start_step_seconds`` is the model timestep when this chunk is the
-    first of a COLD start (not a resume), and ``None`` otherwise. It exempts
-    exactly one thing: a first chunk short enough to end on the model's very
-    first step, where the emission-wind fallback below is legitimate.
 
     Returns
     -------
@@ -152,19 +146,16 @@ def check_health(ds, chunk_idx: int, elapsed_days: float,
         report["precip_conv_mean_mmday"] = float(np.nanmean(precip)) * 86400
         report["precip_conv_max_mmday"] = float(np.nanmax(precip)) * 86400
 
-    # Emission wind provenance (#723): the surface-flux schemes fall back to
-    # the lowest model level only on step 1, so any column still flagged in a
-    # saved chunk means they are emitting ~40 % too much sea salt. The one
-    # legitimate case is a cold start's first chunk that is itself a single
-    # step, which ends ON that step — common in tests, SCM and smoke configs.
+    # Emission-wind provenance (#723). REPORTED, never fatal: this is a bias
+    # indicator, not a blowup signature, and under ``output_averages`` the
+    # saved field is an interval MEAN, in which a cold start's legitimate
+    # single fallback step is 1/N — indistinguishable from a defective step
+    # mid-chunk, and enough to abort a healthy run. The per-step invariant is
+    # pinned by unit tests instead; here the number is printed so a run that
+    # keeps falling back (~1.0 every chunk) is visible.
     if "wind_10m_model_level" in ds:
         flag = ds["wind_10m_model_level"].isel(time=-1).values
         report["emission_wind_model_level_frac"] = float(np.nanmean(flag))
-        report["emission_wind_bootstrap_chunk"] = bool(
-            chunk_idx == 0
-            and cold_start_step_seconds is not None
-            and elapsed_days * 86400.0 <= 1.5 * cold_start_step_seconds
-        )
 
     ok = True
     reasons: list[str] = []
@@ -182,13 +173,6 @@ def check_health(ds, chunk_idx: int, elapsed_days: float,
     if report.get("q_max_gkg", 0) > 100:
         ok = False
         reasons.append(f"q_max={report['q_max_gkg']:.1f} g/kg (> 100)")
-    if (report.get("emission_wind_model_level_frac", 0) > 0
-            and not report.get("emission_wind_bootstrap_chunk", False)):
-        ok = False
-        reasons.append(
-            "emission wind fell back to the lowest model level in "
-            f"{report['emission_wind_model_level_frac']:.1%} of columns"
-        )
 
     report["ok"] = ok
     report["reasons"] = reasons
@@ -232,4 +216,10 @@ def print_report(report: dict) -> None:
             f"  Precip conv: mean {report['precip_conv_mean_mmday']:.4f} mm/day, "
             f"max {report['precip_conv_max_mmday']:.2f} mm/day"
         )
+    if "emission_wind_model_level_frac" in report:
+        # One bootstrap step in an N-step chunk reads 1/N; a run still falling
+        # back reads ~1 in every chunk (#723).
+        print("  Emis wind:   "
+              f"{report['emission_wind_model_level_frac']:.3%} model-level "
+              "(bootstrap step only; ~100% means the 10 m wind is missing)")
     print()

--- a/jcm/diagnostics.py
+++ b/jcm/diagnostics.py
@@ -146,13 +146,10 @@ def check_health(ds, chunk_idx: int, elapsed_days: float) -> tuple[bool, dict]:
         report["precip_conv_mean_mmday"] = float(np.nanmean(precip)) * 86400
         report["precip_conv_max_mmday"] = float(np.nanmax(precip)) * 86400
 
-    # Emission-wind provenance (#723). REPORTED, never fatal: this is a bias
-    # indicator, not a blowup signature, and under ``output_averages`` the
-    # saved field is an interval MEAN, in which a cold start's legitimate
-    # single fallback step is 1/N — indistinguishable from a defective step
-    # mid-chunk, and enough to abort a healthy run. The per-step invariant is
-    # pinned by unit tests instead; here the number is printed so a run that
-    # keeps falling back (~1.0 every chunk) is visible.
+    # Emission-wind provenance (#723). Reported always; fatal only for a
+    # PERSISTENT fallback (see the failure block). Under ``output_averages``
+    # the saved field is an interval mean, so one legitimate bootstrap step is
+    # 1/N — which is why "> 0" cannot be the rule.
     if "wind_10m_model_level" in ds:
         # Over the whole chunk, not ``isel(time=-1)``: with more than one save
         # interval per chunk the last interval never contains step 1, so the
@@ -176,6 +173,23 @@ def check_health(ds, chunk_idx: int, elapsed_days: float) -> tuple[bool, dict]:
     if report.get("q_max_gkg", 0) > 100:
         ok = False
         reasons.append(f"q_max={report['q_max_gkg']:.1f} g/kg (> 100)")
+
+    # A fallback that never stops is a different thing from the bootstrap
+    # step: it reads 1.0 in EVERY chunk (no vdiff term, or wind_10m never
+    # published), and costs +37-46 % sea salt for the whole run. Caught by
+    # bounding the legitimate value rather than by exempting a case:
+    # after the first chunk the flag can only be zero, and a one-step chunk —
+    # the one legitimate way to read 1.0 — can only be the first. So this
+    # needs no timestep and no notion of a cold start, which is what the
+    # earlier exemption needed and crashed on (run.time_step: null).
+    if (chunk_idx > 0
+            and report.get("emission_wind_model_level_frac", 0.0) > 0.5):
+        ok = False
+        reasons.append(
+            "emission wind fell back to the lowest model level in "
+            f"{report['emission_wind_model_level_frac']:.0%} of this chunk — "
+            "the 10 m wind is not being diagnosed, so sea salt is ~40% high"
+        )
 
     report["ok"] = ok
     report["reasons"] = reasons

--- a/jcm/diagnostics.py
+++ b/jcm/diagnostics.py
@@ -146,6 +146,13 @@ def check_health(ds, chunk_idx: int, elapsed_days: float) -> tuple[bool, dict]:
         report["precip_conv_mean_mmday"] = float(np.nanmean(precip)) * 86400
         report["precip_conv_max_mmday"] = float(np.nanmax(precip)) * 86400
 
+    # Emission wind provenance (#723): the surface-flux schemes fall back to
+    # the lowest model level only on step 1, so any column still flagged in a
+    # saved chunk means they are emitting ~40 % too much sea salt.
+    if "wind_10m_model_level" in ds:
+        flag = ds["wind_10m_model_level"].isel(time=-1).values
+        report["emission_wind_model_level_frac"] = float(np.nanmean(flag))
+
     ok = True
     reasons: list[str] = []
     # Any NaN in temperature is a failure — the integration has either
@@ -162,6 +169,12 @@ def check_health(ds, chunk_idx: int, elapsed_days: float) -> tuple[bool, dict]:
     if report.get("q_max_gkg", 0) > 100:
         ok = False
         reasons.append(f"q_max={report['q_max_gkg']:.1f} g/kg (> 100)")
+    if report.get("emission_wind_model_level_frac", 0) > 0:
+        ok = False
+        reasons.append(
+            "emission wind fell back to the lowest model level in "
+            f"{report['emission_wind_model_level_frac']:.1%} of columns"
+        )
 
     report["ok"] = ok
     report["reasons"] = reasons

--- a/jcm/diagnostics.py
+++ b/jcm/diagnostics.py
@@ -154,7 +154,10 @@ def check_health(ds, chunk_idx: int, elapsed_days: float) -> tuple[bool, dict]:
     # pinned by unit tests instead; here the number is printed so a run that
     # keeps falling back (~1.0 every chunk) is visible.
     if "wind_10m_model_level" in ds:
-        flag = ds["wind_10m_model_level"].isel(time=-1).values
+        # Over the whole chunk, not ``isel(time=-1)``: with more than one save
+        # interval per chunk the last interval never contains step 1, so the
+        # bootstrap step would vanish from the report (run=pyses_year).
+        flag = ds["wind_10m_model_level"].values
         report["emission_wind_model_level_frac"] = float(np.nanmean(flag))
 
     ok = True

--- a/jcm/diagnostics_test.py
+++ b/jcm/diagnostics_test.py
@@ -166,6 +166,66 @@ def _budget_dataset(dtype, dyn=0.0, mass=1.0, ptend=5e-12,
     return xr.Dataset(data, coords={"lat": lat, "lon": lon})
 
 
+class TestEmissionWindProvenance(unittest.TestCase):
+    """The bootstrap-only guarantee of #723, enforced per chunk."""
+
+    DT = 30.0 * 60.0          # 30-minute model step
+    ONE_STEP_DAYS = DT / 86400.0
+
+    def _ds(self, flagged_fraction: float):
+        ds = _make_dataset(250.0, 300.0)
+        nt, nx, ny = ds["temperature"].shape
+        flag = np.zeros((nt, nx, ny))
+        n = int(round(flagged_fraction * nx * ny))
+        flag.reshape(nt, -1)[:, :n] = 1.0
+        ds["wind_10m_model_level"] = (("time", "lon", "lat"), flag)
+        return ds
+
+    def test_flag_after_the_first_step_fails_the_chunk(self):
+        ok, report = check_health(self._ds(1.0), 3, 90.0)
+        self.assertFalse(ok)
+        self.assertIn("emission wind", "; ".join(report["reasons"]))
+        self.assertEqual(report["emission_wind_model_level_frac"], 1.0)
+
+    def test_a_single_flagged_column_is_enough(self):
+        ok, _ = check_health(self._ds(1.0 / 16.0), 3, 90.0)
+        self.assertFalse(ok)
+
+    def test_cold_start_first_step_is_exempt(self):
+        # A first chunk exactly one step long ends ON the bootstrap step, where
+        # no surface layer has been diagnosed yet — common in tests, SCM runs
+        # and smoke configs, and not a defect.
+        ok, report = check_health(self._ds(1.0), 0, self.ONE_STEP_DAYS,
+                                  cold_start_step_seconds=self.DT)
+        self.assertTrue(ok)
+        self.assertTrue(report["emission_wind_bootstrap_chunk"])
+        # The flag is still reported, just not fatal.
+        self.assertEqual(report["emission_wind_model_level_frac"], 1.0)
+
+    def test_the_exemption_does_not_loosen_the_gate(self):
+        one = self.ONE_STEP_DAYS
+        # A resume's first chunk carries a real 10 m wind, so no exemption.
+        self.assertFalse(check_health(self._ds(1.0), 0, one)[0])
+        # A cold start whose first chunk is longer than one step must not be
+        # ending on the bootstrap step.
+        self.assertFalse(check_health(self._ds(1.0), 0, 6 * one,
+                                      cold_start_step_seconds=self.DT)[0])
+        # A later chunk never is, whatever its length.
+        self.assertFalse(check_health(self._ds(1.0), 4, one,
+                                      cold_start_step_seconds=self.DT)[0])
+
+    def test_unflagged_chunk_passes(self):
+        ok, report = check_health(self._ds(0.0), 3, 90.0)
+        self.assertTrue(ok)
+        self.assertEqual(report["emission_wind_model_level_frac"], 0.0)
+
+    def test_absent_field_is_not_a_failure(self):
+        # Non-JAM runs publish no such field.
+        ok, report = check_health(_make_dataset(250.0, 300.0), 0, 5.0)
+        self.assertTrue(ok)
+        self.assertNotIn("emission_wind_model_level_frac", report)
+
+
 class TestAerosolBudgetReport(unittest.TestCase):
     def test_no_budget_gauges_returns_empty(self):
         ds = xr.Dataset({"temperature": (("time",), np.zeros(1))})

--- a/jcm/diagnostics_test.py
+++ b/jcm/diagnostics_test.py
@@ -167,63 +167,56 @@ def _budget_dataset(dtype, dyn=0.0, mass=1.0, ptend=5e-12,
 
 
 class TestEmissionWindProvenance(unittest.TestCase):
-    """The bootstrap-only guarantee of #723, enforced per chunk."""
+    """#723's model-level fallback is REPORTED per chunk, never fatal.
 
-    DT = 30.0 * 60.0          # 30-minute model step
-    ONE_STEP_DAYS = DT / 86400.0
+    Under ``output_averages`` the saved field is an interval mean, so a cold
+    start's one legitimate fallback step reads 1/N — the same value a single
+    defective step mid-chunk would give. No fatal rule can separate those, and
+    treating the fraction as fatal aborted a healthy 30-day run at day 5 on
+    1/480. The per-step invariant is pinned in the emission-term tests; here
+    the number only has to reach the report.
+    """
 
     def _ds(self, flagged_fraction: float):
         ds = _make_dataset(250.0, 300.0)
         nt, nx, ny = ds["temperature"].shape
-        flag = np.zeros((nt, nx, ny))
-        n = int(round(flagged_fraction * nx * ny))
-        flag.reshape(nt, -1)[:, :n] = 1.0
+        flag = np.full((nt, nx, ny), flagged_fraction)
         ds["wind_10m_model_level"] = (("time", "lon", "lat"), flag)
         return ds
 
-    def test_flag_after_the_first_step_fails_the_chunk(self):
-        ok, report = check_health(self._ds(1.0), 3, 90.0)
-        self.assertFalse(ok)
-        self.assertIn("emission wind", "; ".join(report["reasons"]))
-        self.assertEqual(report["emission_wind_model_level_frac"], 1.0)
-
-    def test_a_single_flagged_column_is_enough(self):
-        ok, _ = check_health(self._ds(1.0 / 16.0), 3, 90.0)
-        self.assertFalse(ok)
-
-    def test_cold_start_first_step_is_exempt(self):
-        # A first chunk exactly one step long ends ON the bootstrap step, where
-        # no surface layer has been diagnosed yet — common in tests, SCM runs
-        # and smoke configs, and not a defect.
-        ok, report = check_health(self._ds(1.0), 0, self.ONE_STEP_DAYS,
-                                  cold_start_step_seconds=self.DT)
+    def test_bootstrap_fraction_is_reported_and_not_fatal(self):
+        # 1/480: one step of a 5-day chunk at dt = 15 min.
+        ok, report = check_health(self._ds(1.0 / 480.0), 0, 5.0)
         self.assertTrue(ok)
-        self.assertTrue(report["emission_wind_bootstrap_chunk"])
-        # The flag is still reported, just not fatal.
-        self.assertEqual(report["emission_wind_model_level_frac"], 1.0)
+        self.assertAlmostEqual(
+            report["emission_wind_model_level_frac"], 1.0 / 480.0, places=6)
 
-    def test_the_exemption_does_not_loosen_the_gate(self):
-        one = self.ONE_STEP_DAYS
-        # A resume's first chunk carries a real 10 m wind, so no exemption.
-        self.assertFalse(check_health(self._ds(1.0), 0, one)[0])
-        # A cold start whose first chunk is longer than one step must not be
-        # ending on the bootstrap step.
-        self.assertFalse(check_health(self._ds(1.0), 0, 6 * one,
-                                      cold_start_step_seconds=self.DT)[0])
-        # A later chunk never is, whatever its length.
-        self.assertFalse(check_health(self._ds(1.0), 4, one,
-                                      cold_start_step_seconds=self.DT)[0])
-
-    def test_unflagged_chunk_passes(self):
-        ok, report = check_health(self._ds(0.0), 3, 90.0)
+    def test_a_persistent_fallback_is_visible_but_still_not_fatal(self):
+        ok, report = check_health(self._ds(1.0), 7, 200.0)
         self.assertTrue(ok)
-        self.assertEqual(report["emission_wind_model_level_frac"], 0.0)
+        self.assertEqual(report["emission_wind_model_level_frac"], 1.0)
+        self.assertEqual(report["reasons"], [])
 
-    def test_absent_field_is_not_a_failure(self):
+    def test_it_is_printed(self):
+        import contextlib
+        import io
+        _, report = check_health(self._ds(1.0), 7, 200.0)
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            print_report(report)
+        self.assertIn("Emis wind", buf.getvalue())
+
+    def test_absent_field_is_not_reported(self):
         # Non-JAM runs publish no such field.
         ok, report = check_health(_make_dataset(250.0, 300.0), 0, 5.0)
         self.assertTrue(ok)
         self.assertNotIn("emission_wind_model_level_frac", report)
+
+    def test_real_blowup_signatures_still_fail(self):
+        # The demotion must not have loosened the gate's actual job.
+        ds = self._ds(0.0)
+        ds["temperature"] = ds["temperature"] * 0.0 + 600.0
+        self.assertFalse(check_health(ds, 0, 5.0)[0])
 
 
 class TestAerosolBudgetReport(unittest.TestCase):

--- a/jcm/diagnostics_test.py
+++ b/jcm/diagnostics_test.py
@@ -167,14 +167,14 @@ def _budget_dataset(dtype, dyn=0.0, mass=1.0, ptend=5e-12,
 
 
 class TestEmissionWindProvenance(unittest.TestCase):
-    """#723's model-level fallback is REPORTED per chunk, never fatal.
+    """#723's model-level fallback: reported always, fatal only if persistent.
 
     Under ``output_averages`` the saved field is an interval mean, so a cold
     start's one legitimate fallback step reads 1/N — the same value a single
-    defective step mid-chunk would give. No fatal rule can separate those, and
-    treating the fraction as fatal aborted a healthy 30-day run at day 5 on
-    1/480. The per-step invariant is pinned in the emission-term tests; here
-    the number only has to reach the report.
+    defective step mid-chunk would give, which is why "> 0" cannot be the rule
+    (it aborted a healthy 30-day run at day 5 on 1/480). A fallback that never
+    stops is separable though: it reads 1.0 in every chunk, and after the first
+    chunk the flag can only be zero.
     """
 
     def _ds(self, flagged_fraction: float):
@@ -191,11 +191,26 @@ class TestEmissionWindProvenance(unittest.TestCase):
         self.assertAlmostEqual(
             report["emission_wind_model_level_frac"], 1.0 / 480.0, places=6)
 
-    def test_a_persistent_fallback_is_visible_but_still_not_fatal(self):
+    def test_a_persistent_fallback_after_the_first_chunk_fails(self):
+        # 1.0 in a later chunk can only mean the 10 m wind is never diagnosed
+        # (no vdiff term, or wind_10m unpublished) — +37-46 % sea salt for the
+        # whole run, which used to reach the end with only a stdout line.
         ok, report = check_health(self._ds(1.0), 7, 200.0)
+        self.assertFalse(ok)
+        self.assertIn("emission wind", "; ".join(report["reasons"]))
+
+    def test_a_one_step_first_chunk_reads_one_and_still_passes(self):
+        # The only legitimate way to read 1.0: a first chunk of a single step,
+        # where the interval mean IS the bootstrap step. Needs no timestep and
+        # no cold-start flag to tell apart — it can only be chunk 0.
+        self.assertTrue(check_health(self._ds(1.0), 0, 0.02)[0])
+
+    def test_a_single_defective_step_mid_chunk_is_reported_not_fatal(self):
+        # 1/N is the legitimate bootstrap value too, so no rule can separate
+        # them; it is reported and left to the per-step unit tests.
+        ok, report = check_health(self._ds(1.0 / 480.0), 3, 20.0)
         self.assertTrue(ok)
-        self.assertEqual(report["emission_wind_model_level_frac"], 1.0)
-        self.assertEqual(report["reasons"], [])
+        self.assertGreater(report["emission_wind_model_level_frac"], 0.0)
 
     def test_it_is_printed(self):
         import contextlib

--- a/jcm/dycore/pyses/hydra_config_test.py
+++ b/jcm/dycore/pyses/hydra_config_test.py
@@ -43,6 +43,46 @@ class PysesHydraConfigTest(unittest.TestCase):
         names = [t.name for t in model.physics.terms]
         self.assertIn("upper_temperature_relaxation", names)
 
+    def test_delegated_timestep_survives_a_fresh_chunk_on_dinosaur(self):
+        """The fast-lane half of the delegated-timestep guard.
+
+        The pySES version below is the end-to-end one, but it is slow AND
+        importorskip'd, so CI never runs it. This drives the same per-chunk
+        path — integrate, health-check, budget report, netCDF, checkpoint —
+        with ``run.time_step=null`` on a tiny dinosaur model, which
+        ``run_chunked`` accepts because a pre-built model makes the run config's
+        timestep unused. Anything in that path that reads it as a number fails
+        here, in the fast lane.
+        """
+        import tempfile
+        from pathlib import Path
+
+        import numpy as np
+
+        from jcm.model import Model
+        from jcm.physics.held_suarez.held_suarez_physics import (
+            held_suarez_physics,
+        )
+        from jcm.runners import run_chunked
+        from jcm.terrain import TerrainData
+        from jcm.utils import get_coords
+
+        coords = get_coords(np.linspace(0, 1, 9), spectral_truncation=21)
+        model = Model(coords=coords, time_step=60,
+                      terrain=TerrainData.aquaplanet(coords),
+                      physics=held_suarez_physics())
+        cfg = _cfg(["physics=held_suarez", "grid=held_suarez_t31_l8",
+                    "run.time_step=null", "run.total_time=0.5",
+                    "run.save_interval=0.25"])
+        self.assertIsNone(cfg.run.time_step)   # the case under test
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            reports = run_chunked(cfg, chunk_days=0.25,
+                                  output_prefix=f"{tmpdir}/deleg",
+                                  model=model)
+            self.assertGreaterEqual(len(reports), 1)
+            self.assertTrue(list(Path(tmpdir).glob("deleg_day*.nc")))
+
     @pytest.mark.slow
     def test_delegating_config_completes_a_fresh_first_chunk(self):
         """A config whose timestep the dycore owns must survive chunk 1.
@@ -74,10 +114,13 @@ class PysesHydraConfigTest(unittest.TestCase):
             self.assertIsNone(cfg.run.time_step)   # the point of the config
             reports = run(cfg)
 
-        self.assertIsInstance(reports, list)
-        self.assertGreaterEqual(len(reports), 1)
-        self.assertTrue(reports[0]["ok"], reports[0].get("reasons"))
-        self.assertTrue(Path(tmpdir).exists() or True)
+            # Everything the crash happened BETWEEN: the integration finished,
+            # so the chunk must have reached disk and the checkpoint written.
+            self.assertIsInstance(reports, list)
+            self.assertGreaterEqual(len(reports), 1)
+            self.assertTrue(reports[0]["ok"], reports[0].get("reasons"))
+            self.assertTrue(list(Path(tmpdir).glob("deleg_day*.nc")))
+            self.assertTrue(Path(f"{tmpdir}/deleg.ckpt").exists())
 
     def test_dinosaur_default_unchanged(self):
         from jcm.dycore.dinosaur.dycore import DinosaurDycore

--- a/jcm/dycore/pyses/hydra_config_test.py
+++ b/jcm/dycore/pyses/hydra_config_test.py
@@ -43,6 +43,42 @@ class PysesHydraConfigTest(unittest.TestCase):
         names = [t.name for t in model.physics.terms]
         self.assertIn("upper_temperature_relaxation", names)
 
+    @pytest.mark.slow
+    def test_delegating_config_completes_a_fresh_first_chunk(self):
+        """A config whose timestep the dycore owns must survive chunk 1.
+
+        ``run=pyses_year`` sets ``time_step: null`` deliberately, so anything
+        in the per-chunk path that reads it as a number crashes AFTER the
+        integration and BEFORE the checkpoint — losing the chunk. That has now
+        happened twice in one campaign (a health-check argument here, and the
+        scoreable-gate decision of #780), each time in code that ran fine on
+        every config that names its own timestep. Drive a real fresh chunk end
+        to end: integrate, health-check, budget report, netCDF, checkpoint.
+        """
+        pytest.importorskip("pyses")
+        import tempfile
+        from pathlib import Path
+
+        from jcm.runners import run
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg = _cfg([
+                "dycore=pyses_ne30l47", "physics=held_suarez", "run=pyses_year",
+                "dycore.nx=3", "dycore.n_sponge=8",
+                # One short chunk: the first fresh chunk is the whole point.
+                "run.total_time=0.05", "run.chunk_days=0.05",
+                "run.save_interval=0.05",
+                f"run.output_prefix={tmpdir}/deleg",
+                f"run.checkpoint_path={tmpdir}/deleg.ckpt",
+            ])
+            self.assertIsNone(cfg.run.time_step)   # the point of the config
+            reports = run(cfg)
+
+        self.assertIsInstance(reports, list)
+        self.assertGreaterEqual(len(reports), 1)
+        self.assertTrue(reports[0]["ok"], reports[0].get("reasons"))
+        self.assertTrue(Path(tmpdir).exists() or True)
+
     def test_dinosaur_default_unchanged(self):
         from jcm.dycore.dinosaur.dycore import DinosaurDycore
         from jcm.runners import build_model

--- a/jcm/forcing.py
+++ b/jcm/forcing.py
@@ -295,7 +295,10 @@ class ForcingData:
     # — the JAM emission terms fall back to zero on a ``None`` field, so DMS /
     # dust emission is simply inert until the field is supplied.
     dms_seawater: Any = None   # seawater DMS concentration kg/m³ (DmsEmissions)
-    dust_source: Any = None    # dust source / erodibility 0–1 (DustEmissions)
+    # Dust source map for DustEmissions. NOT bounded by 1: CAM's basin factor
+    # is an unbounded weight (#768). physics.jam_dust_source says which
+    # convention the file follows.
+    dust_source: Any = None
 
     # Prescribed oxidant volume mixing ratios for the JAM sulfur chemistry
     # (#496 follow-up): a mapping ``{"oh"|"no3"|"o3"|"h2o2": TimeSeries}`` of
@@ -1160,6 +1163,21 @@ def read_dms_seawater(ds, lat_deg=None, lon_deg=None, var_name="DMS_sea",
     )
 
 
+def is_clipped_erodibility(arr, tol: float = 1e-9) -> bool:
+    """Whether ``arr`` is a CAM erodibility map that was capped at 1 when built.
+
+    The single definition of the predicate: the maximum sits at 1 to within
+    round-off and more than one cell is on that plateau. Tolerant because
+    regridding a clipped map interpolates over the plateau and lands a hair
+    either side of 1 (the shipped t106 bundle peaks at 1.0000000000000002).
+    ``tools/prep_jam_aux_inputs.py`` imports this rather than restating it.
+    """
+    import numpy as _np
+
+    arr = _np.asarray(arr)
+    return bool(arr.max() <= 1.0 + tol and (arr >= 1.0 - tol).sum() > 1)
+
+
 def _reject_truncated_erodibility(da, arr) -> None:
     """Raise on a CAM erodibility map that was capped at 1 when it was built.
 
@@ -1174,11 +1192,7 @@ def _reject_truncated_erodibility(da, arr) -> None:
     text += " " + str(getattr(da, "name", ""))
     if "mbl_bsn_fct_geo" not in text and "/dst_" not in text:
         return
-    # Tolerant, not exact: regridding a clipped map interpolates over the
-    # plateau and lands a hair either side of 1 (the t106 bundle's maximum is
-    # 1.0000000000000002), which an == 1.0 test reads as "not clipped".
-    tol = 1e-9
-    if not (arr.max() <= 1.0 + tol and (arr >= 1.0 - tol).sum() > 1):
+    if not is_clipped_erodibility(arr):
         return
     raise ValueError(
         "This CAM dust-erodibility map was clipped to [0, 1] when it was "

--- a/jcm/forcing.py
+++ b/jcm/forcing.py
@@ -1169,10 +1169,12 @@ def read_dust_source(ds, lat_deg=None, lon_deg=None, var_name="pot_source",
       ``ForcingData.select`` passes non-``TimeSeries`` leaves through
       untouched, so the same field reaches ``DustEmissions`` every step.
 
-    :class:`DustEmissions`' contract is a dimensionless erodibility in
-    **[0, 1]**, so values are clipped — the file encodes missing cells as
-    ``-1`` (its ``missing`` attribute), which the clip maps to zero (no
-    source), and interpolation overshoot above 1 is capped.
+    :class:`DustEmissions` gates the field per its ``source_kind``, so only
+    the lower bound is imposed here: the HAMMOZ file encodes missing cells as
+    ``-1`` (its ``missing`` attribute) and NaN decodes to no source. Values
+    above 1 are kept — CAM's basin factor is an unbounded weight (0-5.7), and
+    capping it truncated 15 % of the global source weight in the strongest
+    source basins (#768).
     """
     if var_name not in ds.data_vars:
         raise ValueError(
@@ -1182,7 +1184,7 @@ def read_dust_source(ds, lat_deg=None, lon_deg=None, var_name="pot_source",
     arr = _orient_to_model_grid(ds[var_name], lat_deg, lon_deg, name=var_name)
     # Missing cells (NaN after decode, or the raw ``-1`` marker) mean "no dust
     # source"; NaN would pass straight through ``clip``, so zero it first.
-    arr = np.clip(np.nan_to_num(arr, nan=0.0, posinf=0.0, neginf=0.0), 0.0, 1.0)
+    arr = np.maximum(np.nan_to_num(arr, nan=0.0, posinf=0.0, neginf=0.0), 0.0)
     if "time" not in ds[var_name].dims:
         # Static (lat, lon) map → bare (lon, lat) array. No time axis to
         # build a TimeSeries from, and DustEmissions reads a 2-D field

--- a/jcm/forcing.py
+++ b/jcm/forcing.py
@@ -235,7 +235,10 @@ class ForcingData:
     alb0: jnp.ndarray # bare-land annual mean albedo (ix,il)
 
     sice_am: jnp.ndarray # sea ice concentration (or TimeSeries thereof)
-    snowc_am: jnp.ndarray # snow cover (used to be snowcl_ob in fortran - but one day of that was snowc_am)
+    # Snow-cover fraction, ZERO where snow never melts (ice-sheet albedo lives
+    # in ``alb0`` instead, so blending it here would double-count): not an
+    # ice-sheet mask.
+    snowc_am: jnp.ndarray # snow cover
     soilw_am: jnp.ndarray # soil moisture (used to be soilwcl_ob in fortran - but one day of that was soilw_am)
     stl_am: jnp.ndarray # temperature over land
     sea_surface_temperature: jnp.ndarray # SST, should come from sea_model.py or some default value

--- a/jcm/forcing.py
+++ b/jcm/forcing.py
@@ -1180,7 +1180,8 @@ def _reject_truncated_erodibility(da, arr) -> None:
         "--outdir <dir>\n"
         "and point forcing.dust_file at "
         "<dir>/dust_erodibility_cam_f05_t<T>.nc (mirror maintainers: re-stage "
-        "bundles/<grid>/dust.nc from it, so `auto` resolves the fixed map). "
+        "bundles/<grid>/dust_erodibility.nc from it, so `auto` resolves the "
+        "fixed map). "
         "forcing.dust_file=null runs dust-free in the meantime."
     )
 

--- a/jcm/forcing.py
+++ b/jcm/forcing.py
@@ -67,8 +67,11 @@ def _validate_bc_fields(ds) -> None:
         "sst":  (220.0, 320.0),  # K
         "icec": (0.0,   1.0),    # fraction
         "alb":  (0.0,   1.0),    # fraction
-        "soilw_am": (0.0, 5.0),  # kg/m^2 (column-integrated soil water)
-        "snowc":    (0.0, 20000.0),  # mm snow depth (we clip > 20000 to 0 anyway, but reject negatives)
+        # SPEEDY's vegetation-weighted root-zone availability INDEX, 1 at
+        # field capacity (jcm.data.bc.compile) — not a water depth. The bound
+        # stays loose to admit legacy files carrying an unnormalised field.
+        "soilw_am": (0.0, 5.0),  # fraction [0, 1]
+        "snowc":    (0.0, 20000.0),  # snow-cover fraction [0, 1]; the loose bound admits legacy mm-depth files, which are clipped later
     }
     for name, (lo, hi) in HARD_RANGES.items():
         if name not in ds.data_vars:
@@ -1171,7 +1174,11 @@ def _reject_truncated_erodibility(da, arr) -> None:
     text += " " + str(getattr(da, "name", ""))
     if "mbl_bsn_fct_geo" not in text and "/dst_" not in text:
         return
-    if not (arr.max() == 1.0 and (arr == 1.0).sum() > 1):
+    # Tolerant, not exact: regridding a clipped map interpolates over the
+    # plateau and lands a hair either side of 1 (the t106 bundle's maximum is
+    # 1.0000000000000002), which an == 1.0 test reads as "not clipped".
+    tol = 1e-9
+    if not (arr.max() <= 1.0 + tol and (arr >= 1.0 - tol).sum() > 1):
         return
     raise ValueError(
         "This CAM dust-erodibility map was clipped to [0, 1] when it was "

--- a/jcm/forcing.py
+++ b/jcm/forcing.py
@@ -1154,6 +1154,37 @@ def read_dms_seawater(ds, lat_deg=None, lon_deg=None, var_name="DMS_sea",
     )
 
 
+def _reject_truncated_erodibility(da, arr) -> None:
+    """Raise on a CAM erodibility map that was capped at 1 when it was built.
+
+    CAM's ``mbl_bsn_fct_geo`` is an unbounded weight (0-5.7); builds before
+    #768 clipped it to [0, 1], which silently truncates 15 % of the global
+    source weight in exactly the basins that dominate dust emission. Such a
+    file is identifiable — it says it is the CAM product and its maximum sits
+    at exactly 1.0 across many cells — so it is refused rather than used, since
+    nothing downstream could tell the truncated map from a correct one.
+    """
+    text = " ".join(str(da.attrs.get(k, "")) for k in ("long_name", "source"))
+    text += " " + str(getattr(da, "name", ""))
+    if "mbl_bsn_fct_geo" not in text and "/dst_" not in text:
+        return
+    if not (arr.max() == 1.0 and (arr == 1.0).sum() > 1):
+        return
+    raise ValueError(
+        "This CAM dust-erodibility map was clipped to [0, 1] when it was "
+        "built: mbl_bsn_fct_geo is an unbounded basin-factor WEIGHT (0-5.7) "
+        "and capping it truncates 15 % of the global source weight, "
+        "concentrated in the strongest source basins (#768). Rebuild it with "
+        "the fixed preparation tool:\n"
+        "  python tools/prep_jam_aux_inputs.py --target-truncation <T> "
+        "--outdir <dir>\n"
+        "and point forcing.dust_file at "
+        "<dir>/dust_erodibility_cam_f05_t<T>.nc (mirror maintainers: re-stage "
+        "bundles/<grid>/dust.nc from it, so `auto` resolves the fixed map). "
+        "forcing.dust_file=null runs dust-free in the meantime."
+    )
+
+
 def read_dust_source(ds, lat_deg=None, lon_deg=None, var_name="pot_source",
                      align_mode: str = "wrap_year"):
     """Read a dust-source/erodibility climatology for ``ForcingData.dust_source``.
@@ -1185,6 +1216,7 @@ def read_dust_source(ds, lat_deg=None, lon_deg=None, var_name="pot_source",
     # Missing cells (NaN after decode, or the raw ``-1`` marker) mean "no dust
     # source"; NaN would pass straight through ``clip``, so zero it first.
     arr = np.maximum(np.nan_to_num(arr, nan=0.0, posinf=0.0, neginf=0.0), 0.0)
+    _reject_truncated_erodibility(ds[var_name], arr)
     if "time" not in ds[var_name].dims:
         # Static (lat, lon) map → bare (lon, lat) array. No time axis to
         # build a TimeSeries from, and DustEmissions reads a 2-D field

--- a/jcm/forcing_assembly.py
+++ b/jcm/forcing_assembly.py
@@ -661,11 +661,14 @@ def _attach_dms(forcing, forcing_cfg, coords):
 def _attach_dust(forcing, forcing_cfg, coords):
     """Attach the dust-source/erodibility map from ``cfg.forcing.dust_file``.
 
-    No-op when unset. Loads a HAMMOZ-style monthly ``pot_source
-    (time, lat, lon)`` climatology (clipped to the [0, 1] erodibility contract
-    of :class:`DustEmissions` — see :func:`jcm.forcing.read_dust_source`) as a
-    ``WRAP_YEAR`` ``TimeSeries`` on ``forcing.dust_source``. Grid handling as
-    in :func:`_attach_dms`.
+    No-op when unset. Loads either convention onto ``forcing.dust_source``
+    (see :func:`jcm.forcing.read_dust_source`): a static CAM erodibility map,
+    an unbounded weight, as a bare array; or a HAMMOZ-style monthly
+    ``pot_source (time, lat, lon)`` fraction as a ``WRAP_YEAR``
+    ``TimeSeries``. Only the lower bound is imposed at load —
+    ``physics.jam_dust_source`` decides how the physics gates it, and
+    ``warn_on_config_traps`` cross-checks the two. Grid handling as in
+    :func:`_attach_dms`.
     """
     if forcing_cfg is None:
         return forcing

--- a/jcm/forcing_test.py
+++ b/jcm/forcing_test.py
@@ -953,11 +953,11 @@ class TestNaturalEmissionReaders(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "latitudes"):
             read_dms_seawater(ds, lat_deg=self.LAT_DESC + 5.0)
 
-    def test_dust_reader_clips_to_unit_interval(self):
+    def test_dust_reader_floors_at_zero_and_keeps_weights_above_one(self):
         from jcm.forcing import WRAP_YEAR, read_dust_source
         vals = np.zeros((12, self.NLAT, self.NLON))
         vals[:, 0, 0] = -1.0    # the file's missing marker
-        vals[:, 1, 1] = 1.5     # interpolation overshoot
+        vals[:, 1, 1] = 1.5     # CAM basin factor > 1 (runs to 5.7)
         vals[:, 2, 2] = 0.7
         vals[0, 3, 3] = np.nan
         ds = self._dataset("pot_source", vals, units="1.")
@@ -965,11 +965,12 @@ class TestNaturalEmissionReaders(unittest.TestCase):
         self.assertEqual(int(ts.align_mode), WRAP_YEAR)
         arr = np.asarray(ts.values)
         self.assertEqual(arr.shape, (12, self.NLON, self.NLAT))
-        self.assertTrue((arr >= 0.0).all() and (arr <= 1.0).all())
-        # -1 → 0; 1.5 → 1; 0.7 preserved (lat flipped: file lat idx i →
-        # ascending idx 3 - i).
+        self.assertTrue((arr >= 0.0).all())
+        # -1 → 0; 1.5 PRESERVED (an unbounded erodibility weight — capping it
+        # truncated the strongest source basins, #768); 0.7 preserved (lat
+        # flipped: file lat idx i → ascending idx 3 - i).
         self.assertEqual(arr[0, 0, 3], 0.0)
-        self.assertEqual(arr[0, 1, 2], 1.0)
+        self.assertEqual(arr[0, 1, 2], 1.5)
         self.assertAlmostEqual(float(arr[0, 2, 1]), 0.7)
         self.assertEqual(arr[0, 3, 0], 0.0)   # NaN → 0
 
@@ -982,7 +983,7 @@ class TestNaturalEmissionReaders(unittest.TestCase):
         from jcm.forcing import TimeSeries, read_dust_source
         vals = np.zeros((self.NLAT, self.NLON))
         vals[0, 0] = -1.0    # missing marker → 0
-        vals[1, 1] = 1.5     # overshoot → 1
+        vals[1, 1] = 1.5     # erodibility weight > 1, preserved
         vals[2, 2] = 0.7
         ds = xr.Dataset(
             {"pot_source": (("lat", "lon"), vals, {"units": "1."})},
@@ -996,11 +997,11 @@ class TestNaturalEmissionReaders(unittest.TestCase):
         self.assertNotIsInstance(out, TimeSeries)
         arr = np.asarray(out)
         self.assertEqual(arr.shape, (self.NLON, self.NLAT))
-        self.assertTrue((arr >= 0.0).all() and (arr <= 1.0).all())
-        # Same clip semantics as the monthly path (lat flips: file idx i →
-        # ascending idx 3 - i).
+        self.assertTrue((arr >= 0.0).all())
+        # Same floor-only semantics as the monthly path (lat flips: file idx i
+        # → ascending idx 3 - i).
         self.assertEqual(arr[0, 3], 0.0)
-        self.assertEqual(arr[1, 2], 1.0)
+        self.assertEqual(arr[1, 2], 1.5)
         self.assertAlmostEqual(float(arr[2, 1]), 0.7)
 
     def _oxidant_ds(self, nlev=5, hybm=None, drop=None):

--- a/jcm/forcing_test.py
+++ b/jcm/forcing_test.py
@@ -974,6 +974,59 @@ class TestNaturalEmissionReaders(unittest.TestCase):
         self.assertAlmostEqual(float(arr[0, 2, 1]), 0.7)
         self.assertEqual(arr[0, 3, 0], 0.0)   # NaN → 0
 
+    def test_dust_reader_rejects_a_clipped_cam_erodibility_build(self):
+        # The pre-#768 build of the CAM map capped an unbounded basin-factor
+        # weight at 1; nothing downstream can tell it from a correct map, so
+        # the reader refuses it with the rebuild command.
+        import xarray as xr
+        from jcm.forcing import read_dust_source
+        vals = np.zeros((self.NLAT, self.NLON))
+        vals[0, :2] = 1.0
+        vals[2, 2] = 0.7
+        ds = xr.Dataset(
+            {"pot_source": (("lat", "lon"), vals,
+                            {"units": "1.",
+                             "long_name": "CAM geomorphic dust source "
+                                          "(mbl_bsn_fct_geo)"})},
+            coords={"lat": self.LAT_DESC, "lon": self.LON},
+        )
+        with self.assertRaisesRegex(ValueError, "prep_jam_aux_inputs"):
+            read_dust_source(ds, lat_deg=self.LAT_DESC[::-1], lon_deg=self.LON)
+
+    def test_dust_reader_accepts_an_unclipped_cam_erodibility_build(self):
+        import xarray as xr
+        from jcm.forcing import read_dust_source
+        vals = np.zeros((self.NLAT, self.NLON))
+        vals[0, :2] = 1.0
+        vals[1, 1] = 4.4          # the basin maxima the clip used to remove
+        ds = xr.Dataset(
+            {"pot_source": (("lat", "lon"), vals,
+                            {"units": "1.",
+                             "long_name": "CAM geomorphic dust source "
+                                          "(mbl_bsn_fct_geo)"})},
+            coords={"lat": self.LAT_DESC, "lon": self.LON},
+        )
+        arr = np.asarray(
+            read_dust_source(ds, lat_deg=self.LAT_DESC[::-1], lon_deg=self.LON))
+        self.assertAlmostEqual(float(arr.max()), 4.4, places=5)
+
+    def test_dust_reader_accepts_a_unit_bounded_potential_source_map(self):
+        # A HAMMOZ potential-source FRACTION legitimately maxes at 1 — it must
+        # not trip the truncated-CAM-build check (different provenance).
+        import xarray as xr
+        from jcm.forcing import read_dust_source
+        vals = np.zeros((self.NLAT, self.NLON))
+        vals[0, :2] = 1.0
+        ds = xr.Dataset(
+            {"pot_source": (("lat", "lon"), vals,
+                            {"units": "1.",
+                             "long_name": "Tegen potential dust source"})},
+            coords={"lat": self.LAT_DESC, "lon": self.LON},
+        )
+        arr = np.asarray(
+            read_dust_source(ds, lat_deg=self.LAT_DESC[::-1], lon_deg=self.LON))
+        self.assertAlmostEqual(float(arr.max()), 1.0)
+
     def test_dust_reader_accepts_static_lat_lon_map(self):
         # A time-invariant potential-source / erodibility map has no `time`
         # axis. DustEmissions reads a bare 2-D field, so the reader must

--- a/jcm/forcing_test.py
+++ b/jcm/forcing_test.py
@@ -993,6 +993,25 @@ class TestNaturalEmissionReaders(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "prep_jam_aux_inputs"):
             read_dust_source(ds, lat_deg=self.LAT_DESC[::-1], lon_deg=self.LON)
 
+    def test_dust_reader_rejects_a_clipped_build_whose_max_rounds_above_one(self):
+        # Regridding a clipped map interpolates over the plateau: the shipped
+        # t106 bundle peaks at 1.0000000000000002, which an exact == 1.0 test
+        # read as "not clipped" and served silently.
+        import xarray as xr
+        from jcm.forcing import read_dust_source
+        vals = np.zeros((self.NLAT, self.NLON))
+        vals[0, :2] = 1.0 + 2e-16
+        vals[2, 2] = 0.7
+        ds = xr.Dataset(
+            {"pot_source": (("lat", "lon"), vals,
+                            {"units": "1.",
+                             "long_name": "CAM geomorphic dust source "
+                                          "(mbl_bsn_fct_geo)"})},
+            coords={"lat": self.LAT_DESC, "lon": self.LON},
+        )
+        with self.assertRaisesRegex(ValueError, "prep_jam_aux_inputs"):
+            read_dust_source(ds, lat_deg=self.LAT_DESC[::-1], lon_deg=self.LON)
+
     def test_dust_reader_accepts_an_unclipped_cam_erodibility_build(self):
         import xarray as xr
         from jcm.forcing import read_dust_source

--- a/jcm/physics/aerosol/jam/emissions/anthropogenic.py
+++ b/jcm/physics/aerosol/jam/emissions/anthropogenic.py
@@ -169,8 +169,19 @@ class AnthropogenicEmissions(PhysicsTerm):
         emi_bb: dict[str, jnp.ndarray] = {}
         for i, sector in enumerate(SUPER_SECTORS):
             def diameter(mode, i=i):
-                d = p.emission_diameter.get(mode.short)
-                return None if d is None else d[i]
+                # No silent fallback: without an emission size the number would
+                # come from the class's equilibrium geometry, which is what
+                # #768 measured as 75x wrong for dust. A population whose
+                # classes this table does not cover has to say so.
+                try:
+                    return p.emission_diameter[mode.short][i]
+                except KeyError:
+                    raise KeyError(
+                        f"No emission diameter for class {mode.short!r}. "
+                        "EmissionParameters.emission_diameter must cover every "
+                        "class the population's primary_emission table names "
+                        "(see SectorDefaults for the CESM values)."
+                    ) from None
 
             weights = gaussian_injection_weights(
                 height_full, dz,

--- a/jcm/physics/aerosol/jam/emissions/anthropogenic.py
+++ b/jcm/physics/aerosol/jam/emissions/anthropogenic.py
@@ -32,6 +32,7 @@ from flax import nnx
 
 from jcm.physics.aerosol.jam.emissions.distributors import (
     emit_over_profile,
+    particle_mean_mass,
 )
 from jcm.physics.aerosol.jam.emissions.injection import (
     gaussian_injection_weights,
@@ -69,6 +70,10 @@ class EmissionParameters:
     injection_thickness: jnp.ndarray    # (n_sector,) [m]
     so4_primary_fraction: jnp.ndarray   # (n_sector,) [-]
     scale: jnp.ndarray                  # overall emission scale
+    # Volume-mean diameters of the emitted size distributions, per super-sector
+    # (see :class:`~...sectors.SectorDefaults`). They set the emitted NUMBER
+    # for a given mass, so they are load-bearing for CCN.
+    emission_diameter: dict             # {class_short: (n_sector,) [m]}
 
     @classmethod
     def default(cls) -> "EmissionParameters":
@@ -83,6 +88,17 @@ class EmissionParameters:
                 len(SUPER_SECTORS), SO4_PRIMARY_FRACTION
             ),
             scale=jnp.asarray(1.0),
+            emission_diameter={
+                "acc": jnp.asarray(
+                    [SECTOR_DEFAULTS[s].so4_accum_diameter for s in SUPER_SECTORS]
+                ),
+                "ait": jnp.asarray(
+                    [SECTOR_DEFAULTS[s].so4_aitken_diameter for s in SUPER_SECTORS]
+                ),
+                "pcm": jnp.asarray(
+                    [SECTOR_DEFAULTS[s].carbon_diameter for s in SUPER_SECTORS]
+                ),
+            },
         )
 
 
@@ -140,17 +156,22 @@ class AnthropogenicEmissions(PhysicsTerm):
                 flux2d, weights, rho, dz
             )
 
-        def add_aerosol(species, mode, flux2d, weights):
-            # Mass into (species, class); implied number from the class's
-            # ``number_factor`` (the family-agnostic mass→number conversion, so
-            # this is unchanged for a sectional bin), both over the same profile.
+        def add_aerosol(species, mode, flux2d, weights, diameter):
+            # Mass into (species, class); implied number from the mean mass of
+            # a freshly emitted particle at this sector's emission volume-mean
+            # diameter (CESM's mass→number convention, m_p = ρ·(π/6)·D³). A
+            # class with no emission size falls back to its own geometry.
             add_mass(mass_name(species, mode.short), flux2d, weights)
             density = self._spec.species_props(species).density
-            add_mass(number_name(mode.short),
-                     flux2d * mode.number_factor / density, weights)
+            m_p = particle_mean_mass(mode, density, diameter)
+            add_mass(number_name(mode.short), flux2d / m_p, weights)
 
         emi_bb: dict[str, jnp.ndarray] = {}
         for i, sector in enumerate(SUPER_SECTORS):
+            def diameter(mode, i=i):
+                d = p.emission_diameter.get(mode.short)
+                return None if d is None else d[i]
+
             weights = gaussian_injection_weights(
                 height_full, dz,
                 p.injection_height[i], p.injection_thickness[i],
@@ -165,7 +186,8 @@ class AnthropogenicEmissions(PhysicsTerm):
             frac = p.so4_primary_fraction[i]
             so4_mass = frac * so2 * SO2_TO_SO4_MASS
             for mode, mode_frac in self._spec.primary_split("so4"):
-                add_aerosol("so4", mode, so4_mass * mode_frac, weights)
+                add_aerosol("so4", mode, so4_mass * mode_frac, weights,
+                            diameter(mode))
             add_mass(gas_name("so2"), (1.0 - frac) * so2, weights)
 
             # Primary carbonaceous mass → the population's primary-carbon
@@ -175,9 +197,10 @@ class AnthropogenicEmissions(PhysicsTerm):
                 # (SO2 as SO2, OC as OC), before speciation/OM scaling.
                 emi_bb = {"so2": so2, "bc": bc, "oc": oc}
             for mode, mode_frac in self._spec.primary_split("bc"):
-                add_aerosol("bc", mode, bc * mode_frac, weights)
+                add_aerosol("bc", mode, bc * mode_frac, weights, diameter(mode))
             for mode, mode_frac in self._spec.primary_split("poa"):
-                add_aerosol("poa", mode, oc * OM_OC_RATIO * mode_frac, weights)
+                add_aerosol("poa", mode, oc * OM_OC_RATIO * mode_frac, weights,
+                            diameter(mode))
 
         tendency = PhysicsTendency(
             u_wind=jnp.zeros_like(state.u_wind),

--- a/jcm/physics/aerosol/jam/emissions/anthropogenic_test.py
+++ b/jcm/physics/aerosol/jam/emissions/anthropogenic_test.py
@@ -114,6 +114,7 @@ class AnthropogenicEmissionsTest(unittest.TestCase):
                 injection_thickness=base.injection_thickness.at[0].set(thickness),
                 so4_primary_fraction=base.so4_primary_fraction.at[0].set(frac),
                 scale=base.scale,
+                emission_diameter=base.emission_diameter,
             )
             tend, _ = AnthropogenicEmissions(params=p)(
                 state, diagnostics, forcing, None
@@ -178,6 +179,7 @@ class BiomassBurningTest(unittest.TestCase):
                 injection_thickness=base.injection_thickness,
                 so4_primary_fraction=base.so4_primary_fraction,
                 scale=base.scale,
+                emission_diameter=base.emission_diameter,
             )
             tend, _ = AnthropogenicEmissions(params=p)(
                 state, diagnostics, forcing, None)
@@ -204,3 +206,42 @@ class FactoryWiringTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class EmissionSizeTest(unittest.TestCase):
+    """Emitted number uses CESM's per-sector volume-mean diameters (#768)."""
+
+    def _number_per_mass(self, sector, channel, mode_short, species):
+        from jcm.physics.aerosol.jam.tracer_layout import number_name
+        state, diagnostics, forcing = _setup(**{channel: _F_BC})
+        tend, _ = AnthropogenicEmissions()(state, diagnostics, forcing, None)
+        rho, dz = diagnostics["air_density"], diagnostics["layer_thickness"]
+        number = _column_integral(tend.tracers[number_name(mode_short)], rho, dz)
+        mass = _column_integral(
+            tend.tracers[mass_name(species, mode_short)], rho, dz)
+        return float(number[0] / mass[0])
+
+    def test_primary_carbon_number_matches_cesm(self):
+        # num_bc_a4 = 1.0*BC ... 0.134e-6 1700  (CMIP7 emission-file mapping)
+        x_mton = 6.0 / (np.pi * SPECIES["bc"].density * 0.134e-6 ** 3)
+        got = self._number_per_mass(
+            "surface_combustion", "emis_surface_combustion_bc", "pcm", "bc")
+        self.assertAlmostEqual(got / x_mton, 1.0, places=4)
+
+    def test_shipping_sulfate_is_emitted_coarser_than_surface(self):
+        from jcm.physics.aerosol.jam.emissions.sectors import SECTOR_DEFAULTS
+        self.assertAlmostEqual(
+            SECTOR_DEFAULTS["shipping"].so4_accum_diameter, 0.261e-6)
+        self.assertAlmostEqual(
+            SECTOR_DEFAULTS["surface_combustion"].so4_accum_diameter, 0.134e-6)
+        surface = self._number_per_mass(
+            "surface_combustion", "emis_surface_combustion_so2", "acc", "so4")
+        shipping = self._number_per_mass(
+            "shipping", "emis_shipping_so2", "acc", "so4")
+        self.assertAlmostEqual(surface / shipping, (0.261 / 0.134) ** 3, places=3)
+
+    def test_aitken_sulfate_number_matches_cesm(self):
+        x_mton = 6.0 / (np.pi * SPECIES["so4"].density * 0.0504e-6 ** 3)
+        got = self._number_per_mass(
+            "surface_combustion", "emis_surface_combustion_so2", "ait", "so4")
+        self.assertAlmostEqual(got / x_mton, 1.0, places=4)

--- a/jcm/physics/aerosol/jam/emissions/distributors.py
+++ b/jcm/physics/aerosol/jam/emissions/distributors.py
@@ -8,21 +8,29 @@ modal path is implemented here; a sectional distributor is future work (#491).
 
 from __future__ import annotations
 
+import math
+
 import jax.numpy as jnp
 
 from jcm.physics.aerosol.jam.population import AerosolMode, ModalAerosolSpec
 from jcm.physics.aerosol.jam.tracer_layout import mass_name, number_name
 
 
-def particle_mean_mass(mode: AerosolMode, species_density: float) -> float:
-    """Mean single-particle mass [kg] of a class at its reference size.
+def particle_mean_mass(mode: AerosolMode, species_density: float,
+                       emission_diameter=None):
+    """Mean single-particle mass [kg] of freshly emitted material.
 
-    ``m_p = ρ_material / number_factor`` — the inverse of the family-agnostic
-    ``mode.number_factor`` (number per unit dry-aerosol volume), so the modal
-    log-normal third-moment formula lives in one place (``AerosolMode``) and a
-    sectional class returns its own mean particle mass through the same call.
+    With an ``emission_diameter`` D (the volume-mean diameter of the *emitted*
+    size distribution) this is CAM's emission mass→number conversion,
+    ``x_mton = 6/(π ρ D³)`` inverted: ``m_p = ρ·(π/6)·D³`` (``dust_model.F90``;
+    the CESM emission files carry the same D per species and sector in their
+    ``mapping_equation``). Freshly emitted particles are not at the mode's
+    equilibrium size, so using the class geometry instead (the ``None``
+    fallback, ``m_p = ρ/number_factor``) overestimates dust number by ~75x.
     """
-    return species_density / mode.number_factor
+    if emission_diameter is None:
+        return species_density / mode.number_factor
+    return species_density * (math.pi / 6.0) * emission_diameter ** 3
 
 
 def emit_over_profile(
@@ -52,8 +60,11 @@ def distribute_surface_flux(
 
     Args:
         spec: the modal population.
-        fluxes: list of ``(species_token, mode_short, mass_flux)`` with
-            ``mass_flux`` shaped ``(ncols,)`` in kg/m²/s.
+        fluxes: list of ``(species_token, mode_short, mass_flux)`` or
+            ``(species_token, mode_short, mass_flux, emission_diameter)`` with
+            ``mass_flux`` shaped ``(ncols,)`` in kg/m²/s and the optional
+            volume-mean diameter [m] of the emitted size distribution (see
+            :func:`particle_mean_mass`).
         air_density: air density [kg/m³].
         layer_thickness: geometric layer thickness [m].
 
@@ -70,13 +81,13 @@ def distribute_surface_flux(
     tends: dict[str, jnp.ndarray] = {}
     number_flux = {mode.short: jnp.zeros((ncols,)) for mode in spec.modes}
 
-    for species, mode_short, mass_flux in fluxes:
+    for species, mode_short, mass_flux, *rest in fluxes:
         mode = spec.mode(mode_short)
         props = spec.species_props(species)
         mname = mass_name(species, mode_short)
         dq = jnp.zeros((nlev, ncols)).at[-1].set(mass_flux * inv)
         tends[mname] = tends.get(mname, jnp.zeros((nlev, ncols))) + dq
-        m_p = particle_mean_mass(mode, props.density)
+        m_p = particle_mean_mass(mode, props.density, *rest)
         number_flux[mode_short] = number_flux[mode_short] + mass_flux / m_p
 
     for mode_short, n_flux in number_flux.items():

--- a/jcm/physics/aerosol/jam/emissions/distributors_test.py
+++ b/jcm/physics/aerosol/jam/emissions/distributors_test.py
@@ -1,8 +1,10 @@
 """Tests for the modal emission distributor."""
 
+import math
 import unittest
 
 import jax.numpy as jnp
+import numpy as np
 
 from jcm.physics.aerosol.jam import MAM4_SPEC, mass_name, number_name
 from jcm.physics.aerosol.jam.emissions.distributors import (
@@ -31,6 +33,28 @@ class DistributorTest(unittest.TestCase):
         self.assertTrue(bool(jnp.all(tends[mname][:-1] == 0.0)))
         self.assertGreater(float(tends[mname][-1, 0]), 0.0)
         self.assertGreater(float(tends[nname][-1, 0]), 0.0)
+
+    def test_emission_diameter_gives_cams_mass_to_number(self):
+        """m_p = rho (pi/6) D^3, i.e. CESM's x_mton = 6/(pi rho D^3) (#768)."""
+        rho = 1700.0
+        m = particle_mean_mass(MAM4_SPEC.mode("primary_carbon"), rho, 0.134e-6)
+        self.assertAlmostEqual(1.0 / m / 4.669e17, 1.0, places=3)
+        self.assertAlmostEqual(m, rho * math.pi / 6.0 * 0.134e-6 ** 3, places=24)
+
+    def test_emission_diameter_changes_the_emitted_number_only(self):
+        air_density = jnp.full((3, 2), 1.2)
+        dz = jnp.full((3, 2), 100.0)
+        flux = jnp.full((2,), 1.0e-10)
+        default = distribute_surface_flux(
+            MAM4_SPEC, [("du", "acc", flux)], air_density, dz)
+        sized = distribute_surface_flux(
+            MAM4_SPEC, [("du", "acc", flux, 0.7806e-6)], air_density, dz)
+        mname, nname = mass_name("du", "acc"), number_name("acc")
+        np.testing.assert_allclose(np.asarray(sized[mname]),
+                                   np.asarray(default[mname]))
+        # The mode's 0.11 um equilibrium size emits ~75x too many particles.
+        ratio = float(default[nname][-1, 0]) / float(sized[nname][-1, 0])
+        self.assertAlmostEqual(ratio / 75.5, 1.0, places=1)
 
 
 if __name__ == "__main__":

--- a/jcm/physics/aerosol/jam/emissions/dms.py
+++ b/jcm/physics/aerosol/jam/emissions/dms.py
@@ -29,7 +29,8 @@ from jcm.physics.aerosol.jam.tracer_layout import gas_name
 from jcm.physics.physics_term import PhysicsTendency, PhysicsTerm
 from jcm.physics.aerosol.jam.emissions.flux_diagnostic import (
     accumulate_emission_fluxes, emission_flux_keys)
-from jcm.physics.aerosol.jam.emissions.surface_wind import wind_10m
+from jcm.physics.aerosol.jam.emissions.surface_wind import (
+    MODEL_LEVEL_WIND_KEY, wind_10m)
 
 _CMH_TO_MS = 0.01 / 3600.0   # cm/h → m/s
 
@@ -67,7 +68,8 @@ class DmsEmissions(PhysicsTerm):
     name: ClassVar[str] = "jam_dms_emissions"
     category: ClassVar[str] = "aerosol_emissions"
     requires: ClassVar[tuple[str, ...]] = ("air_density", "layer_thickness")
-    provides: ClassVar[tuple[str, ...]] = emission_flux_keys()
+    provides: ClassVar[tuple[str, ...]] = (
+        emission_flux_keys() + (MODEL_LEVEL_WIND_KEY,))
 
     def __init__(
         self,
@@ -92,7 +94,7 @@ class DmsEmissions(PhysicsTerm):
         dz = diagnostics["layer_thickness"]
         nlev, ncols = state.temperature.shape
 
-        u10 = wind_10m(state, diagnostics)
+        u10, from_model_level = wind_10m(state, diagnostics)
         sst = self._forcing_field(
             forcing, "sea_surface_temperature", ncols, 288.0
         )
@@ -128,5 +130,7 @@ class DmsEmissions(PhysicsTerm):
             diagnostics, tracer_tends,
             diagnostics["air_density"],
             diagnostics["layer_thickness"])
+        diagnostics = {**diagnostics, MODEL_LEVEL_WIND_KEY: jnp.maximum(
+            diagnostics.get(MODEL_LEVEL_WIND_KEY, 0.0), from_model_level)}
 
         return tendency, diagnostics

--- a/jcm/physics/aerosol/jam/emissions/dms.py
+++ b/jcm/physics/aerosol/jam/emissions/dms.py
@@ -29,6 +29,7 @@ from jcm.physics.aerosol.jam.tracer_layout import gas_name
 from jcm.physics.physics_term import PhysicsTendency, PhysicsTerm
 from jcm.physics.aerosol.jam.emissions.flux_diagnostic import (
     accumulate_emission_fluxes, emission_flux_keys)
+from jcm.physics.aerosol.jam.emissions.surface_wind import wind_10m
 
 _CMH_TO_MS = 0.01 / 3600.0   # cm/h → m/s
 
@@ -91,7 +92,7 @@ class DmsEmissions(PhysicsTerm):
         dz = diagnostics["layer_thickness"]
         nlev, ncols = state.temperature.shape
 
-        u10 = jnp.sqrt(jnp.maximum(state.u_wind[-1] ** 2 + state.v_wind[-1] ** 2, 1.0e-30))
+        u10 = wind_10m(state, diagnostics)
         sst = self._forcing_field(
             forcing, "sea_surface_temperature", ncols, 288.0
         )

--- a/jcm/physics/aerosol/jam/emissions/dms_test.py
+++ b/jcm/physics/aerosol/jam/emissions/dms_test.py
@@ -78,3 +78,26 @@ class DmsTermTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class Wind10mTest(unittest.TestCase):
+    """Nightingale's piston velocity reads the diagnosed 10 m wind (#723)."""
+
+    def test_uses_the_diagnosed_10m_wind(self):
+        from jcm.physics.vertical_diffusion.tte_tke.vertical_diffusion_types import (
+            VerticalDiffusionData,
+        )
+        state, diagnostics, forcing, terrain = _inputs(wind=10.0)
+        nlev, ncols = state.temperature.shape
+        vd = VerticalDiffusionData.zeros((ncols,), nlev).copy(
+            wind_10m=jnp.full((ncols,), 9.04))
+        lowest, _ = DmsEmissions()(state, diagnostics, forcing, terrain)
+        reduced, _ = DmsEmissions()(
+            state, {**diagnostics, "vertical_diffusion": vd}, forcing, terrain)
+        key = gas_name("dms")
+        ratio = (float(reduced.tracers[key][-1, 0])
+                 / float(lowest.tracers[key][-1, 0]))
+        # kw = 0.222 u^2 + 0.333 u, so the reduction is between u and u^2.
+        expect = ((0.222 * 9.04 ** 2 + 0.333 * 9.04)
+                  / (0.222 * 10.0 ** 2 + 0.333 * 10.0))
+        self.assertAlmostEqual(ratio, expect, places=4)

--- a/jcm/physics/aerosol/jam/emissions/dust.py
+++ b/jcm/physics/aerosol/jam/emissions/dust.py
@@ -27,7 +27,10 @@ uses, so the surface gating below follows CLM/CAM directly:
   because no LAI/vegetation boundary field is carried (#777); a vegetation-
   masked monthly source map is the ``tegen_potential`` alternative.
 * ``u*t`` — raised over moist soil by the Fecan et al. (1999) factor CLM
-  applies in ``frc_thr_wet_fct``.
+  applies in ``frc_thr_wet_fct``, on a proxy for the wetness it is defined on
+  (see :func:`wet_threshold_factor`). CLM's ``1/√ρ_air`` dependence of the dry
+  threshold is NOT applied — it is ~10 % over the high-altitude sources and is
+  left folded into the calibratable ``u_threshold``.
 
 Emitted mass is split accum/coarse with CAM's ``dust_emis_sclfctr`` and
 converted to number at the emission bins' volume-mean diameters
@@ -57,17 +60,6 @@ from jcm.physics.aerosol.jam.emissions.flux_diagnostic import (
 #: Source-field conventions ``forcing.dust_source`` may follow.
 SOURCE_KINDS = ("cam_erodibility", "tegen_potential")
 
-#: Gravimetric soil-water content at saturation [kg/kg], used to read the
-#: model's relative soil wetness in the units Fecan's threshold is defined in
-#: (porosity 0.45 over a 1485 kg/m³ dry bulk density, CLM's ``watsat``/``bd``).
-_GWC_SATURATED = 0.30
-
-#: Width of the frozen-ground ramp below the melting point [K]. CLM uses the
-#: top soil layer's liquid fraction; with only a land surface temperature
-#: available the liquid fraction is ramped over the last 2 K.
-_FREEZE_RANGE = 2.0
-
-
 @tree_math.struct
 class DustParameters:
     """Calibratable knobs for the Tegen wind-erosion flux."""
@@ -79,6 +71,8 @@ class DustParameters:
     u_star_default: jnp.ndarray    # fallback friction velocity [m/s]
     source_threshold: jnp.ndarray  # erodibility below this emits nothing [-]
     soil_moisture_threshold: jnp.ndarray  # Fecan gravimetric threshold [kg/kg]
+    soil_water_gwc_scale: jnp.ndarray  # gravimetric water at soilw_am = 1 [kg/kg]
+    freeze_range: jnp.ndarray      # frozen-ground ramp below tmelt [K]
     emission_diameter: jnp.ndarray  # (accum, coarse) volume-mean diameter [m]
 
     @classmethod
@@ -96,6 +90,10 @@ class DustParameters:
             # Fecan gwc_thr for ~20 % clay soil (CLM derives it per gridcell
             # from clay content, which no boundary field here carries).
             soil_moisture_threshold=jnp.asarray(0.04),
+            # ``soilw_am`` = 1 is FIELD CAPACITY (swcap = 0.30 vol), so the
+            # gravimetric water there is swcap·ρ_w/bd with bd = (1−watsat)·2700.
+            soil_water_gwc_scale=jnp.asarray(0.202),
+            freeze_range=jnp.asarray(2.0),
             # ``dust_common::dust_set_params`` mass-weighted diameters of the
             # emitted lognormal (D_vma = 3.5 µm, σ = 2) over those two bins.
             emission_diameter=jnp.asarray([0.7806e-6, 3.8983e-6]),
@@ -129,32 +127,45 @@ def source_weight(source: jnp.ndarray, source_kind: str,
 
 
 def mobilization_fraction(land_fraction: jnp.ndarray, snow_cover: jnp.ndarray,
-                          land_temperature: jnp.ndarray) -> jnp.ndarray:
+                          land_temperature: jnp.ndarray,
+                          freeze_range: jnp.ndarray) -> jnp.ndarray:
     """Fraction of a gridcell that can mobilize dust (CLM ``lnd_frc_mbl``).
 
-    Land only, reduced by snow cover, and shut off over frozen ground (CLM's
-    ``liqfrac``, here ramped over the 2 K below the melting point since no soil
-    ice content is carried). Ocean and sea ice contribute nothing.
+    Land only, reduced by snow cover, and shut off over frozen ground. CLM's
+    ``liqfrac`` is the top soil layer's actual liquid/(liquid+ice) partition,
+    which this model cannot form, so it is approximated by a ramp over
+    ``freeze_range`` below the melting point.
 
     The frozen-ground term is what masks the ice sheets: ``snowc_am`` is zeroed
     on permanent snow by construction (their albedo lives in ``alb`` instead),
     so a snow gate alone would emit dust from Antarctica.
     """
     liquid = jnp.clip(
-        (land_temperature - (c.tmelt - _FREEZE_RANGE)) / _FREEZE_RANGE, 0.0, 1.0)
+        (land_temperature - (c.tmelt - freeze_range)) / freeze_range, 0.0, 1.0)
     return (jnp.clip(land_fraction, 0.0, 1.0)
             * (1.0 - jnp.clip(snow_cover, 0.0, 1.0)) * liquid)
 
 
 def wet_threshold_factor(soil_wetness: jnp.ndarray,
-                         gwc_threshold: jnp.ndarray) -> jnp.ndarray:
+                         gwc_threshold: jnp.ndarray,
+                         gwc_scale: jnp.ndarray) -> jnp.ndarray:
     """Fecan (1999) moist-soil increase of u*t (CLM ``frc_thr_wet_fct``).
 
     ``√(1 + 1.21·(100·(w − w_thr))^0.68)`` above the threshold gravimetric
-    water content, 1 below it. The model carries a relative soil wetness, so
-    ``w = wetness · _GWC_SATURATED``.
+    water content, 1 below it, with ``w = soilw_am · gwc_scale``.
+
+    **The input is a proxy.** Fecan is defined on the TOP soil layer's
+    volumetric water, which no boundary field here carries; ``forcing.soilw_am``
+    is SPEEDY's vegetation-weighted root-zone availability index (#787), which
+    differs three ways: it saturates at field capacity (so ``gwc_scale``
+    defaults to swcap·ρ_w/bd, not porosity/bd — using the latter would
+    overstate the wet end ~1.5x), it blends the 7-28 cm layer that does not dry
+    on the saltation timescale, and it is already vegetation-weighted, which
+    double-counts against the vegetation gate (#777). Deserts sit at
+    ``soilw_am ≈ 0`` where none of this bites; the marginal sources (Sahel,
+    Australia, central Asia) are where it does.
     """
-    gwc = jnp.clip(soil_wetness, 0.0, 1.0) * _GWC_SATURATED
+    gwc = jnp.clip(soil_wetness, 0.0, 1.0) * gwc_scale
     excess = gwc - gwc_threshold
     # Guarded operand: x**0.68 has an infinite derivative at x = 0, which the
     # ``where`` masks in value but not in the reverse pass.
@@ -216,10 +227,11 @@ class DustEmissions(PhysicsTerm):
         mobilization = mobilization_fraction(
             self._surface_field(terrain, "fmask", ncols, 1.0),
             self._surface_field(forcing, "snowc_am", ncols, 0.0),
-            self._surface_field(forcing, "stl_am", ncols, c.tmelt + 15.0))
+            self._surface_field(forcing, "stl_am", ncols, c.tmelt + 15.0),
+            p.freeze_range)
         u_threshold = p.u_threshold * wet_threshold_factor(
             self._surface_field(forcing, "soilw_am", ncols, 0.0),
-            p.soil_moisture_threshold)
+            p.soil_moisture_threshold, p.soil_water_gwc_scale)
 
         u_star = self._u_star(diagnostics, ncols, p)
         g_flux = horizontal_flux(u_star, u_threshold, air_density[-1], p.scale)

--- a/jcm/physics/aerosol/jam/emissions/dust.py
+++ b/jcm/physics/aerosol/jam/emissions/dust.py
@@ -24,7 +24,7 @@ uses, so the surface gating below follows CLM/CAM directly:
   mask. ``source_kind`` selects which convention the field follows.
 * ``mobilization`` — CLM ``lnd_frc_mbl``: the land fraction that is snow-free
   and unfrozen. CLM's vegetation term ``1 − VAI/0.3`` has no counterpart here
-  because no LAI/vegetation boundary field is carried (#769); a vegetation-
+  because no LAI/vegetation boundary field is carried (#777); a vegetation-
   masked monthly source map is the ``tegen_potential`` alternative.
 * ``u*t`` — raised over moist soil by the Fecan et al. (1999) factor CLM
   applies in ``frc_thr_wet_fct``.

--- a/jcm/physics/aerosol/jam/emissions/dust.py
+++ b/jcm/physics/aerosol/jam/emissions/dust.py
@@ -34,7 +34,13 @@ uses, so the surface gating below follows CLM/CAM directly:
 
 Emitted mass is split accum/coarse with CAM's ``dust_emis_sclfctr`` and
 converted to number at the emission bins' volume-mean diameters
-(``dust_common::dust_set_params``), not at the modes' equilibrium sizes.
+(``dust_common::dust_set_params``), not at the modes' equilibrium sizes. The
+density in that conversion is JAM's own 2600 kg/m³, not CAM ``dust_model``'s
+2500: it is the one ``SPECIES["du"].density`` the optics, the microphysics
+core and the ice-nucleation populations all use, so number and mass stay
+mutually consistent here. CAM is internally inconsistent about it
+(``mo_constants`` 2500 vs ``modal_aero_data`` 2.6e3) and the choice is ~4 % in
+emitted number.
 
 References: Tegen et al. (2002), JGR 107; Marticorena & Bergametti (1995);
 Zender et al. (2003); Fecan et al. (1999).
@@ -49,7 +55,6 @@ import tree_math
 from flax import nnx
 
 import jcm.constants as c
-from jcm.constants import grav as _G
 from jcm.physics.aerosol.jam.emissions.distributors import distribute_surface_flux
 from jcm.physics.aerosol.jam.microphysics.mam4_data import MAM4_SPEC
 from jcm.physics.aerosol.jam.population import ModalAerosolSpec
@@ -68,7 +73,6 @@ class DustParameters:
     alpha: jnp.ndarray             # sandblasting efficiency [1/m]
     u_threshold: jnp.ndarray       # dry threshold friction velocity [m/s]
     accum_fraction: jnp.ndarray    # fraction of emitted dust into accum (rest coarse)
-    u_star_default: jnp.ndarray    # fallback friction velocity [m/s]
     source_threshold: jnp.ndarray  # erodibility below this emits nothing [-]
     soil_moisture_threshold: jnp.ndarray  # Fecan gravimetric threshold [kg/kg]
     soil_water_gwc_scale: jnp.ndarray  # gravimetric water at soilw_am = 1 [kg/kg]
@@ -81,11 +85,11 @@ class DustParameters:
             scale=jnp.asarray(1.0),
             alpha=jnp.asarray(1.0e-5),
             u_threshold=jnp.asarray(0.2),
-            # CAM ``dust_emis_sclfctr`` for MAM4 over the (0.1–1, 1–10) µm
-            # emission bins; its 1.65e-5 Aitken share has no home in a
-            # population whose Aitken mode carries no dust.
+            # CAM ``dust_emis_sclfctr`` over the two-bin (0.1–1, 1–10) µm
+            # grid, which is the branch a dust-free Aitken mode corresponds to.
+            # (CAM's 4/5-mode branch adds a third, 1.65e-5 Aitken bin on a
+            # 0.01 µm grid; this population carries no Aitken dust.)
             accum_fraction=jnp.asarray(0.021),
-            u_star_default=jnp.asarray(0.3),
             source_threshold=jnp.asarray(0.1),
             # Fecan gwc_thr for ~20 % clay soil (CLM derives it per gridcell
             # from clay content, which no boundary field here carries).
@@ -107,7 +111,8 @@ def horizontal_flux(
     """Tegen saltation horizontal flux G [kg/m/s] (zero below threshold)."""
     u = jnp.maximum(u_star, 1.0e-3)
     ratio = u_threshold / u
-    g_flux = scale * (air_density / _G) * u ** 3 * (1.0 + ratio) * (1.0 - ratio ** 2)
+    g_flux = (scale * (air_density / c.grav) * u ** 3
+              * (1.0 + ratio) * (1.0 - ratio ** 2))
     return jnp.where(u_star > u_threshold, g_flux, 0.0)
 
 
@@ -199,10 +204,19 @@ class DustEmissions(PhysicsTerm):
         self._spec = spec or MAM4_SPEC
         self._source_kind = source_kind
 
-    def _u_star(self, diagnostics, ncols, params):
-        if "vertical_diffusion" in diagnostics:
-            return diagnostics["vertical_diffusion"].surface_friction_velocity
-        return jnp.full((ncols,), params.u_star_default)
+    def _u_star(self, diagnostics, ncols):
+        """Surface friction velocity, or zero where none has been diagnosed.
+
+        No default: a saltation threshold has no defensible value without a
+        surface layer, and a non-zero fallback would emit dust from every
+        source cell on a composition with no vertical-diffusion term. Zero is
+        also what the carry holds on step 1 of a cold start, so the two
+        no-u* cases behave alike (see the design doc on the step-1 asymmetry).
+        """
+        vdiff = diagnostics.get("vertical_diffusion")
+        if vdiff is None:
+            return jnp.zeros((ncols,))
+        return vdiff.surface_friction_velocity
 
     @staticmethod
     def _surface_field(obj, name, ncols, default):
@@ -233,7 +247,7 @@ class DustEmissions(PhysicsTerm):
             self._surface_field(forcing, "soilw_am", ncols, 0.0),
             p.soil_moisture_threshold, p.soil_water_gwc_scale)
 
-        u_star = self._u_star(diagnostics, ncols, p)
+        u_star = self._u_star(diagnostics, ncols)
         g_flux = horizontal_flux(u_star, u_threshold, air_density[-1], p.scale)
         flux = source * mobilization * p.alpha * g_flux        # kg/m²/s
 

--- a/jcm/physics/aerosol/jam/emissions/dust.py
+++ b/jcm/physics/aerosol/jam/emissions/dust.py
@@ -135,6 +135,10 @@ def mobilization_fraction(land_fraction: jnp.ndarray, snow_cover: jnp.ndarray,
     Land only, reduced by snow cover, and shut off over frozen ground (CLM's
     ``liqfrac``, here ramped over the 2 K below the melting point since no soil
     ice content is carried). Ocean and sea ice contribute nothing.
+
+    The frozen-ground term is what masks the ice sheets: ``snowc_am`` is zeroed
+    on permanent snow by construction (their albedo lives in ``alb`` instead),
+    so a snow gate alone would emit dust from Antarctica.
     """
     liquid = jnp.clip(
         (land_temperature - (c.tmelt - _FREEZE_RANGE)) / _FREEZE_RANGE, 0.0, 1.0)

--- a/jcm/physics/aerosol/jam/emissions/dust.py
+++ b/jcm/physics/aerosol/jam/emissions/dust.py
@@ -9,16 +9,32 @@ to it — the saltation horizontal flux and its sandblasting conversion to a
 vertical (emitted) flux, gated by friction velocity exceeding the threshold:
 
     G = scale · (ρ_air/g) · u*³ · (1 + u*t/u*) · (1 − (u*t/u*)²)   (u* > u*t)
-    F = source · α · G
+    F = source · mobilization · α · G
 
 with ``u*`` the surface friction velocity (from the ``vertical_diffusion``
-diagnostic), ``u*t`` the threshold, ``α`` the sandblasting efficiency, and
-``source`` the prescribed erodibility (0–1). ``source`` is read from
-``forcing.dust_source`` and falls back to zero, so the term is inert (e.g. on
-an aquaplanet) until the field is supplied. The soil-database parameters are
-folded into the calibratable ``source``/``α``/``u*t`` knobs.
+diagnostic), ``u*t`` the threshold and ``α`` the sandblasting efficiency. The
+same ``(1−r)(1+r)²`` White (1979) form is what CLM's ``DustEmisZender2003``
+uses, so the surface gating below follows CLM/CAM directly:
 
-References: Tegen et al. (2002), JGR 107; Marticorena & Bergametti (1995).
+* ``source`` — the prescribed erodibility from ``forcing.dust_source``. For
+  CAM's geomorphic basin factor (``mbl_bsn_fct_geo``, 0–5.7) CAM zeroes cells
+  below ``soil_erod_threshold = 0.1`` and applies **no upper bound**
+  (``dust_model.F90``); a Tegen/HAMMOZ potential-source map is instead a
+  fraction in [0, 1] whose own preprocessing already embeds the land-cover
+  mask. ``source_kind`` selects which convention the field follows.
+* ``mobilization`` — CLM ``lnd_frc_mbl``: the land fraction that is snow-free
+  and unfrozen. CLM's vegetation term ``1 − VAI/0.3`` has no counterpart here
+  because no LAI/vegetation boundary field is carried (#769); a vegetation-
+  masked monthly source map is the ``tegen_potential`` alternative.
+* ``u*t`` — raised over moist soil by the Fecan et al. (1999) factor CLM
+  applies in ``frc_thr_wet_fct``.
+
+Emitted mass is split accum/coarse with CAM's ``dust_emis_sclfctr`` and
+converted to number at the emission bins' volume-mean diameters
+(``dust_common::dust_set_params``), not at the modes' equilibrium sizes.
+
+References: Tegen et al. (2002), JGR 107; Marticorena & Bergametti (1995);
+Zender et al. (2003); Fecan et al. (1999).
 """
 
 from __future__ import annotations
@@ -29,6 +45,7 @@ import jax.numpy as jnp
 import tree_math
 from flax import nnx
 
+import jcm.constants as c
 from jcm.constants import grav as _G
 from jcm.physics.aerosol.jam.emissions.distributors import distribute_surface_flux
 from jcm.physics.aerosol.jam.microphysics.mam4_data import MAM4_SPEC
@@ -37,6 +54,19 @@ from jcm.physics.physics_term import PhysicsTendency, PhysicsTerm
 from jcm.physics.aerosol.jam.emissions.flux_diagnostic import (
     accumulate_emission_fluxes, emission_flux_keys)
 
+#: Source-field conventions ``forcing.dust_source`` may follow.
+SOURCE_KINDS = ("cam_erodibility", "tegen_potential")
+
+#: Gravimetric soil-water content at saturation [kg/kg], used to read the
+#: model's relative soil wetness in the units Fecan's threshold is defined in
+#: (porosity 0.45 over a 1485 kg/m³ dry bulk density, CLM's ``watsat``/``bd``).
+_GWC_SATURATED = 0.30
+
+#: Width of the frozen-ground ramp below the melting point [K]. CLM uses the
+#: top soil layer's liquid fraction; with only a land surface temperature
+#: available the liquid fraction is ramped over the last 2 K.
+_FREEZE_RANGE = 2.0
+
 
 @tree_math.struct
 class DustParameters:
@@ -44,9 +74,12 @@ class DustParameters:
 
     scale: jnp.ndarray             # overall horizontal-flux scale
     alpha: jnp.ndarray             # sandblasting efficiency [1/m]
-    u_threshold: jnp.ndarray       # threshold friction velocity [m/s]
+    u_threshold: jnp.ndarray       # dry threshold friction velocity [m/s]
     accum_fraction: jnp.ndarray    # fraction of emitted dust into accum (rest coarse)
     u_star_default: jnp.ndarray    # fallback friction velocity [m/s]
+    source_threshold: jnp.ndarray  # erodibility below this emits nothing [-]
+    soil_moisture_threshold: jnp.ndarray  # Fecan gravimetric threshold [kg/kg]
+    emission_diameter: jnp.ndarray  # (accum, coarse) volume-mean diameter [m]
 
     @classmethod
     def default(cls) -> "DustParameters":
@@ -54,8 +87,18 @@ class DustParameters:
             scale=jnp.asarray(1.0),
             alpha=jnp.asarray(1.0e-5),
             u_threshold=jnp.asarray(0.2),
-            accum_fraction=jnp.asarray(0.1),
+            # CAM ``dust_emis_sclfctr`` for MAM4 over the (0.1–1, 1–10) µm
+            # emission bins; its 1.65e-5 Aitken share has no home in a
+            # population whose Aitken mode carries no dust.
+            accum_fraction=jnp.asarray(0.021),
             u_star_default=jnp.asarray(0.3),
+            source_threshold=jnp.asarray(0.1),
+            # Fecan gwc_thr for ~20 % clay soil (CLM derives it per gridcell
+            # from clay content, which no boundary field here carries).
+            soil_moisture_threshold=jnp.asarray(0.04),
+            # ``dust_common::dust_set_params`` mass-weighted diameters of the
+            # emitted lognormal (D_vma = 3.5 µm, σ = 2) over those two bins.
+            emission_diameter=jnp.asarray([0.7806e-6, 3.8983e-6]),
         )
 
 
@@ -70,8 +113,54 @@ def horizontal_flux(
     return jnp.where(u_star > u_threshold, g_flux, 0.0)
 
 
+def source_weight(source: jnp.ndarray, source_kind: str,
+                  threshold: jnp.ndarray) -> jnp.ndarray:
+    """Prescribed source field → dimensionless erodibility weight.
+
+    ``cam_erodibility``: CAM's geomorphic basin factor, zeroed below
+    ``soil_erod_threshold`` and **unbounded above** (``dust_model.F90``) — the
+    factor exceeds 1 in the large closed basins that are the strongest dust
+    sources. ``tegen_potential``: a potential-source *fraction*, [0, 1].
+    """
+    s = jnp.maximum(source, 0.0)
+    if source_kind == "cam_erodibility":
+        return jnp.where(s < threshold, 0.0, s)
+    return jnp.minimum(s, 1.0)
+
+
+def mobilization_fraction(land_fraction: jnp.ndarray, snow_cover: jnp.ndarray,
+                          land_temperature: jnp.ndarray) -> jnp.ndarray:
+    """Fraction of a gridcell that can mobilize dust (CLM ``lnd_frc_mbl``).
+
+    Land only, reduced by snow cover, and shut off over frozen ground (CLM's
+    ``liqfrac``, here ramped over the 2 K below the melting point since no soil
+    ice content is carried). Ocean and sea ice contribute nothing.
+    """
+    liquid = jnp.clip(
+        (land_temperature - (c.tmelt - _FREEZE_RANGE)) / _FREEZE_RANGE, 0.0, 1.0)
+    return (jnp.clip(land_fraction, 0.0, 1.0)
+            * (1.0 - jnp.clip(snow_cover, 0.0, 1.0)) * liquid)
+
+
+def wet_threshold_factor(soil_wetness: jnp.ndarray,
+                         gwc_threshold: jnp.ndarray) -> jnp.ndarray:
+    """Fecan (1999) moist-soil increase of u*t (CLM ``frc_thr_wet_fct``).
+
+    ``√(1 + 1.21·(100·(w − w_thr))^0.68)`` above the threshold gravimetric
+    water content, 1 below it. The model carries a relative soil wetness, so
+    ``w = wetness · _GWC_SATURATED``.
+    """
+    gwc = jnp.clip(soil_wetness, 0.0, 1.0) * _GWC_SATURATED
+    excess = gwc - gwc_threshold
+    # Guarded operand: x**0.68 has an infinite derivative at x = 0, which the
+    # ``where`` masks in value but not in the reverse pass.
+    safe = jnp.maximum(excess, 1.0e-12)
+    return jnp.where(excess > 0.0,
+                     jnp.sqrt(1.0 + 1.21 * (100.0 * safe) ** 0.68), 1.0)
+
+
 class DustEmissions(PhysicsTerm):
-    """Wind-erosion dust emission (Tegen flux × prescribed source field)."""
+    """Wind-erosion dust emission (Tegen flux × gated prescribed source)."""
 
     name: ClassVar[str] = "jam_dust_emissions"
     category: ClassVar[str] = "aerosol_emissions"
@@ -83,15 +172,30 @@ class DustEmissions(PhysicsTerm):
         params: DustParameters | None = None,
         *,
         spec: ModalAerosolSpec | None = None,
+        source_kind: str = "cam_erodibility",
     ):
-        """Hold params and the population."""
+        """Hold params, the population and the source-field convention."""
+        if source_kind not in SOURCE_KINDS:
+            raise ValueError(
+                f"Unknown dust source_kind {source_kind!r}; "
+                f"choose one of {list(SOURCE_KINDS)}."
+            )
         self.params = nnx.Param(params or DustParameters.default())
         self._spec = spec or MAM4_SPEC
+        self._source_kind = source_kind
 
     def _u_star(self, diagnostics, ncols, params):
         if "vertical_diffusion" in diagnostics:
             return diagnostics["vertical_diffusion"].surface_friction_velocity
         return jnp.full((ncols,), params.u_star_default)
+
+    @staticmethod
+    def _surface_field(obj, name, ncols, default):
+        """Read a per-column surface field from forcing/terrain, else ``default``."""
+        v = getattr(obj, name, None) if obj is not None else None
+        if v is not None and jnp.size(v) == ncols:
+            return jnp.ravel(v)
+        return jnp.full((ncols,), default)
 
     def __call__(self, state, diagnostics, forcing, terrain):
         p = self.params.get_value()
@@ -99,23 +203,34 @@ class DustEmissions(PhysicsTerm):
         dz = diagnostics["layer_thickness"]
         nlev, ncols = state.temperature.shape
 
-        source = (
-            jnp.clip(jnp.ravel(forcing.dust_source), 0.0, 1.0)
-            if forcing is not None and getattr(forcing, "dust_source", None) is not None
-            and jnp.size(forcing.dust_source) == ncols
-            else jnp.zeros((ncols,))
-        )
+        source = source_weight(
+            self._surface_field(forcing, "dust_source", ncols, 0.0),
+            self._source_kind, p.source_threshold)
+        # Land, snow-free, unfrozen fraction. Absent boundary fields default to
+        # bare warm land so a source map alone still emits (aquaplanet runs
+        # supply no source and stay inert either way).
+        mobilization = mobilization_fraction(
+            self._surface_field(terrain, "fmask", ncols, 1.0),
+            self._surface_field(forcing, "snowc_am", ncols, 0.0),
+            self._surface_field(forcing, "stl_am", ncols, c.tmelt + 15.0))
+        u_threshold = p.u_threshold * wet_threshold_factor(
+            self._surface_field(forcing, "soilw_am", ncols, 0.0),
+            p.soil_moisture_threshold)
+
         u_star = self._u_star(diagnostics, ncols, p)
-        g_flux = horizontal_flux(u_star, p.u_threshold, air_density[-1], p.scale)
-        flux = source * p.alpha * g_flux                       # kg/m²/s
+        g_flux = horizontal_flux(u_star, u_threshold, air_density[-1], p.scale)
+        flux = source * mobilization * p.alpha * g_flux        # kg/m²/s
 
         # The population owns *which* classes receive primary dust (and their
         # default split); the tunable ``accum_fraction`` overrides the fraction
         # for this 2-class fine/coarse scheme. No literal mode names here.
+        # Number comes from each bin's emission volume-mean diameter, CAM's
+        # ``x_mton``, not from the mode's equilibrium size.
         (fine, _), (coarse, _) = self._spec.primary_split("du")
         fluxes = [
-            ("du", fine.short, flux * p.accum_fraction),
-            ("du", coarse.short, flux * (1.0 - p.accum_fraction)),
+            ("du", fine.short, flux * p.accum_fraction, p.emission_diameter[0]),
+            ("du", coarse.short, flux * (1.0 - p.accum_fraction),
+             p.emission_diameter[1]),
         ]
         tracer_tends = distribute_surface_flux(self._spec, fluxes, air_density, dz)
 

--- a/jcm/physics/aerosol/jam/emissions/dust_test.py
+++ b/jcm/physics/aerosol/jam/emissions/dust_test.py
@@ -61,20 +61,31 @@ class SourceGatingTest(unittest.TestCase):
             land_fraction=jnp.asarray([0.0, 1.0, 1.0, 0.5, 1.0]),
             snow_cover=jnp.asarray([0.0, 1.0, 0.0, 0.0, 0.0]),
             land_temperature=jnp.asarray([290.0, 275.0, 240.0, 290.0, 290.0]),
+            freeze_range=DustParameters.default().freeze_range,
         )
         np.testing.assert_allclose(np.asarray(m), [0.0, 0.0, 0.0, 0.5, 1.0])
 
     def test_fecan_wetness_raises_threshold_only_above_gwc_threshold(self):
-        f = wet_threshold_factor(jnp.asarray([0.0, 0.1, 1.0]), jnp.asarray(0.04))
-        # 0.1 relative wetness -> gwc 0.03 < 0.04: still the dry threshold.
+        scale = float(DustParameters.default().soil_water_gwc_scale)
+        f = wet_threshold_factor(jnp.asarray([0.0, 0.1, 1.0]),
+                                 jnp.asarray(0.04), jnp.asarray(scale))
+        # 0.1 of the index -> gwc 0.02 < 0.04: still the dry threshold.
         np.testing.assert_allclose(np.asarray(f[:2]), [1.0, 1.0])
-        expect = math.sqrt(1.0 + 1.21 * (100.0 * (0.30 - 0.04)) ** 0.68)
+        expect = math.sqrt(1.0 + 1.21 * (100.0 * (scale - 0.04)) ** 0.68)
         self.assertAlmostEqual(float(f[2]), expect, places=4)
 
+    def test_gwc_scale_is_field_capacity_not_porosity(self):
+        """soilw_am saturates at field capacity, so the mapping must too."""
+        # swcap = 0.30 vol over a (1 - watsat)*2700 = 1485 kg/m3 bulk density.
+        self.assertAlmostEqual(
+            float(DustParameters.default().soil_water_gwc_scale),
+            0.30 * 1000.0 / 1485.0, places=3)
+
     def test_fecan_gradient_finite_at_the_threshold(self):
-        g = jax.grad(lambda w: jnp.sum(
-            wet_threshold_factor(w, jnp.asarray(0.04))))(
-                jnp.asarray([0.04 / 0.30, 0.5]))
+        scale = float(DustParameters.default().soil_water_gwc_scale)
+        g = jax.grad(lambda w: jnp.sum(wet_threshold_factor(
+            w, jnp.asarray(0.04), jnp.asarray(scale))))(
+                jnp.asarray([0.04 / scale, 0.5]))
         self.assertTrue(np.all(np.isfinite(np.asarray(g))))
 
 
@@ -169,7 +180,10 @@ class DustTermTest(unittest.TestCase):
         np.testing.assert_allclose(np.asarray(p.emission_diameter),
                                    [0.7806e-6, 3.8983e-6], rtol=1e-4)
         # ~1.5e15 #/kg for accumulation dust, not the 1.2e17 the mode's
-        # equilibrium size would give.
+        # equilibrium size would give. The density is jcm's own 2600 (MAM4
+        # specdens_dust), deliberately, not CAM dust_model's mo_constants
+        # 2500 — mass and number must use one density inside this model, and
+        # the 3.8 % difference is a CAM-internal inconsistency.
         rho = MAM4_SPEC.species_props("du").density
         self.assertAlmostEqual(
             6.0 / (math.pi * rho * float(p.emission_diameter[0]) ** 3) / 1.5445e15,
@@ -223,27 +237,36 @@ class DustTermTest(unittest.TestCase):
         self.assertGreater(float(g), 0.0)
 
     def test_grad_through_gating_and_emission_size(self):
-        """Every new knob is a differentiable leaf, not static config."""
+        """The new knobs are differentiable leaves, not static config.
+
+        ``source_threshold`` is the exception by construction: it appears only
+        as a ``jnp.where`` predicate (CAM's hard cut-off), so its gradient is
+        identically zero and only finiteness is asserted for it.
+        """
         state, diagnostics, forcing, terrain = _inputs(u_star=0.8, source=1.0,
                                                        soilw=0.5)
         base = DustParameters.default()
 
-        def loss(threshold, gwc_thr, diameter):
+        def loss(threshold, gwc_thr, diameter, gwc_scale, freeze_range):
             p = dataclasses.replace(
                 base, source_threshold=threshold,
-                soil_moisture_threshold=gwc_thr, emission_diameter=diameter)
+                soil_moisture_threshold=gwc_thr, emission_diameter=diameter,
+                soil_water_gwc_scale=gwc_scale, freeze_range=freeze_range)
             tend, _ = DustEmissions(params=p)(state, diagnostics, forcing,
                                               terrain)
             return sum(jnp.sum(v ** 2) for v in tend.tracers.values())
 
-        g = jax.grad(loss, argnums=(0, 1, 2))(
+        g = jax.grad(loss, argnums=(0, 1, 2, 3, 4))(
             jnp.asarray(0.1), jnp.asarray(0.04),
-            jnp.asarray([0.7806e-6, 3.8983e-6]))
+            jnp.asarray([0.7806e-6, 3.8983e-6]), jnp.asarray(0.202),
+            jnp.asarray(2.0))
         for leaf in jax.tree_util.tree_leaves(g):
             self.assertTrue(np.all(np.isfinite(np.asarray(leaf))))
-        # The wetness threshold and the emission size move the answer.
+        # The wetness threshold, the emission size and the gwc scale move the
+        # answer; the freezing ramp does not here (the column is warm).
         self.assertGreater(abs(float(g[1])), 0.0)
         self.assertTrue(np.any(np.abs(np.asarray(g[2])) > 0.0))
+        self.assertGreater(abs(float(g[3])), 0.0)
 
     def test_no_gating_fields_still_emits(self):
         """Absent boundary fields (aquaplanet/unit tests) fall back to bare land."""
@@ -254,7 +277,8 @@ class DustTermTest(unittest.TestCase):
 
     def test_freezing_ramp_uses_the_melting_point(self):
         m = mobilization_fraction(jnp.asarray(1.0), jnp.asarray(0.0),
-                                  jnp.asarray(c.tmelt))
+                                  jnp.asarray(c.tmelt),
+                                  DustParameters.default().freeze_range)
         self.assertAlmostEqual(float(m), 1.0)
 
 

--- a/jcm/physics/aerosol/jam/emissions/dust_test.py
+++ b/jcm/physics/aerosol/jam/emissions/dust_test.py
@@ -214,14 +214,30 @@ class DustTermTest(unittest.TestCase):
         self.assertGreater(float(dry.tracers[key][-1, 0]),
                            float(wet.tracers[key][-1, 0]))
 
-    def test_tegen_source_kind_clips_to_one(self):
-        args = _inputs(u_star=0.8, source=3.0)
-        cam, _ = DustEmissions()(*args)
-        tegen, _ = DustEmissions(source_kind="tegen_potential")(*args)
+    def test_tegen_source_kind_is_a_fraction_on_its_own_map(self):
+        """Each kind on the map it is for — not the CAM map read as a fraction.
+
+        A [0, 1] potential-source map is used as-is by ``tegen_potential`` and
+        thresholded by ``cam_erodibility``; that difference is the point of the
+        option. Feeding the CAM map (max 5.7) to ``tegen_potential`` would clip
+        the basins #768 exists to keep, which is a misconfiguration
+        ``warn_on_config_traps`` now catches rather than something to pin here.
+        """
+        args = _inputs(u_star=0.8, source=0.5)
         key = mass_name("du", "cor")
+        tegen, _ = DustEmissions(source_kind="tegen_potential")(*args)
+        cam, _ = DustEmissions()(*args)          # threshold 0.1 < 0.5: passes
         self.assertAlmostEqual(
             float(cam.tracers[key][-1, 0]) / float(tegen.tracers[key][-1, 0]),
-            3.0, places=4)
+            1.0, places=6)
+        # Below CAM's threshold the two genuinely differ: CAM zeroes, Tegen
+        # keeps the fraction.
+        sub_args = _inputs(u_star=0.8, source=0.05)
+        self.assertAlmostEqual(
+            float(DustEmissions()(*sub_args)[0].tracers[key][-1, 0]), 0.0)
+        self.assertGreater(
+            float(DustEmissions(source_kind="tegen_potential")(*sub_args)[0]
+                  .tracers[key][-1, 0]), 0.0)
 
     def test_grad_through_alpha(self):
         state, diagnostics, forcing, terrain = _inputs()

--- a/jcm/physics/aerosol/jam/emissions/dust_test.py
+++ b/jcm/physics/aerosol/jam/emissions/dust_test.py
@@ -1,5 +1,7 @@
 """Tests for the Tegen-physics dust emission scheme."""
 
+import dataclasses
+import math
 import types
 import unittest
 
@@ -7,12 +9,17 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from jcm.physics.aerosol.jam import mass_name
+import jcm.constants as c
+from jcm.physics.aerosol.jam import mass_name, number_name
 from jcm.physics.aerosol.jam.emissions.dust import (
     DustEmissions,
     DustParameters,
     horizontal_flux,
+    mobilization_fraction,
+    source_weight,
+    wet_threshold_factor,
 )
+from jcm.physics.aerosol.jam.microphysics.mam4_data import MAM4_SPEC
 
 
 class HorizontalFluxTest(unittest.TestCase):
@@ -29,10 +36,56 @@ class HorizontalFluxTest(unittest.TestCase):
         self.assertGreater(float(lo), 0.0)
 
 
-def _inputs(nlev=3, ncols=2, u_star=0.6, source=0.5):
+class SourceGatingTest(unittest.TestCase):
+    """CAM ``dust_model.F90`` erodibility handling and CLM ``lnd_frc_mbl``."""
+
+    def test_cam_kind_thresholds_and_does_not_clip(self):
+        s = source_weight(jnp.asarray([0.05, 0.1, 0.5, 3.0, -1.0]),
+                          "cam_erodibility", jnp.asarray(0.1))
+        # Below soil_erod_threshold -> 0; at/above it the factor passes through
+        # UNBOUNDED (CAM's basin factor runs to 5.7 in the big source basins).
+        np.testing.assert_allclose(np.asarray(s), [0.0, 0.1, 0.5, 3.0, 0.0])
+
+    def test_tegen_kind_is_a_fraction(self):
+        s = source_weight(jnp.asarray([0.05, 0.5, 3.0]), "tegen_potential",
+                          jnp.asarray(0.1))
+        np.testing.assert_allclose(np.asarray(s), [0.05, 0.5, 1.0])
+
+    def test_unknown_kind_rejected(self):
+        with self.assertRaises(ValueError):
+            DustEmissions(source_kind="mystery_map")
+
+    def test_mobilization_masks_ocean_snow_and_frozen_ground(self):
+        # ocean, snow-covered land, frozen land, half-land, bare warm land
+        m = mobilization_fraction(
+            land_fraction=jnp.asarray([0.0, 1.0, 1.0, 0.5, 1.0]),
+            snow_cover=jnp.asarray([0.0, 1.0, 0.0, 0.0, 0.0]),
+            land_temperature=jnp.asarray([290.0, 275.0, 240.0, 290.0, 290.0]),
+        )
+        np.testing.assert_allclose(np.asarray(m), [0.0, 0.0, 0.0, 0.5, 1.0])
+
+    def test_fecan_wetness_raises_threshold_only_above_gwc_threshold(self):
+        f = wet_threshold_factor(jnp.asarray([0.0, 0.1, 1.0]), jnp.asarray(0.04))
+        # 0.1 relative wetness -> gwc 0.03 < 0.04: still the dry threshold.
+        np.testing.assert_allclose(np.asarray(f[:2]), [1.0, 1.0])
+        expect = math.sqrt(1.0 + 1.21 * (100.0 * (0.30 - 0.04)) ** 0.68)
+        self.assertAlmostEqual(float(f[2]), expect, places=4)
+
+    def test_fecan_gradient_finite_at_the_threshold(self):
+        g = jax.grad(lambda w: jnp.sum(
+            wet_threshold_factor(w, jnp.asarray(0.04))))(
+                jnp.asarray([0.04 / 0.30, 0.5]))
+        self.assertTrue(np.all(np.isfinite(np.asarray(g))))
+
+
+def _inputs(nlev=3, ncols=2, u_star=0.6, source=0.5, land=1.0, snow=0.0,
+            soilw=0.0, land_temp=295.0):
     from jcm.physics.vertical_diffusion.tte_tke.vertical_diffusion_types import (
         VerticalDiffusionData,
     )
+
+    def col(v):
+        return jnp.full((ncols,), v) if np.isscalar(v) else jnp.asarray(v)
 
     state = __import__(
         "jcm.physics_interface", fromlist=["PhysicsState"]
@@ -40,15 +93,19 @@ def _inputs(nlev=3, ncols=2, u_star=0.6, source=0.5):
         temperature=jnp.full((nlev, ncols), 295.0),
     )
     vd = VerticalDiffusionData.zeros((ncols,), nlev).copy(
-        surface_friction_velocity=jnp.full((ncols,), u_star),
+        surface_friction_velocity=col(u_star),
     )
     diagnostics = {
         "air_density": jnp.full((nlev, ncols), 1.2),
         "layer_thickness": jnp.full((nlev, ncols), 100.0),
         "vertical_diffusion": vd,
     }
-    forcing = types.SimpleNamespace(dust_source=jnp.full((ncols,), source))
-    return state, diagnostics, forcing, None
+    forcing = types.SimpleNamespace(
+        dust_source=col(source), snowc_am=col(snow), soilw_am=col(soilw),
+        stl_am=col(land_temp),
+    )
+    terrain = types.SimpleNamespace(fmask=col(land))
+    return state, diagnostics, forcing, terrain
 
 
 class DustTermTest(unittest.TestCase):
@@ -70,24 +127,135 @@ class DustTermTest(unittest.TestCase):
         key = mass_name("du", "cor")
         self.assertAlmostEqual(float(tend.tracers[key][-1, 0]), 0.0)
 
+    def test_gated_map_emits_only_from_the_bare_warm_land_cell(self):
+        """Antarctic, ocean, sub-threshold and >1 erodibility cells (#768)."""
+        state, diagnostics, forcing, terrain = _inputs(
+            ncols=4, u_star=0.8,
+            source=[1.0, 1.0, 0.05, 3.0],      # antarctic, ocean, sub-thr, basin
+            land=[1.0, 0.0, 1.0, 1.0],
+            snow=0.0,
+            land_temp=[235.0, 290.0, 290.0, 290.0],
+        )
+        tend, _ = DustEmissions()(state, diagnostics, forcing, terrain)
+        flux = np.asarray(tend.tracers[mass_name("du", "cor")][-1])
+        np.testing.assert_allclose(flux[:3], 0.0)
+        self.assertGreater(flux[3], 0.0)
+        # The >1 basin factor is NOT clipped: 3.0 emits 3x a unit-source cell.
+        unit, _ = DustEmissions()(*_inputs(ncols=4, u_star=0.8, source=1.0,
+                                           land=1.0, land_temp=290.0))
+        self.assertAlmostEqual(
+            flux[3] / float(unit.tracers[mass_name("du", "cor")][-1, 3]),
+            3.0, places=4)
+
+    def test_mode_split_and_number_match_cam(self):
+        """CAM ``dust_emis_sclfctr`` and ``x_mton = 6/(pi rho D_vwr^3)`` (#768)."""
+        tend, _ = DustEmissions()(*_inputs(u_star=0.8, source=1.0))
+        acc = float(tend.tracers[mass_name("du", "acc")][-1, 0])
+        cor = float(tend.tracers[mass_name("du", "cor")][-1, 0])
+        self.assertAlmostEqual(acc / (acc + cor), 0.021, places=6)
+        self.assertAlmostEqual(cor / (acc + cor), 0.979, places=6)
+
+        rho = MAM4_SPEC.species_props("du").density
+        p = DustParameters.default()
+        for mode, mass, diameter in (("acc", acc, p.emission_diameter[0]),
+                                     ("cor", cor, p.emission_diameter[1])):
+            x_mton = 6.0 / (math.pi * rho * float(diameter) ** 3)
+            self.assertAlmostEqual(
+                float(tend.tracers[number_name(mode)][-1, 0]) / mass / x_mton,
+                1.0, places=4)
+
+    def test_cam_emission_diameters(self):
+        p = DustParameters.default()
+        np.testing.assert_allclose(np.asarray(p.emission_diameter),
+                                   [0.7806e-6, 3.8983e-6], rtol=1e-4)
+        # ~1.5e15 #/kg for accumulation dust, not the 1.2e17 the mode's
+        # equilibrium size would give.
+        rho = MAM4_SPEC.species_props("du").density
+        self.assertAlmostEqual(
+            6.0 / (math.pi * rho * float(p.emission_diameter[0]) ** 3) / 1.5445e15,
+            1.0, places=3)
+
+    def test_population_split_matches_the_term_default(self):
+        (fine, fine_frac), (coarse, coarse_frac) = MAM4_SPEC.primary_split("du")
+        self.assertEqual((fine.short, coarse.short), ("acc", "cor"))
+        self.assertAlmostEqual(fine_frac,
+                               float(DustParameters.default().accum_fraction))
+        self.assertAlmostEqual(fine_frac + coarse_frac, 1.0)
+
+    def test_column_and_batch_agree(self):
+        """One column and a batch of columns give the same per-column flux."""
+        single, _ = DustEmissions()(*_inputs(ncols=1, u_star=0.7, source=0.8,
+                                             soilw=0.3))
+        batch, _ = DustEmissions()(*_inputs(ncols=5, u_star=0.7, source=0.8,
+                                            soilw=0.3))
+        key = mass_name("du", "cor")
+        np.testing.assert_allclose(
+            np.asarray(batch.tracers[key][-1]),
+            np.full(5, float(single.tracers[key][-1, 0])), rtol=1e-6)
+
+    def test_wet_soil_suppresses_emission(self):
+        dry, _ = DustEmissions()(*_inputs(u_star=0.5, source=1.0, soilw=0.0))
+        wet, _ = DustEmissions()(*_inputs(u_star=0.5, source=1.0, soilw=1.0))
+        key = mass_name("du", "cor")
+        self.assertGreater(float(dry.tracers[key][-1, 0]),
+                           float(wet.tracers[key][-1, 0]))
+
+    def test_tegen_source_kind_clips_to_one(self):
+        args = _inputs(u_star=0.8, source=3.0)
+        cam, _ = DustEmissions()(*args)
+        tegen, _ = DustEmissions(source_kind="tegen_potential")(*args)
+        key = mass_name("du", "cor")
+        self.assertAlmostEqual(
+            float(cam.tracers[key][-1, 0]) / float(tegen.tracers[key][-1, 0]),
+            3.0, places=4)
+
     def test_grad_through_alpha(self):
         state, diagnostics, forcing, terrain = _inputs()
+        base = DustParameters.default()
 
         def loss(alpha):
-            term = DustEmissions(
-                params=DustParameters(
-                    scale=jnp.asarray(1.0), alpha=alpha,
-                    u_threshold=jnp.asarray(0.2),
-                    accum_fraction=jnp.asarray(0.1),
-                    u_star_default=jnp.asarray(0.3),
-                )
-            )
+            term = DustEmissions(params=dataclasses.replace(base, alpha=alpha))
             tend, _ = term(state, diagnostics, forcing, terrain)
             return jnp.sum(tend.tracers[mass_name("du", "cor")])
 
         g = jax.grad(loss)(jnp.asarray(1.0e-5))
         self.assertTrue(np.isfinite(float(g)))
         self.assertGreater(float(g), 0.0)
+
+    def test_grad_through_gating_and_emission_size(self):
+        """Every new knob is a differentiable leaf, not static config."""
+        state, diagnostics, forcing, terrain = _inputs(u_star=0.8, source=1.0,
+                                                       soilw=0.5)
+        base = DustParameters.default()
+
+        def loss(threshold, gwc_thr, diameter):
+            p = dataclasses.replace(
+                base, source_threshold=threshold,
+                soil_moisture_threshold=gwc_thr, emission_diameter=diameter)
+            tend, _ = DustEmissions(params=p)(state, diagnostics, forcing,
+                                              terrain)
+            return sum(jnp.sum(v ** 2) for v in tend.tracers.values())
+
+        g = jax.grad(loss, argnums=(0, 1, 2))(
+            jnp.asarray(0.1), jnp.asarray(0.04),
+            jnp.asarray([0.7806e-6, 3.8983e-6]))
+        for leaf in jax.tree_util.tree_leaves(g):
+            self.assertTrue(np.all(np.isfinite(np.asarray(leaf))))
+        # The wetness threshold and the emission size move the answer.
+        self.assertGreater(abs(float(g[1])), 0.0)
+        self.assertTrue(np.any(np.abs(np.asarray(g[2])) > 0.0))
+
+    def test_no_gating_fields_still_emits(self):
+        """Absent boundary fields (aquaplanet/unit tests) fall back to bare land."""
+        state, diagnostics, _, _ = _inputs(u_star=0.8)
+        forcing = types.SimpleNamespace(dust_source=jnp.full((2,), 1.0))
+        tend, _ = DustEmissions()(state, diagnostics, forcing, None)
+        self.assertGreater(float(tend.tracers[mass_name("du", "cor")][-1, 0]), 0.0)
+
+    def test_freezing_ramp_uses_the_melting_point(self):
+        m = mobilization_fraction(jnp.asarray(1.0), jnp.asarray(0.0),
+                                  jnp.asarray(c.tmelt))
+        self.assertAlmostEqual(float(m), 1.0)
 
 
 if __name__ == "__main__":

--- a/jcm/physics/aerosol/jam/emissions/flux_diagnostic.py
+++ b/jcm/physics/aerosol/jam/emissions/flux_diagnostic.py
@@ -24,6 +24,7 @@ from typing import ClassVar
 
 import jax.numpy as jnp
 
+from jcm.physics.aerosol.jam.emissions.surface_wind import MODEL_LEVEL_WIND_KEY
 from jcm.physics.physics_term import PhysicsTerm
 from jcm.physics_interface import PhysicsTendency
 
@@ -118,14 +119,15 @@ def all_flux_keys() -> tuple[str, ...]:
     """Every per-step-reset flux key any helper in this module publishes.
 
     The reset term zeroes the whole family — emissions, biomass-burning
-    splits and both deposition kinds — because all of them accumulate
-    additively within a step and would otherwise integrate across steps
+    splits, both deposition kinds, and the emission-wind provenance flag —
+    because all of them are per-step state that would otherwise carry over
     via the threaded-back diagnostics dict.
     """
     return (emission_flux_keys()
             + tuple(f"emi_bb_{s}" for s in BB_SPECIES)
             + tuple(f"dry_{s}" for s in DEPOSITED_SPECIES)
-            + tuple(f"wet_{s}" for s in DEPOSITED_SPECIES))
+            + tuple(f"wet_{s}" for s in DEPOSITED_SPECIES)
+            + (MODEL_LEVEL_WIND_KEY,))
 
 
 def accumulate_deposition_fluxes(

--- a/jcm/physics/aerosol/jam/emissions/seasalt.py
+++ b/jcm/physics/aerosol/jam/emissions/seasalt.py
@@ -31,7 +31,8 @@ from jcm.physics.aerosol.jam.tracer_layout import mass_name, number_name
 from jcm.physics.physics_term import PhysicsTendency, PhysicsTerm
 from jcm.physics.aerosol.jam.emissions.flux_diagnostic import (
     accumulate_emission_fluxes, emission_flux_keys)
-from jcm.physics.aerosol.jam.emissions.surface_wind import wind_10m
+from jcm.physics.aerosol.jam.emissions.surface_wind import (
+    MODEL_LEVEL_WIND_KEY, wind_10m)
 
 # Gong-scheme constants (mo_ham_m7_emi_seasalt.f90).
 _NBIN = 300
@@ -117,7 +118,8 @@ class SeaSaltEmissions(PhysicsTerm):
     name: ClassVar[str] = "jam_seasalt_emissions"
     category: ClassVar[str] = "aerosol_emissions"
     requires: ClassVar[tuple[str, ...]] = ("air_density", "layer_thickness")
-    provides: ClassVar[tuple[str, ...]] = emission_flux_keys()
+    provides: ClassVar[tuple[str, ...]] = (
+        emission_flux_keys() + (MODEL_LEVEL_WIND_KEY,))
 
     def __init__(
         self,
@@ -157,7 +159,7 @@ class SeaSaltEmissions(PhysicsTerm):
         dz = diagnostics["layer_thickness"]
         nlev, ncols = state.temperature.shape
 
-        u10 = wind_10m(state, diagnostics)
+        u10, from_model_level = wind_10m(state, diagnostics)
         seafrac = self._open_water_fraction(forcing, terrain, ncols)
         wind = p.scale * u10 ** p.wind_exponent * seafrac   # (ncols,)
 
@@ -181,5 +183,7 @@ class SeaSaltEmissions(PhysicsTerm):
             diagnostics, tracer_tends,
             diagnostics["air_density"],
             diagnostics["layer_thickness"])
+        diagnostics = {**diagnostics, MODEL_LEVEL_WIND_KEY: jnp.maximum(
+            diagnostics.get(MODEL_LEVEL_WIND_KEY, 0.0), from_model_level)}
 
         return tendency, diagnostics

--- a/jcm/physics/aerosol/jam/emissions/seasalt.py
+++ b/jcm/physics/aerosol/jam/emissions/seasalt.py
@@ -31,6 +31,7 @@ from jcm.physics.aerosol.jam.tracer_layout import mass_name, number_name
 from jcm.physics.physics_term import PhysicsTendency, PhysicsTerm
 from jcm.physics.aerosol.jam.emissions.flux_diagnostic import (
     accumulate_emission_fluxes, emission_flux_keys)
+from jcm.physics.aerosol.jam.emissions.surface_wind import wind_10m
 
 # Gong-scheme constants (mo_ham_m7_emi_seasalt.f90).
 _NBIN = 300
@@ -156,7 +157,7 @@ class SeaSaltEmissions(PhysicsTerm):
         dz = diagnostics["layer_thickness"]
         nlev, ncols = state.temperature.shape
 
-        u10 = jnp.sqrt(jnp.maximum(state.u_wind[-1] ** 2 + state.v_wind[-1] ** 2, 1.0e-30))
+        u10 = wind_10m(state, diagnostics)
         seafrac = self._open_water_fraction(forcing, terrain, ncols)
         wind = p.scale * u10 ** p.wind_exponent * seafrac   # (ncols,)
 

--- a/jcm/physics/aerosol/jam/emissions/seasalt_test.py
+++ b/jcm/physics/aerosol/jam/emissions/seasalt_test.py
@@ -13,6 +13,9 @@ from jcm.physics.aerosol.jam.emissions.seasalt import (
     SeaSaltParameters,
     gong_class_factors,
 )
+from jcm.physics.aerosol.jam.emissions.surface_wind import (
+    MODEL_LEVEL_WIND_KEY,
+)
 from jcm.physics.aerosol.jam.microphysics.mam4_data import MAM4_SPEC
 
 
@@ -149,5 +152,61 @@ class Wind10mTest(unittest.TestCase):
     def test_falls_back_to_the_lowest_level_without_vdiff(self):
         args = _inputs(wind=10.0)
         self.assertNotIn("vertical_diffusion", args[1])
-        tend, _ = SeaSaltEmissions()(*args)
+        tend, diag = SeaSaltEmissions()(*args)
         self.assertGreater(float(tend.tracers[mass_name("ss", "cor")][-1, 0]), 0.0)
+        # ... and says so: no vdiff term composed => every column flagged.
+        self.assertTrue(bool(jnp.all(diag[MODEL_LEVEL_WIND_KEY] == 1.0)))
+
+    def test_fallback_is_taken_on_step_one_and_never_again(self):
+        """The carry seeds step 1 with a zero-filled vdiff (#723, cf. #673)."""
+        from jcm.physics.vertical_diffusion.tte_tke.vertical_diffusion_types import (
+            VerticalDiffusionData,
+        )
+        state, diagnostics, forcing, terrain = _inputs(wind=10.0)
+        nlev, ncols = state.temperature.shape
+        key = mass_name("ss", "cor")
+
+        # Step 1: exactly what Model._build_initial_physics_carry supplies —
+        # the zero-filled structural template, no step having run yet.
+        step1 = {**diagnostics,
+                 "vertical_diffusion": VerticalDiffusionData.zeros((ncols,), nlev)}
+        tend1, diag1 = SeaSaltEmissions()(state, step1, forcing, terrain)
+        self.assertTrue(bool(jnp.all(diag1[MODEL_LEVEL_WIND_KEY] == 1.0)))
+        unreduced, _ = SeaSaltEmissions()(state, diagnostics, forcing, terrain)
+        self.assertAlmostEqual(float(tend1.tracers[key][-1, 0]),
+                               float(unreduced.tracers[key][-1, 0]), places=12)
+
+        # Step 2: vdiff has run, so the carried 10 m wind is real everywhere.
+        vd = VerticalDiffusionData.zeros((ncols,), nlev).copy(
+            wind_10m=jnp.full((ncols,), 9.04))
+        tend2, diag2 = SeaSaltEmissions()(
+            state, {**diagnostics, "vertical_diffusion": vd}, forcing, terrain)
+        self.assertTrue(bool(jnp.all(diag2[MODEL_LEVEL_WIND_KEY] == 0.0)))
+        self.assertAlmostEqual(
+            float(tend2.tracers[key][-1, 0]) / float(tend1.tracers[key][-1, 0]),
+            (9.04 / 10.0) ** 3.41, places=4)
+
+    def test_flag_is_per_column(self):
+        from jcm.physics.vertical_diffusion.tte_tke.vertical_diffusion_types import (
+            VerticalDiffusionData,
+        )
+        state, diagnostics, forcing, terrain = _inputs(wind=10.0, ncols=2)
+        nlev, ncols = state.temperature.shape
+        vd = VerticalDiffusionData.zeros((ncols,), nlev).copy(
+            wind_10m=jnp.asarray([9.0, 0.0]))
+        _, diag = SeaSaltEmissions()(
+            state, {**diagnostics, "vertical_diffusion": vd}, forcing, terrain)
+        np.testing.assert_allclose(np.asarray(diag[MODEL_LEVEL_WIND_KEY]),
+                                   [0.0, 1.0])
+
+    def test_reset_term_zeroes_the_flag_each_step(self):
+        """Otherwise step 1's flag would persist through the whole run."""
+        from jcm.physics.aerosol.jam.emissions.flux_diagnostic import (
+            ResetEmissionFluxes, all_flux_keys,
+        )
+        self.assertIn(MODEL_LEVEL_WIND_KEY, all_flux_keys())
+        state, diagnostics, forcing, terrain = _inputs(wind=10.0)
+        _, diag = ResetEmissionFluxes()(
+            state, {**diagnostics, MODEL_LEVEL_WIND_KEY: jnp.ones((2,))},
+            forcing, terrain)
+        self.assertTrue(bool(jnp.all(diag[MODEL_LEVEL_WIND_KEY] == 0.0)))

--- a/jcm/physics/aerosol/jam/emissions/seasalt_test.py
+++ b/jcm/physics/aerosol/jam/emissions/seasalt_test.py
@@ -120,3 +120,34 @@ class SeaSaltTermTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class Wind10mTest(unittest.TestCase):
+    """The Gong source reads the diagnosed 10 m wind, not level 1 (#723)."""
+
+    @staticmethod
+    def _with_u10(args, u10):
+        from jcm.physics.vertical_diffusion.tte_tke.vertical_diffusion_types import (
+            VerticalDiffusionData,
+        )
+        state, diagnostics, forcing, terrain = args
+        nlev, ncols = state.temperature.shape
+        vd = VerticalDiffusionData.zeros((ncols,), nlev).copy(
+            wind_10m=jnp.full((ncols,), u10))
+        return state, {**diagnostics, "vertical_diffusion": vd}, forcing, terrain
+
+    def test_uses_the_diagnosed_10m_wind(self):
+        args = _inputs(wind=10.0)
+        lowest, _ = SeaSaltEmissions()(*args)
+        reduced, _ = SeaSaltEmissions()(*self._with_u10(args, 9.04))
+        key = mass_name("ss", "cor")
+        ratio = (float(reduced.tracers[key][-1, 0])
+                 / float(lowest.tracers[key][-1, 0]))
+        # u10**3.41: a 9.6 % wind reduction is a 28 % flux reduction.
+        self.assertAlmostEqual(ratio, (9.04 / 10.0) ** 3.41, places=4)
+
+    def test_falls_back_to_the_lowest_level_without_vdiff(self):
+        args = _inputs(wind=10.0)
+        self.assertNotIn("vertical_diffusion", args[1])
+        tend, _ = SeaSaltEmissions()(*args)
+        self.assertGreater(float(tend.tracers[mass_name("ss", "cor")][-1, 0]), 0.0)

--- a/jcm/physics/aerosol/jam/emissions/sectors.py
+++ b/jcm/physics/aerosol/jam/emissions/sectors.py
@@ -46,19 +46,32 @@ EMITTED_SPECIES: tuple[str, ...] = ("so2", "bc", "oc")
 
 @dataclass(frozen=True)
 class SectorDefaults:
-    """Default smooth-injection geometry for a super-sector [m]."""
+    """Default injection geometry [m] and emitted sizes [m] for a super-sector.
+
+    The emitted sizes are the volume-mean diameters CESM's emission-file
+    generator uses to turn a mass flux into a number flux (the per-file
+    ``mapping_equation`` attribute of the CMIP7 ``num_*`` products, e.g.
+    ``num_bc_a4 = 1.0*BC ... 0.134e-6 1700``): accumulation sulfate 0.134 µm
+    for surface/agricultural sources and 0.261 µm for energy/industrial and
+    shipping, Aitken sulfate 0.0504 µm, primary carbon 0.134 µm.
+    """
 
     injection_height: float     # Gaussian centre height
     injection_thickness: float  # Gaussian width
+    so4_accum_diameter: float = 0.134e-6
+    so4_aitken_diameter: float = 0.0504e-6
+    carbon_diameter: float = 0.134e-6
 
 
 SECTOR_DEFAULTS: dict[str, SectorDefaults] = {
     "surface_combustion": SectorDefaults(injection_height=0.0,
                                          injection_thickness=30.0),
     "elevated_industrial": SectorDefaults(injection_height=50.0,
-                                          injection_thickness=30.0),
+                                          injection_thickness=30.0,
+                                          so4_accum_diameter=0.261e-6),
     "shipping": SectorDefaults(injection_height=0.0,
-                               injection_thickness=30.0),
+                               injection_thickness=30.0,
+                               so4_accum_diameter=0.261e-6),
     # Open biomass burning (HAMMOZ ``EM_FIRE``): smoke is lofted through a deep
     # layer rather than emitted at the surface. Defaults centre the smooth
     # Gaussian ~1 km up with a ~1.5 km width — a clearly elevated, deep profile
@@ -87,8 +100,12 @@ SO2_TO_SO4_MASS = SPECIES["so4"].molar_mass / GAS_SPECIES["so2"].molar_mass
 # Aitken/accumulation sulfate and primary-carbon-mode BC/POA (see
 # ``mam4_data._MAM4_PRIMARY_EMISSION``).
 #
-# Note on emitted size: HAMMOZ/M7 distinguishes fossil-fuel (~0.03 µm) from
-# biomass (~0.075 µm) primary-carbon size. MAM4 carries a *single*
-# primary-carbon mode for both, so that distinction collapses here — biomass and
-# anthropogenic carbon differ only in their injection profile. A per-super-sector
-# emitted size (count-median radius) would be future work (see #498).
+# Note on emitted size: MAM4 carries a *single* primary-carbon mode, and CESM
+# emits both anthropogenic and open-burning carbon at the same 0.134 µm
+# volume-mean diameter, so biomass and anthropogenic carbon differ only in
+# their injection profile. jcm's "surface_combustion" super-sector aggregates
+# CEDS activities that CESM emits at different accumulation-sulfate sizes
+# (0.134 µm agricultural, 0.261 µm solvents/waste); the aggregate takes the
+# 0.134 µm value. CESM sends transport/residential sulfate to the Aitken mode
+# and agricultural/energy/shipping sulfate to accumulation, where the
+# population here splits every sector 50/50 (HAMMOZ ``cmr_sk``/``cmr_sa``).

--- a/jcm/physics/aerosol/jam/emissions/surface_wind.py
+++ b/jcm/physics/aerosol/jam/emissions/surface_wind.py
@@ -10,21 +10,34 @@ from __future__ import annotations
 
 import jax.numpy as jnp
 
+#: Per-column flag published by the emission terms: 1 where the emission wind
+#: fell back to the lowest model level, 0 where the diagnosed 10 m wind was
+#: used. Zeroed every step with the other emission diagnostics, so a run in
+#: which the fallback persists is visible instead of quietly emitting 37-46 %
+#: too much sea salt. Deliberately NOT an ``emis_``/``emi_`` name: those
+#: prefixes select emission *fluxes* in the forcing reader and the burden
+#: report.
+MODEL_LEVEL_WIND_KEY = "wind_10m_model_level"
 
-def wind_10m(state, diagnostics) -> jnp.ndarray:
-    """Diagnosed 10 m wind speed [m/s], shaped ``(ncols,)``.
 
-    Reads the ECHAM ``nsurf_diag`` reduction published by the vertical-diffusion
-    term (which owns the surface-layer profile). Emission terms run before
-    vdiff in the ECHAM ordering, so this is the previous step's 10 m wind —
-    the same one-step lag the dust term's ``u*`` already carries.
+def wind_10m(state, diagnostics):
+    """Emission wind [m/s] and its provenance, both shaped ``(ncols,)``.
 
-    The lowest model level is the fallback wherever no reduction has been
-    diagnosed: with no vertical-diffusion term composed there is no surface
-    layer to reduce through, and on the first step of a run its carry is still
-    zero (a zero 10 m wind under a moving lowest level can only mean "not
-    diagnosed yet", and emitting nothing for a step is worse than emitting
-    unreduced).
+    Returns ``(speed, from_model_level)`` — the ECHAM ``nsurf_diag`` 10 m
+    reduction published by the vertical-diffusion term, and a 0/1 flag per
+    column saying where that was unavailable and the lowest model level was
+    used instead.
+
+    Emission terms run before vdiff in the ECHAM ordering, so the value read
+    here is the previous step's. ``vertical_diffusion`` is a **declared**
+    cross-step slot (``Physics.initial_carry_state``), so this is the
+    deliberate carry #673 distinguishes from an undeclared stale read, and the
+    same one-step lag the dust term's ``u*`` already carries.
+
+    The fallback is therefore reachable only where no 10 m wind can exist: on
+    step 1 of a cold start, whose carry slot is still zero-filled because no
+    step has diagnosed a surface layer yet, or with no vdiff term composed at
+    all. A resumed run carries a real 10 m wind and never takes it.
     """
     lowest = jnp.sqrt(
         jnp.maximum(state.u_wind[-1] ** 2 + state.v_wind[-1] ** 2, 1.0e-30)
@@ -32,6 +45,10 @@ def wind_10m(state, diagnostics) -> jnp.ndarray:
     vdiff = diagnostics.get("vertical_diffusion")
     speed_10m = getattr(vdiff, "wind_10m", None) if vdiff is not None else None
     if speed_10m is None:
-        return lowest
+        return lowest, jnp.ones_like(lowest)
     speed_10m = jnp.ravel(speed_10m)
-    return jnp.where(speed_10m > 0.0, speed_10m, lowest)
+    # A zero 10 m wind under a moving lowest level can only mean "not
+    # diagnosed yet": the reduction is strictly positive wherever it has run.
+    unset = speed_10m <= 0.0
+    return (jnp.where(unset, lowest, speed_10m),
+            unset.astype(lowest.dtype))

--- a/jcm/physics/aerosol/jam/emissions/surface_wind.py
+++ b/jcm/physics/aerosol/jam/emissions/surface_wind.py
@@ -12,11 +12,12 @@ import jax.numpy as jnp
 
 #: Per-column flag published by the emission terms: 1 where the emission wind
 #: fell back to the lowest model level, 0 where the diagnosed 10 m wind was
-#: used. Zeroed every step with the other emission diagnostics, so a run in
-#: which the fallback persists is visible instead of quietly emitting 37-46 %
-#: too much sea salt. Deliberately NOT an ``emis_``/``emi_`` name: those
-#: prefixes select emission *fluxes* in the forcing reader and the burden
-#: report.
+#: used. Zeroed every step with the other emission diagnostics, and reported
+#: per chunk by ``check_health`` (a bias indicator, not a blowup signature, so
+#: it is printed rather than fatal), so a run in which the fallback persists is
+#: visible instead of quietly emitting 37-46 % too much sea salt. Deliberately
+#: NOT an ``emis_``/``emi_`` name: those prefixes select emission *fluxes* in
+#: the forcing reader and the burden report.
 MODEL_LEVEL_WIND_KEY = "wind_10m_model_level"
 
 

--- a/jcm/physics/aerosol/jam/emissions/surface_wind.py
+++ b/jcm/physics/aerosol/jam/emissions/surface_wind.py
@@ -17,14 +17,21 @@ def wind_10m(state, diagnostics) -> jnp.ndarray:
     Reads the ECHAM ``nsurf_diag`` reduction published by the vertical-diffusion
     term (which owns the surface-layer profile). Emission terms run before
     vdiff in the ECHAM ordering, so this is the previous step's 10 m wind —
-    the same one-step lag the dust term's ``u*`` already carries. With no
-    vertical-diffusion term composed at all there is no surface layer to
-    reduce through, and the lowest model level is the only wind available.
+    the same one-step lag the dust term's ``u*`` already carries.
+
+    The lowest model level is the fallback wherever no reduction has been
+    diagnosed: with no vertical-diffusion term composed there is no surface
+    layer to reduce through, and on the first step of a run its carry is still
+    zero (a zero 10 m wind under a moving lowest level can only mean "not
+    diagnosed yet", and emitting nothing for a step is worse than emitting
+    unreduced).
     """
-    vdiff = diagnostics.get("vertical_diffusion")
-    speed_10m = getattr(vdiff, "wind_10m", None) if vdiff is not None else None
-    if speed_10m is not None:
-        return jnp.ravel(speed_10m)
-    return jnp.sqrt(
+    lowest = jnp.sqrt(
         jnp.maximum(state.u_wind[-1] ** 2 + state.v_wind[-1] ** 2, 1.0e-30)
     )
+    vdiff = diagnostics.get("vertical_diffusion")
+    speed_10m = getattr(vdiff, "wind_10m", None) if vdiff is not None else None
+    if speed_10m is None:
+        return lowest
+    speed_10m = jnp.ravel(speed_10m)
+    return jnp.where(speed_10m > 0.0, speed_10m, lowest)

--- a/jcm/physics/aerosol/jam/emissions/surface_wind.py
+++ b/jcm/physics/aerosol/jam/emissions/surface_wind.py
@@ -1,0 +1,30 @@
+"""The 10 m wind the surface-flux emission schemes are calibrated to (#723).
+
+Gong sea salt (``u10**3.41``) and Nightingale DMS (``k_w ~ u10**2``) are both
+fitted to the 10 m wind — HAMMOZ passes ``vphysc%velo10m`` — so reading the
+lowest model level instead biases them high by the surface-layer shear over
+10 m … z₁ (~33 m at L47: +37-46 % sea salt, +20-25 % DMS).
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+
+
+def wind_10m(state, diagnostics) -> jnp.ndarray:
+    """Diagnosed 10 m wind speed [m/s], shaped ``(ncols,)``.
+
+    Reads the ECHAM ``nsurf_diag`` reduction published by the vertical-diffusion
+    term (which owns the surface-layer profile). Emission terms run before
+    vdiff in the ECHAM ordering, so this is the previous step's 10 m wind —
+    the same one-step lag the dust term's ``u*`` already carries. With no
+    vertical-diffusion term composed at all there is no surface layer to
+    reduce through, and the lowest model level is the only wind available.
+    """
+    vdiff = diagnostics.get("vertical_diffusion")
+    speed_10m = getattr(vdiff, "wind_10m", None) if vdiff is not None else None
+    if speed_10m is not None:
+        return jnp.ravel(speed_10m)
+    return jnp.sqrt(
+        jnp.maximum(state.u_wind[-1] ** 2 + state.v_wind[-1] ** 2, 1.0e-30)
+    )

--- a/jcm/physics/aerosol/jam/jam_integration_test.py
+++ b/jcm/physics/aerosol/jam/jam_integration_test.py
@@ -32,12 +32,9 @@ class JamIntegrationTest(unittest.TestCase):
                 aerosol_module="jam", cloud_scheme="2m", **physics_kwargs
             ),
         )
-        # ~3 h (6 steps). Emission -> transport -> microphysics core ->
-        # activation is a multi-step chain on a cold start with no seeded
-        # aerosol, and the natural-emission terms read the previous step's
-        # surface layer, so at 3 steps the core still sees an empty aerosol
-        # state and the activation assertion below measures spin-up rate
-        # rather than coupling.
+        # ~3 h (6 steps): on a cold start with no seeded aerosol the
+        # emission -> transport -> core -> activation chain needs that long to
+        # produce anything, so 3 steps would assert on the spin-up rate.
         return model, model.run(save_interval=0.125, total_time=0.125)
 
     def test_runs_finite_with_ham_aerosol(self):
@@ -74,6 +71,15 @@ class JamIntegrationTest(unittest.TestCase):
         # fails here (measured on a healthy cold-start run: activated_cdnc max
         # ~66, qnc max ~3e-5 after 3 steps).
         physics = predictions.physics
+        # The emission wind fell back to the model level on step 1 only (#723):
+        # by the end of a multi-step run no column is still flagged.
+        from jcm.physics.aerosol.jam.emissions.surface_wind import (
+            MODEL_LEVEL_WIND_KEY,
+        )
+        self.assertEqual(
+            float(np.max(np.asarray(physics[MODEL_LEVEL_WIND_KEY]))), 0.0,
+            "emission wind still falling back to the lowest model level",
+        )
         self.assertIn("activated_cdnc", physics)
         self.assertGreater(
             float(np.max(np.asarray(physics["activated_cdnc"]))), 0.0,

--- a/jcm/physics/aerosol/jam/jam_integration_test.py
+++ b/jcm/physics/aerosol/jam/jam_integration_test.py
@@ -32,8 +32,13 @@ class JamIntegrationTest(unittest.TestCase):
                 aerosol_module="jam", cloud_scheme="2m", **physics_kwargs
             ),
         )
-        # ~1.5 h (3 steps) — enough to exercise tracer transport + coupling.
-        return model, model.run(save_interval=0.0625, total_time=0.0625)
+        # ~3 h (6 steps). Emission -> transport -> microphysics core ->
+        # activation is a multi-step chain on a cold start with no seeded
+        # aerosol, and the natural-emission terms read the previous step's
+        # surface layer, so at 3 steps the core still sees an empty aerosol
+        # state and the activation assertion below measures spin-up rate
+        # rather than coupling.
+        return model, model.run(save_interval=0.125, total_time=0.125)
 
     def test_runs_finite_with_ham_aerosol(self):
         from jcm.physics.aerosol.jam import MAM4_SPEC, mass_name, number_name

--- a/jcm/physics/aerosol/jam/jam_terms.py
+++ b/jcm/physics/aerosol/jam/jam_terms.py
@@ -145,6 +145,7 @@ def jam_aerosol_physics(
     seasalt: SeaSaltParameters | None = None,
     dms: DmsParameters | None = None,
     dust: DustParameters | None = None,
+    dust_source: str = "cam_erodibility",
     anthropogenic: bool = False,
     anthropogenic_params: EmissionParameters | None = None,
     prescribed_speciated: bool = False,
@@ -183,6 +184,12 @@ def jam_aerosol_physics(
         arg_variant: ``"arg2000"`` (default) or ``"ghosh2025"`` activation.
         seasalt/dms/dust: optional ``Parameters`` overrides for the natural
             emission schemes (Gong sea salt, Nightingale DMS, Tegen dust).
+        dust_source: which convention the prescribed dust source map follows
+            — ``"cam_erodibility"`` (default: CAM's geomorphic basin factor,
+            thresholded at 0.1 and unbounded above) or ``"tegen_potential"``
+            (a HAMMOZ-style potential-source fraction in [0, 1] whose own
+            preprocessing embeds the land-cover mask). It selects the gating,
+            not the file: pair it with the matching ``forcing.dust_file``.
         anthropogenic: include prescribed CEDS anthropogenic emissions (#498),
             the *bulk* path (in-model differentiable speciation + smooth
             injection); ``anthropogenic_params`` overrides the defaults.
@@ -237,7 +244,7 @@ def jam_aerosol_physics(
     emissions = [
         SeaSaltEmissions(params=seasalt, spec=spec),
         DmsEmissions(params=dms, spec=spec),
-        DustEmissions(params=dust, spec=spec),
+        DustEmissions(params=dust, spec=spec, source_kind=dust_source),
     ]
     if anthropogenic:
         # Prescribed CEDS anthropogenic SO2/BC/OC (#498); inert until forcing

--- a/jcm/physics/aerosol/jam/microphysics/mam4_data.py
+++ b/jcm/physics/aerosol/jam/microphysics/mam4_data.py
@@ -72,9 +72,10 @@ MAM4_SPECIES = tuple(SPECIES[t] for t in _USED) + (SPECIES["h2o"],)
 #: ``cmr_sa``); primary carbonaceous mass (BC, POA) goes wholly to the
 #: primary-carbon mode (MAM4 carries no BC/POA in the Aitken mode). Dust's
 #: accum/coarse split is CAM's ``dust_emis_sclfctr`` over the 0.1–1 µm and
-#: 1–10 µm emission bins (``dust_model.F90``); its third, 1.65e-5 Aitken
-#: share has no home in a population whose Aitken mode carries no dust. The
-#: dust term lets a tunable parameter override the fractions. Size-mapped
+#: 1–10 µm emission bins (``dust_model.F90``). The
+#: dust term lets a tunable parameter override the fractions. (CAM's 4/5-mode
+#: branch instead splits three bins from 0.01 µm, the extra one taking
+#: 1.65e-5; this population carries no Aitken dust.) Size-mapped
 #: source schemes (Gong sea salt) instead partition over ``classes_for`` and
 #: need no entry.
 _MAM4_PRIMARY_EMISSION = {

--- a/jcm/physics/aerosol/jam/microphysics/mam4_data.py
+++ b/jcm/physics/aerosol/jam/microphysics/mam4_data.py
@@ -71,14 +71,17 @@ MAM4_SPECIES = tuple(SPECIES[t] for t in _USED) + (SPECIES["h2o"],)
 #: split 50/50 into the Aitken and accumulation modes (HAMMOZ ``cmr_sk``/
 #: ``cmr_sa``); primary carbonaceous mass (BC, POA) goes wholly to the
 #: primary-carbon mode (MAM4 carries no BC/POA in the Aitken mode). Dust's
-#: accum/coarse split default (Tegen) lives here too, though the dust term lets
-#: a tunable parameter override the fractions. Size-mapped source schemes (Gong
-#: sea salt) instead partition over ``classes_for`` and need no entry.
+#: accum/coarse split is CAM's ``dust_emis_sclfctr`` over the 0.1–1 µm and
+#: 1–10 µm emission bins (``dust_model.F90``); its third, 1.65e-5 Aitken
+#: share has no home in a population whose Aitken mode carries no dust. The
+#: dust term lets a tunable parameter override the fractions. Size-mapped
+#: source schemes (Gong sea salt) instead partition over ``classes_for`` and
+#: need no entry.
 _MAM4_PRIMARY_EMISSION = {
     "so4": (("ait", 0.5), ("acc", 0.5)),
     "bc": (("pcm", 1.0),),
     "poa": (("pcm", 1.0),),
-    "du": (("acc", 0.1), ("cor", 0.9)),
+    "du": (("acc", 0.021), ("cor", 0.979)),
 }
 
 #: The MAM4 4-mode population.

--- a/jcm/physics/aerosol/jam/optics/optics_integration_test.py
+++ b/jcm/physics/aerosol/jam/optics/optics_integration_test.py
@@ -47,7 +47,10 @@ class OpticsIntegrationTest(unittest.TestCase):
                 radiation=RadiationParameters.default(radiation_interval=0),
             ),
         )
-        predictions = model.run(save_interval=0.0625, total_time=0.0625)
+        # 6 steps, not 3: the emission -> transport -> core -> optics chain
+        # needs the aerosol to reach the core before AOD can be non-zero (see
+        # jam_integration_test).
+        predictions = model.run(save_interval=0.125, total_time=0.125)
         dyn = predictions.dynamics
         self.assertFalse(bool(jnp.any(jnp.isnan(dyn.temperature))))
         self.assertTrue(bool(jnp.all(dyn.temperature > 150.0)))

--- a/jcm/physics/echam/echam_terms.py
+++ b/jcm/physics/echam/echam_terms.py
@@ -81,6 +81,7 @@ def echam_physics(
     jam_optics: bool = True,
     jam_arg_variant: str = "arg2000",
     jam_aqueous_scheme: str = "full",
+    jam_dust_source: str = "cam_erodibility",
     jam_ice_scheme: str = "niemand",
     jam_anthropogenic: bool = False,
     jam_prescribed_speciated: bool = False,
@@ -180,6 +181,8 @@ def echam_physics(
             the JAM aerosol radiatively passive, which controlled A/B
             experiments rely on).
         jam_arg_variant: ``"arg2000"`` (default) or ``"ghosh2025"`` activation.
+        jam_dust_source: convention the ``forcing.dust_file`` source map
+            follows — ``"cam_erodibility"`` (default) or ``"tegen_potential"``.
         jam_ice_scheme: heterogeneous ice nucleation scheme — ``"niemand"``
             (default) or ``"lohmann_diehl"`` (drives the 2M ICNC).
         jam_aqueous_scheme: ``"full"`` (default, HAM port) or ``"simple"``
@@ -443,6 +446,7 @@ def echam_physics(
             optics=jam_optics,
             arg_variant=jam_arg_variant,
             aqueous_scheme=jam_aqueous_scheme,
+            dust_source=jam_dust_source,
             ice_scheme=jam_ice_scheme,
             anthropogenic=jam_anthropogenic,
             prescribed_speciated=jam_prescribed_speciated,

--- a/jcm/physics/surface/echam/surface_physics.py
+++ b/jcm/physics/surface/echam/surface_physics.py
@@ -129,8 +129,8 @@ def surface_physics_step(
     atmospheric_state: AtmosphericForcing,
     surface_state: SurfaceState,
     dt: float,
+    wind_speed_10m: jnp.ndarray,
     params: SurfaceParameters = SurfaceParameters.default(),
-    wind_speed_10m: jnp.ndarray = None,
 ) -> Tuple[SurfaceFluxes, SurfaceTendencies, SurfaceDiagnostics]:
     """Complete surface physics step for all surface types.
     
@@ -140,7 +140,8 @@ def surface_physics_step(
         dt: Time step [s]
         params: Surface parameters
         wind_speed_10m: diagnosed 10 m wind [m/s] (ncol,) for the reported
-            surface diagnostics; ``None`` falls back to the lowest level.
+            surface diagnostics (ECHAM ``nsurf_diag``; the vdiff carry always
+            holds one, so it is required rather than defaulted).
         
     Returns:
         Tuple of (surface_fluxes, tendencies, diagnostics)
@@ -246,8 +247,8 @@ def surface_physics_step(
     
     # Compute diagnostics
     diagnostics = compute_surface_diagnostics(
-        atmospheric_state, surface_state, combined_fluxes, resistances, params,
-        wind_speed_10m,
+        atmospheric_state, surface_state, combined_fluxes, resistances,
+        wind_speed_10m, params,
     )
     
     return combined_fluxes, combined_tendencies, diagnostics
@@ -505,8 +506,7 @@ class EchamSurface(PhysicsTerm):
         # column actually receives are delivered by the vdiff implicit solve
         # and read back below.
         _fluxes, _tendencies, _surface_diag = surface_physics_step(
-            atm_forcing, surface_state, dt, params,
-            jnp.ravel(vdiff.wind_10m),
+            atm_forcing, surface_state, dt, jnp.ravel(vdiff.wind_10m), params,
         )
 
         # No turbulent-flux tendencies here: the vdiff term's implicit solve

--- a/jcm/physics/surface/echam/surface_physics.py
+++ b/jcm/physics/surface/echam/surface_physics.py
@@ -129,7 +129,8 @@ def surface_physics_step(
     atmospheric_state: AtmosphericForcing,
     surface_state: SurfaceState,
     dt: float,
-    params: SurfaceParameters = SurfaceParameters.default()
+    params: SurfaceParameters = SurfaceParameters.default(),
+    wind_speed_10m: jnp.ndarray = None,
 ) -> Tuple[SurfaceFluxes, SurfaceTendencies, SurfaceDiagnostics]:
     """Complete surface physics step for all surface types.
     
@@ -138,6 +139,8 @@ def surface_physics_step(
         surface_state: Surface state
         dt: Time step [s]
         params: Surface parameters
+        wind_speed_10m: diagnosed 10 m wind [m/s] (ncol,) for the reported
+            surface diagnostics; ``None`` falls back to the lowest level.
         
     Returns:
         Tuple of (surface_fluxes, tendencies, diagnostics)
@@ -243,7 +246,8 @@ def surface_physics_step(
     
     # Compute diagnostics
     diagnostics = compute_surface_diagnostics(
-        atmospheric_state, surface_state, combined_fluxes, resistances, params
+        atmospheric_state, surface_state, combined_fluxes, resistances, params,
+        wind_speed_10m,
     )
     
     return combined_fluxes, combined_tendencies, diagnostics
@@ -502,6 +506,7 @@ class EchamSurface(PhysicsTerm):
         # and read back below.
         _fluxes, _tendencies, _surface_diag = surface_physics_step(
             atm_forcing, surface_state, dt, params,
+            jnp.ravel(vdiff.wind_10m),
         )
 
         # No turbulent-flux tendencies here: the vdiff term's implicit solve

--- a/jcm/physics/surface/echam/surface_physics_test.py
+++ b/jcm/physics/surface/echam/surface_physics_test.py
@@ -163,10 +163,17 @@ class TestSurfacePhysicsStep:
         
         self.dt = 3600.0  # 1 hour
     
+    def _wind_10m(self):
+        """Build a diagnosed 10 m wind, as the vdiff carry supplies in a real run."""
+        u = self.atmospheric_state.u_wind
+        v = self.atmospheric_state.v_wind
+        return 0.9 * jnp.sqrt(jnp.maximum(u ** 2 + v ** 2, 1.0e-30))
+
     def test_surface_physics_step_basic(self):
         """Test basic surface physics step."""
         fluxes, tendencies, diagnostics = surface_physics_step(
-            self.atmospheric_state, self.surface_state, self.dt
+            self.atmospheric_state, self.surface_state, self.dt,
+            self._wind_10m(),
         )
         
         assert isinstance(fluxes, SurfaceFluxes)
@@ -190,7 +197,8 @@ class TestSurfacePhysicsStep:
     def test_surface_physics_step_energy_conservation(self):
         """Test energy conservation in surface physics step."""
         fluxes, tendencies, diagnostics = surface_physics_step(
-            self.atmospheric_state, self.surface_state, self.dt
+            self.atmospheric_state, self.surface_state, self.dt,
+            self._wind_10m(),
         )
         
         # Net surface energy flux should be finite
@@ -206,7 +214,8 @@ class TestSurfacePhysicsStep:
     def test_surface_physics_step_flux_consistency(self):
         """Test flux consistency between tiles and means."""
         fluxes, tendencies, diagnostics = surface_physics_step(
-            self.atmospheric_state, self.surface_state, self.dt
+            self.atmospheric_state, self.surface_state, self.dt,
+            self._wind_10m(),
         )
         
         # Check that mean fluxes are consistent with tile fluxes
@@ -232,12 +241,14 @@ class TestSurfacePhysicsStep:
         momentum stress exactly.
         """
         base, _, _ = surface_physics_step(
-            self.atmospheric_state, self.surface_state, self.dt
+            self.atmospheric_state, self.surface_state, self.dt,
+            self._wind_10m(),
         )
         doubled = self.atmospheric_state._replace(
             exchange_coeff_momentum=self.atmospheric_state.exchange_coeff_momentum * 2.0
         )
-        scaled, _, _ = surface_physics_step(doubled, self.surface_state, self.dt)
+        scaled, _, _ = surface_physics_step(doubled, self.surface_state, self.dt,
+                                       self._wind_10m())
 
         assert jnp.allclose(scaled.momentum_u_mean, 2.0 * base.momentum_u_mean, rtol=1e-5)
         assert jnp.allclose(scaled.momentum_v_mean, 2.0 * base.momentum_v_mean, rtol=1e-5)

--- a/jcm/physics/surface/echam/turbulent_fluxes.py
+++ b/jcm/physics/surface/echam/turbulent_fluxes.py
@@ -263,8 +263,8 @@ def compute_surface_diagnostics(
     surface_state: SurfaceState,
     surface_fluxes: SurfaceFluxes,
     resistances: SurfaceResistances,
+    wind_speed_10m: jnp.ndarray,
     params: SurfaceParameters = SurfaceParameters.default(),
-    wind_speed_10m: jnp.ndarray = None,
 ) -> SurfaceDiagnostics:
     """Compute standard surface diagnostics (2m temperature, 10m wind, etc.).
     
@@ -276,8 +276,9 @@ def compute_surface_diagnostics(
         params: Surface parameters
         wind_speed_10m: 10 m wind speed [m/s] (ncol,) from the surface-layer
             profile (ECHAM ``nsurf_diag``, diagnosed by the vertical-diffusion
-            term). ``None`` falls back to the lowest-level wind — the only
-            wind available when no surface-layer reduction is supplied.
+            term). Required: the vdiff carry always holds one, so a fallback
+            here would only ever hide a wiring mistake behind a wind that is
+            not the 10 m wind.
         
     Returns:
         Surface diagnostics
@@ -305,12 +306,10 @@ def compute_surface_diagnostics(
     # 2m dew point (simplified)
     dewpoint_2m = temp_2m - 20.0 * (1.0 - atmospheric_state.humidity / 0.01)
     
-    # 10m wind: the surface-layer reduction when supplied, else the lowest
-    # model level. Components keep the lowest level's direction.
+    # Components keep the lowest level's direction; the magnitude is the
+    # surface-layer reduction the caller diagnosed.
     wind_speed_atm = jnp.sqrt(jnp.maximum(
         atmospheric_state.u_wind**2 + atmospheric_state.v_wind**2, 1.0e-30))
-    if wind_speed_10m is None:
-        wind_speed_10m = wind_speed_atm
     reduction = wind_speed_10m / wind_speed_atm
     u_wind_10m = reduction * atmospheric_state.u_wind
     v_wind_10m = reduction * atmospheric_state.v_wind

--- a/jcm/physics/surface/echam/turbulent_fluxes.py
+++ b/jcm/physics/surface/echam/turbulent_fluxes.py
@@ -263,7 +263,8 @@ def compute_surface_diagnostics(
     surface_state: SurfaceState,
     surface_fluxes: SurfaceFluxes,
     resistances: SurfaceResistances,
-    params: SurfaceParameters = SurfaceParameters.default()
+    params: SurfaceParameters = SurfaceParameters.default(),
+    wind_speed_10m: jnp.ndarray = None,
 ) -> SurfaceDiagnostics:
     """Compute standard surface diagnostics (2m temperature, 10m wind, etc.).
     
@@ -273,6 +274,10 @@ def compute_surface_diagnostics(
         surface_fluxes: Surface fluxes
         resistances: Surface resistances
         params: Surface parameters
+        wind_speed_10m: 10 m wind speed [m/s] (ncol,) from the surface-layer
+            profile (ECHAM ``nsurf_diag``, diagnosed by the vertical-diffusion
+            term). ``None`` falls back to the lowest-level wind — the only
+            wind available when no surface-layer reduction is supplied.
         
     Returns:
         Surface diagnostics
@@ -300,10 +305,15 @@ def compute_surface_diagnostics(
     # 2m dew point (simplified)
     dewpoint_2m = temp_2m - 20.0 * (1.0 - atmospheric_state.humidity / 0.01)
     
-    # 10m wind (use atmospheric wind as approximation)
-    wind_speed_10m = jnp.sqrt(jnp.maximum(atmospheric_state.u_wind**2 + atmospheric_state.v_wind**2, 1.0e-30))
-    u_wind_10m = atmospheric_state.u_wind
-    v_wind_10m = atmospheric_state.v_wind
+    # 10m wind: the surface-layer reduction when supplied, else the lowest
+    # model level. Components keep the lowest level's direction.
+    wind_speed_atm = jnp.sqrt(jnp.maximum(
+        atmospheric_state.u_wind**2 + atmospheric_state.v_wind**2, 1.0e-30))
+    if wind_speed_10m is None:
+        wind_speed_10m = wind_speed_atm
+    reduction = wind_speed_10m / wind_speed_atm
+    u_wind_10m = reduction * atmospheric_state.u_wind
+    v_wind_10m = reduction * atmospheric_state.v_wind
     
     # Friction velocity
     momentum_flux_magnitude = jnp.sqrt(jnp.maximum(
@@ -317,7 +327,7 @@ def compute_surface_diagnostics(
         atmospheric_state.temperature, surface_state.temperature,
         atmospheric_state.humidity, 
         compute_surface_humidity(surface_state.temperature, atmospheric_state.pressure),
-        wind_speed_10m
+        wind_speed_atm
     ), axis=1)
     
     # Energy balance

--- a/jcm/physics/vertical_diffusion/tte_tke/surface_layer.py
+++ b/jcm/physics/vertical_diffusion/tte_tke/surface_layer.py
@@ -217,3 +217,65 @@ def compute_surface_exchange_coefficients_echam_louis(
         surface_exchange_momentum = surface_exchange_momentum.at[:, isfc].set(cfm)
 
     return surface_exchange_heat, surface_exchange_moisture, surface_exchange_momentum
+
+
+@jax.jit
+def wind_10m_reduction(
+    exchange_momentum: jnp.ndarray,
+    wind_speed: jnp.ndarray,
+    z_ref: jnp.ndarray,
+    roughness_momentum: jnp.ndarray,
+    z0m_min: jnp.ndarray,
+    reference_height: float = 10.0,
+) -> jnp.ndarray:
+    """Per-tile ``|U(10 m)| / |U(z_ref)|`` (ECHAM ``nsurf_diag`` 10 m wind).
+
+    ECHAM5 ``vdiff.f90`` / ICON ``mo_surface_diag::nsurf_diag`` interpolate the
+    lowest-level wind down to 10 m along the surface-layer profile actually used
+    for the drag, with ``zrat = 10/z_ref``::
+
+        bn   = ln(z_ref/z0m)                     neutral profile factor
+        bm   = bn·√(CM_n·|U| / CM·|U|)           stability-corrected profile
+        cbn  = ln(1 + (e^bn − 1)·zrat)
+        cbs  = −(bn − bm)·zrat                   stable
+        cbu  = −ln(1 + (e^(bn−bm) − 1)·zrat)     unstable
+        red  = (cbn + [cbs|cbu]) / bm
+
+    The stable/unstable branch is selected by ``CM·|U| < CM_n·|U|``, which is
+    exactly ``Ri > 0`` for both surface-layer schemes here (their stability
+    factors are <1 for stable, ≥1 for unstable, and both equal 1 — with equal
+    ``cbs``/``cbu`` — at ``Ri = 0``), so the Richardson number need not be
+    plumbed out of the coefficient solve.
+
+    Args:
+        exchange_momentum: CM·|U| per tile [m/s] (ncol, nsfc_type).
+        wind_speed: lowest-level wind speed [m/s] (ncol,), the same
+            (``zepdu2``-floored) speed the coefficients were built from.
+        z_ref: lowest full-level height above the surface [m] (ncol,).
+        roughness_momentum: z0m per tile [m] (ncol, nsfc_type).
+        z0m_min: roughness floor [m].
+        reference_height: diagnostic height [m], 10 m by default.
+
+    Returns:
+        Reduction factor per tile (ncol, nsfc_type), in [0, 1].
+
+    """
+    karman = c.karman_const
+    z0 = jnp.maximum(roughness_momentum, z0m_min)
+    # Same bounded z/z0 as the neutral drag the schemes use, so bn is exactly
+    # κ/√CDN and the ratio below is the schemes' own stability factor.
+    zeta = jnp.maximum(z_ref[:, None] / z0, jnp.exp(2.0))
+    bn = jnp.log(zeta)
+    cfnc = wind_speed[:, None] * karman ** 2 / bn ** 2      # neutral CM·|U|
+    f_m = jnp.maximum(exchange_momentum, 1e-12) / jnp.maximum(cfnc, 1e-12)
+    bm = bn / jnp.sqrt(f_m)
+
+    # A lowest level below 10 m leaves the wind unreduced (zrat ≤ 1).
+    zrat = reference_height / jnp.maximum(z_ref, reference_height)[:, None]
+    cbn = jnp.log1p((zeta - 1.0) * zrat)
+    cbs = -(bn - bm) * zrat
+    cbu = -jnp.log1p(jnp.expm1(jnp.clip(bn - bm, -30.0, 30.0)) * zrat)
+    merge = jnp.where(f_m < 1.0, cbs, cbu)
+    # Math-safety clip only: the log profile cannot amplify the wind between
+    # 10 m and the lowest level, nor reverse it.
+    return jnp.clip((cbn + merge) / bm, 0.0, 1.0)

--- a/jcm/physics/vertical_diffusion/tte_tke/surface_layer.py
+++ b/jcm/physics/vertical_diffusion/tte_tke/surface_layer.py
@@ -249,8 +249,9 @@ def wind_10m_reduction(
 
     Args:
         exchange_momentum: CM·|U| per tile [m/s] (ncol, nsfc_type).
-        wind_speed: lowest-level wind speed [m/s] (ncol,), the same
-            (``zepdu2``-floored) speed the coefficients were built from.
+        wind_speed: the speed the coefficients were built from [m/s] (ncol,) —
+            ECHAM floors it at ``zepdu2`` (1 m/s), and passing the raw wind
+            instead would misread that floor as a stability signal.
         z_ref: lowest full-level height above the surface [m] (ncol,).
         roughness_momentum: z0m per tile [m] (ncol, nsfc_type).
         z0m_min: roughness floor [m].

--- a/jcm/physics/vertical_diffusion/tte_tke/surface_layer.py
+++ b/jcm/physics/vertical_diffusion/tte_tke/surface_layer.py
@@ -101,6 +101,11 @@ def compute_surface_exchange_coefficients_echam_louis(
 
     ncol, nsfc_type = temperature_surface.shape
 
+    # Neutral drag for every tile, from the one helper the 10 m reduction also
+    # uses (so the reduction's stability factor is this scheme's own).
+    bn_all, cfn_m_all = echam_louis_neutral_drag(state, params,
+                                                 wind_speed_surface)
+
     # --- Atmospheric inputs at the lowest level (klev) -------------------
     p_air = state.pressure_full[:, -1]            # (ncol,)
     p_sfc = state.pressure_half[:, -1]            # (ncol,)
@@ -176,13 +181,15 @@ def compute_surface_exchange_coefficients_echam_louis(
 
         # ---- Louis (1979) stability + log-law neutral ----------------
         # Effective roughness lengths capped to ½·z_ref via
-        # ``MAX(2, z/z0)`` per ECHAM's lmix-bounded form.
-        log_zm = jnp.log(jnp.maximum(z_ref / z0,  jnp.exp(2.0)))
+        # ``MAX(2, z/z0)`` per ECHAM's lmix-bounded form. The momentum pair
+        # comes from ``echam_louis_neutral_drag`` so the 10 m reduction shares
+        # this scheme's own neutral reference rather than re-deriving it.
+        log_zm = bn_all[:, isfc]
         log_zh = jnp.log(jnp.maximum(z_ref / z0h, jnp.exp(2.0)))
         cdn = (karman * karman) / (log_zm * log_zm)             # neutral drag
         chn = (karman * karman) / (log_zm * log_zh)             # neutral CHN
 
-        cfn_m = jnp.sqrt(jnp.maximum(zdu2, 1.0e-30)) * cdn        # κ²·U/log²
+        cfn_m = cfn_m_all[:, isfc]                                # κ²·U/log²
         cfn_h = jnp.sqrt(jnp.maximum(zdu2, 1.0e-30)) * chn
 
         # Stable branch (Ri > 0): ECHAM Mauritsen-2007 stable form
@@ -272,10 +279,10 @@ def wind_10m_reduction(
            / jnp.maximum(neutral_exchange_momentum, 1e-12))
     bm = bn / jnp.sqrt(f_m)
 
-    # Same 1 m floor on z_ref the exchange coefficients use. A lowest level
-    # below 10 m leaves the wind unreduced (zrat ≤ 1).
-    z1 = jnp.maximum(z_ref, 1.0)
-    zrat = reference_height / jnp.maximum(z1, reference_height)[:, None]
+    # A lowest level below the diagnostic height leaves the wind unreduced
+    # (zrat ≤ 1). This subsumes the coefficients' 1 m floor on z_ref, since
+    # the diagnostic height is 10 m — flooring at 1 m first would be a no-op.
+    zrat = reference_height / jnp.maximum(z_ref, reference_height)[:, None]
     cbn = jnp.log1p(jnp.expm1(jnp.clip(bn, 0.0, 30.0)) * zrat)
     cbs = -(bn - bm) * zrat
     cbu = -jnp.log1p(jnp.expm1(jnp.clip(bn - bm, -30.0, 30.0)) * zrat)
@@ -288,9 +295,10 @@ def wind_10m_reduction(
 def echam_louis_neutral_drag(state, params, wind_speed):
     """``(ln(z/z0), CM_n·|U|)`` of the ECHAM-Louis scheme, per tile.
 
-    The bounded ``z/z0`` and the ``zepdu2``-floored wind are exactly what
-    :func:`compute_surface_exchange_coefficients_echam_louis` builds its drag
-    from, so ``bn = κ/√CDN`` holds for the pair.
+    THE definition, not a copy of one:
+    :func:`compute_surface_exchange_coefficients_echam_louis` calls this for
+    the ``log_zm``/``cfn_m`` its own drag is built on, so ``bn = κ/√CDN``
+    holds for the pair by construction and the two cannot drift.
     """
     z_ref = jnp.maximum(state.height_full[:, -1] - state.height_half[:, -1], 1.0)
     z0 = jnp.maximum(state.roughness_length, params.z0m_min)

--- a/jcm/physics/vertical_diffusion/tte_tke/surface_layer.py
+++ b/jcm/physics/vertical_diffusion/tte_tke/surface_layer.py
@@ -222,10 +222,9 @@ def compute_surface_exchange_coefficients_echam_louis(
 @jax.jit
 def wind_10m_reduction(
     exchange_momentum: jnp.ndarray,
-    wind_speed: jnp.ndarray,
+    neutral_exchange_momentum: jnp.ndarray,
+    log_z_over_z0: jnp.ndarray,
     z_ref: jnp.ndarray,
-    roughness_momentum: jnp.ndarray,
-    z0m_min: jnp.ndarray,
     reference_height: float = 10.0,
 ) -> jnp.ndarray:
     """Per-tile ``|U(10 m)| / |U(z_ref)|`` (ECHAM ``nsurf_diag`` 10 m wind).
@@ -241,6 +240,14 @@ def wind_10m_reduction(
         cbu  = −ln(1 + (e^(bn−bm) − 1)·zrat)     unstable
         red  = (cbn + [cbs|cbu]) / bm
 
+    The neutral profile factor and the neutral exchange velocity are supplied
+    by the caller rather than rebuilt here, because they must be the surface
+    layer scheme's OWN: the two schemes differ in roughness (``z0m_min``-floored
+    ``state.roughness_length`` vs a hard-coded table), in the bound on
+    ``z/z0``, and in whether the wind is ``zepdu2``-floored. Deriving them here
+    would silently mix two drag formulations and read stability where there is
+    none.
+
     The stable/unstable branch is selected by ``CM·|U| < CM_n·|U|``, which is
     exactly ``Ri > 0`` for both surface-layer schemes here (their stability
     factors are <1 for stable, ≥1 for unstable, and both equal 1 — with equal
@@ -249,34 +256,44 @@ def wind_10m_reduction(
 
     Args:
         exchange_momentum: CM·|U| per tile [m/s] (ncol, nsfc_type).
-        wind_speed: the speed the coefficients were built from [m/s] (ncol,) —
-            ECHAM floors it at ``zepdu2`` (1 m/s), and passing the raw wind
-            instead would misread that floor as a stability signal.
+        neutral_exchange_momentum: the same scheme's NEUTRAL CM_n·|U| [m/s]
+            (ncol, nsfc_type).
+        log_z_over_z0: that scheme's neutral profile factor ``ln(z_ref/z0m)``
+            (ncol, nsfc_type).
         z_ref: lowest full-level height above the surface [m] (ncol,).
-        roughness_momentum: z0m per tile [m] (ncol, nsfc_type).
-        z0m_min: roughness floor [m].
         reference_height: diagnostic height [m], 10 m by default.
 
     Returns:
         Reduction factor per tile (ncol, nsfc_type), in [0, 1].
 
     """
-    karman = c.karman_const
-    z0 = jnp.maximum(roughness_momentum, z0m_min)
-    # Same bounded z/z0 as the neutral drag the schemes use, so bn is exactly
-    # κ/√CDN and the ratio below is the schemes' own stability factor.
-    zeta = jnp.maximum(z_ref[:, None] / z0, jnp.exp(2.0))
-    bn = jnp.log(zeta)
-    cfnc = wind_speed[:, None] * karman ** 2 / bn ** 2      # neutral CM·|U|
-    f_m = jnp.maximum(exchange_momentum, 1e-12) / jnp.maximum(cfnc, 1e-12)
+    bn = log_z_over_z0
+    f_m = (jnp.maximum(exchange_momentum, 1e-12)
+           / jnp.maximum(neutral_exchange_momentum, 1e-12))
     bm = bn / jnp.sqrt(f_m)
 
-    # A lowest level below 10 m leaves the wind unreduced (zrat ≤ 1).
-    zrat = reference_height / jnp.maximum(z_ref, reference_height)[:, None]
-    cbn = jnp.log1p((zeta - 1.0) * zrat)
+    # Same 1 m floor on z_ref the exchange coefficients use. A lowest level
+    # below 10 m leaves the wind unreduced (zrat ≤ 1).
+    z1 = jnp.maximum(z_ref, 1.0)
+    zrat = reference_height / jnp.maximum(z1, reference_height)[:, None]
+    cbn = jnp.log1p(jnp.expm1(jnp.clip(bn, 0.0, 30.0)) * zrat)
     cbs = -(bn - bm) * zrat
     cbu = -jnp.log1p(jnp.expm1(jnp.clip(bn - bm, -30.0, 30.0)) * zrat)
     merge = jnp.where(f_m < 1.0, cbs, cbu)
     # Math-safety clip only: the log profile cannot amplify the wind between
     # 10 m and the lowest level, nor reverse it.
     return jnp.clip((cbn + merge) / bm, 0.0, 1.0)
+
+
+def echam_louis_neutral_drag(state, params, wind_speed):
+    """``(ln(z/z0), CM_n·|U|)`` of the ECHAM-Louis scheme, per tile.
+
+    The bounded ``z/z0`` and the ``zepdu2``-floored wind are exactly what
+    :func:`compute_surface_exchange_coefficients_echam_louis` builds its drag
+    from, so ``bn = κ/√CDN`` holds for the pair.
+    """
+    z_ref = jnp.maximum(state.height_full[:, -1] - state.height_half[:, -1], 1.0)
+    z0 = jnp.maximum(state.roughness_length, params.z0m_min)
+    bn = jnp.log(jnp.maximum(z_ref[:, None] / z0, jnp.exp(2.0)))
+    floored = jnp.sqrt(jnp.maximum(wind_speed ** 2, 1.0))[:, None]
+    return bn, floored * c.karman_const ** 2 / bn ** 2

--- a/jcm/physics/vertical_diffusion/tte_tke/surface_layer_test.py
+++ b/jcm/physics/vertical_diffusion/tte_tke/surface_layer_test.py
@@ -189,3 +189,71 @@ class TestECHAMLouisScheme:
             state.surface_temperature, state.temperature[:, -1],
         )
         np.testing.assert_allclose(np.asarray(sCH1), np.asarray(sCH2))
+
+
+class TestWind10mReduction:
+    """ECHAM ``nsurf_diag`` 10 m wind reduction (#723)."""
+
+    def _neutral(self, z_ref, z0):
+        """|U(10)|/|U(z_ref)| = ln(1 + (z/z0 - 1)*10/z) / ln(z/z0)."""
+        return (np.log1p((z_ref / z0 - 1.0) * 10.0 / z_ref)
+                / np.log(z_ref / z0))
+
+    def test_neutral_matches_the_log_profile(self):
+        from .surface_layer import wind_10m_reduction
+        karman = 0.4
+        z_ref, z0, wind = 32.6, 1.5e-4, 6.0
+        cdn = karman ** 2 / np.log(z_ref / z0) ** 2
+        red = wind_10m_reduction(
+            jnp.full((1, 3), wind * cdn),          # neutral CM|U| = CDN|U|
+            jnp.asarray([wind]), jnp.asarray([z_ref]),
+            jnp.full((1, 3), z0), 1.0e-5)
+        expect = self._neutral(z_ref, z0)
+        assert abs(float(red[0, 0]) - expect) < 1e-5
+        # ~0.90 at L47's lowest level over the ocean: the |u|^3.41 sea-salt
+        # source is inflated ~1.4x by using the model level instead.
+        assert 0.88 < expect < 0.92
+
+    def test_ocean_roughness_range(self):
+        for z0, want in ((5e-5, 0.9124), (1.5e-4, 0.9036), (5e-4, 0.8935)):
+            assert abs(self._neutral(32.6, z0) - want) < 1e-3
+
+    def test_unstable_is_closer_to_one_than_stable(self):
+        from .surface_layer import wind_10m_reduction
+        karman, z_ref, z0, wind = 0.4, 32.6, 1.5e-4, 6.0
+        cfnc = wind * karman ** 2 / np.log(z_ref / z0) ** 2
+        args = (jnp.asarray([wind]), jnp.asarray([z_ref]),
+                jnp.full((1, 1), z0), 1.0e-5)
+        red = lambda f: float(
+            wind_10m_reduction(jnp.full((1, 1), f * cfnc), *args)[0, 0])
+        stable, neutral, unstable = red(0.4), red(1.0), red(3.0)
+        assert stable < neutral < unstable <= 1.0
+
+    def test_continuous_across_the_stability_branch(self):
+        from .surface_layer import wind_10m_reduction
+        karman, z_ref, z0, wind = 0.4, 32.6, 1.5e-4, 6.0
+        cfnc = wind * karman ** 2 / np.log(z_ref / z0) ** 2
+        args = (jnp.asarray([wind]), jnp.asarray([z_ref]),
+                jnp.full((1, 1), z0), 1.0e-5)
+        lo = float(wind_10m_reduction(
+            jnp.full((1, 1), cfnc * (1 - 1e-6)), *args)[0, 0])
+        hi = float(wind_10m_reduction(
+            jnp.full((1, 1), cfnc * (1 + 1e-6)), *args)[0, 0])
+        assert abs(lo - hi) < 1e-6
+
+    def test_no_reduction_below_10m_and_bounded(self):
+        from .surface_layer import wind_10m_reduction
+        red = wind_10m_reduction(
+            jnp.full((2, 3), 0.05), jnp.asarray([6.0, 6.0]),
+            jnp.asarray([5.0, 40.0]), jnp.full((2, 3), 1e-3), 1.0e-5)
+        assert np.all(np.asarray(red) <= 1.0) and np.all(np.asarray(red) >= 0.0)
+        # z_ref below the diagnostic height: zrat is capped at 1, no reduction.
+        assert abs(float(red[0, 0]) - 1.0) < 1e-6
+
+    def test_gradient_is_finite(self):
+        import jax
+        from .surface_layer import wind_10m_reduction
+        g = jax.grad(lambda cm: jnp.sum(wind_10m_reduction(
+            cm, jnp.asarray([6.0]), jnp.asarray([32.6]),
+            jnp.full((1, 3), 1.5e-4), 1.0e-5)))(jnp.full((1, 3), 0.01))
+        assert np.all(np.isfinite(np.asarray(g)))

--- a/jcm/physics/vertical_diffusion/tte_tke/surface_layer_test.py
+++ b/jcm/physics/vertical_diffusion/tte_tke/surface_layer_test.py
@@ -200,14 +200,16 @@ class TestWind10mReduction:
                 / np.log(z_ref / z0))
 
     def test_neutral_matches_the_log_profile(self):
+        import jcm.constants as c
         from .surface_layer import wind_10m_reduction
-        karman = 0.4
+        karman = c.karman_const
         z_ref, z0, wind = 32.6, 1.5e-4, 6.0
-        cdn = karman ** 2 / np.log(z_ref / z0) ** 2
+        bn = np.log(z_ref / z0)
+        cfnc = wind * karman ** 2 / bn ** 2
         red = wind_10m_reduction(
-            jnp.full((1, 3), wind * cdn),          # neutral CM|U| = CDN|U|
-            jnp.asarray([wind]), jnp.asarray([z_ref]),
-            jnp.full((1, 3), z0), 1.0e-5)
+            jnp.full((1, 3), cfnc),                # neutral: CM|U| = CM_n|U|
+            jnp.full((1, 3), cfnc), jnp.full((1, 3), bn),
+            jnp.asarray([z_ref]))
         expect = self._neutral(z_ref, z0)
         assert abs(float(red[0, 0]) - expect) < 1e-5
         # ~0.90 at L47's lowest level over the ocean: the |u|^3.41 sea-salt
@@ -218,23 +220,46 @@ class TestWind10mReduction:
         for z0, want in ((5e-5, 0.9124), (1.5e-4, 0.9036), (5e-4, 0.8935)):
             assert abs(self._neutral(32.6, z0) - want) < 1e-3
 
-    def test_unstable_is_closer_to_one_than_stable(self):
+    def test_each_scheme_uses_its_own_neutral_drag(self):
+        """A shared reference reads stability at exact neutral (#783 review)."""
+        import jcm.constants as c
         from .surface_layer import wind_10m_reduction
-        karman, z_ref, z0, wind = 0.4, 32.6, 1.5e-4, 6.0
-        cfnc = wind * karman ** 2 / np.log(z_ref / z0) ** 2
-        args = (jnp.asarray([wind]), jnp.asarray([z_ref]),
-                jnp.full((1, 1), z0), 1.0e-5)
+        z_ref, wind = 32.6, 6.0
+        # Businger-Dyer's hard-coded ocean z0 against a Charnock state z0.
+        bn_bd = np.log(max(z_ref, 1.0) / 1e-4)
+        bn_louis = np.log(z_ref / 2.2e-4)
+        cfnc_bd = wind * c.karman_const ** 2 / bn_bd ** 2
+        own = float(wind_10m_reduction(
+            jnp.full((1, 1), cfnc_bd), jnp.full((1, 1), cfnc_bd),
+            jnp.full((1, 1), bn_bd), jnp.asarray([z_ref]))[0, 0])
+        mixed = float(wind_10m_reduction(
+            jnp.full((1, 1), cfnc_bd),
+            jnp.full((1, 1), wind * c.karman_const ** 2 / bn_louis ** 2),
+            jnp.full((1, 1), bn_louis), jnp.asarray([z_ref]))[0, 0])
+        assert abs(own - self._neutral(z_ref, 1e-4)) < 1e-4   # true neutral
+        assert mixed < own - 0.03                             # spuriously stable
+
+    def test_unstable_is_closer_to_one_than_stable(self):
+        import jcm.constants as c
+        from .surface_layer import wind_10m_reduction
+        z_ref, z0, wind = 32.6, 1.5e-4, 6.0
+        bn = np.log(z_ref / z0)
+        cfnc = wind * c.karman_const ** 2 / bn ** 2
+        args = (jnp.full((1, 1), cfnc), jnp.full((1, 1), bn),
+                jnp.asarray([z_ref]))
         red = lambda f: float(
             wind_10m_reduction(jnp.full((1, 1), f * cfnc), *args)[0, 0])
         stable, neutral, unstable = red(0.4), red(1.0), red(3.0)
         assert stable < neutral < unstable <= 1.0
 
     def test_continuous_across_the_stability_branch(self):
+        import jcm.constants as c
         from .surface_layer import wind_10m_reduction
-        karman, z_ref, z0, wind = 0.4, 32.6, 1.5e-4, 6.0
-        cfnc = wind * karman ** 2 / np.log(z_ref / z0) ** 2
-        args = (jnp.asarray([wind]), jnp.asarray([z_ref]),
-                jnp.full((1, 1), z0), 1.0e-5)
+        z_ref, z0, wind = 32.6, 1.5e-4, 6.0
+        bn = np.log(z_ref / z0)
+        cfnc = wind * c.karman_const ** 2 / bn ** 2
+        args = (jnp.full((1, 1), cfnc), jnp.full((1, 1), bn),
+                jnp.asarray([z_ref]))
         lo = float(wind_10m_reduction(
             jnp.full((1, 1), cfnc * (1 - 1e-6)), *args)[0, 0])
         hi = float(wind_10m_reduction(
@@ -243,9 +268,10 @@ class TestWind10mReduction:
 
     def test_no_reduction_below_10m_and_bounded(self):
         from .surface_layer import wind_10m_reduction
+        bn = np.log(np.asarray([5.0, 40.0])[:, None] / 1e-3)
         red = wind_10m_reduction(
-            jnp.full((2, 3), 0.05), jnp.asarray([6.0, 6.0]),
-            jnp.asarray([5.0, 40.0]), jnp.full((2, 3), 1e-3), 1.0e-5)
+            jnp.full((2, 3), 0.05), jnp.full((2, 3), 0.05),
+            jnp.asarray(bn * np.ones((1, 3))), jnp.asarray([5.0, 40.0]))
         assert np.all(np.asarray(red) <= 1.0) and np.all(np.asarray(red) >= 0.0)
         # z_ref below the diagnostic height: zrat is capped at 1, no reduction.
         assert abs(float(red[0, 0]) - 1.0) < 1e-6
@@ -253,7 +279,8 @@ class TestWind10mReduction:
     def test_gradient_is_finite(self):
         import jax
         from .surface_layer import wind_10m_reduction
+        bn = float(np.log(32.6 / 1.5e-4))
         g = jax.grad(lambda cm: jnp.sum(wind_10m_reduction(
-            cm, jnp.asarray([6.0]), jnp.asarray([32.6]),
-            jnp.full((1, 3), 1.5e-4), 1.0e-5)))(jnp.full((1, 3), 0.01))
+            cm, jnp.full((1, 3), 6.0 * 0.4 ** 2 / bn ** 2),
+            jnp.full((1, 3), bn), jnp.asarray([32.6]))))(jnp.full((1, 3), 0.01))
         assert np.all(np.isfinite(np.asarray(g)))

--- a/jcm/physics/vertical_diffusion/tte_tke/turbulence_coefficients.py
+++ b/jcm/physics/vertical_diffusion/tte_tke/turbulence_coefficients.py
@@ -229,7 +229,11 @@ _BD_Z0_MOMENTUM = jnp.array([1e-4, 1e-3, 1e-1])
 def businger_dyer_neutral_drag(state, wind_speed):
     """``(ln(z/z0), CM_n·|U|)`` of the Businger-Dyer scheme, per tile.
 
-    Sliced to the state's tile count, as the scheme's own per-tile loop is.
+    THE definition: :func:`compute_surface_exchange_coefficients` builds its
+    momentum drag as ``cfnc · stability_momentum`` from this, so the 10 m
+    reduction's ``f_m = CM|U| / CM_n|U|`` is exactly that scheme's own
+    ``stability_momentum`` rather than a re-derivation of it. Sliced to the
+    state's tile count, as the scheme's per-tile loop is.
     """
     z_ref = state.height_full[:, -1] - state.height_half[:, -1]
     z0 = _BD_Z0_MOMENTUM[:state.roughness_length.shape[1]]
@@ -273,7 +277,8 @@ def compute_surface_exchange_coefficients(
 
     z0_heat = _BD_Z0_HEAT
     z0_moisture = _BD_Z0_HEAT
-    z0_momentum = _BD_Z0_MOMENTUM
+    # Momentum: one definition, shared with the 10 m reduction (below).
+    _, cfn_m_all = businger_dyer_neutral_drag(state, wind_speed_surface)
     
     # Reference height (lowest model level)
     z_ref = state.height_full[:, -1] - state.height_half[:, -1]
@@ -330,15 +335,13 @@ def compute_surface_exchange_coefficients(
                                  / jnp.maximum(z0_heat[isfc], 1e-5))
         log_ratio_moisture = jnp.log(jnp.maximum(z_ref, 1.0)
                                      / jnp.maximum(z0_moisture[isfc], 1e-5))
-        log_ratio_momentum = jnp.log(jnp.maximum(z_ref, 1.0)
-                                     / jnp.maximum(z0_momentum[isfc], 1e-5))
-
         exchange_heat = (von_karman**2 * wind_speed_surface *
                         stability_heat / log_ratio_heat**2)
         exchange_moisture = (von_karman**2 * wind_speed_surface *
                            stability_heat / log_ratio_moisture**2)
-        exchange_momentum = (von_karman**2 * wind_speed_surface *
-                             stability_momentum / log_ratio_momentum**2)
+        # CM·|U| = CM_n·|U| · (1/Φm): the neutral factor is the shared one, so
+        # f_m in the 10 m reduction recovers stability_momentum exactly.
+        exchange_momentum = cfn_m_all[:, isfc] * stability_momentum
 
         surface_exchange_heat = surface_exchange_heat.at[:, isfc].set(
             jnp.maximum(exchange_heat, 1e-6)

--- a/jcm/physics/vertical_diffusion/tte_tke/turbulence_coefficients.py
+++ b/jcm/physics/vertical_diffusion/tte_tke/turbulence_coefficients.py
@@ -450,7 +450,10 @@ def compute_turbulence_diagnostics(
     # shaped (ncol, nsfc_type) tensors, so the false-branch tracing
     # is cheap. The scheme field on ``params`` is a tracer under
     # JIT, hence cond rather than a Python ``if``.
-    from .surface_layer import compute_surface_exchange_coefficients_echam_louis
+    from .surface_layer import (
+        compute_surface_exchange_coefficients_echam_louis,
+        wind_10m_reduction,
+    )
 
     wind_speed_surface = jnp.sqrt(
         jnp.maximum(state.u[:, -1]**2 + state.v[:, -1]**2, 1.0e-30))
@@ -494,6 +497,18 @@ def compute_turbulence_diagnostics(
     friction_velocity = compute_friction_velocity(
         surface_momentum_flux_u, surface_momentum_flux_v, air_density
     )
+
+    # 10 m wind (ECHAM ``nsurf_diag``), area-weighted over the tiles from the
+    # same per-tile CM·|U|. Surface-flux parameterizations (sea salt, DMS) are
+    # calibrated to u10, not to the lowest model level — ~33 m at L47.
+    z_ref = state.height_full[:, -1] - state.height_half[:, -1]
+    wind_10m = wind_speed_surface * jnp.sum(
+        state.surface_fraction * wind_10m_reduction(
+            surface_exchange_momentum, wind_speed_surface, z_ref,
+            state.roughness_length, params.z0m_min,
+        ),
+        axis=1,
+    )
     
     # Convective velocity scale (simplified)
     convective_velocity = jnp.maximum(friction_velocity, 0.1)
@@ -508,6 +523,7 @@ def compute_turbulence_diagnostics(
         boundary_layer_height=pbl_height,
         friction_velocity=friction_velocity,
         convective_velocity=convective_velocity,
+        wind_10m=wind_10m,
         richardson_number=ri,
         mixing_length=mixing_length,
         kinetic_energy_dissipation=jnp.zeros(ncol)  # Will be computed by TKE budget

--- a/jcm/physics/vertical_diffusion/tte_tke/turbulence_coefficients.py
+++ b/jcm/physics/vertical_diffusion/tte_tke/turbulence_coefficients.py
@@ -220,6 +220,26 @@ def compute_exchange_coefficients(
     return exchange_coeff_momentum, exchange_coeff_heat, exchange_coeff_moisture
 
 
+#: Businger-Dyer roughness tables [water, ice, land] — this scheme ignores
+#: ``state.roughness_length``, so its neutral drag must be built from these.
+_BD_Z0_HEAT = jnp.array([1e-4, 1e-4, 1e-2])
+_BD_Z0_MOMENTUM = jnp.array([1e-4, 1e-3, 1e-1])
+
+
+def businger_dyer_neutral_drag(state, wind_speed):
+    """``(ln(z/z0), CM_n·|U|)`` of the Businger-Dyer scheme, per tile.
+
+    Sliced to the state's tile count, as the scheme's own per-tile loop is.
+    """
+    z_ref = state.height_full[:, -1] - state.height_half[:, -1]
+    z0 = _BD_Z0_MOMENTUM[:state.roughness_length.shape[1]]
+    bn = jnp.log(jnp.maximum(z_ref, 1.0)[:, None]
+                 / jnp.maximum(z0, 1e-5)[None, :])
+    # 0.4, not c.karman_const: it must match the von_karman this scheme
+    # hard-codes, or a set_constants override desyncs the pair.
+    return bn, wind_speed[:, None] * 0.4 ** 2 / bn ** 2
+
+
 @jax.jit
 def compute_surface_exchange_coefficients(
     state: VDiffState,
@@ -251,11 +271,9 @@ def compute_surface_exchange_coefficients(
     """
     ncol, nsfc_type = temperature_surface.shape
 
-    # Roughness lengths for different surface types
-    # [water, ice, land]
-    z0_heat = jnp.array([1e-4, 1e-4, 1e-2])  # Thermal roughness
-    z0_moisture = jnp.array([1e-4, 1e-4, 1e-2])  # Moisture roughness
-    z0_momentum = jnp.array([1e-4, 1e-3, 1e-1])  # Momentum roughness (rougher)
+    z0_heat = _BD_Z0_HEAT
+    z0_moisture = _BD_Z0_HEAT
+    z0_momentum = _BD_Z0_MOMENTUM
     
     # Reference height (lowest model level)
     z_ref = state.height_full[:, -1] - state.height_half[:, -1]
@@ -452,23 +470,38 @@ def compute_turbulence_diagnostics(
     # JIT, hence cond rather than a Python ``if``.
     from .surface_layer import (
         compute_surface_exchange_coefficients_echam_louis,
+        echam_louis_neutral_drag,
         wind_10m_reduction,
     )
 
     wind_speed_surface = jnp.sqrt(
         jnp.maximum(state.u[:, -1]**2 + state.v[:, -1]**2, 1.0e-30))
-    surface_exchange_heat, surface_exchange_moisture, surface_exchange_momentum = (
-        jax.lax.cond(
-            params.surface_layer_scheme == VDiffParameters.SCHEME_ECHAM_LOUIS,
-            lambda: compute_surface_exchange_coefficients_echam_louis(
-                state, params, wind_speed_surface,
-                state.surface_temperature, state.temperature[:, -1],
-            ),
-            lambda: compute_surface_exchange_coefficients(
-                state, params, wind_speed_surface,
-                state.surface_temperature, state.temperature[:, -1],
-            ),
+    z_ref_sfc = state.height_full[:, -1] - state.height_half[:, -1]
+
+    # The 10 m reduction is computed INSIDE each branch, from that scheme's own
+    # neutral drag: the two schemes differ in roughness, in the bound on z/z0
+    # and in whether the wind is zepdu2-floored, so a shared reference would
+    # read stability where there is none (~13 % on the sea-salt wind term).
+    def _louis():
+        cfh, cfe, cfm = compute_surface_exchange_coefficients_echam_louis(
+            state, params, wind_speed_surface,
+            state.surface_temperature, state.temperature[:, -1],
         )
+        bn, cfnc = echam_louis_neutral_drag(state, params, wind_speed_surface)
+        return cfh, cfe, cfm, wind_10m_reduction(cfm, cfnc, bn, z_ref_sfc)
+
+    def _businger_dyer():
+        cfh, cfe, cfm = compute_surface_exchange_coefficients(
+            state, params, wind_speed_surface,
+            state.surface_temperature, state.temperature[:, -1],
+        )
+        bn, cfnc = businger_dyer_neutral_drag(state, wind_speed_surface)
+        return cfh, cfe, cfm, wind_10m_reduction(cfm, cfnc, bn, z_ref_sfc)
+
+    (surface_exchange_heat, surface_exchange_moisture,
+     surface_exchange_momentum, wind_10m_tile) = jax.lax.cond(
+        params.surface_layer_scheme == VDiffParameters.SCHEME_ECHAM_LOUIS,
+        _louis, _businger_dyer,
     )
     
     # Air density at surface
@@ -501,18 +534,8 @@ def compute_turbulence_diagnostics(
     # 10 m wind (ECHAM ``nsurf_diag``), area-weighted over the tiles from the
     # same per-tile CM·|U|. Surface-flux parameterizations (sea salt, DMS) are
     # calibrated to u10, not to the lowest model level — ~33 m at L47.
-    z_ref = state.height_full[:, -1] - state.height_half[:, -1]
-    # The profile factor must be built from the SAME zepdu2-floored speed the
-    # exchange coefficients were (ECHAM zdu2 = max(|U|^2, 1)); the reduction it
-    # yields then multiplies the true wind.
     wind_10m = wind_speed_surface * jnp.sum(
-        state.surface_fraction * wind_10m_reduction(
-            surface_exchange_momentum,
-            jnp.sqrt(jnp.maximum(wind_speed_surface ** 2, 1.0)), z_ref,
-            state.roughness_length, params.z0m_min,
-        ),
-        axis=1,
-    )
+        state.surface_fraction * wind_10m_tile, axis=1)
     
     # Convective velocity scale (simplified)
     convective_velocity = jnp.maximum(friction_velocity, 0.1)

--- a/jcm/physics/vertical_diffusion/tte_tke/turbulence_coefficients.py
+++ b/jcm/physics/vertical_diffusion/tte_tke/turbulence_coefficients.py
@@ -502,9 +502,13 @@ def compute_turbulence_diagnostics(
     # same per-tile CM·|U|. Surface-flux parameterizations (sea salt, DMS) are
     # calibrated to u10, not to the lowest model level — ~33 m at L47.
     z_ref = state.height_full[:, -1] - state.height_half[:, -1]
+    # The profile factor must be built from the SAME zepdu2-floored speed the
+    # exchange coefficients were (ECHAM zdu2 = max(|U|^2, 1)); the reduction it
+    # yields then multiplies the true wind.
     wind_10m = wind_speed_surface * jnp.sum(
         state.surface_fraction * wind_10m_reduction(
-            surface_exchange_momentum, wind_speed_surface, z_ref,
+            surface_exchange_momentum,
+            jnp.sqrt(jnp.maximum(wind_speed_surface ** 2, 1.0)), z_ref,
             state.roughness_length, params.z0m_min,
         ),
         axis=1,

--- a/jcm/physics/vertical_diffusion/tte_tke/vertical_diffusion.py
+++ b/jcm/physics/vertical_diffusion/tte_tke/vertical_diffusion.py
@@ -776,6 +776,7 @@ class TteTkeVerticalDiffusion(PhysicsTerm):
         kh = vdiff_diagnostics.exchange_coeff_heat.T
         pbl_height = vdiff_diagnostics.boundary_layer_height
         u_star = vdiff_diagnostics.friction_velocity
+        wind_10m = vdiff_diagnostics.wind_10m
 
         # Per-tile surface exchange velocities (CH·|U|, CE·|U|, CM·|U|, all
         # m/s) from the configured surface-layer scheme. The momentum
@@ -831,6 +832,7 @@ class TteTkeVerticalDiffusion(PhysicsTerm):
             surface_exchange_momentum=surface_exchange_momentum,
             pbl_height=pbl_height,
             surface_friction_velocity=u_star,
+            wind_10m=wind_10m,
             surface_evaporation=sfc_fluxes.evaporation,
             surface_sensible_heat=sfc_fluxes.sensible_heat,
             surface_latent_heat=sfc_fluxes.latent_heat,

--- a/jcm/physics/vertical_diffusion/tte_tke/vertical_diffusion_types.py
+++ b/jcm/physics/vertical_diffusion/tte_tke/vertical_diffusion_types.py
@@ -355,15 +355,15 @@ class VerticalDiffusionData:
     surface_friction_velocity: jnp.ndarray  # u* [m/s] (ncols,)
     monin_obukhov_length: jnp.ndarray       # L [m] (ncols,)
 
+    # Diagnosed 10 m wind speed (ECHAM ``vphysc%velo10m``): the reference
+    # height the surface-flux emission schemes are calibrated to.
+    wind_10m: jnp.ndarray            # |U(10 m)| [m/s] (ncols,)
+
     # Grid-mean surface fluxes DELIVERED by the implicit surface-coupled
     # column solve this step (diagnosed from the implicit solution, so they
     # equal the column-integrated vdiff tendencies exactly — the ECHAM
     # ``pev_vdiff == pqhfla`` identity). ``EchamSurface`` republishes these
     # as the public ``surface`` fluxes.
-    # Diagnosed 10 m wind speed (ECHAM ``vphysc%velo10m``): the reference
-    # height the surface-flux emission schemes are calibrated to.
-    wind_10m: jnp.ndarray                # |U(10 m)| [m/s] (ncols,)
-
     surface_evaporation: jnp.ndarray     # E [kg/m²/s] (ncols,), positive up
     surface_sensible_heat: jnp.ndarray   # SH [W/m²] (ncols,), positive up
     surface_latent_heat: jnp.ndarray     # LH [W/m²] (ncols,)

--- a/jcm/physics/vertical_diffusion/tte_tke/vertical_diffusion_types.py
+++ b/jcm/physics/vertical_diffusion/tte_tke/vertical_diffusion_types.py
@@ -247,6 +247,10 @@ class VDiffDiagnostics(NamedTuple):
     friction_velocity: jnp.ndarray        # u* [m/s] (ncol,)
     convective_velocity: jnp.ndarray      # w* [m/s] (ncol,)
 
+    # Grid-mean 10 m wind speed, the reference height every surface-flux
+    # parameterization (sea salt, DMS) is calibrated to.
+    wind_10m: jnp.ndarray                 # |U(10 m)| [m/s] (ncol,)
+
     # Richardson number
     richardson_number: jnp.ndarray        # Bulk Richardson number [-] (ncol, nlev)
 
@@ -356,6 +360,10 @@ class VerticalDiffusionData:
     # equal the column-integrated vdiff tendencies exactly — the ECHAM
     # ``pev_vdiff == pqhfla`` identity). ``EchamSurface`` republishes these
     # as the public ``surface`` fluxes.
+    # Diagnosed 10 m wind speed (ECHAM ``vphysc%velo10m``): the reference
+    # height the surface-flux emission schemes are calibrated to.
+    wind_10m: jnp.ndarray                # |U(10 m)| [m/s] (ncols,)
+
     surface_evaporation: jnp.ndarray     # E [kg/m²/s] (ncols,), positive up
     surface_sensible_heat: jnp.ndarray   # SH [W/m²] (ncols,), positive up
     surface_latent_heat: jnp.ndarray     # LH [W/m²] (ncols,)
@@ -378,6 +386,7 @@ class VerticalDiffusionData:
             pbl_height=jnp.zeros(nodal_shape),
             surface_friction_velocity=jnp.zeros(nodal_shape),
             monin_obukhov_length=jnp.zeros(nodal_shape),
+            wind_10m=jnp.zeros(nodal_shape),
             surface_evaporation=jnp.zeros(nodal_shape),
             surface_sensible_heat=jnp.zeros(nodal_shape),
             surface_latent_heat=jnp.zeros(nodal_shape),
@@ -399,6 +408,7 @@ class VerticalDiffusionData:
             'pbl_height': self.pbl_height,
             'surface_friction_velocity': self.surface_friction_velocity,
             'monin_obukhov_length': self.monin_obukhov_length,
+            'wind_10m': self.wind_10m,
             'surface_evaporation': self.surface_evaporation,
             'surface_sensible_heat': self.surface_sensible_heat,
             'surface_latent_heat': self.surface_latent_heat,

--- a/jcm/runners.py
+++ b/jcm/runners.py
@@ -1766,7 +1766,14 @@ def run_chunked(
         elapsed_sim_days += cur_chunk
 
         ds = preds.to_xarray()
-        ok, report = check_health(ds, chunk_idx, elapsed_sim_days)
+        ok, report = check_health(
+            ds, chunk_idx, elapsed_sim_days,
+            # Only a COLD start's first chunk can legitimately end on step 1
+            # with the emission-wind fallback still flagged (#723); a resume
+            # carries a real 10 m wind from the checkpoint.
+            cold_start_step_seconds=(
+                float(cfg.run.time_step) * 60.0 if first_fresh_chunk else None),
+        )
         report["wall_seconds"] = chunk_wall
         reports.append(report)
         print_report(report)

--- a/jcm/runners.py
+++ b/jcm/runners.py
@@ -1470,6 +1470,52 @@ def warn_on_config_traps(cfg: DictConfig, physics, forcing,
                 "SPv2.1 file out of the box (no macv2_file needed)."
             )
 
+    # 6. The dust source map and the convention the physics reads it with must
+    #    agree (#768). Neither is checked against the other anywhere else:
+    #    tegen_potential on the CAM erodibility map re-clips the basins the
+    #    #768 fix exists to keep (-18 % of the gated source weight, up to 4.4x
+    #    in a single cell) while skipping CAM's 0.1 threshold (+24 %), and the
+    #    reverse reads a [0, 1] fraction as an unbounded weight. The two are
+    #    distinguishable: only the CAM map exceeds 1.
+    if has_jam and forcing is not None and not is_scm:
+        _src = getattr(forcing, "dust_source", None)
+        _kind = str(cfg.get("physics", {}).get("jam_dust_source",
+                                               "cam_erodibility"))
+        if _src is not None:
+            _vals = (_src.values if isinstance(_src, TimeSeries) else _src)
+            _max = float(np.nanmax(np.asarray(_vals))) if np.size(_vals) else 0.0
+            if _kind == "tegen_potential" and _max > 1.0:
+                logger.warning(
+                    "config trap: physics.jam_dust_source=tegen_potential with "
+                    "a dust map whose maximum is %.2f — only CAM's unbounded "
+                    "basin factor exceeds 1, and tegen_potential clips it back "
+                    "to 1 (undoing the #768 declipping) while skipping CAM's "
+                    "0.1 threshold. Use jam_dust_source=cam_erodibility for "
+                    "this file.", _max)
+            elif _kind == "cam_erodibility" and 0.0 < _max <= 1.0:
+                logger.warning(
+                    "config trap: physics.jam_dust_source=cam_erodibility with "
+                    "a dust map bounded by 1 (max %.3f) — CAM's basin factor "
+                    "runs to 5.7, so this is either a Tegen potential-source "
+                    "fraction (use jam_dust_source=tegen_potential) or a "
+                    "pre-#768 clipped build.", _max)
+
+    # 7. Every dust gate reads a boundary field, and forcing=default supplies
+    #    none of them: ForcingData.zeros is a uniform 288.15 K land with no
+    #    snow and no soil moisture, so the land/snow/frozen/moisture gates are
+    #    all wide open and the source map alone decides — Antarctica included.
+    #    config.yaml defaults to forcing=default, so this is the out-of-the-box
+    #    combination, not an exotic one.
+    if has_jam and forcing_kind == "default" and not is_scm:
+        logger.warning(
+            "config trap: JAM prognostic aerosol with forcing=default — the "
+            "aquaplanet default_forcing carries no snow cover, soil moisture "
+            "or land temperature (uniform 288.15 K), so every dust surface "
+            "gate is open and the source map emits wherever it is non-zero, "
+            "ice sheets included. Use forcing=from_file (or forcing=amip/era5) "
+            "for a gated dust source."
+        )
+
 
 def _run_full(cfg: DictConfig, model: Model | None = None) -> ModelPredictions:
     if model is None:

--- a/jcm/runners.py
+++ b/jcm/runners.py
@@ -1766,14 +1766,7 @@ def run_chunked(
         elapsed_sim_days += cur_chunk
 
         ds = preds.to_xarray()
-        ok, report = check_health(
-            ds, chunk_idx, elapsed_sim_days,
-            # Only a COLD start's first chunk can legitimately end on step 1
-            # with the emission-wind fallback still flagged (#723); a resume
-            # carries a real 10 m wind from the checkpoint.
-            cold_start_step_seconds=(
-                float(cfg.run.time_step) * 60.0 if first_fresh_chunk else None),
-        )
+        ok, report = check_health(ds, chunk_idx, elapsed_sim_days)
         report["wall_seconds"] = chunk_wall
         reports.append(report)
         print_report(report)

--- a/jcm/runners_test.py
+++ b/jcm/runners_test.py
@@ -890,10 +890,11 @@ class TestNaturalForcingFilesConfig(unittest.TestCase):
             self.assertEqual(leaf.values.shape, shape)
             self.assertGreater(float(np.abs(np.asarray(leaf.values)).min()),
                                0.0)
-        # DMS converted nmol/L → kg/m³; dust clipped to 1.
+        # DMS converted nmol/L → kg/m³; the dust erodibility weight keeps its
+        # values above 1 (CAM's basin factor is unbounded, #768).
         self.assertAlmostEqual(float(f.dms_seawater.values[0, 0, 0]),
                                2.0 * 6.21324e-8, places=12)
-        self.assertEqual(float(f.dust_source.values.max()), 1.0)
+        self.assertEqual(float(f.dust_source.values.max()), 1.5)
         # kind=default parent keeps the aquaplanet cos²-lat SST profile.
         from jcm.forcing import default_forcing
         np.testing.assert_array_equal(
@@ -2437,7 +2438,7 @@ class TestWarnOnConfigTraps:
         cfg = self._cfg(terrain="from_file",
                         emissions_file="hf://bundles/t63/emissions_pd.nc",
                         dms_file="hf://bundles/t63/dms.nc",
-                        dust_file="hf://bundles/t63/dust.nc",
+                        dust_file="hf://bundles/t63/dust_erodibility.nc",
                         oxidants_file="hf://bundles/t63_l47/oxidants_pd.nc")
         with caplog.at_level("WARNING"):
             warn_on_config_traps(cfg, self._physics("jam_dust_emissions"), None)
@@ -3031,7 +3032,8 @@ class TestBuildForcingAutoEmissionsWiring(unittest.TestCase):
         self.assertEqual(out.get("emissions_file"),
                          "hf://bundles/t63/emissions_pd.nc")
         self.assertEqual(out.get("dms_file"), "hf://bundles/t63/dms.nc")
-        self.assertEqual(out.get("dust_file"), "hf://bundles/t63/dust.nc")
+        self.assertEqual(out.get("dust_file"),
+                         "hf://bundles/t63/dust_erodibility.nc")
         # The level-dependent oxidant bundle does not exist at l8 → auto→None.
         self.assertIsNone(out.get("oxidants_file"))
 
@@ -3095,7 +3097,8 @@ class TestBuildForcingAutoEmissionsWiring(unittest.TestCase):
         self.assertEqual(out.get("emissions_file"),
                          "hf://bundles/t63/emissions_pd.nc")
         self.assertEqual(out.get("dms_file"), "hf://bundles/t63/dms.nc")
-        self.assertEqual(out.get("dust_file"), "hf://bundles/t63/dust.nc")
+        self.assertEqual(out.get("dust_file"),
+                         "hf://bundles/t63/dust_erodibility.nc")
         # The hybrid-level oxidant bundle must NOT be pulled onto sigma.
         self.assertIsNone(out.get("oxidants_file"))
 

--- a/jcm/runners_test.py
+++ b/jcm/runners_test.py
@@ -800,6 +800,75 @@ class TestEmissionsConfig(unittest.TestCase):
                 build_forcing(cfg, coords)
 
 
+class TestDustConfigTraps(unittest.TestCase):
+    """#768: the source map and the convention that reads it must agree."""
+
+    @staticmethod
+    def _cfg(kind="cam_erodibility", forcing_kind="from_file"):
+        from omegaconf import OmegaConf
+        # Minimal, like the other trap tests: a composed cfg would drag the
+        # coords-dependent emission-key warnings in with it.
+        return OmegaConf.create({
+            "terrain": {"kind": "from_file"},
+            "forcing": {"kind": forcing_kind},
+            "physics": {"jam_dust_source": kind},
+        })
+
+    @staticmethod
+    def _physics():
+        import types
+        # _has_jam only looks for a jam_-prefixed term name.
+        return types.SimpleNamespace(terms=[
+            types.SimpleNamespace(name="jam_dust_emissions",
+                                  category="aerosol_emissions")])
+
+    def _forcing(self, values, monthly=False):
+        import types
+
+        import jax.numpy as jnp
+
+        from jcm.forcing import WRAP_YEAR, TimeSeries
+        arr = jnp.asarray(values)
+        src = (TimeSeries(values=arr[jnp.newaxis], time_seconds=jnp.zeros(1),
+                          align_mode=WRAP_YEAR) if monthly else arr)
+        return types.SimpleNamespace(dust_source=src, aerosol_year_weight=1.0,
+                                     aerosol_ann_cycle=1.0)
+
+    def test_tegen_kind_on_the_cam_map_warns(self):
+        # The CAM basin factor exceeds 1; tegen_potential would clip it back.
+        with self.assertLogs("jcm.runners", level="WARNING") as cm:
+            from jcm.runners import warn_on_config_traps
+            warn_on_config_traps(self._cfg("tegen_potential"), self._physics(),
+                                 self._forcing([[0.5, 4.4]]))
+        text = "\n".join(cm.output)
+        self.assertIn("tegen_potential", text)
+
+    def test_cam_kind_on_a_bounded_map_warns(self):
+        with self.assertLogs("jcm.runners", level="WARNING") as cm:
+            from jcm.runners import warn_on_config_traps
+            warn_on_config_traps(self._cfg(), self._physics(),
+                                 self._forcing([[0.2, 0.9]], monthly=True))
+        self.assertIn("cam_erodibility", "\n".join(cm.output))
+
+    def test_matching_kind_and_map_is_silent(self):
+        import logging
+        logger = logging.getLogger("jcm.runners")
+        with self.assertLogs(logger, level="WARNING") as cm:
+            logger.warning("sentinel")
+            from jcm.runners import warn_on_config_traps
+            warn_on_config_traps(self._cfg(), self._physics(),
+                                 self._forcing([[0.5, 4.4]]))
+        self.assertNotIn("jam_dust_source", "\n".join(cm.output))
+
+    def test_default_forcing_with_jam_warns_every_gate_is_open(self):
+        # ForcingData.zeros has no snow, soil moisture or land temperature.
+        with self.assertLogs("jcm.runners", level="WARNING") as cm:
+            from jcm.runners import warn_on_config_traps
+            warn_on_config_traps(self._cfg(forcing_kind="default"),
+                                 self._physics(), None)
+        self.assertIn("forcing=default", "\n".join(cm.output))
+
+
 class TestNaturalForcingFilesConfig(unittest.TestCase):
     """CLI/config plumbing for the DMS / dust / oxidant climatology hooks.
 

--- a/tools/benchmark_test.py
+++ b/tools/benchmark_test.py
@@ -196,7 +196,7 @@ class KeepOutputTest(unittest.TestCase):
 _MIRROR_EMISSION_BUNDLES = frozenset(
     [f"hf://bundles/{g}/{p}"
      for g in ("t63", "t106")
-     for p in ("emissions_pd.nc", "dms.nc", "dust.nc")]
+     for p in ("emissions_pd.nc", "dms.nc", "dust_erodibility.nc")]
     + [f"hf://bundles/{g}_l{lv}/oxidants_pd.nc"
        for g in ("t63", "t106") for lv in (47, 95)]
 )
@@ -233,7 +233,7 @@ class AutoEmissionPrefetchTest(unittest.TestCase):
         self.assertEqual(sorted(_auto_emission_files(cfg)), sorted([
             "hf://bundles/t63/emissions_pd.nc",
             "hf://bundles/t63/dms.nc",
-            "hf://bundles/t63/dust.nc",
+            "hf://bundles/t63/dust_erodibility.nc",
             "hf://bundles/t63_l47/oxidants_pd.nc",
         ]))
         prefetched = _preset_data_files(PRESETS["t63-echam-jam"])
@@ -259,7 +259,7 @@ class AutoEmissionPrefetchTest(unittest.TestCase):
                  "forcing.dust_file=null", "forcing.oxidants_file=null"]
         with_extra = _preset_data_files([*preset, *extra])
         for bundle in ("hf://bundles/t63/emissions_pd.nc",
-                       "hf://bundles/t63/dms.nc", "hf://bundles/t63/dust.nc",
+                       "hf://bundles/t63/dms.nc", "hf://bundles/t63/dust_erodibility.nc",
                        "hf://bundles/t63_l47/oxidants_pd.nc"):
             self.assertNotIn(bundle, with_extra)
 

--- a/tools/prep_jam_aux_inputs.py
+++ b/tools/prep_jam_aux_inputs.py
@@ -101,7 +101,11 @@ def _dust_is_clipped(path: Path) -> bool:
     """Whether a cached dust intermediate is a pre-#768 build capped at 1."""
     with xr.open_dataset(path) as ds:
         arr = ds["pot_source"].values
-    stale = bool(arr.max() == 1.0 and (arr == 1.0).sum() > 1)
+    # Same tolerant predicate as jcm.forcing._reject_truncated_erodibility: a
+    # regridded clipped map peaks a hair either side of 1, and the two checks
+    # must not diverge.
+    tol = 1e-9
+    stale = bool(arr.max() <= 1.0 + tol and (arr >= 1.0 - tol).sum() > 1)
     if stale:
         print(f"{path}: pre-#768 build (capped at 1) — regenerating")
     return stale

--- a/tools/prep_jam_aux_inputs.py
+++ b/tools/prep_jam_aux_inputs.py
@@ -99,13 +99,11 @@ def prep_dust(out: Path) -> None:
 
 def _dust_is_clipped(path: Path) -> bool:
     """Whether a cached dust intermediate is a pre-#768 build capped at 1."""
+    from jcm.forcing import is_clipped_erodibility
+
     with xr.open_dataset(path) as ds:
         arr = ds["pot_source"].values
-    # Same tolerant predicate as jcm.forcing._reject_truncated_erodibility: a
-    # regridded clipped map peaks a hair either side of 1, and the two checks
-    # must not diverge.
-    tol = 1e-9
-    stale = bool(arr.max() <= 1.0 + tol and (arr >= 1.0 - tol).sum() > 1)
+    stale = is_clipped_erodibility(arr)
     if stale:
         print(f"{path}: pre-#768 build (capped at 1) — regenerating")
     return stale

--- a/tools/prep_jam_aux_inputs.py
+++ b/tools/prep_jam_aux_inputs.py
@@ -12,9 +12,9 @@ Sources (all under /glade/campaign/cesm/cesmdata/inputdata):
 * DMS seawater concentration: ``Csw_DMS_Lana2011_f09f09_1750_2100`` — the
   Lana et al. (2011) surface-ocean climatology in nmol/L (verified constant
   across years; any 12-month block is *the* climatology).
-* Dust erodibility: ``dst_1.9x2.5_c090203.nc`` ``mbl_bsn_fct_geo`` — CAM's
-  static geomorphic mobilization-basin factor, used as the [0, 1]
-  potential-source map ``DustEmissions`` expects.
+* Dust erodibility: ``dst_0.23x0.31_c130710.nc`` ``mbl_bsn_fct_geo`` — CAM's
+  static geomorphic mobilization-basin factor (0-5.7, unbounded above), the
+  ``source_kind="cam_erodibility"`` map ``DustEmissions`` expects.
 * Oxidants: ``oxid_1.9x2.5_L26_1850-2015`` OH/NO3/O3/H2O2 [mol/mol] on CAM
   L26 hybrid levels, sampled as 12-month blocks per selected year (1849,
   1855, ..., 2005, 2015). The block nearest ``--year`` is vertically
@@ -74,9 +74,16 @@ def prep_dms(out: Path) -> None:
 
 
 def prep_dust(out: Path) -> None:
-    """Write the static erodibility map: mbl_bsn_fct_geo -> pot_source (lat, lon)."""
+    """Write the static erodibility map: mbl_bsn_fct_geo -> pot_source (lat, lon).
+
+    The basin factor is a *weight*, not a fraction: it runs to 5.7 in the
+    large closed basins that are the world's strongest dust sources, and CAM
+    (``dust_model.F90``) applies no upper bound. Only negatives / missing
+    cells are floored — capping at 1 would truncate 15 % of the global source
+    weight, disproportionately in the Sahara/Taklamakan/Arabian maxima.
+    """
     ds = xr.open_dataset(_DUST_SRC)
-    arr = np.clip(np.nan_to_num(ds["mbl_bsn_fct_geo"].values), 0.0, 1.0)
+    arr = np.maximum(np.nan_to_num(ds["mbl_bsn_fct_geo"].values), 0.0)
     out_ds = xr.Dataset(
         {"pot_source": (("lat", "lon"), arr,
                         {"units": "1",

--- a/tools/prep_jam_aux_inputs.py
+++ b/tools/prep_jam_aux_inputs.py
@@ -97,6 +97,16 @@ def prep_dust(out: Path) -> None:
     print(f"wrote {out} {dict(out_ds.sizes)} max={arr.max():.2f}")
 
 
+def _dust_is_clipped(path: Path) -> bool:
+    """Whether a cached dust intermediate is a pre-#768 build capped at 1."""
+    with xr.open_dataset(path) as ds:
+        arr = ds["pot_source"].values
+    stale = bool(arr.max() == 1.0 and (arr == 1.0).sum() > 1)
+    if stale:
+        print(f"{path}: pre-#768 build (capped at 1) — regenerating")
+    return stale
+
+
 def prep_oxidants(out: Path, year: int, nlev: int = 47) -> None:
     """Vertically remap the CAM L26 oxidant climatology onto ECHAM L47.
 
@@ -281,7 +291,10 @@ def main() -> None:
                 outdir / oxid_name]
     if not products[0].exists():
         prep_dms(products[0])
-    if not products[1].exists():
+    if not products[1].exists() or _dust_is_clipped(products[1]):
+        # Regenerate rather than reuse: a build tree from before #768 holds a
+        # base file whose weights were capped at 1, and reusing it would
+        # republish the truncated map under the corrected product name.
         prep_dust(products[1])
     if not products[2].exists():
         if args.oxid_source == "waccm":


### PR DESCRIPTION
Closes #768, closes #723. Splits out #777 (the one gate that needs a new boundary field).

Five separable defects on the **emission** side of JAM — three in dust, one in the
emitted-number conversion for every primary species, one in the wind the
surface-flux schemes read. The removal side (#722/#776) is untouched, and both
validation arms sit on the same base (`origin/dev` @ `f5c8b354`) so they are not
confounded by it.

## What was wrong, and against what

### #768.1 — the dust source map was ungated (`emissions/dust.py`)

`forcing.dust_source` is CAM's geomorphic basin factor `mbl_bsn_fct_geo`. CAM
(`dust_model.F90`) zeroes it below `soil_erod_threshold = 0.1`, applies **no upper
bound** (it runs to 5.7 in the big closed basins), and multiplies by CLM's
`dust_flux_in`, which already carries the land, snow, soil-moisture and vegetation
masks. jcm clipped it to `[0, 1]` and applied *no* mask — `terrain` was passed to
`__call__` and never used. Hence 9.8 % of global dust from south of 60 S and the
Amazon/Congo out-weighing the Sahara.

The term now applies, per column, the gates CLM applies (`DustEmisZender2003.F90`):

| factor | reference | field |
| --- | --- | --- |
| erodibility, zeroed below 0.1, unbounded above | CAM `soil_erod_threshold` | `forcing.dust_source` |
| land fraction | CLM runs on land columns | `terrain.fmask` |
| snow-free fraction | CLM `lnd_frc_mbl` | `forcing.snowc_am` |
| unfrozen fraction (ramp over the 2 K below `tmelt`) | CLM `liqfrac` | `forcing.stl_am` |
| `u*t · √(1 + 1.21·(100·(w − w_thr))^0.68)` | Fecan (1999) = CLM `frc_thr_wet_fct` | `forcing.soilw_am` |

The saltation flux itself already matched: jcm's `(1+r)(1−r²)` is White's
`(1−r)(1+r)²`, the same form CLM uses.

### #768.2 — mode split

`_MAM4_PRIMARY_EMISSION["du"]` was `(acc 0.1, cor 0.9)`; CAM's `dust_emis_sclfctr`
over the 0.1–1 µm and 1–10 µm bins is `(0.021, 0.979)` — **4.8× too much
accumulation-mode dust**. (CAM's third, 1.65e-5 Aitken share has no home in a
population whose Aitken mode carries no dust.)

### #768.3 — emitted number, for every primary species

`distributors.py` converted emitted mass to number with the mode's *equilibrium*
geometry (`ρ/number_factor` at `dgnum`). CAM and the CESM emission-file generator
both use the volume-mean diameter of the **emission** distribution,
`x_mton = 6/(π ρ D³)`:

| species / class | D [µm] | source |
| --- | ---: | --- |
| dust accumulation (0.1–1 µm bin) | 0.7806 | `dust_common::dust_set_params` |
| dust coarse (1–10 µm bin) | 3.8983 | same |
| primary carbon (BC, POA) | 0.134 | CMIP7 `num_bc_a4` / `num_pom_a4` `mapping_equation` |
| accumulation sulfate (surface, biomass) | 0.134 | `num_so4_a1_ag` |
| accumulation sulfate (energy/industry, shipping) | 0.261 | `num_so4_a1_ene_vertical`, `num_so4_a1_ship_slv` |
| Aitken sulfate | 0.0504 | `num_so4_a2_res_trs` |

For accumulation dust that is **1.54e15 #/kg against 1.17e17 — 75×**, and ~360×
combined with the split. Verified against the shipped CESM files directly: the
implied `num/mass` ratio in `num_bc_a4-em-anthro_…nc` is 4.669e17 #/kg, exactly
`6/(π·1700·(0.134e-6)³)` — i.e. **no σ-correction**, a volume-mean diameter. Every
diameter is a differentiable parameter, not static config.

### #723 — the emission wind was the lowest model level

Gong (`u10^3.41`) and Nightingale (`k_w ~ u10²`) are calibrated to the 10 m wind
(HAMMOZ passes `vphysc%velo10m`); both read `state.u_wind[-1]`, ~33 m at L47.
`TteTkeVerticalDiffusion` now publishes the ECHAM/ICON `nsurf_diag` reduction as
`VerticalDiffusionData.wind_10m`:

```
bn  = ln(z1/z0m)                              neutral profile factor
bm  = bn·√(CM_n|U| / CM|U|)                   stability-corrected
red = [ln(1 + (e^bn − 1)·10/z1) + merge] / bm
merge = −(bn − bm)·10/z1                      stable   (CM|U| < CM_n|U|)
      = −ln(1 + (e^(bn−bm) − 1)·10/z1)        unstable
```

built from the same per-tile `CM·|U|` that drives the surface stress, so the 10 m
wind cannot drift from the momentum exchange. The stable/unstable branch is picked
by `CM|U| < CM_n|U|` — exactly `Ri > 0` for both surface-layer schemes, and the two
branches meet continuously at `Ri = 0` — so no Richardson number has to be plumbed
out of the coefficient solve. The ECHAM surface term's own "10 m wind" diagnostic
was the same defect relabelled and now takes the diagnosed value.

## Before / after — 30 days, `+configuration=ma-t63-l47`, same dates, 1×A100

> **These are a January rate expressed per year, not an annual climatology.**
> Both runs are 30 days from a January start, so every number is a January
> emission rate annualised. Asian dust has a strong spring peak a January window
> cannot contain, and the per-region gate table below shows why: Taklamakan/Gobi
> is frozen (`liqfrac` 0.02) and contributes ~0 in January. An annual run should
> move **dust up** (the Asian and NH mid-latitude sources switch on in spring)
> and the **canonical-region share up** with it, since those sources sit inside
> the boxes. An annual number belongs in the release-validation matrix; what
> these runs establish is the before/after *contrast* on identical dates.

| quantity | before (`origin/dev`) | after (`aba155cc`) | target |
| --- | ---: | ---: | --- |
| dust emission | 5421 Tg/yr | **1263 Tg/yr** | 1000–4000 |
| sea-salt emission | 1130 Tg/yr | **768.9 Tg/yr** (−32 %) | ≈ −30 % |
| DMS flux | 38.8 Tg/yr | 32.5 Tg/yr (−16 %) | −20…−25 % |
| dust south of 60 S | 9.76 % | **0.000 %** | ≈ 0 |
| dust over ocean | 0.65 % | 0.12 % | ≈ 0 |
| six canonical source regions | 19.6 % | **57.6 %** | majority |
| Sahara / Australia | 7.3 % / 7.8 % | 30.9 % / 19.8 % | maxima here |
| annual-mean max | 34.5 S 303.8 E | **14.0 N 16.9 E** (Sahel/Sahara) | desert |
| dust accum : coarse mass | 0.111 | **0.0215** | CAM 0.0215 |
| dust accum : coarse number | 668 | **2.67** | CAM 2.67 |

The residual 0.12 % "over ocean" is fractional-coastline land (`fmask > 0` in
cells the mask calls ocean), not ocean emission.

**Emission-wind provenance, per chunk** (`wind_10m_model_level`, the #723
bootstrap flag — reported, not fatal):

| chunk | 0 | 1 | 2 | 3 | 4 | 5 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| day | 5 | 10 | 15 | 20 | 25 | 30 |
| model-level | **0.208 %** | 0.000 % | 0.000 % | 0.000 % | 0.000 % | 0.000 % |

0.208 % is exactly 1/480 — one step of a 5-day chunk at dt = 15 min, the single
legitimate cold-start fallback — and exactly zero thereafter. That is the
bootstrap-only property measured end to end, not inferred from unit tests.

Maps: `emi_du_before.png`, `emi_du_after4.png`, `dust_source_options.png`,
`emi_maps_{before,after4}.npz` under the session scratchpad `.../emis_audit/`.

## The dust-source option — a maintainer decision point

`physics.jam_dust_source` selects which convention the map follows, **default
`cam_erodibility`** (what the mirror ships):

* `cam_erodibility` — CAM's basin factor: threshold at 0.1, no upper bound.
* `tegen_potential` — a HAMMOZ potential-source *fraction* in `[0, 1]` whose own
  preprocessing embeds the land-cover mask, so no threshold is applied.

The HAMMOZ `dust_potential_sources_T63.nc` that `read_dust_source` has always
advertised **exists nowhere** — not in the repo, on `$SCRATCH`, on `/glade/campaign`,
nor anywhere in the mirror's 45,138 files. So the option is wired and documented,
but there is no second file to run today. What such a map would buy is quantified
offline in #777: multiplying the gated CAM map by CLM's `1 − VAI/0.3` mobilization
fraction (built from `surfdata_1.9x2.5_16pfts_simyr2000`) keeps 19.9 % of the global
source weight and moves it decisively — Sahara 10.0 → 36.6 %, Taklamakan/Gobi
5.0 → 17.1 %, Amazon 8.3 → 0.04 %, Congo 3.9 → 0.03 %, south of 60 S 8.9 → 0.4 %.
**That vegetation gate is the one CLM factor this PR cannot reproduce** (no LAI or
land-cover field exists on `ForcingData`/`TerrainData`), which is why it is split
out as #777 rather than approximated here: it needs a data product, a mirror bundle
and its own validation.

## Data: the published erodibility map was also clipped

`tools/prep_jam_aux_inputs.py` capped the map at 1 when it built it, so the
declipping is half a code fix and half a data fix. Both halves are here:

* the prep tool floors only;
* the corrected map is published as a **new product**,
  `bundles/<grid>/dust_erodibility.nc` (t63 + t106), *not* by re-staging
  `dust.nc` — `jcm.data.remote.fetch` is cache-first and never revalidates, so
  overwriting in place would leave every warm cache silently on the truncated file.
  `mirror_manifest.json` was regenerated with `--stage manifest` (it is pinned by
  `mirror_manifest_test.py`), so `forcing.dust_file=auto` now resolves the corrected
  map; the legacy file stays for reproducibility.
* and because nothing downstream can tell a truncated map from a correct one,
  `read_dust_source` **refuses** one: a file whose own metadata says it is the CAM
  product (`mbl_bsn_fct_geo` / `dst_*.nc`) whose maximum sits at exactly 1.0 across
  many cells is the pre-#768 build, and the error names the rebuild command. A
  genuine `[0, 1]` Tegen map has different provenance and is unaffected; a correct
  CAM build peaks at 4.4 and never trips it. So a missing corrected product fails
  loudly instead of silently reverting the fix.

**Published and verified.** Through the documented pipeline —
`--stage manifest`, `--stage registry` (45,138 entries), `--stage upload` — not by
hand. Cold-cache resolve of both new products, with the sha256 checked against the
registry:

```
bundles/t63/dust_erodibility.nc   -> snapshots/35d3bddc…/bundles/t63/dust_erodibility.nc
  sha256 65836cbc…de83  == registry, size 157933 == 157933
bundles/t106/dust_erodibility.nc  -> snapshots/35d3bddc…/bundles/t106/dust_erodibility.nc
  sha256 b5165001…5870  == registry, size 421102 == 421102
pot_source max = 4.3996   (a clipped build would be 1.0)
VERIFY OK
```

The file the validation runs used is byte-identical to the published product and
to the registry entry (same `65836cbc…` sha256), so what ships is what was
validated. `dust_file=auto` now resolves the corrected map; the legacy `dust.nc`
stays on the mirror for reproducibility and is refused by the reader on every
grid.

## Tests

New/changed: dust source gating (a synthetic map with an Antarctic, an ocean, a
sub-threshold and a >1 cell), the CAM mode split and `x_mton` number conversion
against CAM's numbers, the Fecan factor and its gradient at the threshold, the
`nsurf_diag` reduction against a hand-computed neutral log profile (0.912/0.904/
0.894 for z0 = 5e-5/1.5e-4/5e-4 at z1 = 32.6 m) plus stability monotonicity and
branch continuity, sea-salt/DMS reading the diagnosed wind, per-sector emission
sizes against the CESM files, gradient checks on every new parameter, and a
column-vs-batch agreement check.

Two existing expectations changed *because the reference values changed*: the
forcing-reader tests now assert that an erodibility weight of 1.5 is **preserved**
rather than capped, and the two JAM integration tests run 6 steps instead of 3 —
on a cold start with no seeded aerosol the emission → transport → core →
activation chain needs several steps to produce anything, and at 3 steps those
assertions were measuring cold-start spin-up rate (they tipped to exactly zero on
a 26 % lower, *correct* sea-salt flux). At 6 steps they have more margin than the
3-step numbers ever had (`activated_cdnc` 137 vs 61).

## Gates

`ruff check .` clean. **Gates passed on the tip `d4017300`:**

| gate | result | coverage |
| --- | --- | --- |
| fast (≥90 %) | 2470 passed, 28 skipped | **95.23 %** |
| slow (≥80 %) | 104 passed, 17 skipped | **84.32 %** |

Run in a worktree detached at that commit, not the working tree, so a mid-run
edit cannot contaminate the result — which had happened three times before I
took the `jcm-local-ci` skill's own advice.

Run in a worktree detached at that commit rather than the working tree, so the
result cannot be contaminated by edits landing mid-run — which had happened
three times before I took the `jcm-local-ci` skill's own advice to give the PBS
job its own worktree. (Both gates need `PYTHONPATH=~/dinosaur-sl` in the job or
every dycore test fails on the missing semi-Lagrangian transport — a harness
detail, not a code change.)

Validation: 2 x 30-day T63L47 GPU runs on identical dates
(`$SCRATCH/jam_runs/fix768_{before,after}`), `NaN vars: 0/281` on every chunk of
both. The review's finding 2 changed a default (the Fecan gravimetric mapping,
0.303 → 0.202), so the table above is being regenerated on the final tree.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4x2keECpxEf5JvJ5rM3ty
