### PR TITLE
deps: pin dinosaur>=1.5.0 (semi-Lagrangian core released) and enforce the floor at construction

### DIFF
--- a/.claude/skills/derecho-jcm-runs/SKILL.md
+++ b/.claude/skills/derecho-jcm-runs/SKILL.md
@@ -75,19 +75,18 @@ not under the default run config.
 
 ```bash
 source ~/.venvs/jaxgcm/bin/activate
-export PYTHONPATH=~/dinosaur-sl:$REPO     # SL dinosaur; jcm worktree wins over the venv's editable install
+export PYTHONPATH=$REPO                   # jcm worktree wins over the venv's editable install
 export JAX_PLATFORMS=cuda,cpu
 export MAM4_JAX_ENABLE_X64=0              # f32 MAM4 core (forward-only); f64 default is much slower
 export XLA_PYTHON_CLIENT_MEM_FRACTION=0.93   # 0.85 when ngpus>1 — 0.93 starves CUDA command buffers
 ```
 
-Overridable site paths: `JCM_REPO`, `JCM_VENV`, `JCM_DINOSAUR`, `JAM_INPUTS`,
+Overridable site paths: `JCM_REPO`, `JCM_VENV`, `JAM_INPUTS`,
 `JCM_EMISSIONS`, `PBS_ACCOUNT`, `SCRATCH`.
 
-Transport is always semi-Lagrangian (the Eulerian path was removed) and
-requires a dinosaur carrying PR #135 (`JCM_DINOSAUR`, `~/dinosaur-sl` by
-default). Without it the dycore raises a clear install-instruction error;
-there is no fallback.
+Transport is always semi-Lagrangian (the Eulerian path was removed); the
+venv's dinosaur must be `>= 1.5.0` (`requirements.txt`). Without it the dycore
+raises a clear install-instruction error; there is no fallback.
 
 ## 4. Input data
 

--- a/.claude/skills/derecho-jcm-runs/scripts/mkjob.py
+++ b/.claude/skills/derecho-jcm-runs/scripts/mkjob.py
@@ -23,7 +23,6 @@ USER = os.environ.get("USER", "")
 SCRATCH = os.environ.get("SCRATCH", f"/glade/derecho/scratch/{USER}")
 DEFAULT_REPO = os.environ.get("JCM_REPO", f"{HOME}/jax-gcm-pyses")
 DEFAULT_VENV = os.environ.get("JCM_VENV", f"{HOME}/.venvs/jaxgcm")
-DEFAULT_DINOSAUR = os.environ.get("JCM_DINOSAUR", f"{HOME}/dinosaur-sl")
 DEFAULT_ACCOUNT = os.environ.get("PBS_ACCOUNT", "UCSD0085")
 JAM_INPUTS = os.environ.get("JAM_INPUTS", f"{SCRATCH}/jam_inputs")
 EMISSIONS = os.environ.get(
@@ -146,7 +145,7 @@ def check_compose(a, overrides) -> None:
              if not o.startswith(("run.output", "hydra.run.dir", "+run.checkpoint"))],
            "--cfg", "job"]
     env = {**os.environ, "JAX_PLATFORMS": "cpu",
-           "PYTHONPATH": f"{a.dinosaur}:{a.repo}"}
+           "PYTHONPATH": a.repo}
     r = subprocess.run(cmd, cwd=a.repo, env=env, capture_output=True, text=True)
     if r.returncode != 0:
         sys.exit("COMPOSE FAILED:\n" + (r.stderr or r.stdout)[-2000:])
@@ -232,7 +231,6 @@ def main(argv=None) -> None:
     p.add_argument("--extra", default="", help="raw Hydra overrides")
     p.add_argument("--repo", default=DEFAULT_REPO)
     p.add_argument("--venv", default=DEFAULT_VENV)
-    p.add_argument("--dinosaur", default=DEFAULT_DINOSAUR)
     p.add_argument("--check", action="store_true",
                    help="compose the config before emitting the script")
     a = p.parse_args(argv)
@@ -268,7 +266,7 @@ RUNDIR={rundir}
 mkdir -p "$RUNDIR"
 source {a.venv}/bin/activate
 cd "$REPO"
-export PYTHONPATH={a.dinosaur}:$REPO
+export PYTHONPATH=$REPO
 export JAX_PLATFORMS=cuda,cpu
 export MAM4_JAX_ENABLE_X64=0
 export XLA_PYTHON_CLIENT_MEM_FRACTION={frac}

