### PR TITLE
docs: pick the local reviewer by the session's model — /code-review forks on the parent

### DIFF
--- a/.claude/skills/jcm-dev-workflow/SKILL.md
+++ b/.claude/skills/jcm-dev-workflow/SKILL.md
@@ -76,6 +76,13 @@ lost (hours, with CI in the loop). So before `git push`, on the branch:
 /code-review high        # multi-angle finders + one verifier per finding, diff vs upstream
 ```
 
+**Only from an Opus or Sonnet session.** `/code-review` forks the invoking
+session on the same model with its full context, and fans out the same way;
+from a Fable session it spends Fable tokens at full context and has exhausted
+a session limit. On a Fable session run the same review as an explicit
+`model: opus` general-purpose agent that posts one `gh pr review --comment`
+(recipe in `jcm-local-ci`, "Local Claude review").
+
 Treat the output exactly like a Codex review (step 6): fix every CONFIRMED
 finding, sweep for the same mistake elsewhere, and for anything you decide
 not to change record *why* in the commit or PR body — a finding refuted once

--- a/.claude/skills/jcm-local-ci/SKILL.md
+++ b/.claude/skills/jcm-local-ci/SKILL.md
@@ -54,16 +54,32 @@ budget. GitHub's runners tolerate the serial run; Derecho's do not.
 (`docs/source/design/test_suite_memory.md` covers the related growth in
 retained XLA executables that the root `conftest.py` bounds.)
 
-## Local Claude review — run it BEFORE pushing
+## Local Claude review — run it BEFORE pushing, on the right model
 
-In a Claude Code session on the branch: `/code-review high` reviews the
-diff vs upstream with multi-agent finders + verification — no Actions
-minutes, billed to the Claude session. This is the adversarial self-review
-`jcm-dev-workflow` step 3 requires before every push that changes code:
-Codex credits are finite, and a finding Codex makes that this review would
-have made is a credit burnt and a round lost. Fix or explicitly refute every
-finding before `git push`. For the deep cloud variant use
-`/code-review ultra` (user-triggered, separately billed).
+The adversarial self-review `jcm-dev-workflow` step 3 requires before every
+push that changes code: Codex credits are finite, and a finding Codex makes
+that this review would have made is a credit burnt and a round lost. Fix or
+explicitly refute every finding before `git push`.
+
+**Which reviewer depends on the session's model.** `/code-review high` forks
+the invoking session — same model, full conversation context inherited — and
+its finders and verifiers fan out the same way, so it is billed to *that*
+session at full context. It exhausted a Fable session limit twice on
+2026-09-10 (the failure notices name the model:
+`model sent to the API: claude-fable-5-1`).
+
+- **Opus or Sonnet session:** `/code-review high` on the branch, as before.
+- **Fable session:** do not invoke the skill. Spawn a general-purpose agent
+  with `model: opus`, give it the same scope (reference formulation, JAX
+  hygiene, tests, docs, comment style, diff vs upstream), and have it post one
+  review via `gh pr review <PR> --comment --body-file <file>`. Forward its
+  findings to the authoring agent for fix-and-reply. This is how #776's
+  blocker and #783's second-round findings were caught.
+- If the maintainer explicitly asks for `/code-review` from a Fable session,
+  say first that it will fork on Fable at full context, and confirm.
+
+For the deep cloud variant use `/code-review ultra` (user-triggered,
+separately billed).
 
 ## Codex review comments: always reply inline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,10 +234,17 @@ JAX_PLATFORMS=cpu pytest -n 4  -m "slow" --cov=jcm \
     --cov-config=.coveragerc-pr --cov-fail-under=80
 ```
 
-Then review your own diff adversarially **before pushing** — `/code-review
-high` on the branch, fix or refute every finding (`jcm-dev-workflow` step 3).
-Codex credits are finite and a CI review round takes hours; a finding caught
-locally costs neither.
+Then review your own diff adversarially **before pushing** and fix or refute
+every finding (`jcm-dev-workflow` step 3). Codex credits are finite and a CI
+review round takes hours; a finding caught locally costs neither. **Choose the
+reviewer by the session's model.** `/code-review` forks the invoking session:
+same model, full conversation context inherited, and at `high`/`max` its
+finders and verifiers fan out the same way. From a Fable session that spends
+Fable tokens at full context (it exhausted a session limit twice on
+2026-09-10). On a Fable session spawn an explicit `model: opus` reviewer agent
+with the same scope and have it post one `gh pr review --comment`; run
+`/code-review high` itself only from an Opus or Sonnet session, or when the
+maintainer asks for it knowing it forks on the parent model.
 
 Two traps the gates exist to catch. `JAX_PLATFORMS=cpu` is REQUIRED on GPU
 hosts (every xdist worker otherwise grabs the same GPU and XLA fails with


### PR DESCRIPTION
Docs-only. Follows #798, which made the `/code-review high` self-review step more prominent in CLAUDE.md and both workflow skills.

**Why.** `/code-review` runs as a fork of the invoking session: same model, full conversation context inherited, and at `high`/`max` its finders and verifiers fan out the same way. From a Fable session that means every one of those agents starts with the whole session in context and is billed to it. On 2026-09-10 it exhausted a Fable session limit twice while reviewing #783 (the failure notices name the model: `model sent to the API: claude-fable-5-1`). As written after #798, the repo told every Fable session to do exactly that before every push.

**What changes.** The self-review requirement is unchanged. Each of the three places now says which reviewer to use:

- Opus or Sonnet session: `/code-review high` on the branch, as before.
- Fable session: do not invoke the skill; spawn an explicit `model: opus` general-purpose agent with the same scope and have it post one `gh pr review --comment`, then forward findings to the authoring agent. That pattern caught the #776 blocker and #783's second-round findings.
- If the maintainer asks for `/code-review` from a Fable session, say first that it forks on Fable at full context, and confirm.

Files: `CLAUDE.md` (the PR-workflow paragraph), `.claude/skills/jcm-local-ci/SKILL.md` ("Local Claude review"), `.claude/skills/jcm-dev-workflow/SKILL.md` (step 3). The installed copy at `~/.claude/skills/jcm-local-ci/SKILL.md` on the maintainer's account was updated to the same text out of band; note that the installed `jcm-dev-workflow` copy there predates #798 and carries neither change, so the installed skills want a re-sync from `dev` once this merges.

No code or tests touched; `ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4x2keECpxEf5JvJ5rM3ty