### PR TITLE
skills: adversarial self-review before every push that changes code

### DIFF
--- a/.claude/skills/jcm-dev-workflow/SKILL.md
+++ b/.claude/skills/jcm-dev-workflow/SKILL.md
@@ -79,13 +79,18 @@ lost (hours, with CI in the loop). So before `git push`, on the branch:
 Treat the output exactly like a Codex review (step 6): fix every CONFIRMED
 finding, sweep for the same mistake elsewhere, and for anything you decide
 not to change record *why* in the commit or PR body — a finding refuted once
-locally is not re-argued with Codex later. If the fixes were more than
-trivial, run it again. Only then push. If a diff must go up before the
-review is clean (to share it, to reach GPU CI), open the PR as a **draft**
-and say so in the body; the rule still applies to the next push.
+locally is not re-argued with Codex later. Every fix the review produces
+goes back through step 2 — `ruff check .` and the tests — before the push:
+a review-suggested change is untested code until it does. If the fixes
+were more than trivial, run the review again too. Only then push. If a
+diff must go up before the review is clean (to share it, to reach GPU CI),
+open the PR as a **draft** and say so in the body; the rule still applies
+to the next push.
 
-Scope: any change to code — `jcm/`, `tools/`, `.claude/skills/*/scripts`,
-workflows. Docs-only and comment-only changes are exempt.
+Scope: any change to executable code, wherever it lives — `jcm/`, `tools/`,
+`utils/`, `validation/`, `docs/generate_docs.py`, `.claude/skills/*/scripts`,
+workflows, root scripts such as `run_benchmarks.sh`; the list is
+illustrative, not a boundary. Docs-only and comment-only changes are exempt.
 
 ## 4. Push and open the PR
 

--- a/.claude/skills/jcm-dev-workflow/SKILL.md
+++ b/.claude/skills/jcm-dev-workflow/SKILL.md
@@ -9,8 +9,9 @@ The loop, in order. Each step exists because skipping it costs a CI cycle, a
 review round, or a wrong result.
 
 ```
-branch → atomic commits → test + lint locally → push → PR (linked to issue)
-   → monitor CI *and* Codex → fix/respond → re-review if substantial → ping human
+branch → atomic commits → test + lint locally → adversarial self-review → push
+   → PR (linked to issue) → monitor CI *and* Codex → fix/respond
+   → re-review if substantial → ping human
 ```
 
 ## 1. Work locally, committing atomically
@@ -65,7 +66,28 @@ run**, not just green tests. Verify conservation/physical correctness, and for
 anything performance-related use `jcm-benchmark` — never quote the cumulative
 `sim days/hr` line.
 
-## 3. Push and open the PR
+## 3. Adversarial self-review — before the first push, and before any re-push that changes code
+
+Codex reviews every push and its credits are finite. A finding Codex makes
+that a local reviewer would have made is a credit burnt and a review round
+lost (hours, with CI in the loop). So before `git push`, on the branch:
+
+```
+/code-review high        # multi-angle finders + one verifier per finding, diff vs upstream
+```
+
+Treat the output exactly like a Codex review (step 6): fix every CONFIRMED
+finding, sweep for the same mistake elsewhere, and for anything you decide
+not to change record *why* in the commit or PR body — a finding refuted once
+locally is not re-argued with Codex later. If the fixes were more than
+trivial, run it again. Only then push. If a diff must go up before the
+review is clean (to share it, to reach GPU CI), open the PR as a **draft**
+and say so in the body; the rule still applies to the next push.
+
+Scope: any change to code — `jcm/`, `tools/`, `.claude/skills/*/scripts`,
+workflows. Docs-only and comment-only changes are exempt.
+
+## 4. Push and open the PR
 
 ```bash
 git push -u origin <branch>
@@ -82,7 +104,7 @@ anything performance-affecting, and what you verified. Implementation-specific
 detail and gotchas go here; general design goes in `docs/source/design/` per
 `CLAUDE.md`.
 
-## 4. Monitor CI *and* Codex — both, from one watcher
+## 5. Monitor CI *and* Codex — both, from one watcher
 
 A Codex review arrives **automatically** on push; it is not triggered by you.
 Watch for both, because green CI with unaddressed Codex findings is not done.
@@ -105,7 +127,7 @@ has landed. Make the filter cover **failure signatures too** — a watcher that
 matches only success is silent through a crash, which looks exactly like
 "still running".
 
-## 5. Fix CI, respond to Codex
+## 6. Fix CI, respond to Codex
 
 Fix every CI failure. Do not re-push hoping it was a flake; if you believe it
 is one, say why.
@@ -159,7 +181,7 @@ passed in, aliased, or defaulted. When the invariant is about *provenance*
 ("is this value the post-physics one?"), follow the values, not the
 spellings.
 
-## 6. Re-request review when the response is substantial
+## 7. Re-request review when the response is substantial
 
 If the fixes were more than trivial, ask for another pass with a comment
 containing exactly:
@@ -168,10 +190,10 @@ containing exactly:
 @codex review
 ```
 