--- a/.claude/skills/devbox-jcm-runs/SKILL.md
+++ b/.claude/skills/devbox-jcm-runs/SKILL.md
@@ -98,7 +98,7 @@ PY=/home/dwatsonparris/micromamba/envs/jcm/bin/python   # NOT on PATH
 # or: eval "$(micromamba shell hook --shell bash)" && micromamba activate jcm
 ```
 
-`jcm`, `jax-rrtmgp`, `dinosaur` and `mam4-jax` are **editable installs, so the
+`jcm`, `jax-rrtmgp` and `mam4-jax` are **editable installs, so the
 working tree is the running code**. Check what you are actually running:
 
 ```bash

--- a/.claude/skills/jcm-benchmark/SKILL.md
+++ b/.claude/skills/jcm-benchmark/SKILL.md
@@ -172,7 +172,7 @@ output times dies in `to_xarray()` with an opaque
 
 ## A/B'ing a library version
 
-`jcm`, `jax-rrtmgp`, `dinosaur` and `mam4-jax` are **editable installs — the
+`jcm`, `jax-rrtmgp` and `mam4-jax` are **editable installs — the
 working tree is the running code.** Never `git checkout` a different branch in
 the shared clone to benchmark it; that silently changes the code under anyone
 else's concurrent run.
@@ -201,7 +201,7 @@ do: a six-config sweep here had jax-rrtmgp switch from a feature branch to
 `main` between config 1 and config 2 because someone merged a PR, so the two
 were measuring different radiation code. Nothing failed; the numbers were
 simply incomparable. It was caught only because the report records resolved
-SHAs. Put all of `jcm`, `jax-rrtmgp`, `dinosaur` and `mam4-jax` on
+SHAs. Put all of `jcm`, `jax-rrtmgp` and `mam4-jax` on
 `--pythonpath` as pinned worktrees for any run whose numbers you intend to
 compare across hours.
 

--- a/.claude/skills/jcm-run/SKILL.md
+++ b/.claude/skills/jcm-run/SKILL.md
@@ -153,7 +153,7 @@ reintroduce the assumption in either direction.)
   check_health → to_netcdf → save_checkpoint`, so a crash here loses the whole
   chunk with no checkpoint. Fix by adding the dotted key to
   `ComposablePhysics._EXCLUDED_OUTPUT_KEYS` or registering a band coord.
-- **Editable installs**: `jcm`, `jax-rrtmgp`, `dinosaur` and `mam4-jax` are
+- **Editable installs**: `jcm`, `jax-rrtmgp` and `mam4-jax` are
   installed editable, so **the working tree is the running code**. Check
   `git -C <repo> rev-parse --abbrev-ref HEAD` before trusting any result. The
   site skills cover how to A/B a library version safely (worktree +

--- a/.claude/skills/kubernetes-jcm-runs/scripts/mkjob.py
+++ b/.claude/skills/kubernetes-jcm-runs/scripts/mkjob.py
@@ -32,12 +32,6 @@ import sites as site_profile  # noqa: E402  (local module)
 REPOS = {
     "jcm": ("https://github.com/climate-analytics-lab/jax-gcm",
             "feat/derecho-runs-skill"),
-    # shoyer's semi-lagrangian branch, NOT neuralgcm/dinosaur main: the
-    # SemiLagrangianPrimitiveEquationsHybrid class the SL dycore needs lives
-    # in PR #135 and is not upstream. Pointing at upstream main gets a clone
-    # that imports fine and then fails at model construction with
-    # AttributeError — which is how this was found.
-    "dinosaur-sl": ("https://github.com/shoyer/dinosaur", "semi-lagrangian"),
     "jax-rrtmgp": ("https://github.com/climate-analytics-lab/jax-rrtmgp",
                    "main"),
     # Required by every echam-jam preset and NOT present in the published
@@ -165,7 +159,7 @@ def job(preset: str, a) -> dict:
         for d, (url, sha) in a._resolved.items()
     )
     pythonpath = ":".join(
-        f"/work/{d}" for d in ("dinosaur-sl", "jax-rrtmgp", "mam4-jax"))
+        f"/work/{d}" for d in ("jax-rrtmgp", "mam4-jax"))
     bench = (
         f"python /work/jcm/tools/benchmark.py --preset {preset} "
         f"--months {a.months} --gpu 0 --chunk-days {a.chunk_days} "

--- a/.claude/skills/kubernetes-jcm-runs/scripts/mkrun.py
+++ b/.claude/skills/kubernetes-jcm-runs/scripts/mkrun.py
@@ -30,12 +30,6 @@ import sites as site_profile  # noqa: E402  (local module)
 REPOS = {
     "jcm": ("https://github.com/climate-analytics-lab/jax-gcm",
             "feat/derecho-runs-skill"),
-    # shoyer's semi-lagrangian branch, NOT neuralgcm/dinosaur main: the
-    # SemiLagrangianPrimitiveEquationsHybrid class the SL dycore needs lives
-    # in PR #135 and is not upstream. Pointing at upstream main gets a clone
-    # that imports fine and then fails at model construction with
-    # AttributeError — which is how this was found.
-    "dinosaur-sl": ("https://github.com/shoyer/dinosaur", "semi-lagrangian"),
     "jax-rrtmgp": ("https://github.com/climate-analytics-lab/jax-rrtmgp",
                    "main"),
     # Required by every echam-jam preset and NOT present in the published
@@ -101,7 +95,7 @@ def build(a, resolved) -> dict:
         for d, (url, sha) in resolved.items()
     )
     pythonpath = ":".join(
-        f"/work/{d}" for d in ("dinosaur-sl", "jax-rrtmgp", "mam4-jax"))
+        f"/work/{d}" for d in ("jax-rrtmgp", "mam4-jax"))
     overrides = " ".join([
         f"physics={a.physics}",
         f"grid={a.grid}",

--- a/.claude/skills/kubernetes-jcm-runs/scripts/sites.py
+++ b/.claude/skills/kubernetes-jcm-runs/scripts/sites.py
@@ -58,8 +58,9 @@ NAUTILUS = {
     # the pod rather than on a workstation: gcsfs pulls a newer fsspec, and
     # upgrading fsspec in a shared conda env risks the ``hf://`` mirror path
     # huggingface_hub resolves. A pod env is disposable; a shared one is not.
-    "extra_pip": ["diffrax>=0.7", "matplotlib", "huggingface_hub",
-                  "gcsfs", "zarr"],
+    # dinosaur: the image may carry a release older than jcm's >= 1.5.0 pin.
+    "extra_pip": ["dinosaur>=1.5.0", "diffrax>=0.7", "matplotlib",
+                  "huggingface_hub", "gcsfs", "zarr"],
 }
 
 # A new site must supply every key above. The ones most likely to differ:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ pip install -e .
 ```
 
 JCM requires Python 3.11 or newer. The full dependency set is listed in
