### PR TITLE
Emit sea salt and DMS from a diagnosed 10 m wind (#723)

### DIFF
--- a/docs/design/jam.md
+++ b/docs/design/jam.md
@@ -234,6 +234,87 @@ See `.claude/aerosol_emissions_plan.md` for the full design, the data-source
 investigation (the raw 0.5° gridded CEDS is ESGF-only; a self-hosted compressed
 mirror is a tracked follow-up), and the CESM adapter's documented approximations.
 
+## Natural emissions: the 10 m wind (#723)
+
+### The emission wind is 10 m, not the lowest model level
+
+Gong sea salt (`u10**3.41`) and Nightingale DMS (`k_w ~ u10**2`) are fitted to
+the 10 m wind; HAMMOZ passes `vphysc%velo10m`. Reading the lowest full level
+instead — ~33 m at L47 — inflates sea salt by 37-46 % and DMS by 20-25 %.
+
+`TteTkeVerticalDiffusion` now publishes `VerticalDiffusionData.wind_10m`, the
+ECHAM/ICON `nsurf_diag` reduction of the lowest-level wind along the same
+surface-layer profile that produced the drag:
+
+```
+bn  = ln(z1/z0m)                              neutral profile factor
+bm  = bn * sqrt(CM_n|U| / CM|U|)              stability-corrected
+red = [ln(1 + (e^bn - 1)*10/z1) + merge] / bm
+merge = -(bn - bm)*10/z1                      stable   (CM|U| < CM_n|U|)
+      = -ln(1 + (e^(bn-bm) - 1)*10/z1)        unstable
+```
+
+Building it from the per-tile `CM·|U|` the surface stress already uses means the
+10 m wind cannot drift from the momentum exchange, and the stable/unstable
+branch needs no separate Richardson number (the two branches meet continuously
+at `Ri = 0`, where `CM|U| = CM_n|U|`). The profile factor is built from the
+`zepdu2`-floored speed the coefficients themselves used (`max(|U|, 1 m/s)`),
+or ECHAM's calm-wind floor would be misread as a stability signal; the
+reduction it yields then multiplies the true wind.
+
+Emission terms read the result through `emissions/surface_wind.py`. They run
+*before* vdiff in the ECHAM ordering, so the value is one step old. This is
+the **declared** cross-step carry — `vertical_diffusion` is one of the slots
+`Physics.initial_carry_state` seeds — i.e. the deliberate pattern #673
+distinguishes from an accidental stale `.get()`, and the same lag the dust
+term's `u*` already carries. When #673's `carry_slots` check lands this read
+is one to declare explicitly.
+
+**The fallback to the lowest model level is bootstrap-only, by construction.**
+The 10 m wind *cannot* exist on step 1 of a cold start: emissions run first,
+and the `vertical_diffusion` carry slot is seeded zero-filled
+(`initial_carry_state`; verified — `surface_friction_velocity` and `wind_10m`
+are both exactly 0 there), so no surface layer has been diagnosed yet.
+(A resumed run carries a real 10 m wind and never takes the fallback; nor does
+a composition with no vdiff term, where there is no surface layer at all.)
+Because taking it silently would mean emitting 37-46 % too much sea salt, the
+emission terms publish a per-column flag `wind_10m_model_level` — 1 where the
+model level was used, 0 where the diagnosed wind was — zeroed every step with
+the other emission diagnostics. It is 1 on step 1 of a cold start and 0
+thereafter; `seasalt_test.py` (`test_fallback_is_taken_on_step_one_and_never_again`
+and its companions) asserts exactly that per step, against the zero-filled carry
+a cold start begins with and a populated one thereafter. The JAM integration
+test adds the end-to-end check that no column is still flagged after six steps.
+
+**The three terms behave differently on step 1 of a cold start, deliberately.**
+Dust emits nothing (its carried `u*` is zero, and a saltation threshold has no
+defensible value without a surface layer); sea salt and DMS emit from the
+lowest model level and flag it
+(`|U|` at ~33 m is a defensible approximation of `u10` — it is what the model
+did on every step before #723); and `EchamSurface` has no step-1 case, because
+it runs after vdiff. Unifying them would make one of the three worse: dust
+would have to invent a wind, or sea salt would have to discard a step of a
+legitimate flux for symmetry's sake. The asymmetry follows from what each
+quantity is, and is stated here rather than in three docstrings.
+
+`check_health` **reports** the chunk's fraction — averaged over every save
+interval in the chunk, so the bootstrap step cannot hide in an interval the
+report does not look at — and fails the chunk only on a *persistent* fallback.
+The distinction matters. Under `output_averages` the saved field is an interval
+*mean*, so a cold start's one legitimate fallback step reads `1/N`, the
+identical value a single defective step mid-chunk would give: no rule can
+separate those, and treating `> 0` as fatal aborted a healthy 30-day validation
+run at day 5 on `1/480`, losing the chunk because the bail path skips the
+checkpoint. A fallback that never stops is separable, though — no vdiff term,
+or `wind_10m` never published, reads `1.0` in *every* chunk and costs +37-46 %
+sea salt for the whole run. So the gate is `chunk_idx > 0 and frac > 0.5`:
+after the first chunk the flag can only be zero, and the one legitimate way to
+read `1.0` (a first chunk that is itself a single step) can only be chunk 0.
+That needs no timestep and no cold-start flag — which is what the earlier
+one-step exemption needed, and crashed on for configs whose dycore owns the
+timestep. A single-chunk run degrades to report-only, and the per-step
+invariant stays where it can be checked exactly, in the unit tests.
+
 ### Two emission paths: differentiable bulk vs CAM6-faithful pre-speciated
 
 The above is the **bulk / differentiable** path (`jam_anthropogenic=True`). There

--- a/docs/source/science/aerosol.md
+++ b/docs/source/science/aerosol.md
@@ -208,6 +208,60 @@ re-evaporation ledger); ice nucleation Lohmann & Diehl (2006), Niemand et al.
   prescribed); ``drydep/``; ``sedimentation/``; ``wetdep/``; ``ice_nucleation/``;
   ``optics/optics_term.py``.
 
+#### Sea-salt and DMS emission wind
+
+**What we do.** Both schemes read a diagnosed **10 m** wind, not the lowest
+model level: ``SeaSaltEmissions`` and ``DmsEmissions`` take
+``VerticalDiffusionData.wind_10m`` (see
+[vertical diffusion](vertical_diffusion.md)) through
+``jcm/physics/aerosol/jam/emissions/surface_wind.py::wind_10m``. Emission terms
+run before vertical diffusion in the ECHAM ordering, so the value is the
+previous step's — ``vertical_diffusion`` is a declared cross-step carry slot,
+the same one-step lag the dust term's ``u*`` takes.
+
+On the first step of a cold start no surface layer has been diagnosed yet (the
+carry slot is zero-filled), and both schemes fall back to the lowest level for
+that step, publishing a per-column flag ``wind_10m_model_level`` — 1 where the
+model level was used, 0 where the diagnosed wind was — which
+``ResetEmissionFluxes`` zeroes every step alongside the emission fluxes. A
+resumed run carries a real 10 m wind and never takes the fallback.
+
+**What ECHAM/CAM does.** HAMMOZ passes ``vphysc%velo10m`` to both schemes
+(``mo_vphysc.f90``); Gong (2003) is fitted to ``u10**3.41`` and Nightingale
+et al. (2000) to a piston velocity in ``u10``.
+
+**Why we differ.** We do not, for the wind. The fallback is a `compute`
+consequence of the operator-split ordering — the surface layer is diagnosed
+later in the step than the emissions that consume it — rather than a scheme
+choice, and it is reported rather than hidden.
+
+**Status & known limitations.** The three surface-flux terms behave
+differently on step 1 of a cold start, deliberately: dust emits nothing (its
+carried ``u*`` is zero and a saltation threshold has no defensible value
+without a surface layer), sea salt and DMS emit from the lowest level and flag
+it, and the surface term has no step-1 case because it runs after vertical
+diffusion. ``check_health`` reports the chunk-mean flag and fails a chunk only
+on a *persistent* fallback (``chunk_idx > 0 and frac > 0.5``), because under
+interval averaging the legitimate bootstrap step and a single defective step
+mid-chunk give the same value; the per-step invariant is asserted in the unit
+tests instead. A single-chunk run therefore degrades to report-only.
+
+**Code pointers.**
+- ``jcm/physics/aerosol/jam/emissions/surface_wind.py`` — ``wind_10m``,
+  ``MODEL_LEVEL_WIND_KEY``.
+- ``jcm/physics/aerosol/jam/emissions/seasalt.py`` — ``SeaSaltEmissions``.
+- ``jcm/physics/aerosol/jam/emissions/dms.py`` — ``DmsEmissions``.
+- ``jcm/physics/aerosol/jam/emissions/flux_diagnostic.py`` —
+  ``ResetEmissionFluxes``, ``all_flux_keys``.
+- ``jcm/diagnostics.py`` — ``check_health``.
+
+**Validation evidence.** ``seasalt_test.py`` and ``dms_test.py`` pin the
+reduction against the carry state per step and the flag per column;
+``jcm/diagnostics_test.py`` pins the chunk-level rule. A 30-day T63L47
+integration reduces sea-salt emission by 32 % and the DMS flux by 17 % against
+the lowest-level wind, with the flag reading 1/480 on the first chunk and
+exactly zero on every chunk thereafter.
+
 ## MACv2-SP simple plumes
 
 **What we do.** A faithful port of MACv2-SP (Stevens et al. 2017): nine

--- a/docs/source/science/vertical_diffusion.md
+++ b/docs/source/science/vertical_diffusion.md
@@ -55,6 +55,64 @@ block in the ECHAM ordering.
 - ``jcm/physics/vertical_diffusion/tracer_diffusion.py`` —
   ``TracerVerticalDiffusion``, ``diffuse_tracers_implicit``.
 