-Then monitor again (step 4). Repeat until a review comes back with nothing
+Then monitor again (step 5). Repeat until a review comes back with nothing
 material.
 
-## 7. Hand back to the human only when green
+## 8. Hand back to the human only when green
 
 Ping the user for review once **all** of:
 

--- a/.claude/skills/jcm-local-ci/SKILL.md
+++ b/.claude/skills/jcm-local-ci/SKILL.md
@@ -54,11 +54,15 @@ budget. GitHub's runners tolerate the serial run; Derecho's do not.
 (`docs/source/design/test_suite_memory.md` covers the related growth in
 retained XLA executables that the root `conftest.py` bounds.)
 
-## Local Claude review
+## Local Claude review — run it BEFORE pushing
 
 In a Claude Code session on the branch: `/code-review high` reviews the
 diff vs upstream with multi-agent finders + verification — no Actions
-minutes, billed to the Claude session. For the deep cloud variant use
+minutes, billed to the Claude session. This is the adversarial self-review
+`jcm-dev-workflow` step 3 requires before every push that changes code:
+Codex credits are finite, and a finding Codex makes that this review would
+have made is a credit burnt and a round lost. Fix or explicitly refute every
+finding before `git push`. For the deep cloud variant use
 `/code-review ultra` (user-triggered, separately billed).
 
 ## Codex review comments: always reply inline

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,6 +234,11 @@ JAX_PLATFORMS=cpu pytest -n 4  -m "slow" --cov=jcm \
     --cov-config=.coveragerc-pr --cov-fail-under=80
 ```
 
+Then review your own diff adversarially **before pushing** — `/code-review
+high` on the branch, fix or refute every finding (`jcm-dev-workflow` step 3).
+Codex credits are finite and a CI review round takes hours; a finding caught
+locally costs neither.
+
 Two traps the gates exist to catch. `JAX_PLATFORMS=cpu` is REQUIRED on GPU
 hosts (every xdist worker otherwise grabs the same GPU and XLA fails with
 `CUDA_ERROR_OUT_OF_MEMORY`). And coverage must be measured at **CI


### PR DESCRIPTION
Codex reviews every push and its credits are finite (they ran out on 2026-09-09). Several recent Codex findings were the kind a local adversarial pass catches, so make that pass a required step of the workflow rather than an optional note.

- `jcm-dev-workflow` gains step 3: run `/code-review high` on the branch before the first push and before any re-push that changes code; fix every CONFIRMED finding, sweep for the same mistake elsewhere, record why anything is left unchanged; re-run if fixes were substantial; open as a draft if a diff must go up early. Scope is code (`jcm/`, `tools/`, skill scripts, workflows); docs-only changes are exempt.
- `jcm-local-ci`'s "Local Claude review" section says to run it *before* pushing and points at that step.
- `CLAUDE.md`'s gate list gets the same sentence.

Docs-only, so exempt from the rule it introduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)