-[`requirements.txt`](requirements.txt), including JAX, Flax, Dinosaur,
+[`requirements.txt`](requirements.txt), including JAX, Flax, Dinosaur (≥ 1.5.0),
 Hydra, xarray, and optional RRTMGP support.
 
 ## Quick Start

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -26,7 +26,7 @@ Requirements
 
 - Python ≥ 3.11
 - JAX
-- Dinosaur (the dynamical-core backend shipped with v2.0)
+- Dinosaur ≥ 1.5.0 (the dynamical-core backend)
 - XArray (for I/O and data handling)
 
 See ``requirements.txt`` for the complete list of dependencies.

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -1,6 +1,15 @@
 Release Notes
 =============
 
+Unreleased — dinosaur pinned to a release
+-----------------------------------------
+
+- ``requirements.txt`` requires ``dinosaur>=1.5.0`` instead of the
+  semi-Lagrangian development branch, so jcm can be published to PyPI again.
+  1.5.0 also fixes the hybrid-coordinate temperature equation
+  (neuralgcm/dinosaur#144), so results on ECHAM hybrid levels differ from
+  runs made with earlier dinosaur builds; sigma-level runs are unchanged.
+
 Unreleased — packaged config tree contract; ``experiment`` group renamed
 ------------------------------------------------------------------------
 

--- a/jcm/dycore/dinosaur/dycore.py
+++ b/jcm/dycore/dinosaur/dycore.py
@@ -67,10 +67,8 @@ def physics_specs_from_constants(
 PHYSICS_SPECS = physics_specs_from_constants(PhysicalConstants.default())
 
 
-#: Semi-Lagrangian transport classes jcm requires from dinosaur. They live in
-#: neuralgcm/dinosaur#135 and are not in a released dinosaur yet, so until that
-#: lands the backend needs the fork (``shoyer/dinosaur`` @ ``semi-lagrangian``)
-#: on the path. Pin a minimum dinosaur here once it ships.
+#: Semi-Lagrangian transport classes jcm requires from dinosaur (released in
+#: 1.4.0; ``requirements.txt`` pins >= 1.5.0 for the hybrid-level fix).
 _SL_CLASSES = (
     "SemiLagrangianPrimitiveEquations",
     "SemiLagrangianPrimitiveEquationsHybrid",
@@ -105,10 +103,9 @@ def _require_semi_lagrangian() -> None:
         f"({', '.join(missing)} missing), and jcm's dinosaur backend now "
         "requires it — the Eulerian path has been removed because it rang "
         "negative on sharp sources and NaN'd aerosol microphysics (#521). "
-        "Install the fork until neuralgcm/dinosaur#135 is released:\n"
-        "    pip install 'dinosaur @ git+https://github.com/shoyer/dinosaur"
-        "@semi-lagrangian'\n"
-        "or put a clone of that branch on PYTHONPATH."
+        "Install a current release:\n"
+        "    pip install 'dinosaur>=1.5.0'\n"
+        "and remove any older dinosaur checkout from PYTHONPATH."
     )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,11 @@
 # jcm's dinosaur backend transports tracers semi-Lagrangian ONLY — the
 # Eulerian spectral path was removed because it rang negative on sharp
 # emission sources and NaN'd the aerosol microphysics (#521). The SL core
-# lives in neuralgcm/dinosaur#135 and is not in a released dinosaur yet, so
-# until it ships we install the branch it was developed on.
-#
-# BEFORE RELEASE: replace with a pinned released version, e.g.
-# ``dinosaur>=X.Y`` — a VCS requirement cannot be published to PyPI and
-# makes the wheel uninstallable for downstream users (see #577).
-dinosaur @ git+https://github.com/shoyer/dinosaur@semi-lagrangian
+# (neuralgcm/dinosaur#135) is in dinosaur >= 1.4.0; 1.5.0 also fixes the
+# hybrid-coordinate temperature equation (neuralgcm/dinosaur#144), which
+# ECHAM's hybrid levels depend on, so results on those levels differ from
+# runs made with earlier builds.
+dinosaur>=1.5.0
 # Floor is 0.12.1: that release ADDED `nnx.Variable.get_value()` and deprecated
 # the `.value` property in its favour. jcm reads every nnx.Param/nnx.Variable
 # through `.get_value()` (~94 sites under jcm/physics/**), so on exactly 0.12.0

--- a/tools/release_validation/launch.py
+++ b/tools/release_validation/launch.py
@@ -186,7 +186,7 @@ PBS = """#!/bin/bash
 #PBS -o {logdir}/{name}.log
 set -euo pipefail
 source {venv}/bin/activate
-export PYTHONPATH={dinosaur}:{repo}
+export PYTHONPATH={repo}
 export JAX_PLATFORMS=cuda,cpu
 export MAM4_JAX_ENABLE_X64=0
 export XLA_PYTHON_CLIENT_MEM_FRACTION=0.93
@@ -221,7 +221,6 @@ def main(argv=None):
     repo = str(Path(a.repo).resolve())
     scratch = os.environ.get("SCRATCH", f"{HOME}/scratch")
     venv = os.environ.get("JCM_VENV", f"{HOME}/.venvs/jaxgcm")
-    dinosaur = os.environ.get("JCM_DINOSAUR", f"{HOME}/dinosaur-sl")
     outdir = Path(repo) / "runs"
     outdir.mkdir(exist_ok=True)
 
@@ -244,7 +243,7 @@ def main(argv=None):
             overrides(tag, m, d, rundir) + [f"hydra.run.dir={rundir}"])
         job = PBS.format(
             name=tag, account=a.account, hours=m.get("hours", d["hours"]),
-            logdir=str(outdir), venv=venv, dinosaur=dinosaur, repo=repo,
+            logdir=str(outdir), venv=venv, repo=repo,
             rundir=rundir, ovs=ovs, marker=f"{tag.upper()}_COMPLETE",
         )
         path = outdir / f"{tag}.pbs"


### PR DESCRIPTION
Refs #577. `dinosaur @ git+https://github.com/shoyer/dinosaur@semi-lagrangian` → `dinosaur>=1.5.0`, so jcm can be published to PyPI again.

The semi-Lagrangian core (neuralgcm/dinosaur#135) shipped in dinosaur 1.4.0; the floor is 1.5.0 because that release also fixes the hybrid-coordinate temperature equation (neuralgcm/dinosaur#144). Consequence worth knowing: **results on ECHAM hybrid levels differ from runs made with the development branch** (6-hour T31L47 grey run: 0.035 K RMS in temperature, 5–13 % of the wind RMS); sigma-level runs are bitwise identical. The validated JAM configuration's numbers predate the fix and are re-measured by #780; the stored T63L47 hybrid test fixtures likewise (#789, needs GPU time).

The run tooling (Derecho skill, Kubernetes skill, `tools/release_validation/launch.py`) stops putting a fork checkout on `PYTHONPATH`; the installed dinosaur is the one that runs. Kubernetes pods pip-install `dinosaur>=1.5.0` since the image may carry an older release. Local installs need a one-time `pip install -U 'dinosaur>=1.5.0'`.

Every kwarg jcm passes to the SL classes exists in 1.5.0, and `semi_lagrangian_crank_nicolson_rk2` is unchanged from the branch. Verified in a fresh venv built from `requirements.txt` (dinosaur 1.5.0 from PyPI): fast suite 2376 passed at 92.3 % coverage with only the two macOS-only failures of #784; slow suite 91 passed at 79.68 %, the same figure dev's slow job reports (#786).

Merge before #769/#775/#780 rebase: #775 can drop its `local_ci.sh` PYTHONPATH commit, #780 the `JCM_DINOSAUR` plumbing, and #577's pin commits are superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