+## Ten-metre wind diagnostic
+
+**What we do.** The term publishes a grid-mean 10 m wind speed,
+``VerticalDiffusionData.wind_10m``, alongside the exchange coefficients. It is
+the surface-layer profile evaluated at 10 m rather than an interpolation
+between levels: with ``bn = ln(z₁/z₀ₘ)`` the neutral profile factor and
+``bm = bn·√(CMₙ|U| / CM|U|)`` its stability-corrected counterpart,
+
+```
+zrat = 10/z₁
+cbn  = ln(1 + (e^bn − 1)·zrat)
+red  = [cbn + (stable: −(bn − bm)·zrat | unstable: −ln(1 + (e^(bn−bm) − 1)·zrat))] / bm
+```
+
+and ``|U(10 m)| = red·|U(z₁)|``, area-weighted over the surface tiles. The
+reduction is computed **inside** each surface-layer scheme's ``lax.cond``
+branch, from that scheme's own neutral drag: the two schemes differ in
+roughness (state-carried vs a hard-coded table), in the bound on ``z/z₀`` and
+in whether the wind is ``zepdu2``-floored, and both branches build their
+momentum drag from the same helper the reduction uses, so the pair cannot
+drift. The profile factor uses the ``zepdu2``-floored speed the coefficients
+themselves were built from (``max(|U|, 1 m/s)``), and the resulting reduction
+multiplies the true wind.
+
+**What ECHAM/CAM does.** ECHAM5 ``vdiff.f90`` / ICON
+``mo_surface_diag::nsurf_diag`` compute the 10 m wind by exactly this
+construction, from the ``pbn``/``pbm`` profile factors ``mo_turbulence_diag``
+exports for the purpose; ``zepdu2 = 1 m²/s²`` is ECHAM's calm-wind floor on the
+bulk Richardson number and the drag.
+
+**Why we differ.** We do not. The stable/unstable branch is selected by
+``CM|U| < CMₙ|U|`` rather than by the sign of ``Ri``, which is equivalent for
+both schemes here (their stability factors are <1 stable, ≥1 unstable, and both
+equal 1 — with equal stable and unstable expressions — at ``Ri = 0``) and keeps
+the Richardson number inside the coefficient solve.
+
+**Status & known limitations.** The diagnostic is a grid-mean over the tiles;
+per-tile 10 m winds are computed internally but not published. The Businger-Dyer
+branch's neutral reference uses that scheme's own hard-coded von Kármán constant
+rather than the live ``jcm.constants`` value, so a ``set_constants`` override
+changes the drag and its neutral reference together.
+
+**Code pointers.**
+- ``jcm/physics/vertical_diffusion/tte_tke/surface_layer.py`` —
+  ``wind_10m_reduction``, ``echam_louis_neutral_drag``.
+- ``jcm/physics/vertical_diffusion/tte_tke/turbulence_coefficients.py`` —
+  ``businger_dyer_neutral_drag``, ``compute_turbulence_diagnostics``.
+- ``jcm/physics/vertical_diffusion/tte_tke/vertical_diffusion_types.py`` —
+  ``VerticalDiffusionData``.
+- ``jcm/physics/surface/echam/turbulent_fluxes.py`` —
+  ``compute_surface_diagnostics`` (the reported 10 m wind and its components).
+
+**Validation evidence.**
+``jcm/physics/vertical_diffusion/tte_tke/surface_layer_test.py`` — the neutral
+limit against a hand-computed log profile (0.912/0.904/0.894 for
+z₀ = 5e-5/1.5e-4/5e-4 m at z₁ = 32.6 m), monotonicity in stability, continuity
+across the branch, and that each scheme uses its own neutral drag.
+
 **Validation evidence.**
 ``jcm/physics/vertical_diffusion/tte_tke/`` test suite —
 ``vertical_diffusion_test.py``, ``surface_layer_test.py``,

--- a/jcm/diagnostics.py
+++ b/jcm/diagnostics.py
@@ -146,6 +146,17 @@ def check_health(ds, chunk_idx: int, elapsed_days: float) -> tuple[bool, dict]:
         report["precip_conv_mean_mmday"] = float(np.nanmean(precip)) * 86400
         report["precip_conv_max_mmday"] = float(np.nanmax(precip)) * 86400
 
+    # Emission-wind provenance (#723). Reported always; fatal only for a
+    # PERSISTENT fallback (see the failure block). Under ``output_averages``
+    # the saved field is an interval mean, so one legitimate bootstrap step is
+    # 1/N — which is why "> 0" cannot be the rule.
+    if "wind_10m_model_level" in ds:
+        # Over the whole chunk, not ``isel(time=-1)``: with more than one save
+        # interval per chunk the last interval never contains step 1, so the
+        # bootstrap step would vanish from the report (run=pyses_year).
+        flag = ds["wind_10m_model_level"].values
+        report["emission_wind_model_level_frac"] = float(np.nanmean(flag))
+
     ok = True
     reasons: list[str] = []
     # Any NaN in temperature is a failure — the integration has either
@@ -162,6 +173,23 @@ def check_health(ds, chunk_idx: int, elapsed_days: float) -> tuple[bool, dict]:
     if report.get("q_max_gkg", 0) > 100:
         ok = False
         reasons.append(f"q_max={report['q_max_gkg']:.1f} g/kg (> 100)")
+
+    # A fallback that never stops is a different thing from the bootstrap
+    # step: it reads 1.0 in EVERY chunk (no vdiff term, or wind_10m never
+    # published), and costs +37-46 % sea salt for the whole run. Caught by
+    # bounding the legitimate value rather than by exempting a case:
+    # after the first chunk the flag can only be zero, and a one-step chunk —
+    # the one legitimate way to read 1.0 — can only be the first. So this
+    # needs no timestep and no notion of a cold start, which is what the
+    # earlier exemption needed and crashed on (run.time_step: null).
+    if (chunk_idx > 0
+            and report.get("emission_wind_model_level_frac", 0.0) > 0.5):
+        ok = False
+        reasons.append(
+            "emission wind fell back to the lowest model level in "
+            f"{report['emission_wind_model_level_frac']:.0%} of this chunk — "
+            "the 10 m wind is not being diagnosed, so sea salt is ~40% high"
+        )
 
     report["ok"] = ok
     report["reasons"] = reasons
@@ -205,4 +233,10 @@ def print_report(report: dict) -> None:
             f"  Precip conv: mean {report['precip_conv_mean_mmday']:.4f} mm/day, "
             f"max {report['precip_conv_max_mmday']:.2f} mm/day"
         )
+    if "emission_wind_model_level_frac" in report:
+        # One bootstrap step in an N-step chunk reads 1/N; a run still falling
+        # back reads ~1 in every chunk (#723).
+        print("  Emis wind:   "
+              f"{report['emission_wind_model_level_frac']:.3%} model-level "
+              "(bootstrap step only; ~100% means the 10 m wind is missing)")
     print()

--- a/jcm/diagnostics_test.py
+++ b/jcm/diagnostics_test.py
@@ -166,6 +166,74 @@ def _budget_dataset(dtype, dyn=0.0, mass=1.0, ptend=5e-12,
     return xr.Dataset(data, coords={"lat": lat, "lon": lon})
 
 
+class TestEmissionWindProvenance(unittest.TestCase):
+    """#723's model-level fallback: reported always, fatal only if persistent.
+
+    Under ``output_averages`` the saved field is an interval mean, so a cold
+    start's one legitimate fallback step reads 1/N — the same value a single
+    defective step mid-chunk would give, which is why "> 0" cannot be the rule
+    (it aborted a healthy 30-day run at day 5 on 1/480). A fallback that never
+    stops is separable though: it reads 1.0 in every chunk, and after the first
+    chunk the flag can only be zero.
+    """
+
+    def _ds(self, flagged_fraction: float):
+        ds = _make_dataset(250.0, 300.0)
+        nt, nx, ny = ds["temperature"].shape
+        flag = np.full((nt, nx, ny), flagged_fraction)
+        ds["wind_10m_model_level"] = (("time", "lon", "lat"), flag)
+        return ds
+
+    def test_bootstrap_fraction_is_reported_and_not_fatal(self):
+        # 1/480: one step of a 5-day chunk at dt = 15 min.
+        ok, report = check_health(self._ds(1.0 / 480.0), 0, 5.0)
+        self.assertTrue(ok)
+        self.assertAlmostEqual(
+            report["emission_wind_model_level_frac"], 1.0 / 480.0, places=6)
+
+    def test_a_persistent_fallback_after_the_first_chunk_fails(self):
+        # 1.0 in a later chunk can only mean the 10 m wind is never diagnosed
+        # (no vdiff term, or wind_10m unpublished) — +37-46 % sea salt for the
+        # whole run, which used to reach the end with only a stdout line.
+        ok, report = check_health(self._ds(1.0), 7, 200.0)
+        self.assertFalse(ok)
+        self.assertIn("emission wind", "; ".join(report["reasons"]))
+
+    def test_a_one_step_first_chunk_reads_one_and_still_passes(self):
+        # The only legitimate way to read 1.0: a first chunk of a single step,
+        # where the interval mean IS the bootstrap step. Needs no timestep and
+        # no cold-start flag to tell apart — it can only be chunk 0.
+        self.assertTrue(check_health(self._ds(1.0), 0, 0.02)[0])
+
+    def test_a_single_defective_step_mid_chunk_is_reported_not_fatal(self):
+        # 1/N is the legitimate bootstrap value too, so no rule can separate
+        # them; it is reported and left to the per-step unit tests.
+        ok, report = check_health(self._ds(1.0 / 480.0), 3, 20.0)
+        self.assertTrue(ok)
+        self.assertGreater(report["emission_wind_model_level_frac"], 0.0)
+
+    def test_it_is_printed(self):
+        import contextlib
+        import io
+        _, report = check_health(self._ds(1.0), 7, 200.0)
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            print_report(report)
+        self.assertIn("Emis wind", buf.getvalue())
+
+    def test_absent_field_is_not_reported(self):
+        # Non-JAM runs publish no such field.
+        ok, report = check_health(_make_dataset(250.0, 300.0), 0, 5.0)
+        self.assertTrue(ok)
+        self.assertNotIn("emission_wind_model_level_frac", report)
+
+    def test_real_blowup_signatures_still_fail(self):
+        # The demotion must not have loosened the gate's actual job.
+        ds = self._ds(0.0)
+        ds["temperature"] = ds["temperature"] * 0.0 + 600.0
+        self.assertFalse(check_health(ds, 0, 5.0)[0])
+
+
 class TestAerosolBudgetReport(unittest.TestCase):
     def test_no_budget_gauges_returns_empty(self):
         ds = xr.Dataset({"temperature": (("time",), np.zeros(1))})

--- a/jcm/dycore/pyses/hydra_config_test.py
+++ b/jcm/dycore/pyses/hydra_config_test.py
@@ -43,6 +43,85 @@ class PysesHydraConfigTest(unittest.TestCase):
         names = [t.name for t in model.physics.terms]
         self.assertIn("upper_temperature_relaxation", names)
 
+    def test_delegated_timestep_survives_a_fresh_chunk_on_dinosaur(self):
+        """The fast-lane half of the delegated-timestep guard.
+
+        The pySES version below is the end-to-end one, but it is slow AND
+        importorskip'd, so CI never runs it. This drives the same per-chunk
+        path — integrate, health-check, budget report, netCDF, checkpoint —
+        with ``run.time_step=null`` on a tiny dinosaur model, which
+        ``run_chunked`` accepts because a pre-built model makes the run config's
+        timestep unused. Anything in that path that reads it as a number fails
+        here, in the fast lane.
+        """
+        import tempfile
+        from pathlib import Path
+
+        import numpy as np
+
+        from jcm.model import Model
+        from jcm.physics.held_suarez.held_suarez_physics import (
+            held_suarez_physics,
+        )
+        from jcm.runners import run_chunked
+        from jcm.terrain import TerrainData
+        from jcm.utils import get_coords
+
+        coords = get_coords(np.linspace(0, 1, 9), spectral_truncation=21)
+        model = Model(coords=coords, time_step=60,
+                      terrain=TerrainData.aquaplanet(coords),
+                      physics=held_suarez_physics())
+        cfg = _cfg(["physics=held_suarez", "grid=held_suarez_t31_l8",
+                    "run.time_step=null", "run.total_time=0.5",
+                    "run.save_interval=0.25"])
+        self.assertIsNone(cfg.run.time_step)   # the case under test
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            reports = run_chunked(cfg, chunk_days=0.25,
+                                  output_prefix=f"{tmpdir}/deleg",
+                                  model=model)
+            self.assertGreaterEqual(len(reports), 1)
+            self.assertTrue(list(Path(tmpdir).glob("deleg_day*.nc")))
+
+    @pytest.mark.slow
+    def test_delegating_config_completes_a_fresh_first_chunk(self):
+        """A config whose timestep the dycore owns must survive chunk 1.
+
+        ``run=pyses_year`` sets ``time_step: null`` deliberately, so anything
+        in the per-chunk path that reads it as a number crashes AFTER the
+        integration and BEFORE the checkpoint — losing the chunk. That has now
+        happened twice in one campaign (a health-check argument here, and the
+        scoreable-gate decision of #780), each time in code that ran fine on
+        every config that names its own timestep. Drive a real fresh chunk end
+        to end: integrate, health-check, budget report, netCDF, checkpoint.
+        """
+        pytest.importorskip("pyses")
+        import tempfile
+        from pathlib import Path
+
+        from jcm.runners import run
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg = _cfg([
+                "dycore=pyses_ne30l47", "physics=held_suarez", "run=pyses_year",
+                "dycore.nx=3", "dycore.n_sponge=8",
+                # One short chunk: the first fresh chunk is the whole point.
+                "run.total_time=0.05", "run.chunk_days=0.05",
+                "run.save_interval=0.05",
+                f"run.output_prefix={tmpdir}/deleg",
+                f"run.checkpoint_path={tmpdir}/deleg.ckpt",
+            ])
+            self.assertIsNone(cfg.run.time_step)   # the point of the config
+            reports = run(cfg)
+
+            # Everything the crash happened BETWEEN: the integration finished,
+            # so the chunk must have reached disk and the checkpoint written.
+            self.assertIsInstance(reports, list)
+            self.assertGreaterEqual(len(reports), 1)
+            self.assertTrue(reports[0]["ok"], reports[0].get("reasons"))
+            self.assertTrue(list(Path(tmpdir).glob("deleg_day*.nc")))
+            self.assertTrue(Path(f"{tmpdir}/deleg.ckpt").exists())
+
     def test_dinosaur_default_unchanged(self):
         from jcm.dycore.dinosaur.dycore import DinosaurDycore
         from jcm.runners import build_model

--- a/jcm/physics/aerosol/jam/emissions/distributors.py
+++ b/jcm/physics/aerosol/jam/emissions/distributors.py
@@ -28,9 +28,9 @@ def particle_mean_mass(mode: AerosolMode, species_density: float,
     the emitted and equilibrium sizes differ.
 
     The mechanism only; no scheme in this module supplies a diameter yet.
-    Each emission scheme owns the size its own reference prescribes — HAM's
-    (Stier et al. 2005) for the HAMMOZ schemes this package ports — so the
-    values arrive with the scheme, not here.
+    Each emission scheme owns the size its own reference prescribes, and this
+    is a HAMMOZ package: the primary-carbon and primary-sulfate sizes come
+    from HAM (Stier et al. 2005) with the emissions port, not from CAM/CESM.
     """
     if emission_diameter is None:
         return species_density / mode.number_factor

--- a/jcm/physics/aerosol/jam/emissions/distributors.py
+++ b/jcm/physics/aerosol/jam/emissions/distributors.py
@@ -8,21 +8,33 @@ modal path is implemented here; a sectional distributor is future work (#491).
 
 from __future__ import annotations
 
+import math
+
 import jax.numpy as jnp
 
 from jcm.physics.aerosol.jam.population import AerosolMode, ModalAerosolSpec
 from jcm.physics.aerosol.jam.tracer_layout import mass_name, number_name
 
 
-def particle_mean_mass(mode: AerosolMode, species_density: float) -> float:
-    """Mean single-particle mass [kg] of a class at its reference size.
+def particle_mean_mass(mode: AerosolMode, species_density: float,
+                       emission_diameter=None):
+    """Mean single-particle mass [kg] of freshly emitted material.
 
-    ``m_p = ρ_material / number_factor`` — the inverse of the family-agnostic
-    ``mode.number_factor`` (number per unit dry-aerosol volume), so the modal
-    log-normal third-moment formula lives in one place (``AerosolMode``) and a
-    sectional class returns its own mean particle mass through the same call.
+    Freshly emitted particles are not at their class's equilibrium size, so a
+    scheme that knows the volume-mean diameter D of the size distribution it
+    emits into passes it and gets ``m_p = ρ·(π/6)·D³``; the ``None`` fallback
+    is the class's own geometry, ``m_p = ρ/number_factor``. Since the emitted
+    number for a given mass scales as D⁻³, the difference is large wherever
+    the emitted and equilibrium sizes differ.
+
+    The mechanism only; no scheme in this module supplies a diameter yet.
+    Each emission scheme owns the size its own reference prescribes — HAM's
+    (Stier et al. 2005) for the HAMMOZ schemes this package ports — so the
+    values arrive with the scheme, not here.
     """
-    return species_density / mode.number_factor
+    if emission_diameter is None:
+        return species_density / mode.number_factor
+    return species_density * (math.pi / 6.0) * emission_diameter ** 3
 
 
 def emit_over_profile(
@@ -52,8 +64,11 @@ def distribute_surface_flux(
 
     Args:
         spec: the modal population.
-        fluxes: list of ``(species_token, mode_short, mass_flux)`` with
-            ``mass_flux`` shaped ``(ncols,)`` in kg/m²/s.
+        fluxes: list of ``(species_token, mode_short, mass_flux)`` or
+            ``(species_token, mode_short, mass_flux, emission_diameter)`` with
+            ``mass_flux`` shaped ``(ncols,)`` in kg/m²/s and the optional
+            volume-mean diameter [m] of the emitted size distribution (see
+            :func:`particle_mean_mass`); omitted, the class geometry is used.
         air_density: air density [kg/m³].
         layer_thickness: geometric layer thickness [m].
 
@@ -70,13 +85,13 @@ def distribute_surface_flux(
     tends: dict[str, jnp.ndarray] = {}
     number_flux = {mode.short: jnp.zeros((ncols,)) for mode in spec.modes}
 
-    for species, mode_short, mass_flux in fluxes:
+    for species, mode_short, mass_flux, *rest in fluxes:
         mode = spec.mode(mode_short)
         props = spec.species_props(species)
         mname = mass_name(species, mode_short)
         dq = jnp.zeros((nlev, ncols)).at[-1].set(mass_flux * inv)
         tends[mname] = tends.get(mname, jnp.zeros((nlev, ncols))) + dq
-        m_p = particle_mean_mass(mode, props.density)
+        m_p = particle_mean_mass(mode, props.density, *rest)
         number_flux[mode_short] = number_flux[mode_short] + mass_flux / m_p
 
     for mode_short, n_flux in number_flux.items():

--- a/jcm/physics/aerosol/jam/emissions/distributors_test.py
+++ b/jcm/physics/aerosol/jam/emissions/distributors_test.py
@@ -32,6 +32,33 @@ class DistributorTest(unittest.TestCase):
         self.assertGreater(float(tends[mname][-1, 0]), 0.0)
         self.assertGreater(float(tends[nname][-1, 0]), 0.0)
 
+    def test_emission_diameter_sets_the_emitted_number(self):
+        """m_p = rho (pi/6) D^3 when a scheme supplies its emitted size."""
+        import math
+        rho = MAM4_SPEC.species_props("ss").density
+        d = 0.3e-6
+        m = particle_mean_mass(MAM4_SPEC.mode("accum"), rho, d)
+        self.assertAlmostEqual(m, rho * math.pi / 6.0 * d ** 3, places=24)
+
+    def test_emission_diameter_changes_number_only(self):
+        air_density = jnp.full((3, 2), 1.2)
+        dz = jnp.full((3, 2), 100.0)
+        flux = jnp.full((2,), 1.0e-10)
+        default = distribute_surface_flux(
+            MAM4_SPEC, [("ss", "acc", flux)], air_density, dz)
+        sized = distribute_surface_flux(
+            MAM4_SPEC, [("ss", "acc", flux, 0.3e-6)], air_density, dz)
+        mname, nname = mass_name("ss", "acc"), number_name("acc")
+        self.assertEqual(float(sized[mname][-1, 0]), float(default[mname][-1, 0]))
+        # Number scales as D^-3 against the class's equilibrium geometry.
+        mode = MAM4_SPEC.mode("accum")
+        rho = MAM4_SPEC.species_props("ss").density
+        expect = particle_mean_mass(mode, rho) / particle_mean_mass(
+            mode, rho, 0.3e-6)
+        self.assertAlmostEqual(
+            float(sized[nname][-1, 0]) / float(default[nname][-1, 0]),
+            expect, places=3)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/jcm/physics/aerosol/jam/emissions/dms.py
+++ b/jcm/physics/aerosol/jam/emissions/dms.py
@@ -29,6 +29,8 @@ from jcm.physics.aerosol.jam.tracer_layout import gas_name
 from jcm.physics.physics_term import PhysicsTendency, PhysicsTerm
 from jcm.physics.aerosol.jam.emissions.flux_diagnostic import (
     accumulate_emission_fluxes, emission_flux_keys)
+from jcm.physics.aerosol.jam.emissions.surface_wind import (
+    MODEL_LEVEL_WIND_KEY, wind_10m)
 
 _CMH_TO_MS = 0.01 / 3600.0   # cm/h → m/s
 
@@ -66,7 +68,8 @@ class DmsEmissions(PhysicsTerm):
     name: ClassVar[str] = "jam_dms_emissions"
     category: ClassVar[str] = "aerosol_emissions"
     requires: ClassVar[tuple[str, ...]] = ("air_density", "layer_thickness")
-    provides: ClassVar[tuple[str, ...]] = emission_flux_keys()
+    provides: ClassVar[tuple[str, ...]] = (
+        emission_flux_keys() + (MODEL_LEVEL_WIND_KEY,))
 
     def __init__(
         self,
@@ -91,7 +94,7 @@ class DmsEmissions(PhysicsTerm):
         dz = diagnostics["layer_thickness"]
         nlev, ncols = state.temperature.shape
 
-        u10 = jnp.sqrt(jnp.maximum(state.u_wind[-1] ** 2 + state.v_wind[-1] ** 2, 1.0e-30))
+        u10, from_model_level = wind_10m(state, diagnostics)
         sst = self._forcing_field(
             forcing, "sea_surface_temperature", ncols, 288.0
         )
@@ -127,5 +130,7 @@ class DmsEmissions(PhysicsTerm):
             diagnostics, tracer_tends,
             diagnostics["air_density"],
             diagnostics["layer_thickness"])
+        diagnostics = {**diagnostics, MODEL_LEVEL_WIND_KEY: jnp.maximum(
+            diagnostics.get(MODEL_LEVEL_WIND_KEY, 0.0), from_model_level)}
 
         return tendency, diagnostics

--- a/jcm/physics/aerosol/jam/emissions/dms_test.py
+++ b/jcm/physics/aerosol/jam/emissions/dms_test.py
@@ -78,3 +78,26 @@ class DmsTermTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class Wind10mTest(unittest.TestCase):
+    """Nightingale's piston velocity reads the diagnosed 10 m wind (#723)."""
+
+    def test_uses_the_diagnosed_10m_wind(self):
+        from jcm.physics.vertical_diffusion.tte_tke.vertical_diffusion_types import (
+            VerticalDiffusionData,
+        )
+        state, diagnostics, forcing, terrain = _inputs(wind=10.0)
+        nlev, ncols = state.temperature.shape
+        vd = VerticalDiffusionData.zeros((ncols,), nlev).copy(
+            wind_10m=jnp.full((ncols,), 9.04))
+        lowest, _ = DmsEmissions()(state, diagnostics, forcing, terrain)
+        reduced, _ = DmsEmissions()(
+            state, {**diagnostics, "vertical_diffusion": vd}, forcing, terrain)
+        key = gas_name("dms")
+        ratio = (float(reduced.tracers[key][-1, 0])
+                 / float(lowest.tracers[key][-1, 0]))
+        # kw = 0.222 u^2 + 0.333 u, so the reduction is between u and u^2.
+        expect = ((0.222 * 9.04 ** 2 + 0.333 * 9.04)
+                  / (0.222 * 10.0 ** 2 + 0.333 * 10.0))
+        self.assertAlmostEqual(ratio, expect, places=4)

--- a/jcm/physics/aerosol/jam/emissions/flux_diagnostic.py
+++ b/jcm/physics/aerosol/jam/emissions/flux_diagnostic.py
@@ -24,6 +24,7 @@ from typing import ClassVar
 
 import jax.numpy as jnp
 
+from jcm.physics.aerosol.jam.emissions.surface_wind import MODEL_LEVEL_WIND_KEY
 from jcm.physics.physics_term import PhysicsTerm
 from jcm.physics_interface import PhysicsTendency
 
@@ -118,14 +119,15 @@ def all_flux_keys() -> tuple[str, ...]:
     """Every per-step-reset flux key any helper in this module publishes.
 
     The reset term zeroes the whole family — emissions, biomass-burning
-    splits and both deposition kinds — because all of them accumulate
-    additively within a step and would otherwise integrate across steps
+    splits, both deposition kinds, and the emission-wind provenance flag —
+    because all of them are per-step state that would otherwise carry over
     via the threaded-back diagnostics dict.
     """
     return (emission_flux_keys()
             + tuple(f"emi_bb_{s}" for s in BB_SPECIES)
             + tuple(f"dry_{s}" for s in DEPOSITED_SPECIES)
-            + tuple(f"wet_{s}" for s in DEPOSITED_SPECIES))
+            + tuple(f"wet_{s}" for s in DEPOSITED_SPECIES)
+            + (MODEL_LEVEL_WIND_KEY,))
 
 
 def accumulate_deposition_fluxes(

--- a/jcm/physics/aerosol/jam/emissions/seasalt.py
+++ b/jcm/physics/aerosol/jam/emissions/seasalt.py
@@ -31,6 +31,8 @@ from jcm.physics.aerosol.jam.tracer_layout import mass_name, number_name
 from jcm.physics.physics_term import PhysicsTendency, PhysicsTerm
 from jcm.physics.aerosol.jam.emissions.flux_diagnostic import (
     accumulate_emission_fluxes, emission_flux_keys)
+from jcm.physics.aerosol.jam.emissions.surface_wind import (
+    MODEL_LEVEL_WIND_KEY, wind_10m)
 
 # Gong-scheme constants (mo_ham_m7_emi_seasalt.f90).
 _NBIN = 300
@@ -116,7 +118,8 @@ class SeaSaltEmissions(PhysicsTerm):
     name: ClassVar[str] = "jam_seasalt_emissions"
     category: ClassVar[str] = "aerosol_emissions"
     requires: ClassVar[tuple[str, ...]] = ("air_density", "layer_thickness")
-    provides: ClassVar[tuple[str, ...]] = emission_flux_keys()
+    provides: ClassVar[tuple[str, ...]] = (
+        emission_flux_keys() + (MODEL_LEVEL_WIND_KEY,))
 
     def __init__(
         self,
@@ -156,7 +159,7 @@ class SeaSaltEmissions(PhysicsTerm):
         dz = diagnostics["layer_thickness"]
         nlev, ncols = state.temperature.shape
 
-        u10 = jnp.sqrt(jnp.maximum(state.u_wind[-1] ** 2 + state.v_wind[-1] ** 2, 1.0e-30))
+        u10, from_model_level = wind_10m(state, diagnostics)
         seafrac = self._open_water_fraction(forcing, terrain, ncols)
         wind = p.scale * u10 ** p.wind_exponent * seafrac   # (ncols,)
 
@@ -180,5 +183,7 @@ class SeaSaltEmissions(PhysicsTerm):
             diagnostics, tracer_tends,
             diagnostics["air_density"],
             diagnostics["layer_thickness"])
+        diagnostics = {**diagnostics, MODEL_LEVEL_WIND_KEY: jnp.maximum(
+            diagnostics.get(MODEL_LEVEL_WIND_KEY, 0.0), from_model_level)}
 
         return tendency, diagnostics

--- a/jcm/physics/aerosol/jam/emissions/seasalt_test.py
+++ b/jcm/physics/aerosol/jam/emissions/seasalt_test.py
@@ -13,6 +13,9 @@ from jcm.physics.aerosol.jam.emissions.seasalt import (
     SeaSaltParameters,
     gong_class_factors,
 )
+from jcm.physics.aerosol.jam.emissions.surface_wind import (
+    MODEL_LEVEL_WIND_KEY,
+)
 from jcm.physics.aerosol.jam.microphysics.mam4_data import MAM4_SPEC
 
 
@@ -120,3 +123,90 @@ class SeaSaltTermTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class Wind10mTest(unittest.TestCase):
+    """The Gong source reads the diagnosed 10 m wind, not level 1 (#723)."""
+
+    @staticmethod
+    def _with_u10(args, u10):
+        from jcm.physics.vertical_diffusion.tte_tke.vertical_diffusion_types import (
+            VerticalDiffusionData,
+        )
+        state, diagnostics, forcing, terrain = args
+        nlev, ncols = state.temperature.shape
+        vd = VerticalDiffusionData.zeros((ncols,), nlev).copy(
+            wind_10m=jnp.full((ncols,), u10))
+        return state, {**diagnostics, "vertical_diffusion": vd}, forcing, terrain
+
+    def test_uses_the_diagnosed_10m_wind(self):
+        args = _inputs(wind=10.0)
+        lowest, _ = SeaSaltEmissions()(*args)
+        reduced, _ = SeaSaltEmissions()(*self._with_u10(args, 9.04))
+        key = mass_name("ss", "cor")
+        ratio = (float(reduced.tracers[key][-1, 0])
+                 / float(lowest.tracers[key][-1, 0]))
+        # u10**3.41: a 9.6 % wind reduction is a 28 % flux reduction.
+        self.assertAlmostEqual(ratio, (9.04 / 10.0) ** 3.41, places=4)
+
+    def test_falls_back_to_the_lowest_level_without_vdiff(self):
+        args = _inputs(wind=10.0)
+        self.assertNotIn("vertical_diffusion", args[1])
+        tend, diag = SeaSaltEmissions()(*args)
+        self.assertGreater(float(tend.tracers[mass_name("ss", "cor")][-1, 0]), 0.0)
+        # ... and says so: no vdiff term composed => every column flagged.
+        self.assertTrue(bool(jnp.all(diag[MODEL_LEVEL_WIND_KEY] == 1.0)))
+
+    def test_fallback_is_taken_on_step_one_and_never_again(self):
+        """The carry seeds step 1 with a zero-filled vdiff (#723, cf. #673)."""
+        from jcm.physics.vertical_diffusion.tte_tke.vertical_diffusion_types import (
+            VerticalDiffusionData,
+        )
+        state, diagnostics, forcing, terrain = _inputs(wind=10.0)
+        nlev, ncols = state.temperature.shape
+        key = mass_name("ss", "cor")
+
+        # Step 1: exactly what Model._build_initial_physics_carry supplies —
+        # the zero-filled structural template, no step having run yet.
+        step1 = {**diagnostics,
+                 "vertical_diffusion": VerticalDiffusionData.zeros((ncols,), nlev)}
+        tend1, diag1 = SeaSaltEmissions()(state, step1, forcing, terrain)
+        self.assertTrue(bool(jnp.all(diag1[MODEL_LEVEL_WIND_KEY] == 1.0)))
+        unreduced, _ = SeaSaltEmissions()(state, diagnostics, forcing, terrain)
+        self.assertAlmostEqual(float(tend1.tracers[key][-1, 0]),
+                               float(unreduced.tracers[key][-1, 0]), places=12)
+
+        # Step 2: vdiff has run, so the carried 10 m wind is real everywhere.
+        vd = VerticalDiffusionData.zeros((ncols,), nlev).copy(
+            wind_10m=jnp.full((ncols,), 9.04))
+        tend2, diag2 = SeaSaltEmissions()(
+            state, {**diagnostics, "vertical_diffusion": vd}, forcing, terrain)
+        self.assertTrue(bool(jnp.all(diag2[MODEL_LEVEL_WIND_KEY] == 0.0)))
+        self.assertAlmostEqual(
+            float(tend2.tracers[key][-1, 0]) / float(tend1.tracers[key][-1, 0]),
+            (9.04 / 10.0) ** 3.41, places=4)
+
+    def test_flag_is_per_column(self):
+        from jcm.physics.vertical_diffusion.tte_tke.vertical_diffusion_types import (
+            VerticalDiffusionData,
+        )
+        state, diagnostics, forcing, terrain = _inputs(wind=10.0, ncols=2)
+        nlev, ncols = state.temperature.shape
+        vd = VerticalDiffusionData.zeros((ncols,), nlev).copy(
+            wind_10m=jnp.asarray([9.0, 0.0]))
+        _, diag = SeaSaltEmissions()(
+            state, {**diagnostics, "vertical_diffusion": vd}, forcing, terrain)
+        np.testing.assert_allclose(np.asarray(diag[MODEL_LEVEL_WIND_KEY]),
+                                   [0.0, 1.0])
+
+    def test_reset_term_zeroes_the_flag_each_step(self):
+        """Otherwise step 1's flag would persist through the whole run."""
+        from jcm.physics.aerosol.jam.emissions.flux_diagnostic import (
+            ResetEmissionFluxes, all_flux_keys,
+        )
+        self.assertIn(MODEL_LEVEL_WIND_KEY, all_flux_keys())
+        state, diagnostics, forcing, terrain = _inputs(wind=10.0)
+        _, diag = ResetEmissionFluxes()(
+            state, {**diagnostics, MODEL_LEVEL_WIND_KEY: jnp.ones((2,))},
+            forcing, terrain)
+        self.assertTrue(bool(jnp.all(diag[MODEL_LEVEL_WIND_KEY] == 0.0)))

--- a/jcm/physics/aerosol/jam/emissions/surface_wind.py
+++ b/jcm/physics/aerosol/jam/emissions/surface_wind.py
@@ -1,0 +1,55 @@
+"""The 10 m wind the surface-flux emission schemes are calibrated to (#723).
+
+Gong sea salt (``u10**3.41``) and Nightingale DMS (``k_w ~ u10**2``) are both
+fitted to the 10 m wind — HAMMOZ passes ``vphysc%velo10m`` — so reading the
+lowest model level instead biases them high by the surface-layer shear over
+10 m … z₁ (~33 m at L47: +37-46 % sea salt, +20-25 % DMS).
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+
+#: Per-column flag published by the emission terms: 1 where the emission wind
+#: fell back to the lowest model level, 0 where the diagnosed 10 m wind was
+#: used. Zeroed every step with the other emission diagnostics, and reported
+#: per chunk by ``check_health`` (a bias indicator, not a blowup signature, so
+#: it is printed rather than fatal), so a run in which the fallback persists is
+#: visible instead of quietly emitting 37-46 % too much sea salt. Deliberately
+#: NOT an ``emis_``/``emi_`` name: those prefixes select emission *fluxes* in
+#: the forcing reader and the burden report.
+MODEL_LEVEL_WIND_KEY = "wind_10m_model_level"
+
+
+def wind_10m(state, diagnostics):
+    """Emission wind [m/s] and its provenance, both shaped ``(ncols,)``.
+
+    Returns ``(speed, from_model_level)`` — the ECHAM ``nsurf_diag`` 10 m
+    reduction published by the vertical-diffusion term, and a 0/1 flag per
+    column saying where that was unavailable and the lowest model level was
+    used instead.
+
+    Emission terms run before vdiff in the ECHAM ordering, so the value read
+    here is the previous step's. ``vertical_diffusion`` is a **declared**
+    cross-step slot (``Physics.initial_carry_state``), so this is the
+    deliberate carry #673 distinguishes from an undeclared stale read, and the
+    same one-step lag the dust term's ``u*`` already carries.
+
+    The fallback is therefore reachable only where no 10 m wind can exist: on
+    step 1 of a cold start, whose carry slot is still zero-filled because no
+    step has diagnosed a surface layer yet, or with no vdiff term composed at
+    all. A resumed run carries a real 10 m wind and never takes it.
+    """
+    lowest = jnp.sqrt(
+        jnp.maximum(state.u_wind[-1] ** 2 + state.v_wind[-1] ** 2, 1.0e-30)
+    )
+    vdiff = diagnostics.get("vertical_diffusion")
+    speed_10m = getattr(vdiff, "wind_10m", None) if vdiff is not None else None
+    if speed_10m is None:
+        return lowest, jnp.ones_like(lowest)
+    speed_10m = jnp.ravel(speed_10m)
+    # A zero 10 m wind under a moving lowest level can only mean "not
+    # diagnosed yet": the reduction is strictly positive wherever it has run.
+    unset = speed_10m <= 0.0
+    return (jnp.where(unset, lowest, speed_10m),
+            unset.astype(lowest.dtype))

--- a/jcm/physics/aerosol/jam/jam_integration_test.py
+++ b/jcm/physics/aerosol/jam/jam_integration_test.py
@@ -32,8 +32,10 @@ class JamIntegrationTest(unittest.TestCase):
                 aerosol_module="jam", cloud_scheme="2m", **physics_kwargs
             ),
         )
-        # ~1.5 h (3 steps) — enough to exercise tracer transport + coupling.
-        return model, model.run(save_interval=0.0625, total_time=0.0625)
+        # ~3 h (6 steps): on a cold start with no seeded aerosol the
+        # emission -> transport -> core -> activation chain needs that long to
+        # produce anything, so 3 steps would assert on the spin-up rate.
+        return model, model.run(save_interval=0.125, total_time=0.125)
 
     def test_runs_finite_with_ham_aerosol(self):
         from jcm.physics.aerosol.jam import MAM4_SPEC, mass_name, number_name
@@ -69,6 +71,15 @@ class JamIntegrationTest(unittest.TestCase):
         # fails here (measured on a healthy cold-start run: activated_cdnc max
         # ~66, qnc max ~3e-5 after 3 steps).
         physics = predictions.physics
+        # The emission wind fell back to the model level on step 1 only (#723):
+        # by the end of a multi-step run no column is still flagged.
+        from jcm.physics.aerosol.jam.emissions.surface_wind import (
+            MODEL_LEVEL_WIND_KEY,
+        )
+        self.assertEqual(
+            float(np.max(np.asarray(physics[MODEL_LEVEL_WIND_KEY]))), 0.0,
+            "emission wind still falling back to the lowest model level",
+        )
         self.assertIn("activated_cdnc", physics)
         self.assertGreater(
             float(np.max(np.asarray(physics["activated_cdnc"]))), 0.0,

--- a/jcm/physics/aerosol/jam/optics/optics_integration_test.py
+++ b/jcm/physics/aerosol/jam/optics/optics_integration_test.py
@@ -47,7 +47,10 @@ class OpticsIntegrationTest(unittest.TestCase):
                 radiation=RadiationParameters.default(radiation_interval=0),
             ),
         )
-        predictions = model.run(save_interval=0.0625, total_time=0.0625)
+        # 6 steps, not 3: the emission -> transport -> core -> optics chain
+        # needs the aerosol to reach the core before AOD can be non-zero (see
+        # jam_integration_test).
+        predictions = model.run(save_interval=0.125, total_time=0.125)
         dyn = predictions.dynamics
         self.assertFalse(bool(jnp.any(jnp.isnan(dyn.temperature))))
         self.assertTrue(bool(jnp.all(dyn.temperature > 150.0)))

--- a/jcm/physics/surface/echam/surface_physics.py
+++ b/jcm/physics/surface/echam/surface_physics.py
@@ -129,7 +129,8 @@ def surface_physics_step(
     atmospheric_state: AtmosphericForcing,
     surface_state: SurfaceState,
     dt: float,
-    params: SurfaceParameters = SurfaceParameters.default()
+    wind_speed_10m: jnp.ndarray,
+    params: SurfaceParameters = SurfaceParameters.default(),
 ) -> Tuple[SurfaceFluxes, SurfaceTendencies, SurfaceDiagnostics]:
     """Complete surface physics step for all surface types.
     
@@ -138,6 +139,9 @@ def surface_physics_step(
         surface_state: Surface state
         dt: Time step [s]
         params: Surface parameters
+        wind_speed_10m: diagnosed 10 m wind [m/s] (ncol,) for the reported
+            surface diagnostics (ECHAM ``nsurf_diag``; the vdiff carry always
+            holds one, so it is required rather than defaulted).
         
     Returns:
         Tuple of (surface_fluxes, tendencies, diagnostics)
@@ -163,7 +167,7 @@ def surface_physics_step(
     # routines in this module (``compute_bulk_richardson_number`` /
     # ``compute_stability_functions`` / ``compute_exchange_coefficients``)
     # remain available and tested as a surface-side reference scheme, but are
-    # not in the default flux path. ``ri_bulk`` above is still used for
+    # no longer in the default flux path. ``ri_bulk`` above is still used for
     # the aerodynamic-resistance diagnostics below.
     exchange_coeff_momentum = atmospheric_state.exchange_coeff_momentum
     exchange_coeff_heat = atmospheric_state.exchange_coeff_heat
@@ -243,7 +247,8 @@ def surface_physics_step(
     
     # Compute diagnostics
     diagnostics = compute_surface_diagnostics(
-        atmospheric_state, surface_state, combined_fluxes, resistances, params
+        atmospheric_state, surface_state, combined_fluxes, resistances,
+        wind_speed_10m, params,
     )
     
     return combined_fluxes, combined_tendencies, diagnostics
@@ -501,7 +506,7 @@ class EchamSurface(PhysicsTerm):
         # column actually receives are delivered by the vdiff implicit solve
         # and read back below.
         _fluxes, _tendencies, _surface_diag = surface_physics_step(
-            atm_forcing, surface_state, dt, params,
+            atm_forcing, surface_state, dt, jnp.ravel(vdiff.wind_10m), params,
         )
 
         # No turbulent-flux tendencies here: the vdiff term's implicit solve
@@ -526,9 +531,9 @@ class EchamSurface(PhysicsTerm):
         # Publish the DELIVERED fluxes diagnosed from the vdiff implicit
         # solution. By the ECHAM ``pev_vdiff`` identity these equal the
         # column-integrated vdiff tendencies exactly, so ``evaporation ==
-        # effective_evaporation`` — there is no raw-vs-damped distinction and
-        # no imp_moist factor. The field is kept for API stability (the
-        # Tiedtke moisture-budget closure reads it).
+        # effective_evaporation`` — the raw-vs-damped distinction (and the
+        # imp_moist factor) no longer exists. The field is kept for API
+        # stability (the Tiedtke moisture-budget closure reads it).
         evaporation = vdiff.surface_evaporation.reshape(ncols)
         surface_out = prev_surface.copy(
             sensible_heat_flux=vdiff.surface_sensible_heat.reshape(ncols),

--- a/jcm/physics/surface/echam/surface_physics_test.py
+++ b/jcm/physics/surface/echam/surface_physics_test.py
@@ -163,10 +163,17 @@ class TestSurfacePhysicsStep:
         
         self.dt = 3600.0  # 1 hour
     
+    def _wind_10m(self):
+        """Build a diagnosed 10 m wind, as the vdiff carry supplies in a real run."""
+        u = self.atmospheric_state.u_wind
+        v = self.atmospheric_state.v_wind
+        return 0.9 * jnp.sqrt(jnp.maximum(u ** 2 + v ** 2, 1.0e-30))
+
     def test_surface_physics_step_basic(self):
         """Test basic surface physics step."""
         fluxes, tendencies, diagnostics = surface_physics_step(
-            self.atmospheric_state, self.surface_state, self.dt
+            self.atmospheric_state, self.surface_state, self.dt,
+            self._wind_10m(),
         )
         
         assert isinstance(fluxes, SurfaceFluxes)
@@ -190,7 +197,8 @@ class TestSurfacePhysicsStep:
     def test_surface_physics_step_energy_conservation(self):
         """Test energy conservation in surface physics step."""
         fluxes, tendencies, diagnostics = surface_physics_step(
-            self.atmospheric_state, self.surface_state, self.dt
+            self.atmospheric_state, self.surface_state, self.dt,
+            self._wind_10m(),
         )
         
         # Net surface energy flux should be finite
@@ -206,7 +214,8 @@ class TestSurfacePhysicsStep:
     def test_surface_physics_step_flux_consistency(self):
         """Test flux consistency between tiles and means."""
         fluxes, tendencies, diagnostics = surface_physics_step(
-            self.atmospheric_state, self.surface_state, self.dt
+            self.atmospheric_state, self.surface_state, self.dt,
+            self._wind_10m(),
         )
         
         # Check that mean fluxes are consistent with tile fluxes
@@ -232,12 +241,14 @@ class TestSurfacePhysicsStep:
         momentum stress exactly.
         """
         base, _, _ = surface_physics_step(
-            self.atmospheric_state, self.surface_state, self.dt
+            self.atmospheric_state, self.surface_state, self.dt,
+            self._wind_10m(),
         )
         doubled = self.atmospheric_state._replace(
             exchange_coeff_momentum=self.atmospheric_state.exchange_coeff_momentum * 2.0
         )
-        scaled, _, _ = surface_physics_step(doubled, self.surface_state, self.dt)
+        scaled, _, _ = surface_physics_step(doubled, self.surface_state, self.dt,
+                                       self._wind_10m())
 
         assert jnp.allclose(scaled.momentum_u_mean, 2.0 * base.momentum_u_mean, rtol=1e-5)
         assert jnp.allclose(scaled.momentum_v_mean, 2.0 * base.momentum_v_mean, rtol=1e-5)

--- a/jcm/physics/surface/echam/turbulent_fluxes.py
+++ b/jcm/physics/surface/echam/turbulent_fluxes.py
@@ -263,7 +263,8 @@ def compute_surface_diagnostics(
     surface_state: SurfaceState,
     surface_fluxes: SurfaceFluxes,
     resistances: SurfaceResistances,
-    params: SurfaceParameters = SurfaceParameters.default()
+    wind_speed_10m: jnp.ndarray,
+    params: SurfaceParameters = SurfaceParameters.default(),
 ) -> SurfaceDiagnostics:
     """Compute standard surface diagnostics (2m temperature, 10m wind, etc.).
     
@@ -273,6 +274,11 @@ def compute_surface_diagnostics(
         surface_fluxes: Surface fluxes
         resistances: Surface resistances
         params: Surface parameters
+        wind_speed_10m: 10 m wind speed [m/s] (ncol,) from the surface-layer
+            profile (ECHAM ``nsurf_diag``, diagnosed by the vertical-diffusion
+            term). Required: the vdiff carry always holds one, so a fallback
+            here would only ever hide a wiring mistake behind a wind that is
+            not the 10 m wind.
         
     Returns:
         Surface diagnostics
@@ -300,10 +306,13 @@ def compute_surface_diagnostics(
     # 2m dew point (simplified)
     dewpoint_2m = temp_2m - 20.0 * (1.0 - atmospheric_state.humidity / 0.01)
     
-    # 10m wind (use atmospheric wind as approximation)
-    wind_speed_10m = jnp.sqrt(jnp.maximum(atmospheric_state.u_wind**2 + atmospheric_state.v_wind**2, 1.0e-30))
-    u_wind_10m = atmospheric_state.u_wind
-    v_wind_10m = atmospheric_state.v_wind
+    # Components keep the lowest level's direction; the magnitude is the
+    # surface-layer reduction the caller diagnosed.
+    wind_speed_atm = jnp.sqrt(jnp.maximum(
+        atmospheric_state.u_wind**2 + atmospheric_state.v_wind**2, 1.0e-30))
+    reduction = wind_speed_10m / wind_speed_atm
+    u_wind_10m = reduction * atmospheric_state.u_wind
+    v_wind_10m = reduction * atmospheric_state.v_wind
     
     # Friction velocity
     momentum_flux_magnitude = jnp.sqrt(jnp.maximum(
@@ -317,7 +326,7 @@ def compute_surface_diagnostics(
         atmospheric_state.temperature, surface_state.temperature,
         atmospheric_state.humidity, 
         compute_surface_humidity(surface_state.temperature, atmospheric_state.pressure),
-        wind_speed_10m
+        wind_speed_atm
     ), axis=1)
     
     # Energy balance

--- a/jcm/physics/vertical_diffusion/tte_tke/surface_layer.py
+++ b/jcm/physics/vertical_diffusion/tte_tke/surface_layer.py
@@ -101,6 +101,11 @@ def compute_surface_exchange_coefficients_echam_louis(
 
     ncol, nsfc_type = temperature_surface.shape
 
+    # Neutral drag for every tile, from the one helper the 10 m reduction also
+    # uses (so the reduction's stability factor is this scheme's own).
+    bn_all, cfn_m_all = echam_louis_neutral_drag(state, params,
+                                                 wind_speed_surface)
+
     # --- Atmospheric inputs at the lowest level (klev) -------------------
     p_air = state.pressure_full[:, -1]            # (ncol,)
     p_sfc = state.pressure_half[:, -1]            # (ncol,)
@@ -176,13 +181,15 @@ def compute_surface_exchange_coefficients_echam_louis(
 
         # ---- Louis (1979) stability + log-law neutral ----------------
         # Effective roughness lengths capped to ½·z_ref via
-        # ``MAX(2, z/z0)`` per ECHAM's lmix-bounded form.
-        log_zm = jnp.log(jnp.maximum(z_ref / z0,  jnp.exp(2.0)))
+        # ``MAX(2, z/z0)`` per ECHAM's lmix-bounded form. The momentum pair
+        # comes from ``echam_louis_neutral_drag`` so the 10 m reduction shares
+        # this scheme's own neutral reference rather than re-deriving it.
+        log_zm = bn_all[:, isfc]
         log_zh = jnp.log(jnp.maximum(z_ref / z0h, jnp.exp(2.0)))
         cdn = (karman * karman) / (log_zm * log_zm)             # neutral drag
         chn = (karman * karman) / (log_zm * log_zh)             # neutral CHN
 
-        cfn_m = jnp.sqrt(jnp.maximum(zdu2, 1.0e-30)) * cdn        # κ²·U/log²
+        cfn_m = cfn_m_all[:, isfc]                                # κ²·U/log²
         cfn_h = jnp.sqrt(jnp.maximum(zdu2, 1.0e-30)) * chn
 
         # Stable branch (Ri > 0): ECHAM Mauritsen-2007 stable form
@@ -217,3 +224,84 @@ def compute_surface_exchange_coefficients_echam_louis(
         surface_exchange_momentum = surface_exchange_momentum.at[:, isfc].set(cfm)
 
     return surface_exchange_heat, surface_exchange_moisture, surface_exchange_momentum
+
+
+@jax.jit
+def wind_10m_reduction(
+    exchange_momentum: jnp.ndarray,
+    neutral_exchange_momentum: jnp.ndarray,
+    log_z_over_z0: jnp.ndarray,
+    z_ref: jnp.ndarray,
+    reference_height: float = 10.0,
+) -> jnp.ndarray:
+    """Per-tile ``|U(10 m)| / |U(z_ref)|`` (ECHAM ``nsurf_diag`` 10 m wind).
+
+    ECHAM5 ``vdiff.f90`` / ICON ``mo_surface_diag::nsurf_diag`` interpolate the
+    lowest-level wind down to 10 m along the surface-layer profile actually used
+    for the drag, with ``zrat = 10/z_ref``::
+
+        bn   = ln(z_ref/z0m)                     neutral profile factor
+        bm   = bn·√(CM_n·|U| / CM·|U|)           stability-corrected profile
+        cbn  = ln(1 + (e^bn − 1)·zrat)
+        cbs  = −(bn − bm)·zrat                   stable
+        cbu  = −ln(1 + (e^(bn−bm) − 1)·zrat)     unstable
+        red  = (cbn + [cbs|cbu]) / bm
+
+    The neutral profile factor and the neutral exchange velocity are supplied
+    by the caller rather than rebuilt here, because they must be the surface
+    layer scheme's OWN: the two schemes differ in roughness (``z0m_min``-floored
+    ``state.roughness_length`` vs a hard-coded table), in the bound on
+    ``z/z0``, and in whether the wind is ``zepdu2``-floored. Deriving them here
+    would silently mix two drag formulations and read stability where there is
+    none.
+
+    The stable/unstable branch is selected by ``CM·|U| < CM_n·|U|``, which is
+    exactly ``Ri > 0`` for both surface-layer schemes here (their stability
+    factors are <1 for stable, ≥1 for unstable, and both equal 1 — with equal
+    ``cbs``/``cbu`` — at ``Ri = 0``), so the Richardson number need not be
+    plumbed out of the coefficient solve.
+
+    Args:
+        exchange_momentum: CM·|U| per tile [m/s] (ncol, nsfc_type).
+        neutral_exchange_momentum: the same scheme's NEUTRAL CM_n·|U| [m/s]
+            (ncol, nsfc_type).
+        log_z_over_z0: that scheme's neutral profile factor ``ln(z_ref/z0m)``
+            (ncol, nsfc_type).
+        z_ref: lowest full-level height above the surface [m] (ncol,).
+        reference_height: diagnostic height [m], 10 m by default.
+
+    Returns:
+        Reduction factor per tile (ncol, nsfc_type), in [0, 1].
+
+    """
+    bn = log_z_over_z0
+    f_m = (jnp.maximum(exchange_momentum, 1e-12)
+           / jnp.maximum(neutral_exchange_momentum, 1e-12))
+    bm = bn / jnp.sqrt(f_m)
+
+    # A lowest level below the diagnostic height leaves the wind unreduced
+    # (zrat ≤ 1). This subsumes the coefficients' 1 m floor on z_ref, since
+    # the diagnostic height is 10 m — flooring at 1 m first would be a no-op.
+    zrat = reference_height / jnp.maximum(z_ref, reference_height)[:, None]
+    cbn = jnp.log1p(jnp.expm1(jnp.clip(bn, 0.0, 30.0)) * zrat)
+    cbs = -(bn - bm) * zrat
+    cbu = -jnp.log1p(jnp.expm1(jnp.clip(bn - bm, -30.0, 30.0)) * zrat)
+    merge = jnp.where(f_m < 1.0, cbs, cbu)
+    # Math-safety clip only: the log profile cannot amplify the wind between
+    # 10 m and the lowest level, nor reverse it.
+    return jnp.clip((cbn + merge) / bm, 0.0, 1.0)
+
+
+def echam_louis_neutral_drag(state, params, wind_speed):
+    """``(ln(z/z0), CM_n·|U|)`` of the ECHAM-Louis scheme, per tile.
+
+    THE definition, not a copy of one:
+    :func:`compute_surface_exchange_coefficients_echam_louis` calls this for
+    the ``log_zm``/``cfn_m`` its own drag is built on, so ``bn = κ/√CDN``
+    holds for the pair by construction and the two cannot drift.
+    """
+    z_ref = jnp.maximum(state.height_full[:, -1] - state.height_half[:, -1], 1.0)
+    z0 = jnp.maximum(state.roughness_length, params.z0m_min)
+    bn = jnp.log(jnp.maximum(z_ref[:, None] / z0, jnp.exp(2.0)))
+    floored = jnp.sqrt(jnp.maximum(wind_speed ** 2, 1.0))[:, None]
+    return bn, floored * c.karman_const ** 2 / bn ** 2

--- a/jcm/physics/vertical_diffusion/tte_tke/surface_layer_test.py
+++ b/jcm/physics/vertical_diffusion/tte_tke/surface_layer_test.py
@@ -189,3 +189,98 @@ class TestECHAMLouisScheme:
             state.surface_temperature, state.temperature[:, -1],
         )
         np.testing.assert_allclose(np.asarray(sCH1), np.asarray(sCH2))
+
+
+class TestWind10mReduction:
+    """ECHAM ``nsurf_diag`` 10 m wind reduction (#723)."""
+
+    def _neutral(self, z_ref, z0):
+        """|U(10)|/|U(z_ref)| = ln(1 + (z/z0 - 1)*10/z) / ln(z/z0)."""
+        return (np.log1p((z_ref / z0 - 1.0) * 10.0 / z_ref)
+                / np.log(z_ref / z0))
+
+    def test_neutral_matches_the_log_profile(self):
+        import jcm.constants as c
+        from .surface_layer import wind_10m_reduction
+        karman = c.karman_const
+        z_ref, z0, wind = 32.6, 1.5e-4, 6.0
+        bn = np.log(z_ref / z0)
+        cfnc = wind * karman ** 2 / bn ** 2
+        red = wind_10m_reduction(
+            jnp.full((1, 3), cfnc),                # neutral: CM|U| = CM_n|U|
+            jnp.full((1, 3), cfnc), jnp.full((1, 3), bn),
+            jnp.asarray([z_ref]))
+        expect = self._neutral(z_ref, z0)
+        assert abs(float(red[0, 0]) - expect) < 1e-5
+        # ~0.90 at L47's lowest level over the ocean: the |u|^3.41 sea-salt
+        # source is inflated ~1.4x by using the model level instead.
+        assert 0.88 < expect < 0.92
+
+    def test_ocean_roughness_range(self):
+        for z0, want in ((5e-5, 0.9124), (1.5e-4, 0.9036), (5e-4, 0.8935)):
+            assert abs(self._neutral(32.6, z0) - want) < 1e-3
+
+    def test_each_scheme_uses_its_own_neutral_drag(self):
+        """A shared reference reads stability at exact neutral (#783 review)."""
+        import jcm.constants as c
+        from .surface_layer import wind_10m_reduction
+        z_ref, wind = 32.6, 6.0
+        # Businger-Dyer's hard-coded ocean z0 against a Charnock state z0.
+        bn_bd = np.log(max(z_ref, 1.0) / 1e-4)
+        bn_louis = np.log(z_ref / 2.2e-4)
+        cfnc_bd = wind * c.karman_const ** 2 / bn_bd ** 2
+        own = float(wind_10m_reduction(
+            jnp.full((1, 1), cfnc_bd), jnp.full((1, 1), cfnc_bd),
+            jnp.full((1, 1), bn_bd), jnp.asarray([z_ref]))[0, 0])
+        mixed = float(wind_10m_reduction(
+            jnp.full((1, 1), cfnc_bd),
+            jnp.full((1, 1), wind * c.karman_const ** 2 / bn_louis ** 2),
+            jnp.full((1, 1), bn_louis), jnp.asarray([z_ref]))[0, 0])
+        assert abs(own - self._neutral(z_ref, 1e-4)) < 1e-4   # true neutral
+        assert mixed < own - 0.03                             # spuriously stable
+
+    def test_unstable_is_closer_to_one_than_stable(self):
+        import jcm.constants as c
+        from .surface_layer import wind_10m_reduction
+        z_ref, z0, wind = 32.6, 1.5e-4, 6.0
+        bn = np.log(z_ref / z0)
+        cfnc = wind * c.karman_const ** 2 / bn ** 2
+        args = (jnp.full((1, 1), cfnc), jnp.full((1, 1), bn),
+                jnp.asarray([z_ref]))
+        red = lambda f: float(
+            wind_10m_reduction(jnp.full((1, 1), f * cfnc), *args)[0, 0])
+        stable, neutral, unstable = red(0.4), red(1.0), red(3.0)
+        assert stable < neutral < unstable <= 1.0
+
+    def test_continuous_across_the_stability_branch(self):
+        import jcm.constants as c
+        from .surface_layer import wind_10m_reduction
+        z_ref, z0, wind = 32.6, 1.5e-4, 6.0
+        bn = np.log(z_ref / z0)
+        cfnc = wind * c.karman_const ** 2 / bn ** 2
+        args = (jnp.full((1, 1), cfnc), jnp.full((1, 1), bn),
+                jnp.asarray([z_ref]))
+        lo = float(wind_10m_reduction(
+            jnp.full((1, 1), cfnc * (1 - 1e-6)), *args)[0, 0])
+        hi = float(wind_10m_reduction(
+            jnp.full((1, 1), cfnc * (1 + 1e-6)), *args)[0, 0])
+        assert abs(lo - hi) < 1e-6
+
+    def test_no_reduction_below_10m_and_bounded(self):
+        from .surface_layer import wind_10m_reduction
+        bn = np.log(np.asarray([5.0, 40.0])[:, None] / 1e-3)
+        red = wind_10m_reduction(
+            jnp.full((2, 3), 0.05), jnp.full((2, 3), 0.05),
+            jnp.asarray(bn * np.ones((1, 3))), jnp.asarray([5.0, 40.0]))
+        assert np.all(np.asarray(red) <= 1.0) and np.all(np.asarray(red) >= 0.0)
+        # z_ref below the diagnostic height: zrat is capped at 1, no reduction.
+        assert abs(float(red[0, 0]) - 1.0) < 1e-6
+
+    def test_gradient_is_finite(self):
+        import jax
+        from .surface_layer import wind_10m_reduction
+        bn = float(np.log(32.6 / 1.5e-4))
+        g = jax.grad(lambda cm: jnp.sum(wind_10m_reduction(
+            cm, jnp.full((1, 3), 6.0 * 0.4 ** 2 / bn ** 2),
+            jnp.full((1, 3), bn), jnp.asarray([32.6]))))(jnp.full((1, 3), 0.01))
+        assert np.all(np.isfinite(np.asarray(g)))

--- a/jcm/physics/vertical_diffusion/tte_tke/turbulence_coefficients.py
+++ b/jcm/physics/vertical_diffusion/tte_tke/turbulence_coefficients.py
@@ -120,12 +120,13 @@ def compute_mixing_length(
     # Stability function: reduce mixing length for stable conditions.
     #
     # The natural form ``(1 - Ri/Ri_crit)²`` is only physically meaningful
-    # for ``0 ≤ Ri < Ri_crit``, so ``Ri`` is capped at zero first. Without
-    # that cap, negative (unstable) Richardson numbers drive the squared
-    # factor unboundedly upward — Ri = -100 gives ``(1 - (-400))² = 160 000``,
-    # scaling the mixing length to ~10¹⁴ m, propagating into Km/Kh and the
-    # implicit matrix solve, and NaN'ing the atmosphere within a couple of
-    # timesteps.
+    # for ``0 ≤ Ri < Ri_crit``. The previous version applied it without
+    # capping ``Ri`` at zero, which let negative (unstable) Richardson
+    # numbers drive the squared factor unboundedly upward — Ri = -100
+    # gives ``(1 - (-400))² = 160 000``, scaling the mixing length to
+    # ~10¹⁴ m, propagating into Km/Kh and the implicit matrix solve, and
+    # NaN'ing the atmosphere within a couple of timesteps in averaged
+    # mode (the snapshot path happened to dodge the worst columns).
     #
     # Bounded form: clip Ri to [0, Ri_crit] before squaring. Unstable
     # columns get neutral-strength mixing (factor = 1); stable columns
@@ -219,6 +220,30 @@ def compute_exchange_coefficients(
     return exchange_coeff_momentum, exchange_coeff_heat, exchange_coeff_moisture
 
 
+#: Businger-Dyer roughness tables [water, ice, land] — this scheme ignores
+#: ``state.roughness_length``, so its neutral drag must be built from these.
+_BD_Z0_HEAT = jnp.array([1e-4, 1e-4, 1e-2])
+_BD_Z0_MOMENTUM = jnp.array([1e-4, 1e-3, 1e-1])
+
+
+def businger_dyer_neutral_drag(state, wind_speed):
+    """``(ln(z/z0), CM_n·|U|)`` of the Businger-Dyer scheme, per tile.
+
+    THE definition: :func:`compute_surface_exchange_coefficients` builds its
+    momentum drag as ``cfnc · stability_momentum`` from this, so the 10 m
+    reduction's ``f_m = CM|U| / CM_n|U|`` is exactly that scheme's own
+    ``stability_momentum`` rather than a re-derivation of it. Sliced to the
+    state's tile count, as the scheme's per-tile loop is.
+    """
+    z_ref = state.height_full[:, -1] - state.height_half[:, -1]
+    z0 = _BD_Z0_MOMENTUM[:state.roughness_length.shape[1]]
+    bn = jnp.log(jnp.maximum(z_ref, 1.0)[:, None]
+                 / jnp.maximum(z0, 1e-5)[None, :])
+    # 0.4, not c.karman_const: it must match the von_karman this scheme
+    # hard-codes, or a set_constants override desyncs the pair.
+    return bn, wind_speed[:, None] * 0.4 ** 2 / bn ** 2
+
+
 @jax.jit
 def compute_surface_exchange_coefficients(
     state: VDiffState,
@@ -250,11 +275,10 @@ def compute_surface_exchange_coefficients(
     """
     ncol, nsfc_type = temperature_surface.shape
 
-    # Roughness lengths for different surface types
-    # [water, ice, land]
-    z0_heat = jnp.array([1e-4, 1e-4, 1e-2])  # Thermal roughness
-    z0_moisture = jnp.array([1e-4, 1e-4, 1e-2])  # Moisture roughness
-    z0_momentum = jnp.array([1e-4, 1e-3, 1e-1])  # Momentum roughness (rougher)
+    z0_heat = _BD_Z0_HEAT
+    z0_moisture = _BD_Z0_HEAT
+    # Momentum: one definition, shared with the 10 m reduction (below).
+    _, cfn_m_all = businger_dyer_neutral_drag(state, wind_speed_surface)
     
     # Reference height (lowest model level)
     z_ref = state.height_full[:, -1] - state.height_half[:, -1]
@@ -311,15 +335,13 @@ def compute_surface_exchange_coefficients(
                                  / jnp.maximum(z0_heat[isfc], 1e-5))
         log_ratio_moisture = jnp.log(jnp.maximum(z_ref, 1.0)
                                      / jnp.maximum(z0_moisture[isfc], 1e-5))
-        log_ratio_momentum = jnp.log(jnp.maximum(z_ref, 1.0)
-                                     / jnp.maximum(z0_momentum[isfc], 1e-5))
-
         exchange_heat = (von_karman**2 * wind_speed_surface *
                         stability_heat / log_ratio_heat**2)
         exchange_moisture = (von_karman**2 * wind_speed_surface *
                            stability_heat / log_ratio_moisture**2)
-        exchange_momentum = (von_karman**2 * wind_speed_surface *
-                             stability_momentum / log_ratio_momentum**2)
+        # CM·|U| = CM_n·|U| · (1/Φm): the neutral factor is the shared one, so
+        # f_m in the 10 m reduction recovers stability_momentum exactly.
+        exchange_momentum = cfn_m_all[:, isfc] * stability_momentum
 
         surface_exchange_heat = surface_exchange_heat.at[:, isfc].set(
             jnp.maximum(exchange_heat, 1e-6)
@@ -449,22 +471,40 @@ def compute_turbulence_diagnostics(
     # shaped (ncol, nsfc_type) tensors, so the false-branch tracing
     # is cheap. The scheme field on ``params`` is a tracer under
     # JIT, hence cond rather than a Python ``if``.
-    from .surface_layer import compute_surface_exchange_coefficients_echam_louis
+    from .surface_layer import (
+        compute_surface_exchange_coefficients_echam_louis,
+        echam_louis_neutral_drag,
+        wind_10m_reduction,
+    )
 
     wind_speed_surface = jnp.sqrt(
         jnp.maximum(state.u[:, -1]**2 + state.v[:, -1]**2, 1.0e-30))
-    surface_exchange_heat, surface_exchange_moisture, surface_exchange_momentum = (
-        jax.lax.cond(
-            params.surface_layer_scheme == VDiffParameters.SCHEME_ECHAM_LOUIS,
-            lambda: compute_surface_exchange_coefficients_echam_louis(
-                state, params, wind_speed_surface,
-                state.surface_temperature, state.temperature[:, -1],
-            ),
-            lambda: compute_surface_exchange_coefficients(
-                state, params, wind_speed_surface,
-                state.surface_temperature, state.temperature[:, -1],
-            ),
+    z_ref_sfc = state.height_full[:, -1] - state.height_half[:, -1]
+
+    # The 10 m reduction is computed INSIDE each branch, from that scheme's own
+    # neutral drag: the two schemes differ in roughness, in the bound on z/z0
+    # and in whether the wind is zepdu2-floored, so a shared reference would
+    # read stability where there is none (~13 % on the sea-salt wind term).
+    def _louis():
+        cfh, cfe, cfm = compute_surface_exchange_coefficients_echam_louis(
+            state, params, wind_speed_surface,
+            state.surface_temperature, state.temperature[:, -1],
         )
+        bn, cfnc = echam_louis_neutral_drag(state, params, wind_speed_surface)
+        return cfh, cfe, cfm, wind_10m_reduction(cfm, cfnc, bn, z_ref_sfc)
+
+    def _businger_dyer():
+        cfh, cfe, cfm = compute_surface_exchange_coefficients(
+            state, params, wind_speed_surface,
+            state.surface_temperature, state.temperature[:, -1],
+        )
+        bn, cfnc = businger_dyer_neutral_drag(state, wind_speed_surface)
+        return cfh, cfe, cfm, wind_10m_reduction(cfm, cfnc, bn, z_ref_sfc)
+
+    (surface_exchange_heat, surface_exchange_moisture,
+     surface_exchange_momentum, wind_10m_tile) = jax.lax.cond(
+        params.surface_layer_scheme == VDiffParameters.SCHEME_ECHAM_LOUIS,
+        _louis, _businger_dyer,
     )
     
     # Air density at surface
@@ -493,6 +533,12 @@ def compute_turbulence_diagnostics(
     friction_velocity = compute_friction_velocity(
         surface_momentum_flux_u, surface_momentum_flux_v, air_density
     )
+
+    # 10 m wind (ECHAM ``nsurf_diag``), area-weighted over the tiles from the
+    # same per-tile CM·|U|. Surface-flux parameterizations (sea salt, DMS) are
+    # calibrated to u10, not to the lowest model level — ~33 m at L47.
+    wind_10m = wind_speed_surface * jnp.sum(
+        state.surface_fraction * wind_10m_tile, axis=1)
     
     # Convective velocity scale (simplified)
     convective_velocity = jnp.maximum(friction_velocity, 0.1)
@@ -507,6 +553,7 @@ def compute_turbulence_diagnostics(
         boundary_layer_height=pbl_height,
         friction_velocity=friction_velocity,
         convective_velocity=convective_velocity,
+        wind_10m=wind_10m,
         richardson_number=ri,
         mixing_length=mixing_length,
         kinetic_energy_dissipation=jnp.zeros(ncol)  # Will be computed by TKE budget

--- a/jcm/physics/vertical_diffusion/tte_tke/vertical_diffusion.py
+++ b/jcm/physics/vertical_diffusion/tte_tke/vertical_diffusion.py
@@ -661,10 +661,11 @@ class TteTkeVerticalDiffusion(PhysicsTerm):
         if tke.ndim == 3:
             tke = tke.reshape(nlev, ncols)
         # Carried from the previous step exactly like TKE (ECHAM keeps
-        # ``pthvvar`` in the restart file). Carrying it is what makes the
-        # variance prognostic: re-zeroing it each step would give its
-        # source/dissipation balance only one step to build up, pinning it at
-        # its floor and forcing the convective ``zlift`` to read a constant.
+        # ``pthvvar`` in the restart file). This used to be re-zeroed every
+        # step, which made the variance non-prognostic in practice: its
+        # source/dissipation balance never had more than one step to build
+        # up, so it sat at its floor and could not be used for anything —
+        # the reason the convective ``zlift`` had to read a constant.
         thv_variance = prev_vdiff.thv_variance
         if thv_variance.ndim == 3:
             thv_variance = thv_variance.reshape(nlev, ncols)
@@ -775,12 +776,13 @@ class TteTkeVerticalDiffusion(PhysicsTerm):
         kh = vdiff_diagnostics.exchange_coeff_heat.T
         pbl_height = vdiff_diagnostics.boundary_layer_height
         u_star = vdiff_diagnostics.friction_velocity
+        wind_10m = vdiff_diagnostics.wind_10m
 
         # Per-tile surface exchange velocities (CH·|U|, CE·|U|, CM·|U|, all
         # m/s) from the configured surface-layer scheme. The momentum
-        # coefficient is a real CM·|U| (Louis/Businger drag), not the interior
-        # diffusivity Km[lowest] (m²/s) — tiling the surface stress from that
-        # would make the surface-stress implicit-damping factor in the
+        # coefficient is now a real CM·|U| (Louis/Businger drag), not the
+        # interior diffusivity Km[lowest] (m²/s) it used to be tiled from —
+        # that mismatch made the surface-stress implicit-damping factor in the
         # ``echam_surface`` term dimensionally wrong.
         surface_exchange_heat = vdiff_diagnostics.surface_exchange_heat
         surface_exchange_moisture = vdiff_diagnostics.surface_exchange_moisture
@@ -830,6 +832,7 @@ class TteTkeVerticalDiffusion(PhysicsTerm):
             surface_exchange_momentum=surface_exchange_momentum,
             pbl_height=pbl_height,
             surface_friction_velocity=u_star,
+            wind_10m=wind_10m,
             surface_evaporation=sfc_fluxes.evaporation,
             surface_sensible_heat=sfc_fluxes.sensible_heat,
             surface_latent_heat=sfc_fluxes.latent_heat,

--- a/jcm/physics/vertical_diffusion/tte_tke/vertical_diffusion_types.py
+++ b/jcm/physics/vertical_diffusion/tte_tke/vertical_diffusion_types.py
@@ -247,6 +247,10 @@ class VDiffDiagnostics(NamedTuple):
     friction_velocity: jnp.ndarray        # u* [m/s] (ncol,)
     convective_velocity: jnp.ndarray      # w* [m/s] (ncol,)
 
+    # Grid-mean 10 m wind speed, the reference height every surface-flux
+    # parameterization (sea salt, DMS) is calibrated to.
+    wind_10m: jnp.ndarray                 # |U(10 m)| [m/s] (ncol,)
+
     # Richardson number
     richardson_number: jnp.ndarray        # Bulk Richardson number [-] (ncol, nlev)
 
@@ -351,6 +355,10 @@ class VerticalDiffusionData:
     surface_friction_velocity: jnp.ndarray  # u* [m/s] (ncols,)
     monin_obukhov_length: jnp.ndarray       # L [m] (ncols,)
 
+    # Diagnosed 10 m wind speed (ECHAM ``vphysc%velo10m``): the reference
+    # height the surface-flux emission schemes are calibrated to.
+    wind_10m: jnp.ndarray            # |U(10 m)| [m/s] (ncols,)
+
     # Grid-mean surface fluxes DELIVERED by the implicit surface-coupled
     # column solve this step (diagnosed from the implicit solution, so they
     # equal the column-integrated vdiff tendencies exactly — the ECHAM
@@ -378,6 +386,7 @@ class VerticalDiffusionData:
             pbl_height=jnp.zeros(nodal_shape),
             surface_friction_velocity=jnp.zeros(nodal_shape),
             monin_obukhov_length=jnp.zeros(nodal_shape),
+            wind_10m=jnp.zeros(nodal_shape),
             surface_evaporation=jnp.zeros(nodal_shape),
             surface_sensible_heat=jnp.zeros(nodal_shape),
             surface_latent_heat=jnp.zeros(nodal_shape),
@@ -399,6 +408,7 @@ class VerticalDiffusionData:
             'pbl_height': self.pbl_height,
             'surface_friction_velocity': self.surface_friction_velocity,
             'monin_obukhov_length': self.monin_obukhov_length,
+            'wind_10m': self.wind_10m,
             'surface_evaporation': self.surface_evaporation,
             'surface_sensible_heat': self.surface_sensible_heat,
             'surface_latent_heat': self.surface_latent_heat,


### PR DESCRIPTION
Closes #723. Split from #783, which is being divided: the dust source is redone
as a HAMMOZ/Tegen port under #802, and this is the 10 m emission wind and its
tooling.

## What was wrong

Gong (2003) sea salt (`u10**3.41`) and Nightingale (2000) DMS (`k_w ~ u10²`)
are calibrated to the **10 m** wind — HAMMOZ passes `vphysc%velo10m`
(`mo_vphysc.f90`) — but both read `state.u_wind[-1]`, the lowest full level,
~33 m at L47. Over the ocean that is ≈1.10× u10, which the exponents amplify to
+37-46 % on sea salt and +20-25 % on DMS.

## What this does

`TteTkeVerticalDiffusion` publishes the ECHAM5 `vdiff.f90` / ICON
`mo_surface_diag::nsurf_diag` reduction as `VerticalDiffusionData.wind_10m`:

```
bn   = ln(z1/z0m)                              neutral profile factor
bm   = bn·√(CM_n|U| / CM|U|)                   stability-corrected
zrat = 10/z1
red  = [ln(1 + (e^bn − 1)·zrat) + merge] / bm
merge = −(bn − bm)·zrat                        stable   (CM|U| < CM_n|U|)
      = −ln(1 + (e^(bn−bm) − 1)·zrat)          unstable
```

Three properties worth the reviewer's attention:

* **Computed inside each scheme's `lax.cond` branch**, from that scheme's own
  neutral drag. ECHAM-Louis and Businger-Dyer differ in roughness (state-carried
  vs a hard-coded table), in the bound on `z/z0`, and in whether the wind is
  `zepdu2`-floored; both branches now build their momentum drag *from* the same
  helper the reduction uses, so the pair cannot drift. A shared reference read
  stable at exact neutral over ocean (0.863 vs 0.900 — −13 % on the sea-salt
  wind term).
* **The `zepdu2` floor is respected**: the profile factor uses the
  `max(|U|, 1 m/s)` speed the coefficients were built from, or the calm-wind
  floor reads as a stability signal (0.9931 against the correct 0.9038 at
  |U| = 0.5 m/s). The resulting reduction multiplies the true wind.
* **The stable/unstable branch** is selected by `CM|U| < CM_n|U|` — exactly
  `Ri > 0` for both schemes, continuous at `Ri = 0` — so the Richardson number
  stays inside the coefficient solve.

Emissions run before vdiff in the ECHAM ordering, so the value is the previous
step's: `vertical_diffusion` is a **declared** cross-step carry slot
(`initial_carry_state`), the same one-step lag `DustEmissions` already takes for
`u*`, and the deliberate pattern #673 distinguishes from an undeclared stale
read. On step 1 of a cold start the slot is still zero-filled, so both schemes
fall back to the lowest level and publish a per-column `wind_10m_model_level`
flag that `ResetEmissionFluxes` zeroes each step. `check_health` reports the
chunk mean and fails only a **persistent** fallback (`chunk_idx > 0 and
frac > 0.5`): under interval averaging the legitimate bootstrap step and one
defective step mid-chunk give the same `1/N`, so the per-step invariant is
asserted in the unit tests instead.

The ECHAM surface term's own "10 m wind" diagnostic was the same defect
relabelled and now takes the diagnosed value.

## Validation

30 days at T63L47, `+configuration=ma-t63-l47`, identical dates. **These numbers
come from the combined branch (#783), which also changed dust**; the sea-salt
and DMS figures are unaffected by the dust half, and the dust numbers are
deliberately not quoted here.

| quantity | before | after |
| --- | ---: | ---: |
| sea-salt emission | 1130 Tg/yr | **768.9 Tg/yr** (−32 %) |
| DMS flux | 38.8 Tg/yr | **32.5 Tg/yr** (−17 %) |

Emission-wind provenance per chunk (`wind_10m_model_level`):

| chunk | 0 | 1 | 2 | 3 | 4 | 5 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| day | 5 | 10 | 15 | 20 | 25 | 30 |
| model-level | **0.208 %** | 0.000 % | 0.000 % | 0.000 % | 0.000 % | 0.000 % |

0.208 % is exactly 1/480 — one step of a 5-day chunk at dt = 15 min — and zero
thereafter: the bootstrap-only property measured end to end.

## Gates

`ruff check .` clean. Gates passed in a worktree detached at `ea069911`:

| gate | result | coverage |
| --- | --- | --- |
| fast (≥90 %) | 2453 passed, 28 skipped | **95.24 %** |
| slow (≥80 %) | 106 passed, 17 skipped | **84.36 %** |

`docs/science_pointers_test.py` green (9 passed).

## Also here

* **The emission-size mechanism** (`distributors.py`): `particle_mean_mass`
  takes an optional volume-mean diameter of the *emitted* distribution, since
  emitted number scales as D⁻³ and fresh particles are not at their class's
  equilibrium size. **Mechanism only** — every existing caller keeps the class
  geometry. #783 populated it for BC, POA and primary sulfate from the CESM
  emission files; that is a CAM number inside a HAMMOZ package, the same class
  of substitution the dust split rejects, so those species keep `dev`'s
  behaviour here and take HAM's own sizes (Stier et al. 2005) with the
  Tegen/HAM emissions port.
* **Delegated-timestep guards**: `run=pyses_year` sets `time_step: null`
  because the dycore owns the timestep, so anything in the per-chunk path that
  reads it as a number crashes after the integration and before the checkpoint.
  A fast-lane dinosaur test (13 s) and a slow end-to-end pySES test cover it;
  both were verified to fail on a reintroduced `float(None)`.
* Science-doc entries per the #771 rule: the 10 m diagnostic in
  `vertical_diffusion.md`, the sea-salt/DMS emission wind in `aerosol.md`. Dust
  entries belong to #802.

## Not here

Everything dust: the source map and its gating, the CAM erodibility product and
its mirror publication, the `jam_dust_source` option, the mode split and dust
emission sizes. #802 supersedes that work with a HAMMOZ/Tegen port on the
supplied HAMMOZ inputs. #777 and #787 stay open as artefacts of the superseded
approach.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4x2keECpxEf5JvJ5rM3ty
